### PR TITLE
Fixes typo in minikube instruction

### DIFF
--- a/yt/documentation/en/_includes/overview/try-yt.md
+++ b/yt/documentation/en/_includes/overview/try-yt.md
@@ -111,7 +111,7 @@ Configure network access to the web interface and proxy
 $ minikube service ytsaurus-ui --url
 http://192.168.49.2:30539
 
-$ minikube service http-proxies --url
+$ minikube service http-proxies-lb --url
 http://192.168.49.2:30228
 ```
 

--- a/yt/documentation/ru/_includes/overview/try-yt.md
+++ b/yt/documentation/ru/_includes/overview/try-yt.md
@@ -110,7 +110,7 @@ ytsaurus-ui-deployment-67db6cc9b6-nwq25   1/1     Running     0          2m11s
 $ minikube service ytsaurus-ui --url
 http://192.168.49.2:30539
 
-$ minikube service http-proxies --url
+$ minikube service http-proxies-lb --url
 http://192.168.49.2:30228
 ```
 


### PR DESCRIPTION
Looks like svc name is incorrect
`http-proxies-lb` works for me

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
