### PR TITLE
chore(sdk/go): use xerrors from library

### DIFF
--- a/yt/chyt/controller/go.mod
+++ b/yt/chyt/controller/go.mod
@@ -8,9 +8,9 @@ require (
 	go.uber.org/atomic v1.10.0
 	go.uber.org/zap v1.23.0
 	go.ytsaurus.tech/library/go/core/log v0.0.2
+	go.ytsaurus.tech/library/go/core/xerrors v0.0.2
 	go.ytsaurus.tech/library/go/ptr v0.0.1
 	go.ytsaurus.tech/yt/go v0.0.2
-	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2
 )
 
 require (
@@ -29,10 +29,10 @@ require (
 	github.com/spf13/pflag v1.0.6-0.20201009195203-85dd5c8bc61c // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.ytsaurus.tech/library/go/blockcodecs v0.0.1 // indirect
-	go.ytsaurus.tech/library/go/core/xerrors v0.0.2 // indirect
 	go.ytsaurus.tech/library/go/x/xreflect v0.0.1 // indirect
 	go.ytsaurus.tech/library/go/x/xruntime v0.0.3 // indirect
 	golang.org/x/crypto v0.5.0 // indirect
 	golang.org/x/sys v0.4.0 // indirect
+	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )

--- a/yt/chyt/controller/internal/strawberry/helpers.go
+++ b/yt/chyt/controller/internal/strawberry/helpers.go
@@ -7,11 +7,11 @@ import (
 	"regexp"
 	"text/template"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yterrors"
-	"golang.org/x/xerrors"
 )
 
 var (

--- a/yt/go/guid/guid.go
+++ b/yt/go/guid/guid.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 
 	"github.com/gofrs/uuid"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 // GUID is 16-byte value.

--- a/yt/go/mapreduce/io.go
+++ b/yt/go/mapreduce/io.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strconv"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 type jobContext struct {

--- a/yt/go/mapreduce/io_linux.go
+++ b/yt/go/mapreduce/io_linux.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"syscall"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/skiff"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 type skiffReader struct {

--- a/yt/go/mapreduce/mapreduce.go
+++ b/yt/go/mapreduce/mapreduce.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"io"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/mapreduce/spec"
 	"go.ytsaurus.tech/yt/go/yt"
-	"golang.org/x/xerrors"
 )
 
 func jobCommand(job Job, outputPipes int) string {

--- a/yt/go/mapreduce/prepare.go
+++ b/yt/go/mapreduce/prepare.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/tink/go/keyset"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/mapreduce/spec"
 	"go.ytsaurus.tech/yt/go/schema"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yterrors"
-	"golang.org/x/xerrors"
 )
 
 type prepareAction func(ctx context.Context, p *prepare) error

--- a/yt/go/schema/infer.go
+++ b/yt/go/schema/infer.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"sort"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 var (

--- a/yt/go/skiff/decoder.go
+++ b/yt/go/skiff/decoder.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"reflect"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 type opCache map[reflect.Type][]fieldOp

--- a/yt/go/skiff/encoder.go
+++ b/yt/go/skiff/encoder.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"reflect"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 type Encoder struct {

--- a/yt/go/skiff/reader.go
+++ b/yt/go/skiff/reader.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"math"
 
-	"golang.org/x/xerrors"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 )
 
 const (

--- a/yt/go/skiff/types.go
+++ b/yt/go/skiff/types.go
@@ -3,8 +3,8 @@ package skiff
 import (
 	"reflect"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 var (

--- a/yt/go/wire/encode.go
+++ b/yt/go/wire/encode.go
@@ -4,9 +4,9 @@ import (
 	"encoding"
 	"reflect"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/schema"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 type NameTable []NameTableEntry

--- a/yt/go/ypath/lexer.go
+++ b/yt/go/ypath/lexer.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 func isHex(b byte) bool {

--- a/yt/go/yson/infer.go
+++ b/yt/go/yson/infer.go
@@ -3,7 +3,7 @@ package yson
 import (
 	"reflect"
 
-	"golang.org/x/xerrors"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 )
 
 // InferAttrs infers attribute names from struct.

--- a/yt/go/yson/ypath.go
+++ b/yt/go/yson/ypath.go
@@ -3,7 +3,7 @@ package yson
 import (
 	"fmt"
 
-	"golang.org/x/xerrors"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 )
 
 // SliceYPathAttrs splits ypath into attributes and path.

--- a/yt/go/yt/acl.go
+++ b/yt/go/yt/acl.go
@@ -1,6 +1,6 @@
 package yt
 
-import "golang.org/x/xerrors"
+import "go.ytsaurus.tech/library/go/core/xerrors"
 
 // TODO(dakovalkov): create a different type for Permission
 type Permission = string

--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -13,8 +13,8 @@ import (
 	"go.ytsaurus.tech/library/go/core/log"
 	"go.ytsaurus.tech/library/go/core/log/nop"
 	zaplog "go.ytsaurus.tech/library/go/core/log/zap"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/guid"
-	"golang.org/x/xerrors"
 )
 
 type Config struct {

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -19,11 +19,11 @@ import (
 	_ "go.ytsaurus.tech/library/go/blockcodecs/all"
 	"go.ytsaurus.tech/library/go/core/log"
 	"go.ytsaurus.tech/library/go/core/log/ctxlog"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yson"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/internal"
 	"go.ytsaurus.tech/yt/go/yterrors"
-	"golang.org/x/xerrors"
 )
 
 func decodeYTErrorFromHeaders(h http.Header) (ytErr *yterrors.Error, err error) {

--- a/yt/go/yt/internal/httpclient/table_reader.go
+++ b/yt/go/yt/internal/httpclient/table_reader.go
@@ -5,11 +5,11 @@ import (
 	"io"
 	"reflect"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yson"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/internal/smartreader"
-	"golang.org/x/xerrors"
 )
 
 type tableReader struct {

--- a/yt/go/yt/internal/retrier.go
+++ b/yt/go/yt/internal/retrier.go
@@ -10,9 +10,9 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"go.ytsaurus.tech/library/go/core/log"
 	"go.ytsaurus.tech/library/go/core/log/ctxlog"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yterrors"
-	"golang.org/x/xerrors"
 )
 
 type Retrier struct {

--- a/yt/go/yt/internal/retrier_test.go
+++ b/yt/go/yt/internal/retrier_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
-	"golang.org/x/xerrors"
 )
 
 type netError struct {

--- a/yt/go/yt/internal/rpcclient/helpers.go
+++ b/yt/go/yt/internal/rpcclient/helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/library/go/ptr"
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/proto/client/api/rpc_proxy"
@@ -13,7 +14,6 @@ import (
 	"go.ytsaurus.tech/yt/go/yson"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yterrors"
-	"golang.org/x/xerrors"
 )
 
 // unexpectedStatusCode is last effort attempt to get useful error message from a failed request.

--- a/yt/go/yt/internal/rpcclient/mutation_retrier.go
+++ b/yt/go/yt/internal/rpcclient/mutation_retrier.go
@@ -9,10 +9,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"go.ytsaurus.tech/library/go/core/log"
 	"go.ytsaurus.tech/library/go/core/log/ctxlog"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/bus"
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/yt"
-	"golang.org/x/xerrors"
 )
 
 type MutationRetrier struct {

--- a/yt/go/yt/internal/transaction.go
+++ b/yt/go/yt/internal/transaction.go
@@ -5,11 +5,11 @@ import (
 	"io"
 
 	"go.ytsaurus.tech/library/go/core/log"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yson"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/internal/smartreader"
-	"golang.org/x/xerrors"
 )
 
 type TxInterceptor struct {

--- a/yt/go/yt/writer.go
+++ b/yt/go/yt/writer.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"errors"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yson"
-	"golang.org/x/xerrors"
 )
 
 var (

--- a/yt/go/yt/ythttp/new.go
+++ b/yt/go/yt/ythttp/new.go
@@ -4,10 +4,10 @@ package ythttp
 import (
 	"testing"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/mapreduce"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/internal/httpclient"
-	"golang.org/x/xerrors"
 )
 
 func checkNotInsideJob(c *yt.Config) error {

--- a/yt/go/yt/ytrpc/new.go
+++ b/yt/go/yt/ytrpc/new.go
@@ -3,10 +3,10 @@ package ytrpc
 import (
 	"testing"
 
+	"go.ytsaurus.tech/library/go/core/xerrors"
 	"go.ytsaurus.tech/yt/go/mapreduce"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/internal/rpcclient"
-	"golang.org/x/xerrors"
 )
 
 func checkNotInsideJob(c *yt.Config) error {

--- a/yt/go/yterrors/error_test.go
+++ b/yt/go/yterrors/error_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/xerrors"
+	"go.ytsaurus.tech/library/go/core/xerrors"
 )
 
 func TestNewError(t *testing.T) {


### PR DESCRIPTION
YTsaurus have xerrors in library - why not use this instead external experimental package?

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
