### PR TITLE
feat(sdk/go): add init attributes for create node options

### DIFF
--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -125,6 +125,12 @@ type CreateNodeOptions struct {
 	*PrerequisiteOptions
 }
 
+func (options *CreateNodeOptions) initAttributes() {
+	if options.Attributes == nil {
+		options.Attributes = map[string]interface{}{}
+	}
+}
+
 type CreateObjectOptions struct {
 	Recursive      bool `http:"recursive"`
 	IgnoreExisting bool `http:"ignore_existing"`

--- a/yt/go/yt/tables.go
+++ b/yt/go/yt/tables.go
@@ -79,9 +79,7 @@ type CreateTableOption func(options *CreateNodeOptions)
 
 func WithSchema(schema schema.Schema) CreateTableOption {
 	return func(options *CreateNodeOptions) {
-		if options.Attributes == nil {
-			options.Attributes = map[string]interface{}{}
-		}
+		options.initAttributes()
 
 		options.Attributes["schema"] = schema
 	}
@@ -89,9 +87,7 @@ func WithSchema(schema schema.Schema) CreateTableOption {
 
 func WithInferredSchema(row interface{}) CreateTableOption {
 	return func(options *CreateNodeOptions) {
-		if options.Attributes == nil {
-			options.Attributes = map[string]interface{}{}
-		}
+		options.initAttributes()
 
 		options.Attributes["schema"] = schema.MustInfer(row)
 	}
@@ -111,9 +107,7 @@ func WithRecursive() CreateTableOption {
 
 func WithAttributes(attrs map[string]interface{}) CreateTableOption {
 	return func(options *CreateNodeOptions) {
-		if options.Attributes == nil {
-			options.Attributes = map[string]interface{}{}
-		}
+		options.initAttributes()
 
 		for k, v := range attrs {
 			if _, ok := options.Attributes[k]; !ok {


### PR DESCRIPTION
Move check map initialization to CreateNodeOptions method for reuse in option functions

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
