### PR TITLE
refactor(sdk/go): use struct instead struct+var for credentials key

### DIFF
--- a/yt/go/yt/credentials.go
+++ b/yt/go/yt/credentials.go
@@ -70,12 +70,10 @@ func (c *ServiceTicketCredentials) SetExtension(req *rpc.TRequestHeader) {
 	)
 }
 
-type credentials struct{}
-
-var credentialsKey credentials
+type credentialsCtxKey struct{}
 
 func ContextCredentials(ctx context.Context) Credentials {
-	if v := ctx.Value(&credentialsKey); v != nil {
+	if v := ctx.Value(credentialsCtxKey{}); v != nil {
 		return v.(Credentials)
 	}
 
@@ -84,5 +82,5 @@ func ContextCredentials(ctx context.Context) Credentials {
 
 // WithCredentials allows overriding client credentials on per-call basis.
 func WithCredentials(ctx context.Context, credentials Credentials) context.Context {
-	return context.WithValue(ctx, &credentialsKey, credentials)
+	return context.WithValue(ctx, credentialsCtxKey{}, credentials)
 }


### PR DESCRIPTION
Use empty struct instead struct+var - code will be cleaner and for this case usually use this combination.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
