### PR TITLE
Primitive support of building with clang 16

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,7 +4,7 @@ openssl/1.1.1s
 zlib/1.2.13
 
 [tool_requires]
-bison/3.5.3
+bison/3.8.2
 m4/1.4.19
 ragel/6.10
 yasm/1.3.0

--- a/contrib/libs/poco/Foundation/include/Poco/Timespan.h
+++ b/contrib/libs/poco/Foundation/include/Poco/Timespan.h
@@ -66,20 +66,8 @@ public:
 	void swap(Timespan& timespan);
 		/// Swaps the Timespan with another one.
 
-	bool operator == (const Timespan& ts) const;
-	bool operator != (const Timespan& ts) const;
-	bool operator >  (const Timespan& ts) const;
-	bool operator >= (const Timespan& ts) const;
-	bool operator <  (const Timespan& ts) const;
-	bool operator <= (const Timespan& ts) const;
+	auto operator<=>(const Timespan & ts) const = default;
 
-	bool operator == (TimeDiff microSeconds) const;
-	bool operator != (TimeDiff microSeconds) const;
-	bool operator >  (TimeDiff microSeconds) const;
-	bool operator >= (TimeDiff microSeconds) const;
-	bool operator <  (TimeDiff microSeconds) const;
-	bool operator <= (TimeDiff microSeconds) const;
-	
 	Timespan operator + (const Timespan& d) const;
 	Timespan operator - (const Timespan& d) const;
 	Timespan& operator += (const Timespan& d);
@@ -211,78 +199,6 @@ inline int Timespan::useconds() const
 inline Timespan::TimeDiff Timespan::totalMicroseconds() const
 {
 	return _span;
-}
-
-
-inline bool Timespan::operator == (const Timespan& ts) const
-{
-	return _span == ts._span;
-}
-
-
-inline bool Timespan::operator != (const Timespan& ts) const
-{
-	return _span != ts._span;
-}
-
-
-inline bool Timespan::operator >  (const Timespan& ts) const
-{
-	return _span > ts._span;
-}
-
-
-inline bool Timespan::operator >= (const Timespan& ts) const
-{
-	return _span >= ts._span;
-}
-
-
-inline bool Timespan::operator <  (const Timespan& ts) const
-{
-	return _span < ts._span;
-}
-
-
-inline bool Timespan::operator <= (const Timespan& ts) const
-{
-	return _span <= ts._span;
-}
-
-
-inline bool Timespan::operator == (TimeDiff microSeconds) const
-{
-	return _span == microSeconds;
-}
-
-
-inline bool Timespan::operator != (TimeDiff microSeconds) const
-{
-	return _span != microSeconds;
-}
-
-
-inline bool Timespan::operator >  (TimeDiff microSeconds) const
-{
-	return _span > microSeconds;
-}
-
-
-inline bool Timespan::operator >= (TimeDiff microSeconds) const
-{
-	return _span >= microSeconds;
-}
-
-
-inline bool Timespan::operator <  (TimeDiff microSeconds) const
-{
-	return _span < microSeconds;
-}
-
-
-inline bool Timespan::operator <= (TimeDiff microSeconds) const
-{
-	return _span <= microSeconds;
 }
 
 

--- a/contrib/restricted/magic_enum/CMakeLists.txt
+++ b/contrib/restricted/magic_enum/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 
 add_library(contrib-restricted-magic_enum INTERFACE)
-target_include_directories(contrib-restricted-magic_enum INTERFACE
+target_include_directories(contrib-restricted-magic_enum SYSTEM INTERFACE
   ${CMAKE_SOURCE_DIR}/contrib/restricted/magic_enum/include
 )
 target_link_libraries(contrib-restricted-magic_enum INTERFACE

--- a/util/generic/hash_table.h
+++ b/util/generic/hash_table.h
@@ -91,9 +91,6 @@ struct __yhashtable_iterator {
     bool operator==(const iterator& it) const {
         return cur == it.cur;
     }
-    bool operator!=(const iterator& it) const {
-        return cur != it.cur;
-    }
     bool IsEnd() const {
         return !cur;
     }
@@ -137,9 +134,6 @@ struct __yhashtable_const_iterator {
     const_iterator operator++(int);
     bool operator==(const const_iterator& it) const {
         return cur == it.cur;
-    }
-    bool operator!=(const const_iterator& it) const {
-        return cur != it.cur;
     }
     bool IsEnd() const {
         return !cur;

--- a/yt/yt/library/query/engine/CMakeLists.txt
+++ b/yt/yt/library/query/engine/CMakeLists.txt
@@ -265,25 +265,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/hyperloglog_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/hyperloglog_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/hyperloglog_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/hyperloglog.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/hyperloglog.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/hyperloglog_merged.bc
   -internalize
   -internalize-public-api-list=cardinality_init#cardinality_update#cardinality_merge#cardinality_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/hyperloglog_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/hyperloglog.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/hyperloglog.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/hyperloglog_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_merged.bc
@@ -292,25 +290,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/farm_hash.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/farm_hash.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_merged.bc
   -internalize
   -internalize-public-api-list=farm_hash
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/farm_hash.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/farm_hash.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/farm_hash_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_merged.bc
@@ -319,25 +315,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/bigb_hash.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/bigb_hash.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_merged.bc
   -internalize
   -internalize-public-api-list=bigb_hash
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/bigb_hash.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/bigb_hash.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/bigb_hash_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_merged.bc
@@ -346,25 +340,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/make_map.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/make_map.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_merged.bc
   -internalize
   -internalize-public-api-list=make_map
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/make_map.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/make_map.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/make_map_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_merged.bc
@@ -373,25 +365,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/str_conv.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/str_conv.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_merged.bc
   -internalize
   -internalize-public-api-list=numeric_to_string#parse_int64#parse_uint64#parse_double
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/str_conv.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/str_conv.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/str_conv_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_merged.bc
@@ -400,25 +390,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/regex.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/regex.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_merged.bc
   -internalize
   -internalize-public-api-list=regex_full_match#regex_partial_match#regex_replace_first#regex_replace_all#regex_extract#regex_escape
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/regex.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/regex.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/regex_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_merged.bc
@@ -427,25 +415,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/avg.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/avg.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_merged.bc
   -internalize
   -internalize-public-api-list=avg_init#avg_update#avg_merge#avg_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/avg.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/avg.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/avg_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_merged.bc
@@ -454,25 +440,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/concat.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/concat.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_merged.bc
   -internalize
   -internalize-public-api-list=concat
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/concat.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/concat.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/concat_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_merged.bc
@@ -481,25 +465,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/first.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/first.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_merged.bc
   -internalize
   -internalize-public-api-list=first_init#first_update#first_merge#first_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/first.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/first.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/first_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_merged.bc
@@ -508,25 +490,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_prefix.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_prefix.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_merged.bc
   -internalize
   -internalize-public-api-list=is_prefix
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_prefix.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_prefix.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_prefix_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_merged.bc
@@ -535,25 +515,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_substr.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_substr.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_merged.bc
   -internalize
   -internalize-public-api-list=is_substr
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_substr.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/is_substr.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/is_substr_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_merged.bc
@@ -562,25 +540,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/to_any.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/to_any.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_merged.bc
   -internalize
   -internalize-public-api-list=to_any
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/to_any.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/to_any.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/to_any_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_merged.bc
@@ -589,25 +565,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/max.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/max.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_merged.bc
   -internalize
   -internalize-public-api-list=max_init#max_update#max_merge#max_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/max.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/max.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/max_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_merged.bc
@@ -616,25 +590,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/min.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/min.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_merged.bc
   -internalize
   -internalize-public-api-list=min_init#min_update#min_merge#min_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/min.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/min.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/min_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_merged.bc
@@ -643,25 +615,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sleep.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sleep.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_merged.bc
   -internalize
   -internalize-public-api-list=sleep#sleep
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sleep.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sleep.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sleep_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_merged.bc
@@ -670,25 +640,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sum.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sum.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_merged.bc
   -internalize
   -internalize-public-api-list=sum_init#sum_update#sum_merge#sum_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sum.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/sum.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/sum_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_merged.bc
@@ -697,25 +665,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/ypath_get.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/ypath_get.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_merged.bc
   -internalize
   -internalize-public-api-list=try_get_int64#get_int64#try_get_uint64#get_uint64#try_get_double#get_double#try_get_boolean#get_boolean#try_get_string#get_string#try_get_any#get_any
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/ypath_get.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/ypath_get.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/ypath_get_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_merged.bc
@@ -724,25 +690,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/lower.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/lower.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_merged.bc
   -internalize
   -internalize-public-api-list=lower
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/lower.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/lower.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/lower_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_merged.bc
@@ -751,25 +715,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/length.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/length.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_merged.bc
   -internalize
   -internalize-public-api-list=length
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/length.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/length.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/length_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_merged.bc
@@ -778,25 +740,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/dates.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/dates.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_merged.bc
   -internalize
   -internalize-public-api-list=format_timestamp#timestamp_floor_hour#timestamp_floor_day#timestamp_floor_week#timestamp_floor_month#timestamp_floor_year
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/dates.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/dates.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/dates_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_merged.bc
@@ -805,25 +765,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/format_guid.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/format_guid.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_merged.bc
   -internalize
   -internalize-public-api-list=format_guid
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/format_guid.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/format_guid.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/format_guid_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_merged.bc
@@ -832,25 +790,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/list_contains.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/list_contains.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_merged.bc
   -internalize
   -internalize-public-api-list=list_contains
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/list_contains.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/list_contains.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/list_contains_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_merged.bc
@@ -859,25 +815,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/any_to_yson_string.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/any_to_yson_string.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_merged.bc
   -internalize
   -internalize-public-api-list=any_to_yson_string
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/any_to_yson_string.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/any_to_yson_string.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/any_to_yson_string_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_merged.bc
@@ -886,25 +840,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/has_permissions.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/has_permissions.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_merged.bc
   -internalize
   -internalize-public-api-list=has_permissions
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/has_permissions.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/has_permissions.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/has_permissions_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/xdelta_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/xdelta_merged.bc
@@ -913,11 +865,7 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/xdelta_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/xdelta_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
-  -internalize
-  -internalize-public-api-list=xdelta_init#xdelta_update#xdelta_merge#xdelta_finalize
+  -p 'default<O2>,globalopt,globaldce'
 )
 add_custom_command(
   OUTPUT
@@ -929,6 +877,8 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/udf/xdelta3.c.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/engine/xdelta_merged.bc
+  -internalize
+  -internalize-public-api-list=xdelta_init#xdelta_update#xdelta_merge#xdelta_finalize
 )
 llvm_compile_c(library-query-engine.global
   ${CMAKE_SOURCE_DIR}/yt/yt/library/query/engine/udf/avg.c

--- a/yt/yt/library/query/unittests/udf/CMakeLists.txt
+++ b/yt/yt/library/query/unittests/udf/CMakeLists.txt
@@ -68,25 +68,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf_merged.bc
   -internalize
   -internalize-public-api-list=malloc_udf
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/malloc_udf_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_merged.bc
@@ -95,25 +93,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs.c.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs.c.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_merged.bc
   -internalize
   -internalize-public-api-list=seventyfive#strtol_udf#exp_udf#tolower_udf#is_null_udf#string_equals_42_udf#abs_udf#sum_udf#throw_if_negative_udf#avg_udaf_init#avg_udaf_update#avg_udaf_merge#avg_udaf_finalize
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs.c.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs.c.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_merged.bc
@@ -122,25 +118,23 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
+  -p 'default<O2>,globalopt,globaldce'
+)
+add_custom_command(
+  OUTPUT
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_merged.bc
+  DEPENDS
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc.cpp.bc
+  COMMAND
+  ${LLVMLINK}
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc.cpp.bc
+  -o
+  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_merged.bc
   -internalize
   -internalize-public-api-list=udf_with_function_context
 )
 add_custom_command(
   OUTPUT
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_merged.bc
-  DEPENDS
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc.cpp.bc
-  COMMAND
-  ${LLVMLINK}
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc.cpp.bc
-  -o
-  ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/test_udfs_fc_merged.bc
-)
-add_custom_command(
-  OUTPUT
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/xor_aggregate_optimized.bc
   DEPENDS
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/xor_aggregate_merged.bc
@@ -149,11 +143,7 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/xor_aggregate_merged.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/xor_aggregate_optimized.bc
-  -O2
-  -globalopt
-  -globaldce
-  -internalize
-  -internalize-public-api-list=xor_aggregate_init#xor_aggregate_update#xor_aggregate_merge#xor_aggregate_finalize
+  -p 'default<O2>,globalopt,globaldce'
 )
 add_custom_command(
   OUTPUT
@@ -165,6 +155,8 @@ add_custom_command(
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/xor_aggregate.c.bc
   -o
   ${CMAKE_BINARY_DIR}/yt/yt/library/query/unittests/udf/xor_aggregate_merged.bc
+  -internalize
+  -internalize-public-api-list=xor_aggregate_init#xor_aggregate_update#xor_aggregate_merge#xor_aggregate_finalize
 )
 llvm_compile_c(query-unittests-udf.global
   ${CMAKE_SOURCE_DIR}/yt/yt/library/query/unittests/udf/malloc_udf.c


### PR DESCRIPTION
More information is provided in each commit message.

P.S. I'm not sure if those cmake files related to bitcode generators should be changed in such way. It seems to be auto-generated by some tool (maybe ya.make).

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en