### PR TITLE
Put attribute(weak) in a GCC-compatible position

### DIFF
--- a/library/cpp/yt/malloc/malloc.cpp
+++ b/library/cpp/yt/malloc/malloc.cpp
@@ -7,13 +7,13 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-Y_WEAK extern "C" size_t nallocx(size_t size, int /*flags*/) noexcept
+extern "C" Y_WEAK size_t nallocx(size_t size, int /*flags*/) noexcept
 {
     return size;
 }
 
 #ifndef _win_
-Y_WEAK extern "C" size_t malloc_usable_size(void* /*ptr*/) noexcept
+extern "C" Y_WEAK size_t malloc_usable_size(void* /*ptr*/) noexcept
 {
     return 0;
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

In addition to #89, there is one more minor fix. GCC doesn't allow putting `__attribute__((weak))` before the `extern "C"` and produces non-weak symbols. Proof: https://godbolt.org/z/h48fYsGMW