### PR TITLE
Fix parse_bash_command_line function for some corner cases.

### DIFF
--- a/yt/python/yt/wrapper/job_tool.py
+++ b/yt/python/yt/wrapper/job_tool.py
@@ -73,7 +73,7 @@ def parse_bash_command_line(command_line):
         else:
             return environment_variables.strip(), command_with_args[0], command_with_args[1]
 
-    return "", command_line, ""
+    return environment_variables.strip(), command_with_args[0], ""
 
 
 def make_run_sh(job_path, operation_id, job_id, sandbox_path, command, environment,


### PR DESCRIPTION
Current ```parse_bash_command_line``` function doesn't work correctly for some cases. F.e. ```"YT_USE_CLIENT_PROTOBUF=0 ./cppbinary"```. As a result you will get ```"", "YT_USE_CLIENT_PROTOBUF=0 ./cppbinary", ""```. Fix that behaviour.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
