### PR TITLE
feat: support tablet, tablet_cell and tablet_cell_bundle management through java-client

### DIFF
--- a/yt/java/ytsaurus-client-core/src/main/java/tech/ytsaurus/core/cypress/CypressNodeType.java
+++ b/yt/java/ytsaurus-client-core/src/main/java/tech/ytsaurus/core/cypress/CypressNodeType.java
@@ -24,6 +24,9 @@ public enum CypressNodeType implements StringValueEnum {
     REPLICATED_TABLE(425, "replicated_table"),
 
     // Tablet Manager stuff.
+    TABLET_CELL(700, "tablet_cell"),
+    TABLET(702, "tablet"),
+    TABLET_CELL_BUNDLE(706, "tablet_cell_bundle"),
     TABLE_REPLICA(709, "table_replica");
 
     public static final StringValueEnumResolver<CypressNodeType> R = StringValueEnumResolver.of(CypressNodeType.class);


### PR DESCRIPTION
There were missing constants in `CypressNodeType` enum to manage tablet parts

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
