### PR TITLE
Fix typo in method arg

### DIFF
--- a/yt/python/yt/wrapper/spec_builders.py
+++ b/yt/python/yt/wrapper/spec_builders.py
@@ -1967,8 +1967,8 @@ class SortSpecBuilder(SpecBuilder):
         return _set_spec_value(self, "input_table_paths", paths)
 
     @spec_option("The path of the output table")
-    def output_table_path(self, size):
-        return _set_spec_value(self, "output_table_path", size)
+    def output_table_path(self, path):
+        return _set_spec_value(self, "output_table_path", path)
 
     @spec_option("The approximate count of partition jobs")
     def partition_job_count(self, count):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
