### PR TITLE
Add missed _apply_spec_defaults to vanilla job spec builder 

### DIFF
--- a/yt/python/yt/wrapper/spec_builders.py
+++ b/yt/python/yt/wrapper/spec_builders.py
@@ -2202,6 +2202,8 @@ class VanillaSpecBuilder(SpecBuilder):
                 client=client,
                 requires_format=False,
             )
+
+        spec = self._apply_spec_defaults(spec, client=client)
         return spec
 
     def supports_user_job_spec(self):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
