### PR TITLE
Respect "default_role_filter" config option for HTTP redirects

### DIFF
--- a/yt/yt/server/http_proxy/helpers.cpp
+++ b/yt/yt/server/http_proxy/helpers.cpp
@@ -357,7 +357,7 @@ void ProcessDebugHeaders(const IRequestPtr& /*request*/, const IResponseWriterPt
 
 void RedirectToDataProxy(const IRequestPtr& request, const IResponseWriterPtr& response, const TCoordinatorPtr& coordinator)
 {
-    auto target = coordinator->AllocateProxy("data");
+    auto target = coordinator->AllocateProxy(coordinator->GetConfig()->DefaultRoleFilter.value_or("data"));
     if (target) {
         auto url = request->GetUrl();
         TString protocol;


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Without this change it is impossible to separate control and data proxies as operator sets "default_role_filter" to "default" and coordinator isses redirects to a hardcoded "data" role.
