### PR TITLE
Get rid of yt/yt/library/program dependency on yt/yt/library/containers.

### DIFF
--- a/yt/yt/library/program/CMakeLists.txt
+++ b/yt/yt/library/program/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(yt-library-program PUBLIC
   yt-yt-core
   core-service_discovery-yp
   yt-library-monitoring
-  yt-library-containers
   library-profiling-solomon
   library-profiling-tcmalloc
   library-profiling-perf

--- a/yt/yt/library/program/config.cpp
+++ b/yt/yt/library/program/config.cpp
@@ -103,12 +103,8 @@ void TSingletonsConfig::Register(TRegistrar registrar)
         .Default(true);
     registrar.Parameter("enable_resource_tracker", &TThis::EnableResourceTracker)
         .Default(true);
-    registrar.Parameter("enable_porto_resource_tracker", &TThis::EnablePortoResourceTracker)
-        .Default(false);
     registrar.Parameter("resource_tracker_vcpu_factor", &TThis::ResourceTrackerVCpuFactor)
         .Optional();
-    registrar.Parameter("pod_spec", &TThis::PodSpec)
-        .DefaultNew();
     registrar.Parameter("heap_profiler", &TThis::HeapProfiler)
         .DefaultNew();
 

--- a/yt/yt/library/program/config.h
+++ b/yt/yt/library/program/config.h
@@ -22,8 +22,6 @@
 
 #include <yt/yt/library/profiling/solomon/exporter.h>
 
-#include <yt/yt/library/containers/config.h>
-
 #include <yt/yt/library/tracing/jaeger/tracer.h>
 
 #include <library/cpp/yt/stockpile/stockpile.h>
@@ -149,9 +147,7 @@ public:
     TStockpileConfigPtr Stockpile;
     bool EnableRefCountedTrackerProfiling;
     bool EnableResourceTracker;
-    bool EnablePortoResourceTracker;
     std::optional<double> ResourceTrackerVCpuFactor;
-    NContainers::TPodSpecConfigPtr PodSpec;
     THeapProfilerConfigPtr HeapProfiler;
 
     REGISTER_YSON_STRUCT(TSingletonsConfig);

--- a/yt/yt/library/program/helpers.cpp
+++ b/yt/yt/library/program/helpers.cpp
@@ -16,19 +16,14 @@
 
 #include <yt/yt/library/profiling/resource_tracker/resource_tracker.h>
 
-#include <yt/yt/library/containers/config.h>
-#include <yt/yt/library/containers/porto_resource_tracker.h>
-
 #include <yt/yt/core/logging/log_manager.h>
 
 #include <yt/yt/core/concurrency/execution_stack.h>
 #include <yt/yt/core/concurrency/periodic_executor.h>
-#include <yt/yt/core/concurrency/private.h>
 
 #include <tcmalloc/malloc_extension.h>
 
 #include <yt/yt/core/net/address.h>
-#include <yt/yt/core/net/local_address.h>
 
 #include <yt/yt/core/rpc/dispatcher.h>
 #include <yt/yt/core/rpc/grpc/dispatcher.h>
@@ -36,8 +31,6 @@
 #include <yt/yt/core/service_discovery/yp/service_discovery.h>
 
 #include <yt/yt/core/threading/spin_wait_slow_path_logger.h>
-
-#include <library/cpp/yt/threading/spin_wait_hook.h>
 
 #include <library/cpp/yt/memory/atomic_intrusive_ptr.h>
 
@@ -235,10 +228,6 @@ void ConfigureSingletonsImpl(const TConfig& config)
         if (config->ResourceTrackerVCpuFactor.has_value()) {
             NProfiling::SetVCpuFactor(config->ResourceTrackerVCpuFactor.value());
         }
-    }
-
-    if (config->EnablePortoResourceTracker) {
-        NContainers::EnablePortoResourceTracker(config->PodSpec);
     }
 }
 

--- a/yt/yt/library/program/ya.make
+++ b/yt/yt/library/program/ya.make
@@ -16,7 +16,6 @@ PEERDIR(
     yt/yt/core
     yt/yt/core/service_discovery/yp
     yt/yt/library/monitoring
-    yt/yt/library/containers
     yt/yt/library/profiling/solomon
     yt/yt/library/profiling/tcmalloc
     yt/yt/library/profiling/perf

--- a/yt/yt/server/tools/ya.make
+++ b/yt/yt/server/tools/ya.make
@@ -13,6 +13,7 @@ SRCS(
 
 PEERDIR(
     yt/yt/library/process
+    yt/yt/library/containers
     yt/yt/library/program
 
     yt/yt/core

--- a/yt/yt/ytlib/program/config.cpp
+++ b/yt/yt/ytlib/program/config.cpp
@@ -1,5 +1,7 @@
 #include "config.h"
 
+#include <yt/yt/library/containers/config.h>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -9,6 +11,10 @@ void TNativeSingletonsConfig::Register(TRegistrar registrar)
     registrar.Parameter("chunk_client_dispatcher", &TThis::ChunkClientDispatcher)
         .DefaultNew();
     registrar.Parameter("native_authentication_manager", &TThis::NativeAuthenticationManager)
+        .DefaultNew();
+    registrar.Parameter("enable_porto_resource_tracker", &TThis::EnablePortoResourceTracker)
+        .Default(false);
+    registrar.Parameter("pod_spec", &TThis::PodSpec)
         .DefaultNew();
 }
 

--- a/yt/yt/ytlib/program/config.h
+++ b/yt/yt/ytlib/program/config.h
@@ -6,6 +6,8 @@
 
 #include <yt/yt/ytlib/chunk_client/config.h>
 
+#include <yt/yt/library/containers/public.h>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -17,6 +19,9 @@ public:
     NChunkClient::TDispatcherConfigPtr ChunkClientDispatcher;
 
     NAuth::TNativeAuthenticationManagerConfigPtr NativeAuthenticationManager;
+
+    bool EnablePortoResourceTracker;
+    NContainers::TPodSpecConfigPtr PodSpec;
 
     REGISTER_YSON_STRUCT(TNativeSingletonsConfig);
 

--- a/yt/yt/ytlib/program/helpers.cpp
+++ b/yt/yt/ytlib/program/helpers.cpp
@@ -6,6 +6,8 @@
 
 #include <yt/yt/ytlib/chunk_client/dispatcher.h>
 
+#include <yt/yt/library/containers/porto_resource_tracker.h>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -16,6 +18,10 @@ void ConfigureNativeSingletons(const TNativeSingletonsConfigPtr& config)
 
     NChunkClient::TDispatcher::Get()->Configure(config->ChunkClientDispatcher);
     NAuth::TNativeAuthenticationManager::Get()->Configure(config->NativeAuthenticationManager);
+
+    if (config->EnablePortoResourceTracker) {
+        NContainers::EnablePortoResourceTracker(config->PodSpec);
+    }
 }
 
 void ReconfigureNativeSingletons(


### PR DESCRIPTION
The first one is designed to be an auxillary target for bootstrapping all
yt/yt/core-level singletons. At some moment a couple of container runtime related
singletons were introduced, imposing a redunadnt dependency on yt/yt/library/containers,
which is a quite heavy dependency (including Porto and CRI clients).

After YQL plugin started configuring YT singletons, it also broke YDB Piglet whitelist
around this commit: https://github.com/ydb-platform/ydb/commit/d28c55ab25cc8cedab8a5f4736c0d66e88b3da95

This commit moves container-related singletons to yt/yt/ytlib/program which keeps them available
in YT server processes and removes them from other users of yt/yt/library/program.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
