### PR TITLE
Fix redundant chunk_meta.proto import.

### DIFF
--- a/yt/yt/ytlib/chunk_client/proto/chunk_service.proto
+++ b/yt/yt/ytlib/chunk_client/proto/chunk_service.proto
@@ -9,7 +9,6 @@ import "yt_proto/yt/client/chunk_client/proto/chunk_meta.proto";
 import "yt_proto/yt/client/chunk_client/proto/data_statistics.proto";
 import "yt_proto/yt/client/chunk_client/proto/chunk_spec.proto";
 import "yt_proto/yt/client/chunk_client/proto/confirm_chunk_replica_info.proto";
-import "yt_proto/yt/client/table_chunk_format/proto/chunk_meta.proto";
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This fixes the following warning:
```
yt/ytlib/chunk_client/proto/chunk_service.proto:12:1: warning: Import yt_proto/yt/client/table_chunk_format/proto/chunk_meta.proto is unused.
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
