### PR TITLE
Remove using transaction_id with FakeTransaction

### DIFF
--- a/yt/python/yt/wrapper/heavy_commands.py
+++ b/yt/python/yt/wrapper/heavy_commands.py
@@ -16,7 +16,7 @@ from .format import YtFormatReadError
 
 import yt.logger as logger
 
-from yt.common import join_exceptions
+from yt.common import join_exceptions, YT_NULL_TRANSACTION_ID as null_transaction_id
 
 try:
     from yt.packages.six.moves import xrange
@@ -86,7 +86,10 @@ def process_read_exception(exception):
 
 
 class FakeTransaction(object):
-    def __enter__(self):
+    def __init__(self):
+        self.transaction_id = null_transaction_id
+
+    def __enter__(self): 
         return self
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
FakeTransaction doesn't have transaction_id and I've encountered such error in that [row](https://github.com/valinurovdenis/ytsaurus/blob/main/yt/python/yt/wrapper/heavy_commands.py#L376). Maybe it is worth passing None in case of FakeTransaction.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
