### PR TITLE
Replace confusing KeyError with YtError

### DIFF
--- a/yt/python/yt/wrapper/spec_builders.py
+++ b/yt/python/yt/wrapper/spec_builders.py
@@ -99,6 +99,10 @@ def _set_spec_value(builder, key, value):
 
 def _is_tables_sorted(table, client):
     def _is_sorted(sort_attributes):
+        node_type = sort_attributes["type"]
+        if node_type != "table":
+            raise YtError('"{}" must be a table, but current node type is "{}"'.format(table, node_type))
+
         if not parse_bool(sort_attributes["sorted"]):
             return False
         if "columns" in table.attributes and not is_prefix(sort_attributes["sorted_by"],
@@ -107,7 +111,7 @@ def _is_tables_sorted(table, client):
         return True
 
     table = TablePath(table, client=client)
-    sort_attributes = get(table + "/@", attributes=["sorted", "sorted_by"], client=client)
+    sort_attributes = get(table + "/@", attributes=["type", "sorted", "sorted_by"], client=client)
     return apply_function_to_result(_is_sorted, sort_attributes)
 
 

--- a/yt/python/yt/wrapper/spec_builders.py
+++ b/yt/python/yt/wrapper/spec_builders.py
@@ -98,21 +98,21 @@ def _set_spec_value(builder, key, value):
 
 
 def _is_tables_sorted(table, client):
-    def _is_sorted(sort_attributes):
-        node_type = sort_attributes["type"]
+    def _is_sorted(table_attributes):
+        node_type = table_attributes["type"]
         if node_type != "table":
             raise YtError('"{}" must be a table, but current node type is "{}"'.format(table, node_type))
 
-        if not parse_bool(sort_attributes["sorted"]):
+        if not parse_bool(table_attributes["sorted"]):
             return False
-        if "columns" in table.attributes and not is_prefix(sort_attributes["sorted_by"],
+        if "columns" in table.attributes and not is_prefix(table_attributes["sorted_by"],
                                                            table.attributes["columns"]):
             return False
         return True
 
     table = TablePath(table, client=client)
-    sort_attributes = get(table + "/@", attributes=["type", "sorted", "sorted_by"], client=client)
-    return apply_function_to_result(_is_sorted, sort_attributes)
+    table_attributes = get(table + "/@", attributes=["type", "sorted", "sorted_by"], client=client)
+    return apply_function_to_result(_is_sorted, table_attributes)
 
 
 def _is_cpp_job(command):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Right now the following command (for example you think that `/path/to/not/table/node` works as "all tables in map_node"):

```bash
yt merge /path/to/not/table/node /something
```

Fails with this error:

```python
Traceback (most recent call last):
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/cli_helpers.py", line 77, in run_main
    main_func()
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/cli/yt_binary.py", line 2639, in main_func
    args.func(**func_args)
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/cli/yt_binary.py", line 1342, in handler
    operation = function(*args, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-5>", line 2, in run_merge
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/common.py", line 421, in forbidden_inside_job
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/run_operation_commands.py", line 115, in run_merge
    return run_operation(spec_builder, sync=sync, enable_optimizations=True, client=client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-8>", line 2, in run_operation
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/common.py", line 421, in forbidden_inside_job
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/run_operation_commands.py", line 599, in run_operation
    spec_builder.prepare(client=client)
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 1917, in prepare
    mode = "sorted" if all(batch_apply(_is_tables_sorted, self.get_input_table_paths(),
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/batch_helpers.py", line 16, in batch_apply
    return [result.get_result() if result is not None else None for result in results]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/batch_helpers.py", line 16, in <listcomp>
    return [result.get_result() if result is not None else None for result in results]
            ^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/batch_response.py", line 18, in get_result
    self._output = function(self._output)
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 102, in _is_sorted
    if not parse_bool(sort_attributes["sorted"]):
                      ~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'sorted'

```