### PR TITLE
Fix Python version to 3.8 for all docker images.

### DIFF
--- a/yt/docker/chyt/Dockerfile
+++ b/yt/docker/chyt/Dockerfile
@@ -14,10 +14,10 @@ COPY ./credits/ytserver-clickhouse.CREDITS /usr/bin/ytserver-clickhouse.CREDITS
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
   curl \
   less \
-  python3.7 \
+  python3.8 \
   python3-pip
 
-RUN python3 -m pip install ytsaurus-client
+RUN python3.8 -m pip install ytsaurus-client
 
 RUN ln -s /usr/local/bin/yt /usr/bin/yt -f
 

--- a/yt/docker/query-tracker/Dockerfile
+++ b/yt/docker/query-tracker/Dockerfile
@@ -32,10 +32,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   iputils-ping \
   lsb-release \
   openjdk-11-jdk \
-  python3.7 \
+  python3.8 \
   python3-pip \
   libidn11-dev \
-  python3.7-distutils
+  python3.8-distutils
 
 COPY ./ytsaurus_python /tmp/ytsaurus_python
 RUN for package in client yson local native_driver; \
@@ -44,11 +44,11 @@ RUN for package in client yson local native_driver; \
     wheel_path="${dist_dir}/$(ls ${dist_dir} | grep "^ytsaurus_$package.*whl$")"; \
     echo "DIST_DIR: ${dist_dir}"; \
     echo "WHEEL_PATH: ${wheel_path}"; \
-    python3.7 -m pip install ${wheel_path}; \
+    python3.8 -m pip install ${wheel_path}; \
   done
 
 # Default python to be used by python3 jobs, for compatibility with jupyter tutorial.
-RUN ln -s /usr/bin/python3.7 /usr/bin/python3 -f
+RUN ln -s /usr/bin/python3.8 /usr/bin/python3 -f
 # Force lsb_release to use python it was born to use.
 RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release
 

--- a/yt/docker/queue-agent/Dockerfile
+++ b/yt/docker/queue-agent/Dockerfile
@@ -29,10 +29,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   dnsutils \
   iputils-ping \
   lsb-release \
-  python3.7 \
+  python3.8 \
   python3-pip \
   libidn11-dev \
-  python3.7-distutils
+  python3.8-distutils
 
 COPY ./ytsaurus_python /tmp/ytsaurus_python
 RUN for package in client yson local native_driver; \
@@ -41,11 +41,11 @@ RUN for package in client yson local native_driver; \
     wheel_path="${dist_dir}/$(ls ${dist_dir} | grep "^ytsaurus_$package.*whl$")"; \
     echo "DIST_DIR: ${dist_dir}"; \
     echo "WHEEL_PATH: ${wheel_path}"; \
-    python3.7 -m pip install ${wheel_path}; \
+    python3.8 -m pip install ${wheel_path}; \
   done
 
 # Default python to be used by python3 jobs, for compatibility with jupyter tutorial.
-RUN ln -s /usr/bin/python3.7 /usr/bin/python3 -f
+RUN ln -s /usr/bin/python3.8 /usr/bin/python3 -f
 # Force lsb_release to use python it was born to use.
 RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release
 

--- a/yt/docker/systest/Dockerfile
+++ b/yt/docker/systest/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   dnsutils \
   iputils-ping \
   lsb-release \
-  python3.7 \
+  python3.8 \
   python3-pip \
-  python3.7-distutils \
+  python3.8-distutils \
   openjdk-11-jdk
 
 COPY ./ytsaurus_python /tmp/ytsaurus_python
@@ -31,9 +31,9 @@ RUN set -eux; \
     wheel_path="${dist_dir}/$(ls ${dist_dir} | grep "^ytsaurus_$package.*whl$")"; \
     echo "DIST_DIR: ${dist_dir}"; \
     echo "WHEEL_PATH: ${wheel_path}"; \
-    python3.7 -m pip install ${wheel_path}; \
+    python3.8 -m pip install ${wheel_path}; \
   done
 
-RUN python3.7 -m pip install numpy
+RUN python3.8 -m pip install numpy
 
 COPY ./systest /usr/bin/systest

--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -50,23 +50,23 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   iputils-ping \
   lsb-release \
   openjdk-11-jdk \
-  python3.7 \
+  python3.8 \
   python3-pip \
   libidn11-dev \
-  python3.7-distutils
+  python3.8-distutils
 
 COPY ./ytsaurus_python /tmp/ytsaurus_python
 RUN for package in client yson local native_driver; \
   do \
     dist_dir="/tmp/ytsaurus_python/ytsaurus_${package}_dist"; \
     wheel_path="${dist_dir}/$(ls ${dist_dir} | grep "^ytsaurus_$package.*whl$")"; \
-    python3.7 -m pip install ${wheel_path}; \
+    python3.8 -m pip install ${wheel_path}; \
   done
 
 RUN ln -s /usr/lib/jvm/java-11-openjdk-amd64 /opt/jdk11
 
 # Default python to be used by python3 jobs, for compatibility with jupyter tutorial.
-RUN ln -s /usr/bin/python3.7 /usr/bin/python3 -f
+RUN ln -s /usr/bin/python3.8 /usr/bin/python3 -f
 # Force lsb_release to use python it was born to use.
 RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release
 


### PR DESCRIPTION
This fixes incompatibility of fresh ytsaurus-python with python3.7
around argcomplete>=3.1.4 requirement, and consequent lack of yt
library and binary in server images.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
