### PR TITLE
Add python requests into peerdir for intergration tests

### DIFF
--- a/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
+++ b/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
@@ -24,6 +24,7 @@ REQUIREMENTS(
 INCLUDE(${ARCADIA_ROOT}/yt/opensource.inc)
 
 PEERDIR(
+    contrib/python/requests
     contrib/python/zstandard
 
     yt/yt/tests/library


### PR DESCRIPTION
For example, without this change this command fails:
./ya make -A -L yt/yt/tests/integration/node

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
