### PR TITLE
Allow to pass single SortColumn to build_schema_sorted_by

### DIFF
--- a/yt/python/yt/wrapper/schema/table_schema.py
+++ b/yt/python/yt/wrapper/schema/table_schema.py
@@ -154,7 +154,7 @@ class TableSchema(object):
         return self
 
     def build_schema_sorted_by(self, sort_columns):
-        if isinstance(sort_columns, str):
+        if isinstance(sort_columns, str) or isinstance(sort_columns, SortColumn):
             sort_columns = [sort_columns]
 
         sort_columns = self._to_sort_columns(sort_columns)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

It is already allowed to pass single `str`. This change helps to avoid confusing error.