### PR TITLE
#175 Add AccessControlObject parameter to StartQuery and AlterQuery

### DIFF
--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -1373,9 +1373,10 @@ type QueryTrackerOptions struct {
 }
 
 type StartQueryOptions struct {
-	Settings    any   `http:"settings,omitnil"`
-	Draft       *bool `http:"draft,omitnil"`
-	Annotations any   `http:"annotations,omitnil"`
+	Settings            any     `http:"settings,omitnil"`
+	Draft               *bool   `http:"draft,omitnil"`
+	Annotations         any     `http:"annotations,omitnil"`
+	AccessControlObject *string `http:"access_control_object,omitnil"`
 
 	*QueryTrackerOptions
 }
@@ -1423,7 +1424,8 @@ type ReadQueryResultOptions struct {
 }
 
 type AlterQueryOptions struct {
-	Annotations any `http:"annotations,omitnil"`
+	Annotations         any     `http:"annotations,omitnil"`
+	AccessControlObject *string `http:"access_control_object,omitnil"`
 
 	*QueryTrackerOptions
 }

--- a/yt/go/yt/internal/params_gen.go
+++ b/yt/go/yt/internal/params_gen.go
@@ -1038,6 +1038,10 @@ func writeStartQueryOptions(w *yson.Writer, o *yt.StartQueryOptions) {
 		w.MapKeyString("annotations")
 		w.Any(o.Annotations)
 	}
+	if o.AccessControlObject != nil {
+		w.MapKeyString("access_control_object")
+		w.Any(o.AccessControlObject)
+	}
 	writeQueryTrackerOptions(w, o.QueryTrackerOptions)
 }
 
@@ -1147,6 +1151,10 @@ func writeAlterQueryOptions(w *yson.Writer, o *yt.AlterQueryOptions) {
 	if o.Annotations != nil {
 		w.MapKeyString("annotations")
 		w.Any(o.Annotations)
+	}
+	if o.AccessControlObject != nil {
+		w.MapKeyString("access_control_object")
+		w.Any(o.AccessControlObject)
 	}
 	writeQueryTrackerOptions(w, o.QueryTrackerOptions)
 }


### PR DESCRIPTION
Adjusting go sdk to work with newly introduced functionality from this PR: https://github.com/ytsaurus/ytsaurus/pull/190

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
