### PR TITLE
Add AccessControlObject parameter to StartQuery and AlterQuery requests

### DIFF
--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -1373,9 +1373,10 @@ type QueryTrackerOptions struct {
 }
 
 type StartQueryOptions struct {
-	Settings    any   `http:"settings,omitnil"`
-	Draft       *bool `http:"draft,omitnil"`
-	Annotations any   `http:"annotations,omitnil"`
+	Settings            any     `http:"settings,omitnil"`
+	Draft               *bool   `http:"draft,omitnil"`
+	Annotations         any     `http:"annotations,omitnil"`
+	AccessControlObject *string `http:"access_control_object,omitnil"`
 
 	*QueryTrackerOptions
 }
@@ -1423,7 +1424,8 @@ type ReadQueryResultOptions struct {
 }
 
 type AlterQueryOptions struct {
-	Annotations any `http:"annotations,omitnil"`
+	Annotations         any     `http:"annotations,omitnil"`
+	AccessControlObject *string `http:"access_control_object,omitnil"`
 
 	*QueryTrackerOptions
 }

--- a/yt/go/yt/internal/params_gen.go
+++ b/yt/go/yt/internal/params_gen.go
@@ -1038,6 +1038,10 @@ func writeStartQueryOptions(w *yson.Writer, o *yt.StartQueryOptions) {
 		w.MapKeyString("annotations")
 		w.Any(o.Annotations)
 	}
+	if o.AccessControlObject != nil {
+		w.MapKeyString("access_control_object")
+		w.Any(o.AccessControlObject)
+	}
 	writeQueryTrackerOptions(w, o.QueryTrackerOptions)
 }
 
@@ -1147,6 +1151,10 @@ func writeAlterQueryOptions(w *yson.Writer, o *yt.AlterQueryOptions) {
 	if o.Annotations != nil {
 		w.MapKeyString("annotations")
 		w.Any(o.Annotations)
+	}
+	if o.AccessControlObject != nil {
+		w.MapKeyString("access_control_object")
+		w.Any(o.AccessControlObject)
 	}
 	writeQueryTrackerOptions(w, o.QueryTrackerOptions)
 }

--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -1203,6 +1203,7 @@ def add_start_query_parser(add_parser):
     add_structured_argument(parser, "--settings", help="additional settings of a query in structured form")
     add_structured_argument(parser, "--files", help='query files, a YSON list of files, each of which is represented by a map with keys "name", "content", "type".'
                                                     'Field "type" is one of "raw_inline_data", "url"')
+    parser.add_argument("--access-control-object", type=str, help='optional access control object name')
     parser.add_argument("--stage", type=str, help='query tracker stage, defaults to "production"')
 
 

--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -2430,7 +2430,7 @@ class YtClient(ClientState):
     def start_query(
             self,
             engine, query,
-            settings=None, files=None, stage=None, annotations=None):
+            settings=None, files=None, stage=None, annotations=None, access_control_object=None):
         """
         Start query.
 
@@ -2446,12 +2446,13 @@ class YtClient(ClientState):
         :type stage: str
         :param annotations: a dictionary of annotations
         :type stage: dict or None
+        :param access_control_object: access control object name to constraint access to a query
+        :type access_control_object: str or None
         """
         return client_api.start_query(
             engine, query,
             client=self,
-            settings=settings, files=files, stage=stage, annotations=annotations)
-
+            settings=settings, files=files, stage=stage, annotations=annotations, access_control_object=access_control_object)
     def start_spark_cluster(
             self,
             spark_worker_core_count, spark_worker_memory_limit, spark_worker_count,

--- a/yt/python/yt/wrapper/query_commands.py
+++ b/yt/python/yt/wrapper/query_commands.py
@@ -7,7 +7,7 @@ from .common import datetime_to_string, set_param, get_value
 from datetime import datetime
 
 
-def start_query(engine, query, settings=None, files=None, stage=None, annotations=None, client=None):
+def start_query(engine, query, settings=None, files=None, stage=None, annotations=None, access_control_object=None, client=None):
     """Start query.
 
     :param engine: one of "ql", "yql".
@@ -22,6 +22,8 @@ def start_query(engine, query, settings=None, files=None, stage=None, annotation
     :type stage: str
     :param annotations: a dictionary of annotations
     :type stage: dict or None
+    :param access_control_object: access control object name to constraint access to a query
+    :type access_control_object: str or None
     """
 
     params = {
@@ -32,6 +34,9 @@ def start_query(engine, query, settings=None, files=None, stage=None, annotation
         "stage": get_value(stage, "production"),
         "annotations": get_value(annotations, {}),
     }
+
+    if access_control_object is not None:
+        params["access_control_object"] = access_control_object
 
     response = make_formatted_request("start_query", params, format=None, client=client)
 


### PR DESCRIPTION
Adjusting go and python sdk and cli to work with newly introduced functionality from this PR: https://github.com/ytsaurus/ytsaurus/pull/190 (added one parameter -- access_control_object)

Issue: #175 

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
