### PR TITLE
Wait for first slot when starting CRI pods

### DIFF
--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -984,12 +984,19 @@ public:
                 podSpec->Name = Format("%v%v", SlotPodPrefix, slotIndex);
                 podSpec->Resources.CpuLimit = cpuLimit;
                 PodSpecs_.push_back(podSpec);
-                podFutures.push_back(Executor_->RunPodSandbox(podSpec));
+                auto podFuture = Executor_->RunPodSandbox(podSpec);
+                podFutures.push_back(podFuture);
+
+                // Wait for the first slot, otherwise containerd runs parallel
+                // pull for sandbox_image (pause) if it is not cached yet.
+                if (slotIndex == 0) {
+                    WaitFor(podFuture)
+                        .ThrowOnError();
+                }
 
                 SlotCpusetCpus_.push_back(EmptyCpuSet);
             }
 
-            // FIXME(khlebnikov) add pull policy "IfNotPresent'
             auto imageFuture = Executor_->PullImage(TCriImageDescriptor{
                 .Image = Config_->JobProxyImage,
             });


### PR DESCRIPTION
Otherwise containerd runs parallel pull for sandbox_image (pause)
if it is not cached yet.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
