### PR TITLE
Catch and wrap only ImportError exception in spyt when cannot import yt client

### DIFF
--- a/yt/spark/spark-over-yt/spyt-package/src/main/python/spyt/dependency_utils.py
+++ b/yt/spark/spark-over-yt/spyt-package/src/main/python/spyt/dependency_utils.py
@@ -2,7 +2,7 @@ def require_yt_client():
     try:
         import yt.wrapper  # noqa: F401
         from yt.wrapper import YtClient  # noqa: F401
-    except Exception as e:
+    except ImportError as e:
         raise ImportError(
             "Please install ytsaurus-client (or yandex-yt for internal Yandex users). "
             "These libraries cannot be installed at the same time"


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
