### PR TITLE
Fix cgroups statistics fetcher for cgroups with ":" in name

### DIFF
--- a/yt/yt/library/containers/cgroups_new.cpp
+++ b/yt/yt/library/containers/cgroups_new.cpp
@@ -236,14 +236,14 @@ void TSelfCGroupsStatisticsFetcher::DetectSelfCGroup()
 
     auto rawSelfCGroups = TFileInput("/proc/self/cgroup").ReadAll();
     for (auto line : SplitString(rawSelfCGroups, "\n")) {
-        auto tokens = SplitString(line, ":");
         // NB: CGroup name may contain ":".
+        std::vector<TString> tokens = StringSplitter(line).Split(':').Limit(3);
         if (tokens.size() < 3) {
             continue;
         }
 
         const auto& cgroupType = tokens[1];
-        auto cgroup = JoinStrings(tokens.begin() + 2, tokens.end(), ":");
+        const auto& cgroup = tokens[2];
 
         if (cgroupType == "memory") {
             if (NFS::Exists(Format("/sys/fs/cgroup/memory/%v/memory.stat", cgroup))) {

--- a/yt/yt/library/containers/cgroups_new.cpp
+++ b/yt/yt/library/containers/cgroups_new.cpp
@@ -242,7 +242,7 @@ void TSelfCGroupsStatisticsFetcher::DetectSelfCGroup()
             continue;
         }
 
-        auto cgroupType = tokens[1];
+        const auto& cgroupType = tokens[1];
         auto cgroup = JoinStrings(tokens.begin() + 2, tokens.end(), ":");
 
         if (cgroupType == "memory") {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
