### PR TITLE
Use correct table path in error message (and avoid aborts) when output schema illegally missing

### DIFF
--- a/yt/cpp/mapreduce/interface/operation.cpp
+++ b/yt/cpp/mapreduce/interface/operation.cpp
@@ -337,11 +337,7 @@ void TJobOperationPreparer::FinallyValidate() const
     TApiUsageError error;
     error << "Output table schemas are missing: ";
     for (auto i : illegallyMissingSchemaIndices) {
-        error << "no. " << i;
-        if (auto path = Context_.GetOutputPath(i)) {
-            error << "(" << *path << ")";
-        }
-        error << "; ";
+        error << "no. " << i << " (" << Context_.GetOutputPath(i).GetOrElse("<unknown path>") << "); ";
     }
     ythrow std::move(error);
 }

--- a/yt/cpp/mapreduce/interface/operation.cpp
+++ b/yt/cpp/mapreduce/interface/operation.cpp
@@ -338,7 +338,7 @@ void TJobOperationPreparer::FinallyValidate() const
     error << "Output table schemas are missing: ";
     for (auto i : illegallyMissingSchemaIndices) {
         error << "no. " << i;
-        if (auto path = Context_.GetInputPath(i)) {
+        if (auto path = Context_.GetOutputPath(i)) {
             error << "(" << *path << ")";
         }
         error << "; ";


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes this abort (and invalid messages in case `Inputs.size() >= Outputs_.size()`):
```bash
              | VERIFY failed (2023-12-19T13:27:19.546072+0300):
              |   /root/.conan2/p/b/twix-3d94e104ee873/b/ytsaurus/yt/cpp/mapreduce/client/prepare_operation.cpp:114
              |   GetInputPath(): requirement index < static_cast<int>(Inputs_.size()) failed
              | NPrivate::InternalPanicImpl(int, char const*, char const*, int, int, int, TBasicStringBuf<char, std::char_traits<char> >, char const*, unsigned long)+572 (0x16CFF3C)
              | NPrivate::Panic(NPrivate::TStaticBuf const&, int, char const*, char const*, char const*, ...)+284 (0x16C80BC)
              | NYT::NDetail::TOperationPreparationContext::GetInputPath(int) const+251 (0x1022E7B)
              | NYT::TJobOperationPreparer::FinallyValidate() const+627 (0x108FDD3)
```