### PR TITLE
Fix controller agent common operation options config

### DIFF
--- a/yt/yt/server/controller_agent/config-inl.h
+++ b/yt/yt/server/controller_agent/config-inl.h
@@ -19,7 +19,7 @@ void TControllerAgentConfig::UpdateOptions(TOptions* options, NYT::NYTree::INode
     }
 
     if (*options) {
-        *options = ConvertTo<TOptions>(PatchNode(patch, ConvertTo<INodePtr>(*options)));
+        *options = ConvertTo<TOptions>(PatchNode(ConvertTo<INodePtr>(*options), patch));
     } else {
         *options = ConvertTo<TOptions>(patch);
     }


### PR DESCRIPTION
"operation_options" works as patch for all operation options.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
