### PR TITLE
Fix mkdirs race on test cleanup

### DIFF
--- a/yt/python/yt/environment/arcadia_interop/arcadia_interop.py
+++ b/yt/python/yt/environment/arcadia_interop/arcadia_interop.py
@@ -307,7 +307,7 @@ def save_sandbox(sandbox_path, output_subpath):
         return
 
     output_path_dir = os.path.dirname(output_path)
-    os.makedirs(output_path_dir)
+    os.makedirs(output_path_dir, exist_ok=True)
     try:
         os.rename(sandbox_path, output_path)
         return


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Fixes: https://github.com/ytsaurus/ytsaurus/issues/280

With this fix `ya make -A .` didn't fail on any test in `yt/python/yt/wrapper/tests/py3_only` (I checked it twice).