### PR TITLE
Make CRI CreateContainer uncancellable

### DIFF
--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -408,9 +408,11 @@ public:
 
         FillPodSandboxConfig(req->mutable_sandbox_config(), *podSpec);
 
-        return req->Invoke().Apply(BIND([name = ctSpec->Name] (const TCriRuntimeApi::TRspCreateContainerPtr& rsp) -> TCriDescriptor {
-            return TCriDescriptor{.Name = "", .Id = rsp->container_id()};
-        }));
+        return req->Invoke()
+            .Apply(BIND([name = ctSpec->Name] (const TCriRuntimeApi::TRspCreateContainerPtr& rsp) -> TCriDescriptor {
+                return TCriDescriptor{.Name = name, .Id = rsp->container_id()};
+            }))
+            .ToUncancelable();
     }
 
     TFuture<void> StartContainer(const TCriDescriptor& descriptor) override


### PR DESCRIPTION
Code in contianerd is non-atomic and may leave garbage after cancellation.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
