### PR TITLE
Do not discard range attr (and other attrs) in input tables for CppJob

### DIFF
--- a/yt/cpp/mapreduce/client/py_helpers.cpp
+++ b/yt/cpp/mapreduce/client/py_helpers.cpp
@@ -48,7 +48,9 @@ TStructuredJobTableList NodeToStructuredTablePaths(const TNode& node, const TOpe
         if (inputNode.IsNull()) {
             ++intermediateTableCount;
         } else {
-            paths.emplace_back(inputNode.AsString());
+            NYT::TRichYPath path;
+            NYT::Deserialize(path, inputNode);
+            paths.emplace_back(std::move(path));
         }
     }
     paths = NRawClient::CanonizeYPaths(/* retryPolicy */ nullptr, preparer.GetContext(), paths);


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Unfortunately, I cannot test this change, since the OS version does not have the cython parts, in particular the `CppJob`.

But I need this patch because I copied the code from this commit (this code has been removed from the OS repository): https://github.com/ytsaurus/ytsaurus/commit/4bc99c326b3e8ac8d04d9fa55c594ac6d345c34c
