### PR TITLE
Add unimplemented ProtobufFormat to python API

### DIFF
--- a/yt/python/yt/wrapper/format.py
+++ b/yt/python/yt/wrapper/format.py
@@ -856,6 +856,31 @@ class ArrowFormat(Format):
         raise YtFormatError("_dump_row is not supported in Arrow")
 
 
+class ProtobufFormat(Format):
+    """Protobuf format.
+    .. seealso:: `C++ protobuf format in the docs <https://ytsaurus.tech/docs/en/api/cpp/protobuf>`_
+
+    This format is not supported in python API yet and it is only needed for compatibility with the C++ API
+    (to allow to create operation spec with this format).
+    """
+
+    def __init__(self, attributes=None, raw=None, encoding=_ENCODING_SENTINEL):
+        all_attributes = Format._make_attributes(get_value(attributes, {}), {}, {})
+        super(ProtobufFormat, self).__init__("protobuf", all_attributes, raw, encoding)
+
+    def load_row(self, stream, raw=None):
+        """Not supported."""
+        raise YtFormatError("load_row is not supported in ProtobufFormat")
+
+    def load_rows(self, stream, raw=None):
+        """Not supported."""
+        raise YtFormatError("load_rows is not supported in ProtobufFormat")
+
+    def _dump_row(self, row, stream):
+        """Not supported."""
+        raise YtFormatError("_dump_row is not supported in ProtobufFormat")
+
+
 class YamrFormat(Format):
     """YAMR legacy data format. Deprecated!
 
@@ -1509,7 +1534,8 @@ def create_format(yson_name, attributes=None, **kwargs):
         "yson": YsonFormat,
         "json": JsonFormat,
         "skiff": SkiffFormat,
-        "arrow": ArrowFormat
+        "arrow": ArrowFormat,
+        "protobuf": ProtobufFormat,
     }
 
     if name not in NAME_TO_FORMAT:

--- a/yt/python/yt/wrapper/format.py
+++ b/yt/python/yt/wrapper/format.py
@@ -860,8 +860,7 @@ class ProtobufFormat(Format):
     """Protobuf format.
     .. seealso:: `C++ protobuf format in the docs <https://ytsaurus.tech/docs/en/api/cpp/protobuf>`_
 
-    This format is not supported in python API yet and it is only needed for compatibility with the C++ API
-    (to allow to create operation spec with this format).
+    This format is not supported in python API yet and it is only needed for compatibility with the C++ API.
     """
 
     def __init__(self, attributes=None, raw=None, encoding=_ENCODING_SENTINEL):


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

I craft cppjob spec via python (because it is impossible to use `CppJob` in OS, more info is in https://github.com/ytsaurus/ytsaurus/pull/283).
This patch fixes this error:

```python
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/client_impl.py", line 2113, in run_map_reduce
    return client_api.run_map_reduce(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-7>", line 2, in run_map_reduce
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/common.py", line 421, in forbidden_inside_job
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/run_operation_commands.py", line 254, in run_map_reduce
    return run_operation(spec_builder, sync=sync, enable_optimizations=True, client=client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<decorator-gen-8>", line 2, in run_operation
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/common.py", line 421, in forbidden_inside_job
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/run_operation_commands.py", line 607, in run_operation
    spec = spec_builder.build(client=client)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 1218, in build
    spec = self._do_build(client)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 1824, in _do_build
    spec, intermediate_stream_schemas = self._do_build_mapper(
                                        ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 1723, in _do_build_mapper
    spec, input_tables, mapper_output_tables = self._build_user_job_spec(
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 1087, in _build_user_job_spec
    spec[job_type], input_tables, output_tables = job_spec_builder.build(
                                                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/spec_builders.py", line 798, in build
    input_format, output_format = _prepare_operation_formats(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/table_helpers.py", line 328, in _prepare_operation_formats
    input_format = _prepare_format(input_format, format)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/table_helpers.py", line 273, in _prepare_format
    return create_format(format)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/twix/python3.11/lib/python3.11/site-packages/yt/wrapper/format.py", line 1516, in create_format
    raise YtFormatError("Incorrect format " + name)
yt.wrapper.format.YtFormatError: Incorrect format protobuf

```