### PR TITLE
Add YQL test on `SELECT sum(field) from table;`

### DIFF
--- a/yt/yql/tests/test_simple.py
+++ b/yt/yql/tests/test_simple.py
@@ -180,6 +180,19 @@ class TestSimpleQueriesYql(TestQueriesYqlBase):
         result = query.read_result(0)
         assert_items_equal([{"column0": 2}], result)
 
+    @authors("aleksandr.gaev")
+    def test_sum(self, query_tracker, yql_agent):
+        create("table", "//tmp/t1", attributes={
+            "schema": [{"name": "a", "type": "int64"}]
+        })
+        rows = [{"a": 42}, {"a": 43}]
+        write_table("//tmp/t1", rows)
+
+        query = start_query("yql", "select sum(a) from `//tmp/t1`")
+        query.track()
+        result = query.read_result(0)
+        assert_items_equal([{"column0": 85}], result)
+
 
 class TestYqlAgent(TestQueriesYqlBase):
     NUM_TEST_PARTITIONS = 8


### PR DESCRIPTION
Locally this test and `test_complex_query` fails with an error:

```
yt/yql/tests <py3test> [size:large] [tags: ya:external, ya:fat, ya:force_sandbox, ya:full_logs, ya:noretries, ya:relwithdebinfo, ya:sandbox_coverage, ya:sys_info, ya:yt]
------ sole chunk ran 21 tests (total:1093.45s - test:1093.42s)
[fail] test_simple.py::TestSimpleQueriesYql[2]::test_complex_query (mpereskokova) [default-linux-x86_64-debug] (78.35s)
yt/yql/tests/test_simple.py:179: in test_complex_query
    query.track()
yt/yt/tests/library/yt_queries.py:42: in track
    raise YtError.from_dict(query["error"])
E   yt.common.YtError: Query 30127226-39ecd1db-4255d6aa-cebf4cac failed
E       YQL plugin call failed
E           There are some issues
E               Execution
E                   Execution of node: Result
E                       Could not parse yson node
E
E   ***** Details:
E   Query 30127226-39ecd1db-4255d6aa-cebf4cac failed
E       origin          localhost on 2024-01-05T17:23:46.752187Z (pid 2108014, tid a620876691c3c2cc, fid fffef2789b01fdbf)
E       thread          Control
E       trace_id        3e4ceb82-25a8879d-e9585810-317c594f
E       span_id         569715473153061958
E       query_id        30127226-39ecd1db-4255d6aa-cebf4cac
E   YQL plugin call failed
E       origin          localhost on 2024-01-05T17:23:46.026059Z (pid 2108062, tid e92bdf7879449ba, fid fffef278bb89a97a)
E       thread          Yql:0
E       trace_id        3e4ceb82-25a8879d-e9585810-317c594f
E       span_id         13182155925322827878
E       request_id      98c6bde3-f7f78b22-2bed67d9-bcdba298
E       connection_id   cb927627-a60a9559-59709eec-5c05a3ef
E       verification_mode none
E       realm_id        0-0-0-0
E       timeout         86400000
E       method          StartQuery
E       address         localhost:15088
E       encryption_mode optional
E       service         TYqlService
E   There are some issues
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:23:47.531511Z
E   Execution
E       code            31060
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:23:47.531475Z
E       yql_status      Core exec
E       severity        Fatal
E   Execution of node: Result
E       code            30000
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:23:47.531436Z
E       end_position    {'column': 1, 'row': 1}
E       yql_status      Default error
E       severity        Fatal
E       start_position  {'column': 1, 'row': 1}
E   Could not parse yson node
E       code            30001
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:23:47.531363Z
E       end_position    {'column': 1, 'row': 1}
E       yql_status      Unexpected
E       severity        Fatal
E       start_position  {'column': 1, 'row': 1}
Log: /home/aleksandr.gaev/ytsaurus/yt/yql/tests/test-results/py3test/testing_out_stuff/test_simple.py.TestSimpleQueriesYql.2.test_complex_query.(mpereskokova).log
Logsdir: /home/aleksandr.gaev/ytsaurus/yt/yql/tests/test-results/py3test/testing_out_stuff
[fail] test_simple.py::TestSimpleQueriesYql[3]::test_sum (aleksandr.gaev) [default-linux-x86_64-debug] (81.02s)
yt/yql/tests/test_simple.py:192: in test_sum
    query.track()
yt/yt/tests/library/yt_queries.py:42: in track
    raise YtError.from_dict(query["error"])
E   yt.common.YtError: Query 8011e3b7-ba632dba-6c1b7e18-5dfd3e6b failed
E       YQL plugin call failed
E           There are some issues
E               Execution
E                   Execution of node: Result
E                       Could not parse yson node
E
E   ***** Details:
E   Query 8011e3b7-ba632dba-6c1b7e18-5dfd3e6b failed
E       origin          localhost on 2024-01-05T17:25:05.598537Z (pid 2110172, tid 607fbeaa4aba89b9, fid fffef274f832efac)
E       thread          Control
E       trace_id        9934370d-404bb017-23146cc0-a1b84ef9
E       span_id         6589778721916281300
E       query_id        8011e3b7-ba632dba-6c1b7e18-5dfd3e6b
E   YQL plugin call failed
E       origin          localhost on 2024-01-05T17:24:59.325286Z (pid 2110221, tid c2250f33eb5dd6c, fid fffef278c524f6f1)
E       thread          Yql:63
E       trace_id        3435f2bf-79ba5dc6-c793d9cc-76208e44
E       span_id         5761310561287502637
E       request_id      cc269e8a-d83af8c8-336514b6-a1fa0d15
E       connection_id   51e82005-21a95948-37d6fa82-a436b4ea
E       verification_mode none
E       realm_id        0-0-0-0
E       timeout         86400000
E       method          StartQuery
E       address         localhost:21901
E       encryption_mode optional
E       service         TYqlService
E   There are some issues
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:25:06.178048Z
E   Execution
E       code            31060
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:25:06.177989Z
E       yql_status      Core exec
E       severity        Fatal
E   Execution of node: Result
E       code            30000
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:25:06.177926Z
E       end_position    {'column': 1, 'row': 1}
E       yql_status      Default error
E       severity        Fatal
E       start_position  {'column': 1, 'row': 1}
E   Could not parse yson node
E       code            30001
E       origin          nebius-yt-dev.eu-north1.internal on 2024-01-05T17:25:06.177801Z
E       end_position    {'column': 1, 'row': 1}
E       yql_status      Unexpected
E       severity        Fatal
E       start_position  {'column': 1, 'row': 1}
Log: /home/aleksandr.gaev/ytsaurus/yt/yql/tests/test-results/py3test/testing_out_stuff/test_simple.py.TestSimpleQueriesYql.3.test_sum.(aleksandr.gaev).log
Logsdir: /home/aleksandr.gaev/ytsaurus/yt/yql/tests/test-results/py3test/testing_out_stuff
------ FAIL: 19 - GOOD, 2 - FAIL yt/yql/tests

Total 3 suites:
	2 - GOOD
	1 - FAIL
Total 25 tests:
	23 - GOOD
	2 - FAIL
Failed
```

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
