### PR TITLE
Add password_is_temporary attribute to a user. Allow it to be specified in SetUserPassword API

### DIFF
--- a/yt/yt/client/api/security_client.h
+++ b/yt/yt/client/api/security_client.h
@@ -70,7 +70,9 @@ struct TCheckPermissionByAclResult
 
 struct TSetUserPasswordOptions
     : public TTimeoutOptions
-{ };
+{
+    bool PasswordIsTemporary = false;
+};
 
 struct TIssueTokenOptions
     : public TTimeoutOptions

--- a/yt/yt/client/driver/authentication_commands.cpp
+++ b/yt/yt/client/driver/authentication_commands.cpp
@@ -16,6 +16,12 @@ void TSetUserPasswordCommand::Register(TRegistrar registrar)
     registrar.Parameter("current_password_sha256", &TThis::CurrentPasswordSha256_)
         .Default();
     registrar.Parameter("new_password_sha256", &TThis::NewPasswordSha256_);
+    registrar.ParameterWithUniversalAccessor<bool>(
+        "password_is_temporary",
+        [] (TThis* command) -> bool& {
+            return command->Options.PasswordIsTemporary;
+        })
+        .Default(false);
 }
 
 void TSetUserPasswordCommand::DoExecute(ICommandContextPtr context)

--- a/yt/yt/tests/integration/master/test_users.py
+++ b/yt/yt/tests/integration/master/test_users.py
@@ -728,6 +728,41 @@ class TestUsers(YTEnvSetup):
         set("//sys/users/u/@name", "v", authenticated_user="u")
         wait(lambda: self._get_last_seen_time("v") > last_seen, timeout=2)
 
+    @authors("krock21")
+    def test_password_temporary(self):
+        if self.DRIVER_BACKEND == "rpc":
+            return
+
+        create_user("u")
+        assert not exists("//sys/users/u/@password_is_temporary")
+
+        set_user_password("u", "p1")
+        assert get("//sys/users/u/@password_is_temporary") is False
+
+        set_user_password("u", "p2", password_is_temporary=True)
+        assert get("//sys/users/u/@password_is_temporary") is True
+
+        set("//sys/users/u/@password_is_temporary", "abc")
+        assert get("//sys/users/u/@password_is_temporary") == "abc"
+
+        set_user_password("u", "p3", current_password="p2", password_is_temporary=True)
+        assert get("//sys/users/u/@password_is_temporary") is True
+
+        set_user_password("u", "p4")
+        assert get("//sys/users/u/@password_is_temporary") is False
+
+        set("//sys/users/u/@password_is_temporary", False)
+        assert get("//sys/users/u/@password_is_temporary") is False
+
+        set("//sys/users/u/@password_is_temporary", True)
+        assert get("//sys/users/u/@password_is_temporary") is True
+
+        set("//sys/users/u/@password_is_temporary", "cde")
+        assert get("//sys/users/u/@password_is_temporary") == "cde"
+
+        remove("//sys/users/u/@password_is_temporary")
+        assert not exists("//sys/users/u/@password_is_temporary")
+
 
 ##################################################################
 

--- a/yt/yt/ytlib/api/native/client_authentication_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_authentication_impl.cpp
@@ -42,6 +42,7 @@ void TClient::DoSetUserPassword(
     auto attributes = nodeFactory->CreateMap();
     attributes->AddChild("hashed_password", ConvertToNode(hashedNewPassword));
     attributes->AddChild("password_salt", ConvertToNode(newPasswordSalt));
+    attributes->AddChild("password_is_temporary", ConvertToNode(options.PasswordIsTemporary));
     WaitFor(rootClient->MultisetAttributesNode(
         path,
         attributes,


### PR DESCRIPTION
Issue: #227 

UI issue: https://github.com/ytsaurus/ytsaurus-ui/issues/240

SetUserPassword action now may add `@password_is_temporary` property to a user

This property will be examined by UI in order to force a user on /change_password page

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
