### PR TITLE
Fix chunk spec fetcher usage with ordered dynamic tables

### DIFF
--- a/yt/yt/server/queue_agent/queue_static_table_exporter.cpp
+++ b/yt/yt/server/queue_agent/queue_static_table_exporter.cpp
@@ -446,7 +446,8 @@ private:
         chunkSpecFetcher->Add(
             QueueObject_.ObjectId,
             QueueObject_.ExternalCellTag,
-            QueueObject_.ChunkCount);
+            // XXX(achulkov2, gritukan): YT-11825
+            /*chunkCount*/ -1);
 
         WaitFor(chunkSpecFetcher->Fetch())
             .ThrowOnError();


### PR DESCRIPTION
Fix critical bug in queue agent static exports.

Using TMasterChunkSpecFetcher with ordered dynamic tables has been broken for a while now: due to a bug in pagination, you cannot fetch chunks past index 100k (in ordered dynamic tables the first chunk index is not 0 in case of trimmed chunks). One needs to specify the chunk count to be -1 as a workaround.