### PR TITLE
stable/23.1 next.2

### DIFF
--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -97,6 +97,15 @@ public:
 
     void Kill(int /*signal*/) override
     {
+        if (Finished_) {
+            return;
+        }
+        Finished_ = true;
+
+        if (!Started_) {
+            THROW_ERROR_EXCEPTION("Process is not started yet");
+        }
+
         YT_LOG_DEBUG("Killing process");
         WaitFor(Executor_->StopContainer(ContainerDescriptor_))
             .ThrowOnError();
@@ -158,6 +167,13 @@ private:
         YT_LOG_DEBUG("Spawning process (Command: %v, Environment: %v)",
             ContainerSpec_->Command[0],
             ContainerSpec_->Environment);
+
+        YT_VERIFY(!Started_);
+        Started_ = true;
+
+        if (Finished_) {
+            THROW_ERROR_EXCEPTION("Process is already killed");
+        }
 
         WaitFor(Executor_->StartContainer(ContainerDescriptor_))
             .ThrowOnError();

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -223,6 +223,7 @@ public:
         : Config_(std::move(config))
         , RuntimeApi_(CreateRetryingChannel(Config_, channelFactory->CreateChannel(Config_->RuntimeEndpoint)))
         , ImageApi_(CreateRetryingChannel(Config_, channelFactory->CreateChannel(Config_->ImageEndpoint)))
+        , Attempt_(RandomNumber<ui32>())
     { }
 
     TString GetPodCgroup(TString podName) const override
@@ -377,6 +378,9 @@ public:
         {
             auto* metadata = config->mutable_metadata();
             metadata->set_name(containerSpec->Name);
+
+            // Set unique attempt for each newly created container.
+            metadata->set_attempt(Attempt_++);
         }
 
         {
@@ -635,6 +639,8 @@ private:
     const TCriExecutorConfigPtr Config_;
     TCriRuntimeApi RuntimeApi_;
     TCriImageApi ImageApi_;
+
+    std::atomic<ui32> Attempt_;
 
     THashMap<TString, TFuture<void>> InflightImagePulls_;
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, SpinLock_);

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -420,9 +420,11 @@ public:
 
         FillPodSandboxConfig(req->mutable_sandbox_config(), *podSpec);
 
-        return req->Invoke().Apply(BIND([name = ctSpec->Name] (const TCriRuntimeApi::TRspCreateContainerPtr& rsp) -> TCriDescriptor {
-            return TCriDescriptor{.Name = "", .Id = rsp->container_id()};
-        }));
+        return req->Invoke()
+            .Apply(BIND([name = ctSpec->Name] (const TCriRuntimeApi::TRspCreateContainerPtr& rsp) -> TCriDescriptor {
+                return TCriDescriptor{.Name = name, .Id = rsp->container_id()};
+            }))
+            .ToUncancelable();
     }
 
     TFuture<void> StartContainer(const TCriDescriptor& descriptor) override

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -134,14 +134,6 @@ private:
         ContainerSpec_->Arguments = std::vector<TString>(Args_.begin() + 1, Args_.end());
         ContainerSpec_->WorkingDirectory = WorkingDirectory_;
 
-        ContainerSpec_->BindMounts.emplace_back(
-            NCri::TCriBindMount {
-                .ContainerPath = WorkingDirectory_,
-                .HostPath = WorkingDirectory_,
-                .ReadOnly = false,
-            }
-        );
-
         for (const auto& keyVal : Env_) {
             TStringBuf key, val;
             if (TStringBuf(keyVal).TrySplit('=', key, val)) {

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -89,6 +89,7 @@ public:
         , PodDescriptor_(podDescriptor)
         , PodSpec_(std::move(podSpec))
         , PollPeriod_(pollPeriod)
+        , Logger(NCri::Logger)
     {
         // Just for symmetry with sibling classes.
         AddArgument(Path_);
@@ -96,6 +97,7 @@ public:
 
     void Kill(int /*signal*/) override
     {
+        YT_LOG_DEBUG("Killing process");
         WaitFor(Executor_->StopContainer(ContainerDescriptor_))
             .ThrowOnError();
     }
@@ -122,6 +124,8 @@ private:
     const TCriPodSpecPtr PodSpec_;
     const TDuration PollPeriod_;
 
+    NLogging::TLogger Logger;
+
     TCriDescriptor ContainerDescriptor_;
 
     TPeriodicExecutorPtr AsyncWaitExecutor_;
@@ -141,10 +145,20 @@ private:
             }
         }
 
+        Logger.AddTag("Pod: %v", PodDescriptor_);
+
+        YT_LOG_DEBUG("Creating container (Container: %v)",
+            ContainerSpec_->Name);
+
         ContainerDescriptor_ = WaitFor(Executor_->CreateContainer(ContainerSpec_, PodDescriptor_, PodSpec_))
             .ValueOrThrow();
 
-        YT_LOG_DEBUG("Spawning process (Command: %v, Container: %v)", ContainerSpec_->Command[0], ContainerDescriptor_);
+        Logger.AddTag("Container: %v", ContainerDescriptor_);
+
+        YT_LOG_DEBUG("Spawning process (Command: %v, Environment: %v)",
+            ContainerSpec_->Command[0],
+            ContainerSpec_->Environment);
+
         WaitFor(Executor_->StartContainer(ContainerDescriptor_))
             .ThrowOnError();
 
@@ -172,7 +186,7 @@ private:
         auto status = response->status();
         if (status.state() == NProto::CONTAINER_EXITED) {
             auto error = DecodeExitCode(status.exit_code(), status.reason());
-            YT_LOG_DEBUG(error, "Process finished (Container: %v)", ContainerDescriptor_);
+            YT_LOG_DEBUG(error, "Process finished");
             YT_UNUSED_FUTURE(AsyncWaitExecutor_->Stop());
             FinishedPromise_.TrySet(error);
         }

--- a/yt/yt/server/job_proxy/environment.cpp
+++ b/yt/yt/server/job_proxy/environment.cpp
@@ -11,6 +11,7 @@
 #include <yt/yt/ytlib/job_proxy/private.h>
 
 #include <util/system/fs.h>
+#include <util/system/user.h>
 
 #ifdef _linux_
 #include <yt/yt/library/containers/cgroup.h>
@@ -819,6 +820,12 @@ class TCriUserJobEnvironment
     : public IUserJobEnvironment
 {
 public:
+    TCriUserJobEnvironment() {
+        TString username = ::GetUsername();
+        Environment_.push_back("USER=" + username);
+        Environment_.push_back("LOGNAME=" + username);
+    }
+
     TDuration GetBlockIOWatchdogPeriod() const override
     {
         // No IO watchdog for simple job environment.
@@ -913,8 +920,7 @@ public:
     //! Returns the list of environment-specific environment variables in key=value format.
     const std::vector<TString>& GetEnvironmentVariables() const override
     {
-        static std::vector<TString> emptyEnvironment;
-        return emptyEnvironment;
+        return Environment_;
     }
 
     i64 GetMajorPageFaultCount() const override
@@ -924,6 +930,7 @@ public:
 
 private:
     TAtomicIntrusivePtr<TProcessBase> Process_;
+    std::vector<TString> Environment_;
 };
 
 DECLARE_REFCOUNTED_CLASS(TCriUserJobEnvironment)

--- a/yt/yt/server/job_proxy/job_proxy.cpp
+++ b/yt/yt/server/job_proxy/job_proxy.cpp
@@ -172,7 +172,7 @@ TString TJobProxy::GetPreparationPath() const
 
 TString TJobProxy::GetSlotPath() const
 {
-    if (!Config_->RootPath || Config_->TestRootFS) {
+    if ((!Config_->RootPath && !Config_->DockerImage) || Config_->TestRootFS) {
         return NFs::CurrentWorkingDirectory();
     }
 

--- a/yt/yt/server/lib/job_proxy/config.cpp
+++ b/yt/yt/server/lib/job_proxy/config.cpp
@@ -82,6 +82,8 @@ void TJobProxyConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("slot_index", &TThis::SlotIndex);
 
+    registrar.Parameter("slot_path", &TThis::SlotPath);
+
     registrar.Parameter("tmpfs_manager", &TThis::TmpfsManager)
         .DefaultNew();
 

--- a/yt/yt/server/lib/job_proxy/config.h
+++ b/yt/yt/server/lib/job_proxy/config.h
@@ -156,6 +156,8 @@ public:
     // Job-specific parameters.
     int SlotIndex = -1;
 
+    TString SlotPath;
+
     TTmpfsManagerConfigPtr TmpfsManager;
 
     TMemoryTrackerConfigPtr MemoryTracker;

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -2209,6 +2209,7 @@ TJobProxyConfigPtr TJob::CreateConfig()
 
     proxyConfig->JobTestingOptions = JobTestingOptions_;
     proxyConfig->SlotIndex = Slot_->GetSlotIndex();
+    proxyConfig->SlotPath = Slot_->GetSlotPath();
 
     if (RootVolume_) {
         proxyConfig->RootPath = RootVolume_->GetPath();

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -939,12 +939,19 @@ public:
                 podSpec->Name = Format("%v%v", SlotPodPrefix, slotIndex);
                 podSpec->Resources.CpuLimit = cpuLimit;
                 PodSpecs_.push_back(podSpec);
-                podFutures.push_back(Executor_->RunPodSandbox(podSpec));
+                auto podFuture = Executor_->RunPodSandbox(podSpec);
+                podFutures.push_back(podFuture);
+
+                // Wait for the first slot, otherwise containerd runs parallel
+                // pull for sandbox_image (pause) if it is not cached yet.
+                if (slotIndex == 0) {
+                    WaitFor(podFuture)
+                        .ThrowOnError();
+                }
 
                 SlotCpusetCpus_.push_back(EmptyCpuSet);
             }
 
-            // FIXME(khlebnikov) add pull policy "IfNotPresent'
             auto imageFuture = Executor_->PullImage(TCriImageDescriptor{
                 .Image = Config_->JobProxyImage,
             });

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1046,6 +1046,18 @@ private:
         }
         spec->Credentials.Gid = ::getgid();
 
+        spec->BindMounts.push_back(NCri::TCriBindMount{
+            .ContainerPath = config->SlotPath,
+            .HostPath = config->SlotPath,
+            .ReadOnly = false,
+        });
+
+        spec->BindMounts.push_back(NCri::TCriBindMount{
+            .ContainerPath = "/slot",
+            .HostPath = config->SlotPath,
+            .ReadOnly = false,
+        });
+
         for (const auto& bind : Config_->JobProxyBindMounts) {
             spec->BindMounts.push_back(NCri::TCriBindMount{
                 .ContainerPath = bind->InternalPath,

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -43,6 +43,7 @@
 #include <util/generic/guid.h>
 
 #include <util/system/execpath.h>
+#include <util/system/user.h>
 
 namespace NYT::NExecNode {
 
@@ -1052,6 +1053,17 @@ private:
             // FIXME(khlebnikov): Use own group or "nogroup"
         }
         spec->Credentials.Gid = ::getgid();
+
+        if (!spec->Environment.contains("USER")) {
+            TString username;
+            if (config->DoNotSetUserId) {
+                username = ::GetUsername();
+            } else {
+                username = Format("%v%v", SlotPodPrefix, slotIndex);
+            }
+            spec->Environment["USER"] = username;
+            spec->Environment["LOGNAME"] = username;
+        }
 
         spec->BindMounts.push_back(NCri::TCriBindMount{
             .ContainerPath = config->SlotPath,

--- a/yt/yt/server/node/exec_node/job_workspace_builder.cpp
+++ b/yt/yt/server/node/exec_node/job_workspace_builder.cpp
@@ -437,8 +437,8 @@ private:
 
         if (Context_.DockerImage) {
             return MakeFuture(TError(
-                EErrorCode::RootVolumePreparationFailed,
-                "Docker image is not supported in Porto job environment"));
+                EErrorCode::DockerImagePullingFailed,
+                "External docker image is not supported in Porto job environment"));
         }
 
         const auto& slot = Context_.Slot;
@@ -637,8 +637,9 @@ private:
         SetJobPhase(EJobPhase::PreparingRootVolume);
 
         if (!Context_.LayerArtifactKeys.empty()) {
-            return MakeFuture(TError(EErrorCode::RootVolumePreparationFailed,
-                "Proto layers are not supported in CRI job environment"));
+            return MakeFuture(TError(
+                EErrorCode::LayerUnpackingFailed,
+                "Porto layers are not supported in CRI job environment"));
         }
 
         if (const auto& dockerImage = Context_.DockerImage) {

--- a/yt/yt/server/node/exec_node/job_workspace_builder.cpp
+++ b/yt/yt/server/node/exec_node/job_workspace_builder.cpp
@@ -186,6 +186,45 @@ void TJobWorkspaceBuilder::MakeArtifactSymlinks()
     YT_LOG_INFO("Artifact symlinks are made");
 }
 
+void TJobWorkspaceBuilder::PrepareArtifactBinds()
+{
+    const auto& slot = Context_.Slot;
+
+    YT_LOG_INFO(
+        "Setting permissions for artifacts (ArtifactCount: %v)",
+        std::size(Context_.Artifacts));
+
+    for (const auto& artifact : Context_.Artifacts) {
+        if (!artifact.BypassArtifactCache && !artifact.CopyFile) {
+            YT_VERIFY(artifact.Chunk);
+
+            int permissions = artifact.Executable ? 0755 : 0644;
+
+            YT_LOG_INFO(
+                "Set permissions for artifact (FileName: %v, Permissions: "
+                "%v, SandboxKind: %v, CompressedDataSize: %v)",
+                artifact.Name,
+                permissions,
+                artifact.SandboxKind,
+                artifact.Key.GetCompressedDataSize());
+
+            SetPermissions(
+                artifact.Chunk->GetFileName(),
+                permissions);
+
+            // Create mount-point path and file, to own it and be able to cleanup.
+            auto sandboxPath = slot->GetSandboxPath(artifact.SandboxKind);
+            auto artifactPath = CombinePaths(sandboxPath, artifact.Name);
+            MakeDirRecursive(GetDirectoryName(artifactPath));
+            TFile bindFile(artifactPath, CreateAlways | WrOnly);
+        } else {
+            YT_VERIFY(artifact.SandboxKind == ESandboxKind::User);
+        }
+    }
+
+    YT_LOG_INFO("Permissions for artifacts set");
+}
+
 TFuture<TJobWorkspaceBuildingResult> TJobWorkspaceBuilder::Run()
 {
     VERIFY_THREAD_AFFINITY(JobThread);
@@ -346,37 +385,6 @@ public:
     }
 
 private:
-    void SetArtifactPermissions()
-    {
-        YT_LOG_INFO(
-            "Setting permissions for artifacts (ArtifactCount: %v)",
-            std::size(Context_.Artifacts));
-
-        for (const auto& artifact : Context_.Artifacts) {
-            if (!artifact.BypassArtifactCache && !artifact.CopyFile) {
-                YT_VERIFY(artifact.Chunk);
-
-                int permissions = artifact.Executable ? 0755 : 0644;
-
-                YT_LOG_INFO(
-                    "Set permissions for artifact (FileName: %v, Permissions: "
-                    "%v, SandboxKind: %v, CompressedDataSize: %v)",
-                    artifact.Name,
-                    permissions,
-                    artifact.SandboxKind,
-                    artifact.Key.GetCompressedDataSize());
-
-                SetPermissions(
-                    artifact.Chunk->GetFileName(),
-                    permissions);
-            } else {
-                YT_VERIFY(artifact.SandboxKind == ESandboxKind::User);
-            }
-        }
-
-        YT_LOG_INFO("Permissions for artifacts set");
-    }
-
     TFuture<void> DoPrepareSandboxDirectories() override
     {
         VERIFY_THREAD_AFFINITY(JobThread);
@@ -390,10 +398,10 @@ private:
         ResultHolder_.TmpfsPaths = WaitFor(slot->PrepareSandboxDirectories(Context_.UserSandboxOptions))
             .ValueOrThrow();
 
-        if (Context_.LayerArtifactKeys.empty() || !Context_.UserSandboxOptions.EnableArtifactBinds) {
-            MakeArtifactSymlinks();
+        if (Context_.UserSandboxOptions.EnableArtifactBinds && !Context_.LayerArtifactKeys.empty()) {
+            PrepareArtifactBinds();
         } else {
-            SetArtifactPermissions();
+            MakeArtifactSymlinks();
         }
 
         YT_LOG_INFO("Finished preparing sandbox directories");
@@ -610,7 +618,11 @@ private:
         ResultHolder_.TmpfsPaths = WaitFor(slot->PrepareSandboxDirectories(Context_.UserSandboxOptions))
             .ValueOrThrow();
 
-        MakeArtifactSymlinks();
+        if (Context_.UserSandboxOptions.EnableArtifactBinds) {
+            PrepareArtifactBinds();
+        } else {
+            MakeArtifactSymlinks();
+        }
 
         YT_LOG_INFO("Finished preparing sandbox directories");
 

--- a/yt/yt/server/node/exec_node/job_workspace_builder.h
+++ b/yt/yt/server/node/exec_node/job_workspace_builder.h
@@ -123,6 +123,8 @@ protected:
 
     void MakeArtifactSymlinks();
 
+    void PrepareArtifactBinds();
+
 private:
     template<TFuture<void>(TJobWorkspaceBuilder::*Step)()>
     TCallback<TFuture<void>()> MakeStep();

--- a/yt/yt/tests/integration/node/test_layers.py
+++ b/yt/yt/tests/integration/node/test_layers.py
@@ -20,22 +20,10 @@ import time
 from collections import Counter
 
 
-class TestLayers(YTEnvSetup):
+class TestLayersBase(YTEnvSetup):
     NUM_SCHEDULERS = 1
-    DELTA_NODE_CONFIG = {
-        "exec_agent": {
-            "test_root_fs": True,
-            "use_artifact_binds": True,
-            "use_common_root_fs_quota": True,
-            "slot_manager": {
-                "job_environment": {
-                    "type": "porto",
-                },
-            },
-        }
-    }
 
-    USE_PORTO = True
+    INVALID_EXTERNAL_IMAGE = "registry.invalid/image:tag"
 
     def setup_files(self):
         create("file", "//tmp/layer1")
@@ -60,6 +48,23 @@ class TestLayers(YTEnvSetup):
         write_file("//tmp/static_cat", open("layers/static_cat", "rb").read())
 
         set("//tmp/static_cat/@executable", True)
+
+
+class TestLayers(TestLayersBase):
+    USE_PORTO = True
+
+    DELTA_NODE_CONFIG = {
+        "exec_agent": {
+            "test_root_fs": True,
+            "use_artifact_binds": True,
+            "use_common_root_fs_quota": True,
+            "slot_manager": {
+                "job_environment": {
+                    "type": "porto",
+                },
+            },
+        }
+    }
 
     @authors("ilpauzner")
     def test_disabled_layer_locations(self):
@@ -497,6 +502,7 @@ class TestDockerImage(TestLayers):
     @staticmethod
     def run_map(docker_image, **kwargs):
         spec = {
+            "max_failed_job_count": 1,
             "mapper": {
                 "docker_image": docker_image,
             },
@@ -569,6 +575,59 @@ class TestDockerImage(TestLayers):
 
         with raises_yt_error(f'Tags document "{TestDockerImage.TAG_DOCUMENT_PATH}" is not a map'):
             self.run_map(f"{TestDockerImage.IMAGE}:tag")
+
+    @authors("khlebnikov")
+    @pytest.mark.timeout(180)
+    def test_invalid_external_image(self):
+        self.create_tables()
+
+        with raises_yt_error('External docker image is not supported in Porto job environment'):
+            self.run_map(self.INVALID_EXTERNAL_IMAGE)
+
+
+@authors("khlebnikov")
+class TestCriDockerImage(TestLayersBase):
+    JOB_ENVIRONMENT_TYPE = "cri"
+
+    INPUT_TABLE = "//tmp/input_table"
+    OUTPUT_TABLE = "//tmp/output_table"
+    MAP_COMMAND = "cat"
+
+    def create_tables(self):
+        create("table", self.INPUT_TABLE)
+        create("table", self.OUTPUT_TABLE)
+
+        write_table(self.INPUT_TABLE, [{"a": 1}])
+
+    def run_map(self, **kwargs):
+        return map(
+            in_=self.INPUT_TABLE,
+            out=self.OUTPUT_TABLE,
+            command=self.MAP_COMMAND,
+            spec={
+                "max_failed_job_count": 1,
+                "mapper": kwargs,
+            },
+        )
+
+    @authors("khlebnikov")
+    @pytest.mark.timeout(180)
+    def test_invalid_external_image(self):
+        self.create_tables()
+
+        with raises_yt_error('Failed to pull docker image'):
+            self.run_map(docker_image=self.INVALID_EXTERNAL_IMAGE)
+
+    @authors("khlebnikov")
+    @pytest.mark.timeout(180)
+    def test_unsupported_layers(self):
+        self.create_tables()
+
+        create("file", "//tmp/empty_layer")
+        write_file("//tmp/empty_layer", b'\0'*1024)  # valid empty tar archive
+
+        with raises_yt_error('Porto layers are not supported in CRI job environment'):
+            self.run_map(layer_paths=["//tmp/empty_layer"])
 
 
 @authors("psushin")


### PR DESCRIPTION
- Fix CRI job environment for use_artifact_binds=true
  For job-proxy working directory bind slot identical to host path.
  For user-job add second bind to "/slot".
  
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/235
  
  (cherry picked from commit fae6279a930a4c994afa6262ea04cdbd6cb92b79)
- Wait for first slot when starting CRI pods
  Otherwise containerd runs parallel pull for sandbox_image (pause)
  if it is not cached yet.
  
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/254
  
  (cherry picked from commit 66bd4ffe3e9d68ef71f7b56db2b72bcfbc8a1d3f)
- Do not retry job with unsupported docker_image or layer_paths
  Job should not be retried after errors DockerImagePullingFailed or
  LayerUnpackingFailed unlike more generic RootVolumePreparationFailed.
  
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/242
  
  Co-authored-by: galtsev <galtsev@ytsaurus.tech>
  
  (cherry picked from commit 6f5173be0d5245c7d1212d7b97a83782b01a6622)
- Deduplicate concurrent image pulls in CRI executor
  CRI API does not prevent concurrent pulling same docker image.
  
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/253
  
  (cherry picked from commit 9b02ee8e1c6851dd9bfa438878af9e8c78d2418a)
- Set environment variables USER and LOGNAME for CRI jobs
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/250
  
  Co-authored-by: gudqeit <gudqeit@ytsaurus.tech>
  
  (cherry picked from commit b896915b54a77b4009ca815d61b933fbeaf802fb)
- Better logging for CRI process operations
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/288
  
  (cherry picked from commit e666f60ff96f018c5c146895fec8f8db92723006)
- Make CRI CreateContainer uncancellable
  Code in contianerd is non-atomic and may leave garbage after cancellation.
  
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/289
  
  (cherry picked from commit 139bd6a6a599283d6a50a3029359116774887c7d)
- Fix race between TCriProcess spawn and kill
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/293
  
  (cherry picked from commit 1893e1fb235c2a92d53416b4b00d1e51a65d5cb8)
- Cosmetics
  (cherry picked from commit 73775b73d3ced2f3d4a9c68a7828dd98fee987fd)
- Set unique attempt for each cri contianer create
  - Set unique attempt for each CRI container create
  
  I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/292
  
  (cherry picked from commit dbe3bae51a9530e89ec6d116503cc486b4d1f982)
- Retry CRI requests when containerd is not initialized
  Containerd does not report correct error code in this case yet.
  Thus we have to check error message.
  
  Link: https://github.com/containerd/containerd/pull/9565
  (cherry picked from commit 35d421f3e392ea2077238b5155b243da87030ecd)
  
