### PR TITLE
Use round-robin scheduling for node replication queues

### DIFF
--- a/yt/yt/server/master/CMakeLists.txt
+++ b/yt/yt/server/master/CMakeLists.txt
@@ -369,6 +369,7 @@ target_sources(yt-server-master PRIVATE
   ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_replacer.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_replica.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_replicator.cpp
+  ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_replication_queue.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_requisition.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_scanner.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/master/chunk_server/chunk_sealer.cpp

--- a/yt/yt/server/master/chunk_server/chunk_replication_queue.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_replication_queue.cpp
@@ -1,0 +1,121 @@
+#include "chunk_replication_queue.h"
+
+#include <yt/yt/core/misc/collection_helpers.h>
+
+namespace NYT::NChunkServer {
+
+using namespace NChunkClient;
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TChunkReplicationQueue::TChunkReplicationQueue::Add(
+    TChunkIdWithIndex chunkIdWithIndex,
+    int targetMediumIndex)
+{
+    auto [it, inserted] = Queue_.emplace(chunkIdWithIndex, TMediumSet());
+    if (inserted) {
+        RandomIterator_ = it;
+    }
+    it->second.set(targetMediumIndex);
+}
+
+void TChunkReplicationQueue::TChunkReplicationQueue::Erase(
+    TChunkIdWithIndex chunkIdWithIndex,
+    int targetMediumIndex)
+{
+    auto it = Queue_.find(chunkIdWithIndex);
+    YT_VERIFY(it != Queue_.end());
+    it->second.reset(targetMediumIndex);
+
+    if (it->second.none()) {
+        Erase(it);
+    }
+}
+
+void TChunkReplicationQueue::TChunkReplicationQueue::Erase(TChunkIdWithIndex chunkIdWithIndex)
+{
+    Erase(Queue_.find(chunkIdWithIndex));
+}
+
+void TChunkReplicationQueue::TChunkReplicationQueue::Erase(TIterator it)
+{
+    if (it == Queue_.end()) {
+        return;
+    }
+
+    if (RandomIterator_ == it) {
+        AdvanceRandomIterator();
+    }
+    Queue_.erase(it);
+    if (Queue_.empty()) {
+        RandomIterator_ = Queue_.end();
+    }
+}
+
+TChunkReplicationQueue::TIterator TChunkReplicationQueue::PickRandomChunk()
+{
+    auto it = RandomIterator_;
+    AdvanceRandomIterator();
+    return it;
+}
+
+TChunkReplicationQueue::TIterator TChunkReplicationQueue::begin()
+{
+    return Queue_.begin();
+}
+
+TChunkReplicationQueue::TIterator TChunkReplicationQueue::end()
+{
+    return Queue_.end();
+}
+
+TChunkReplicationQueue::TIterator TChunkReplicationQueue::find(NChunkClient::TChunkIdWithIndex chunkIdWithIndex)
+{
+    return Queue_.find(chunkIdWithIndex);
+}
+
+size_t TChunkReplicationQueue::size() const
+{
+    return Queue_.size();
+}
+
+bool TChunkReplicationQueue::empty() const
+{
+    return Queue_.empty();
+}
+
+void TChunkReplicationQueue::clear()
+{
+    Queue_.clear();
+    RandomIterator_ = Queue_.end();
+}
+
+void TChunkReplicationQueue::Shrink()
+{
+    if (Queue_.empty()) {
+        ShrinkHashTable(Queue_);
+        RandomIterator_ = Queue_.end();
+        return;
+    }
+
+    auto randomChunk = RandomIterator_->first;
+    ShrinkHashTable(Queue_);
+    RandomIterator_ = Queue_.find(randomChunk);
+    YT_VERIFY(RandomIterator_ != Queue_.end());
+}
+
+void TChunkReplicationQueue::AdvanceRandomIterator()
+{
+    if (RandomIterator_ == Queue_.end()) {
+        return;
+    }
+
+    ++RandomIterator_;
+    if (RandomIterator_ == Queue_.end()) {
+        RandomIterator_ = Queue_.begin();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkServer

--- a/yt/yt/server/master/chunk_server/chunk_replication_queue.h
+++ b/yt/yt/server/master/chunk_server/chunk_replication_queue.h
@@ -1,0 +1,47 @@
+#include "public.h"
+
+#include <yt/yt/client/chunk_client/chunk_replica.h>
+
+namespace NYT::NChunkServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TChunkReplicationQueue
+{
+public:
+    using TIterator = THashMap<NChunkClient::TChunkIdWithIndex, TMediumSet>::iterator;
+
+    void Add(NChunkClient::TChunkIdWithIndex chunkIdWithIndex, int targetMediumIndex);
+    void Erase(NChunkClient::TChunkIdWithIndex chunkIdWithIndex, int targetMediumIndex);
+    void Erase(NChunkClient::TChunkIdWithIndex chunkIdWithIndex);
+    void Erase(TIterator iterator);
+
+    TIterator PickRandomChunk();
+
+    TIterator begin();
+    TIterator end();
+
+    TIterator find(NChunkClient::TChunkIdWithIndex chunkIdWithIndex);
+
+    [[nodiscard]] size_t size() const;
+
+    [[nodiscard]] bool empty() const;
+
+    void clear();
+
+    void Shrink();
+
+private:
+    //! Key:
+    //!   Encodes chunk and one of its parts (for erasure chunks only, others use GenericChunkReplicaIndex).
+    //! Value:
+    //!   Indicates media where acting as replication targets for this chunk.
+    THashMap<NChunkClient::TChunkIdWithIndex, TMediumSet> Queue_;
+    TIterator RandomIterator_ = Queue_.end();
+
+    void AdvanceRandomIterator();
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkServer

--- a/yt/yt/server/master/node_tracker_server/node.h
+++ b/yt/yt/server/master/node_tracker_server/node.h
@@ -5,6 +5,7 @@
 #include <yt/yt/server/master/cell_master/public.h>
 
 #include <yt/yt/server/master/chunk_server/chunk_location.h>
+#include <yt/yt/server/master/chunk_server/chunk_replication_queue.h>
 
 #include <yt/yt/server/master/maintenance_tracker_server/maintenance_target.h>
 
@@ -222,18 +223,11 @@ public:
     bool IsValidWriteTarget() const;
     bool WasValidWriteTarget(EWriteTargetValidityChange change) const;
 
-    //! Indexed by priority. Each map is as follows:
-    //! Key:
-    //!   Encodes chunk and one of its parts (for erasure chunks only, others use GenericChunkReplicaIndex).
-    //! Value:
-    //!   Indicates media where acting as replication targets for this chunk.
-    using TChunkPushReplicationQueue = THashMap<NChunkClient::TChunkIdWithIndex, TMediumSet>;
-    using TChunkPushReplicationQueues = std::vector<TChunkPushReplicationQueue>;
+    using TChunkPushReplicationQueues = std::vector<NChunkServer::TChunkReplicationQueue>;
     DEFINE_BYREF_RW_PROPERTY(TChunkPushReplicationQueues, ChunkPushReplicationQueues);
 
     //! Has the same structure as push replication queues.
-    using TChunkPullReplicationQueue = THashMap<NChunkClient::TChunkIdWithIndex, TMediumSet>;
-    using TChunkPullReplicationQueues = std::vector<TChunkPullReplicationQueue>;
+    using TChunkPullReplicationQueues = std::vector<NChunkServer::TChunkReplicationQueue>;
     DEFINE_BYREF_RW_PROPERTY(TChunkPullReplicationQueues, ChunkPullReplicationQueues);
 
     // For chunks in push queue, its correspondent pull queue node id.

--- a/yt/yt/server/master/ya.make
+++ b/yt/yt/server/master/ya.make
@@ -90,6 +90,7 @@ SRCS(
     chunk_server/chunk_replacer.cpp
     chunk_server/chunk_replica.cpp
     chunk_server/chunk_replicator.cpp
+    chunk_server/chunk_replication_queue.cpp
     chunk_server/chunk_requisition.cpp
     chunk_server/chunk_scanner.cpp
     chunk_server/chunk_sealer.cpp

--- a/yt/yt/tests/integration/master/test_chunk_server.py
+++ b/yt/yt/tests/integration/master/test_chunk_server.py
@@ -2,7 +2,7 @@ from yt_env_setup import YTEnvSetup, Restarter, NODES_SERVICE, MASTERS_SERVICE
 
 from yt_commands import (
     authors, create_user, wait, create, ls, get, set, remove, exists,
-    start_transaction, insert_rows, build_snapshot, gc_collect, concatenate, create_account,
+    start_transaction, insert_rows, build_snapshot, gc_collect, concatenate, create_account, create_rack,
     read_table, write_table, write_journal, merge, sync_create_cells, sync_mount_table, sync_unmount_table, sync_control_chunk_replicator, get_singular_chunk_id,
     multicell_sleep, update_nodes_dynamic_config, switch_leader, ban_node, add_maintenance, remove_maintenance,
     set_node_decommissioned, execute_command, is_active_primary_master_leader, is_active_primary_master_follower,
@@ -494,6 +494,41 @@ class TestChunkServer(YTEnvSetup):
 
         add_maintenance("cluster_node", nodes[3], "pending_restart", "")
         wait(lambda: len(get(f"#{chunk_id}/@stored_replicas")) == 19)
+
+    @authors("gritukan")
+    def test_replication_queue_fairness(self):
+        set("//sys/@config/incumbent_manager/scheduler/incumbents/chunk_replicator/use_followers", False)
+        sleep(1.0)
+
+        create("table", "//tmp/t1")
+        write_table("<append=%true>//tmp/t1", {"a": "b"})
+        chunk_id = get_singular_chunk_id("//tmp/t1")
+        wait(lambda: len(get(f"#{chunk_id}/@stored_replicas")) == 3)
+
+        set("//sys/@config/chunk_manager/max_misscheduled_replication_jobs_per_heartbeat", 1)
+
+        create_rack("r1")
+        create_rack("r2")
+
+        for idx, node in enumerate(ls("//sys/cluster_nodes")):
+            set(f"//sys/cluster_nodes/{node}/@rack", "r1" if idx % 2 == 0 else "r2")
+            set(f"//sys/cluster_nodes/{node}/@resource_limits_overrides/replication_slots", 1)
+            wait(lambda: get(f"//sys/cluster_nodes/{node}/@resource_limits/replication_slots") == 1)
+
+        # Now we try to replicate at most one chunk per job heartbeat.
+
+        # Make sure that all replication queues are filled with some chunks that
+        # cannot be placed safely.
+        create("table", "//tmp/t2", attributes={"erasure_codec": "isa_lrc_12_2_2"})
+        chunk_count = 30
+        for _ in range(chunk_count):
+            write_table("<append=%true>//tmp/t2", {"a": "b"})
+
+        wait(lambda: len(get("//sys/unsafely_placed_chunks")) == chunk_count)
+
+        # Replication should still work.
+        set("//tmp/t1/@replication_factor", 4)
+        wait(lambda: len(get(f"#{chunk_id}/@stored_replicas")) == 4)
 
 
 ##################################################################


### PR DESCRIPTION
Without round-robin replication may become stuck in case if node replication queues are filled with chunks that are impossible to replicate (for example, erasure chunks in case of too few racks)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/206

(cherry picked from commit d06f5f999973d58710320accbd8c2c4c7642b55d)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
