### PR TITLE
Introduce per-object profiling in queue agent

### DIFF
--- a/yt/yt/server/lib/alert_manager/alert_manager.cpp
+++ b/yt/yt/server/lib/alert_manager/alert_manager.cpp
@@ -11,12 +11,24 @@
 namespace NYT::NAlertManager {
 
 using namespace NConcurrency;
+using namespace NLogging;
+using namespace NProfiling;
+using namespace NThreading;
 using namespace NYson;
 using namespace NYTree;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static const auto& Logger = AlertManagerLogger;
+TError TAlert::GetTaggedError() const
+{
+    std::vector<TErrorAttribute> errorAttributes;
+    errorAttributes.reserve(Tags.size());
+    for (const auto& tag : Tags) {
+        errorAttributes.emplace_back(tag.first, tag.second);
+    }
+
+    return Error << errorAttributes;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -24,34 +36,37 @@ class TAlertManager
     : public IAlertManager
 {
 public:
-    explicit TAlertManager(IInvokerPtr controlInvoker)
-        : ControlInvoker_(std::move(controlInvoker))
+    TAlertManager(NLogging::TLogger logger, NProfiling::TProfiler alertProfiler, IInvokerPtr invoker)
+        : Logger(std::move(logger))
+        , AlertProfiler_(std::move(alertProfiler))
+        , Invoker_(std::move(invoker))
         , OrchidService_(IYPathService::FromProducer(
-            BIND(&TAlertManager::BuildOrchid, MakeWeak(this)))->Via(ControlInvoker_))
+            BIND(&TAlertManager::BuildOrchid, MakeWeak(this)))->Via(Invoker_))
         , DynamicConfig_(New<TAlertManagerDynamicConfig>())
         , AlertCollectionExecutor_(New<TPeriodicExecutor>(
-            ControlInvoker_,
+            Invoker_,
             BIND(&TAlertManager::CollectAlerts, MakeWeak(this)),
             DynamicConfig_->AlertCollectionPeriod))
     { }
 
-    NYTree::IYPathServicePtr GetOrchidService() const
+    IYPathServicePtr GetOrchidService() const override
     {
         return OrchidService_;
     }
 
-    void Start()
+    void Start() override
     {
         AlertCollectionExecutor_->Start();
     }
 
     void Reconfigure(
         const TAlertManagerDynamicConfigPtr& oldConfig,
-        const TAlertManagerDynamicConfigPtr& newConfig)
+        const TAlertManagerDynamicConfigPtr& newConfig) override
     {
-        VERIFY_SERIALIZED_INVOKER_AFFINITY(ControlInvoker_);
-
-        DynamicConfig_ = newConfig;
+        {
+            auto guard = WriterGuard(SpinLock_);
+            DynamicConfig_ = newConfig;
+        }
 
         AlertCollectionExecutor_->SetPeriod(newConfig->AlertCollectionPeriod);
 
@@ -61,56 +76,184 @@ public:
             ConvertToYsonString(newConfig, EYsonFormat::Text));
     }
 
-private:
-    const IInvokerPtr ControlInvoker_;
-    const NYTree::IYPathServicePtr OrchidService_;
-
-    TAlertManagerDynamicConfigPtr DynamicConfig_;
-    NConcurrency::TPeriodicExecutorPtr AlertCollectionExecutor_;
-
-    std::vector<TAlert> Alerts_;
-
     void CollectAlerts()
     {
-        VERIFY_SERIALIZED_INVOKER_AFFINITY(ControlInvoker_);
+        std::vector<TAlert> rawAlerts;
+        PopulateAlerts_.Fire(&rawAlerts);
 
-        std::vector<TAlert> alerts;
-        PopulateAlerts_.Fire(&alerts);
-        Alerts_.swap(alerts);
+        struct TAggregatedAlert
+        {
+            std::optional<TErrorCode> ErrorCode;
+            std::optional<TString> Description;
+            std::vector<TError> Errors;
+        };
+        THashMap<TString, TAggregatedAlert> categoryToAggregatedAlerts;
 
-        THashSet<TString> encounteredCategories;
+        THashMap<TString, THashSet<TTagList>> uniqueAlerts;
 
-        for (const auto& alert : Alerts_) {
-            InsertOrCrash(encounteredCategories, alert.Category);
+        for (const auto& rawAlert: rawAlerts) {
+            // Each category + tags combination should be unique.
+            InsertOrCrash(uniqueAlerts[rawAlert.Category], rawAlert.Tags);
 
-            YT_LOG_WARNING(alert.Error);
+            auto& aggregatedAlert = categoryToAggregatedAlerts[rawAlert.Category];
+
+            // Error codes and descriptions should be equal for alerts in the same category.
+            if (!aggregatedAlert.ErrorCode) {
+                aggregatedAlert.ErrorCode = rawAlert.ErrorCode;
+            } else {
+                YT_VERIFY(*aggregatedAlert.ErrorCode == rawAlert.ErrorCode);
+            }
+            // TODO(achulkov2): Avoid duplicating description strings? Doesn't seem to be worth the hassle for now.
+            if (!aggregatedAlert.Description) {
+                aggregatedAlert.Description = rawAlert.Description;
+            } else {
+                YT_VERIFY(*aggregatedAlert.Description == rawAlert.Description);
+            }
+            aggregatedAlert.Errors.push_back(rawAlert.GetTaggedError());
         }
+
+        THashMap<TString, TError> alerts;
+        for (const auto& [category, aggregatedAlert] : categoryToAggregatedAlerts) {
+            alerts.emplace(category, TError(*aggregatedAlert.ErrorCode, *aggregatedAlert.Description) << aggregatedAlert.Errors);
+        }
+
+        auto guard = WriterGuard(SpinLock_);
+        Alerts_ = alerts;
 
         YT_LOG_DEBUG("Collected alerts (Count: %v)", Alerts_.size());
     }
 
+    THashMap<TString, TError> GetAlerts() const override
+    {
+        auto guard = ReaderGuard(SpinLock_);
+
+        return Alerts_;
+    }
+
+    TLogger GetLogger() const override
+    {
+        return Logger;
+    }
+
+    TProfiler GetAlertProfiler() const override
+    {
+        return AlertProfiler_;
+    }
+
     void BuildOrchid(NYson::IYsonConsumer* consumer) const
     {
-        VERIFY_SERIALIZED_INVOKER_AFFINITY(ControlInvoker_);
-
         BuildYsonFluently(consumer)
             .BeginAttributes()
                 .Item("opaque").Value(true)
             .EndAttributes()
-            .DoMapFor(Alerts_, [] (TFluentMap fluent, const auto& alert) {
-                fluent
-                    .Item(alert.Category).Value(alert.Error);
-            });
+            .Value(GetAlerts());
     }
+
+    DEFINE_SIGNAL_OVERRIDE(void(std::vector<TAlert>*), PopulateAlerts);
+
+private:
+    const NLogging::TLogger Logger;
+    const TProfiler AlertProfiler_;
+    const IInvokerPtr Invoker_;
+    const IYPathServicePtr OrchidService_;
+    TAlertManagerDynamicConfigPtr DynamicConfig_;
+    const TPeriodicExecutorPtr AlertCollectionExecutor_;
+
+    YT_DECLARE_SPIN_LOCK(TReaderWriterSpinLock, SpinLock_);
+    THashMap<TString, TError> Alerts_;
 };
 
 DEFINE_REFCOUNTED_TYPE(TAlertManager)
 
+IAlertManagerPtr CreateAlertManager(NLogging::TLogger logger, NProfiling::TProfiler alertProfiler, IInvokerPtr invoker)
+{
+    return New<TAlertManager>(std::move(logger), std::move(alertProfiler), std::move(invoker));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-IAlertManagerPtr CreateAlertManager(IInvokerPtr controlInvoker)
+class TAlertCollector
+    : public IAlertCollector
 {
-    return New<TAlertManager>(std::move(controlInvoker));
+public:
+    TAlertCollector(const IAlertManagerPtr& alertManager)
+        : AlertManager_(alertManager)
+        , AlertProfiler_(alertManager->GetAlertProfiler())
+        , Logger(alertManager->GetLogger())
+    {
+        alertManager->SubscribePopulateAlerts(PopulateAlertsCallback_);
+    }
+    ~TAlertCollector()
+    {
+        if (auto alertManager = AlertManager_.Lock()) {
+            alertManager->UnsubscribePopulateAlerts(PopulateAlertsCallback_);
+        }
+    }
+
+
+    void StageAlert(TAlert alert) override
+    {
+        auto guard = WriterGuard(SpinLock_);
+
+        EmplaceOrCrash(StagedAlerts_[alert.Category], alert.Tags, alert);
+        CategoryToGauges_[alert.Category].try_emplace(
+            alert.Tags,
+            AlertProfiler_.WithTag("category", alert.Category).WithTags(TTagSet{alert.Tags}).Gauge("/alerts"));
+
+        YT_LOG_DEBUG(alert.Error, "Staged alert (Category: %v, Description: %v, Tags: %v)", alert.Category, alert.Description, alert.Tags);
+    }
+
+    void PublishAlerts() override
+    {
+        auto guard = WriterGuard(SpinLock_);
+
+        for (const auto& [category, tagsToGauges] : CategoryToGauges_) {
+            auto tagsToAlertsIt = StagedAlerts_.find(category);
+            for (const auto& [tags, gauge] : tagsToGauges) {
+                if (tagsToAlertsIt != StagedAlerts_.end() && tagsToAlertsIt->second.contains(tags)) {
+                    gauge.Update(1);
+                } else {
+                    gauge.Update(0);
+                }
+            }
+        }
+
+        Alerts_.clear();
+        for (const auto& [category, tagsToAlerts] : StagedAlerts_) {
+            auto alerts = GetValues(tagsToAlerts);
+            Alerts_.insert(Alerts_.end(), std::make_move_iterator(alerts.begin()), std::make_move_iterator(alerts.end()));
+        }
+
+        YT_LOG_DEBUG("Publishing staged alerts (Count: %v)", StagedAlerts_.size());
+
+        StagedAlerts_.clear();
+    }
+
+private:
+    const TCallback<void(std::vector<TAlert>*)> PopulateAlertsCallback_ =
+        BIND(&TAlertCollector::DoPopulateAlerts, MakeWeak(this));
+    const TWeakPtr<IAlertManager> AlertManager_;
+    const NProfiling::TProfiler AlertProfiler_;
+    const NLogging::TLogger Logger;
+
+    YT_DECLARE_SPIN_LOCK(NThreading::TReaderWriterSpinLock, SpinLock_);
+    std::vector<TAlert> Alerts_;
+    THashMap<TString, THashMap<NProfiling::TTagList, TAlert>> StagedAlerts_;
+    THashMap<TString, THashMap<NProfiling::TTagList, NProfiling::TGauge>> CategoryToGauges_;
+
+    void DoPopulateAlerts(std::vector<TAlert>* alerts)
+    {
+        auto guard = ReaderGuard(SpinLock_);
+
+        alerts->insert(alerts->end(), Alerts_.begin(), Alerts_.end());
+    }
+};
+
+DEFINE_REFCOUNTED_TYPE(TAlertCollector)
+
+IAlertCollectorPtr CreateAlertCollector(const IAlertManagerPtr& alertManager)
+{
+    return New<TAlertCollector>(alertManager);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/alert_manager/alert_manager.cpp
+++ b/yt/yt/server/lib/alert_manager/alert_manager.cpp
@@ -183,13 +183,13 @@ public:
     {
         alertManager->SubscribePopulateAlerts(PopulateAlertsCallback_);
     }
+
     ~TAlertCollector()
     {
         if (auto alertManager = AlertManager_.Lock()) {
             alertManager->UnsubscribePopulateAlerts(PopulateAlertsCallback_);
         }
     }
-
 
     void StageAlert(TAlert alert) override
     {
@@ -251,9 +251,9 @@ private:
 
 DEFINE_REFCOUNTED_TYPE(TAlertCollector)
 
-IAlertCollectorPtr CreateAlertCollector(const IAlertManagerPtr& alertManager)
+IAlertCollectorPtr CreateAlertCollector(IAlertManagerPtr alertManager)
 {
-    return New<TAlertCollector>(alertManager);
+    return New<TAlertCollector>(std::move(alertManager));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/alert_manager/alert_manager.h
+++ b/yt/yt/server/lib/alert_manager/alert_manager.h
@@ -10,31 +10,106 @@ namespace NYT::NAlertManager {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! NB: Please read the comments below to get a picture of when error attribtutes should be specified in tags vs. the error itself.
 struct TAlert
 {
+    //! Numeric error code corresponding to a YT error enum declaration.
+    TErrorCode ErrorCode;
+    //! Human-readable representation of the error code above.
+    //! NB: Alerts with the same category name *must* have the same error code value.
     TString Category;
+    //! Human-readable description of alert instance.
+    //! It is possible to have different description variants for the same error code,
+    //! but only one description can be used for a group of alerts at any moment in the alert manager's lifetime.
+    TString Description;
+    //! A set of tags to be added to the error as attributes *and* used in profiling.
+    //! The intent of these tags is to distinguish between alerts within the same category.
+    //! E.g. when the same operation is performed for different clusters, each alert within the category should be
+    //! tagged with the cluster name. They will be grouped together under the same category. In profiling, the metrics
+    //! would be parametrized by the category as well as the specified cluster name.
+    //! NB: Therefore, alerts must be uniquely defined by their error code and tag set.
+    NProfiling::TTagList Tags;
+    //! Reported error.
+    //! This error could have additional attributes that are diagnostically relevant but not needed as a profiling tag.
     TError Error;
+
+    //! Returns the specified error with the specified tags attached as error attributes.
+    TError GetTaggedError() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Periodically collects alerts from subscribed components and groups them by specified alert categories.
+//! To produce an alert for a category, all raw errors in this category are aggregated into inner errors of a single error
+//! with the specified top-level error code and description.
+//! Stored alerts can be exported via the provided orchid service.
+//! It is recommended to utilize the collector interface below, but subscribers can also implement alert collection callback themselves.
+//! NB: Subscribers must guarantee that alerts have a unique error code + tag set combination.
+//! NB: It is recommended to submit alerts with error codes from a single YT error enum within one alert manager.
+//!
+//! Thread affinity: any.
 struct IAlertManager
     : public TRefCounted
 {
-    virtual NYTree::IYPathServicePtr GetOrchidService() const = 0;
-
     virtual void Start() = 0;
 
     virtual void Reconfigure(
         const TAlertManagerDynamicConfigPtr& oldConfig,
         const TAlertManagerDynamicConfigPtr& newConfig) = 0;
 
-    DEFINE_SIGNAL(void(std::vector<TAlert>*), PopulateAlerts);
+    //! Returns an orchid service representing a snapshot of the stored alerts.
+    virtual NYTree::IYPathServicePtr GetOrchidService() const = 0;
+    //! Returns a snapshot of managed alerts.
+    virtual THashMap<TString, TError> GetAlerts() const = 0;
+
+    virtual NLogging::TLogger GetLogger() const = 0;
+    virtual NProfiling::TProfiler GetAlertProfiler() const = 0;
+
+    DECLARE_INTERFACE_SIGNAL(void(std::vector<TAlert>*), PopulateAlerts);
 };
 
 DEFINE_REFCOUNTED_TYPE(IAlertManager)
 
-IAlertManagerPtr CreateAlertManager(IInvokerPtr controlInvoker);
+//! If a non-default (non-dummy) profiler is specified and alert collectors are used, metrics
+//! corresponding to the alert categories and tags will be reported by emitting 0/1 values to a gauge.
+IAlertManagerPtr CreateAlertManager(
+    NLogging::TLogger logger,
+    NProfiling::TProfiler alertProfiler = {},
+    IInvokerPtr invoker = GetCurrentInvoker());
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! A helper-class for storing and publishing per-component alerts, as well as reporting alert-based metrics.
+//! The purpose of this class is to isolate alert lifetimes across components and logical processes of a service.
+//! While the alert manager serves as a central export point of all of the alerts of a service, each collector is
+//! responsible for grouping alerts with the same stage-publish cycle, as well as managing the corresponding gauges.
+//! Different logical components and regular processes with differing periods should use different collectors.
+//! Alerts from different collectors can share the same category, in which case they will be grouped together by the alert manager into a single aggregated alert.
+//! This allows grouping alerts from multiple similar user-configurable periodic processes (e.g. exports from queues into static tables).
+//!
+//! Thread affinity: any.
+struct IAlertCollector
+    : public TRefCounted
+{
+public:
+    //! Stages and stores alert.
+    //! NB: The descriptions of staged alerts should be equal within the same category. This means that you
+    //! can use the same category for alerts with different descriptions, but not within the same stage-publish cycle.
+    //! Otherwise, it would be unclear what description the alert manager should use when grouping these alerts together.
+    virtual void StageAlert(TAlert alert) = 0;
+    //! Publishes alerts so they are visible to the alert manager. Reports metrics on all known category + tags combinations.
+    //! NB: Stored gauges are persistent. If an alert with some (category, tags) combinations was staged during the lifetime of this class,
+    //! 0/1 values will be reported for it up until the collector is destroyed. This is necessary for reporting that an alert is no longer applicable.
+    //! NB: Due to the comment above, it is important to keep the number of (category, tags) combinations very reasonably finite, since each of them causes a sensor to be produced.
+    virtual void PublishAlerts() = 0;
+
+    // TODO(achulkov2): Implement some mechanism for clearing out unnneeded gauges.
+};
+
+DEFINE_REFCOUNTED_TYPE(IAlertCollector)
+
+//! The alert collector will subscribe itself to the manager upon construction and unsubscribe upon destruction.
+IAlertCollectorPtr CreateAlertCollector(const IAlertManagerPtr& alertManager);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/lib/alert_manager/alert_manager.h
+++ b/yt/yt/server/lib/alert_manager/alert_manager.h
@@ -103,13 +103,13 @@ public:
     //! NB: Due to the comment above, it is important to keep the number of (category, tags) combinations very reasonably finite, since each of them causes a sensor to be produced.
     virtual void PublishAlerts() = 0;
 
-    // TODO(achulkov2): Implement some mechanism for clearing out unnneeded gauges.
+    // TODO(achulkov2): Implement some mechanism for clearing out unneeded gauges.
 };
 
 DEFINE_REFCOUNTED_TYPE(IAlertCollector)
 
 //! The alert collector will subscribe itself to the manager upon construction and unsubscribe upon destruction.
-IAlertCollectorPtr CreateAlertCollector(const IAlertManagerPtr& alertManager);
+IAlertCollectorPtr CreateAlertCollector(IAlertManagerPtr alertManager);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/lib/alert_manager/helpers-inl.h
+++ b/yt/yt/server/lib/alert_manager/helpers-inl.h
@@ -9,14 +9,10 @@ namespace NYT::NAlertManager {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class EErrorCode>
-TAlert CreateAlert(const TError& error)
+    requires std::is_enum_v<EErrorCode>
+TAlert CreateAlert(EErrorCode errorCode, TString description, NProfiling::TTagList tags, TError error)
 {
-    auto category = static_cast<EErrorCode>(static_cast<int>(error.GetCode()));
-
-    static const auto possibleAlertErrorCodes = TEnumTraits<EErrorCode>::GetDomainValues();
-    YT_VERIFY(std::find(possibleAlertErrorCodes.begin(), possibleAlertErrorCodes.end(), category) != possibleAlertErrorCodes.end());
-
-    return TAlert{FormatEnum(category), error};
+    return {errorCode, FormatEnum(errorCode), std::move(description), std::move(tags), std::move(error)};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/alert_manager/helpers.h
+++ b/yt/yt/server/lib/alert_manager/helpers.h
@@ -7,7 +7,8 @@ namespace NYT::NAlertManager {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class EErrorCode>
-TAlert CreateAlert(const TError& error);
+    requires std::is_enum_v<EErrorCode>
+TAlert CreateAlert(EErrorCode errorCode, TString description, NProfiling::TTagList tags, TError error);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/lib/alert_manager/public.h
+++ b/yt/yt/server/lib/alert_manager/public.h
@@ -8,6 +8,7 @@ namespace NYT::NAlertManager {
 
 DECLARE_REFCOUNTED_STRUCT(IAlertManager)
 DECLARE_REFCOUNTED_CLASS(TAlertManagerDynamicConfig)
+DECLARE_REFCOUNTED_STRUCT(IAlertCollector)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/query_tracker/bootstrap.cpp
+++ b/yt/yt/server/query_tracker/bootstrap.cpp
@@ -149,7 +149,7 @@ void TBootstrap::DoRun()
 
     HttpServer_ = NHttp::CreateServer(Config_->CreateMonitoringHttpServerConfig());
 
-    AlertManager_ = CreateAlertManager(ControlInvoker_);
+    AlertManager_ = CreateAlertManager(QueryTrackerLogger, TProfiler{}, ControlInvoker_);
 
     if (Config_->CoreDumper) {
         CoreDumper_ = NCoreDump::CreateCoreDumper(Config_->CoreDumper);
@@ -202,11 +202,11 @@ void TBootstrap::DoRun()
         DynamicConfigManager_->GetConfig()->QueryTracker,
         SelfAddress_,
         ControlInvoker_,
+        CreateAlertCollector(AlertManager_),
         NativeClient_,
         Config_->Root,
         Config_->MinRequiredStateVersion);
 
-    AlertManager_->SubscribePopulateAlerts(BIND(&IQueryTracker::PopulateAlerts, QueryTracker_));
     AlertManager_->Start();
 
     QueryTracker_->Start();

--- a/yt/yt/server/query_tracker/query_tracker.h
+++ b/yt/yt/server/query_tracker/query_tracker.h
@@ -22,8 +22,6 @@ struct IQueryTracker
     virtual void Start() = 0;
 
     virtual void Reconfigure(const TQueryTrackerDynamicConfigPtr& config) = 0;
-
-    virtual void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IQueryTracker)
@@ -34,6 +32,7 @@ IQueryTrackerPtr CreateQueryTracker(
     TQueryTrackerDynamicConfigPtr config,
     TString selfAddress,
     IInvokerPtr controlInvoker,
+    NAlertManager::IAlertCollectorPtr alertCollector,
     NApi::NNative::IClientPtr stateClient,
     NYPath::TYPath stateRoot,
     int minRequiredStateVersion);

--- a/yt/yt/server/queue_agent/config.cpp
+++ b/yt/yt/server/queue_agent/config.cpp
@@ -64,6 +64,8 @@ void TQueueControllerDynamicConfig::Register(TRegistrar registrar)
         .Default();
     registrar.Parameter("enable_queue_static_export", &TThis::EnableQueueStaticExport)
         .Default(false);
+    registrar.Parameter("alert_manager", &TThis::AlertManager)
+        .DefaultNew();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/queue_agent/config.h
+++ b/yt/yt/server/queue_agent/config.h
@@ -114,6 +114,8 @@ public:
 
     bool EnableQueueStaticExport;
 
+    NAlertManager::TAlertManagerDynamicConfigPtr AlertManager;
+
     REGISTER_YSON_STRUCT(TQueueControllerDynamicConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/server/queue_agent/cypress_synchronizer.h
+++ b/yt/yt/server/queue_agent/cypress_synchronizer.h
@@ -24,8 +24,6 @@ struct ICypressSynchronizer
     virtual void OnDynamicConfigChanged(
         const TCypressSynchronizerDynamicConfigPtr& oldConfig,
         const TCypressSynchronizerDynamicConfigPtr& newConfig) = 0;
-
-    virtual void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(ICypressSynchronizer)
@@ -34,7 +32,8 @@ ICypressSynchronizerPtr CreateCypressSynchronizer(
     TCypressSynchronizerConfigPtr config,
     IInvokerPtr controlInvoker,
     NQueueClient::TDynamicStatePtr dynamicState,
-    NHiveClient::TClientDirectoryPtr clientDirectory);
+    NHiveClient::TClientDirectoryPtr clientDirectory,
+    NAlertManager::IAlertCollectorPtr alertCollector);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/queue_agent/private.h
+++ b/yt/yt/server/queue_agent/private.h
@@ -33,6 +33,9 @@ YT_DEFINE_ERROR_ENUM(
 
     ((QueueAgentPassFailed)                                       (3025))
 
+    ((QueueAgentQueueControllerStaticExportFailed)                (3035))
+    ((QueueAgentQueueControllerTrimFailed)                        (3036))
+
     ((QueueAgentShardingManagerPassFailed)                        (3050))
 );
 

--- a/yt/yt/server/queue_agent/profile_manager.cpp
+++ b/yt/yt/server/queue_agent/profile_manager.cpp
@@ -122,6 +122,11 @@ public:
         , Logger(logger)
     { }
 
+    TProfiler GetQueueProfiler() const override
+    {
+        return QueueProfiler_;
+    }
+
     void Profile(
         const TQueueSnapshotPtr& previousQueueSnapshot,
         const TQueueSnapshotPtr& currentQueueSnapshot) override

--- a/yt/yt/server/queue_agent/profile_manager.h
+++ b/yt/yt/server/queue_agent/profile_manager.h
@@ -14,6 +14,8 @@ struct IQueueProfileManager
     virtual void Profile(
         const TQueueSnapshotPtr& previousQueueSnapshot,
         const TQueueSnapshotPtr& currentQueueSnapshot) = 0;
+
+    virtual NProfiling::TProfiler GetQueueProfiler() const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IQueueProfileManager)

--- a/yt/yt/server/queue_agent/queue_agent.h
+++ b/yt/yt/server/queue_agent/queue_agent.h
@@ -49,6 +49,7 @@ public:
         IInvokerPtr controlInvoker,
         NQueueClient::TDynamicStatePtr dynamicState,
         NCypressElection::ICypressElectionManagerPtr electionManager,
+        NAlertManager::IAlertCollectorPtr alertCollector,
         TString agentId);
 
     void Start();
@@ -58,8 +59,6 @@ public:
     void OnDynamicConfigChanged(
         const TQueueAgentDynamicConfigPtr& oldConfig,
         const TQueueAgentDynamicConfigPtr& newConfig);
-
-    void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const;
 
     // IObjectStore implementation.
 
@@ -77,6 +76,7 @@ private:
     const IInvokerPtr ControlInvoker_;
     const NQueueClient::TDynamicStatePtr DynamicState_;
     const NCypressElection::ICypressElectionManagerPtr ElectionManager_;
+    const NAlertManager::IAlertCollectorPtr AlertCollector_;
     const NConcurrency::IThreadPoolPtr ControllerThreadPool_;
     const NConcurrency::TPeriodicExecutorPtr PassExecutor_;
 
@@ -115,8 +115,6 @@ private:
 
     TEnumIndexedArray<EObjectKind, NYTree::INodePtr> ObjectServiceNodes_;
 
-    std::vector<NAlertManager::TAlert> Alerts_;
-
     NYTree::IYPathServicePtr RedirectYPathRequest(const TString& host, TStringBuf queryRoot, TStringBuf key) const;
 
     void BuildObjectYson(
@@ -130,8 +128,6 @@ private:
 
     //! Stops periodic passes and destroys all controllers.
     void DoStop();
-
-    void DoPopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const;
 
     TTaggedProfilingCounters& GetOrCreateTaggedProfilingCounters(const NQueueClient::TProfilingTags& profilingTags);
 

--- a/yt/yt/server/queue_agent/queue_agent_sharding_manager.h
+++ b/yt/yt/server/queue_agent/queue_agent_sharding_manager.h
@@ -24,14 +24,13 @@ struct IQueueAgentShardingManager
     virtual void OnDynamicConfigChanged(
         const TQueueAgentShardingManagerDynamicConfigPtr& oldConfig,
         const TQueueAgentShardingManagerDynamicConfigPtr& newConfig) = 0;
-
-    virtual void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IQueueAgentShardingManager)
 
 IQueueAgentShardingManagerPtr CreateQueueAgentShardingManager(
     IInvokerPtr controlInvoker,
+    NAlertManager::IAlertCollectorPtr alertCollector,
     NQueueClient::TDynamicStatePtr dynamicState,
     NDiscoveryClient::IMemberClientPtr memberClient,
     NDiscoveryClient::IDiscoveryClientPtr discoveryClient,

--- a/yt/yt/server/queue_agent/queue_static_table_exporter.cpp
+++ b/yt/yt/server/queue_agent/queue_static_table_exporter.cpp
@@ -491,7 +491,7 @@ private:
 
         if (!ExportConfig_.UseUpperBoundForTableNames) {
             unixTs -= periodInSeconds;
-    }
+        }
 
         auto instant = TInstant::Seconds(unixTs);
 

--- a/yt/yt/server/queue_agent/queue_static_table_exporter.cpp
+++ b/yt/yt/server/queue_agent/queue_static_table_exporter.cpp
@@ -1,4 +1,5 @@
 #include "queue_static_table_exporter.h"
+#include "private.h"
 
 #include <yt/yt/ytlib/chunk_client/chunk_spec_fetcher.h>
 #include <yt/yt/ytlib/chunk_client/chunk_teleporter.h>
@@ -25,10 +26,12 @@
 namespace NYT::NQueueAgent {
 
 using namespace NApi;
+using namespace NAlertManager;
 using namespace NConcurrency;
 using namespace NChunkClient;
 using namespace NCypressClient;
 using namespace NHiveClient;
+using namespace NProfiling;
 using namespace NObjectClient;
 using namespace NQueueClient;
 using namespace NRpc;
@@ -52,7 +55,7 @@ public:
     TChunkId LastChunk;
     TTimestamp MaxTimestamp;
     i64 RowCount;
-    // TODO(achulkov2): Chunk count?
+    i64 ChunkCount;
 
     REGISTER_YSON_STRUCT(TTabletExportProgress);
 
@@ -63,6 +66,8 @@ public:
         registrar.Parameter("max_timestamp", &TThis::MaxTimestamp)
             .Default(NullTimestamp);
         registrar.Parameter("row_count", &TThis::RowCount)
+            .Default(0);
+        registrar.Parameter("chunk_count", &TThis::ChunkCount)
             .Default(0);
     }
 };
@@ -89,6 +94,7 @@ public:
         }
 
         tabletProgressIt->second->LastChunk = chunkId;
+        ++tabletProgressIt->second->ChunkCount;
         tabletProgressIt->second->MaxTimestamp = std::max(tabletProgressIt->second->MaxTimestamp, maxTimestamp);
         tabletProgressIt->second->RowCount = rowCount;
     }
@@ -108,6 +114,21 @@ public:
 
 DEFINE_REFCOUNTED_TYPE(TExportProgress)
 
+struct TProgressDiff
+{
+    i64 RowCount = 0;
+    i64 ChunkCount = 0;
+
+    TProgressDiff(const TExportProgressPtr& currentProgress, const TExportProgressPtr& newProgress)
+    {
+        for (const auto& [tabletIndex, newTabletProgress] : newProgress->Tablets) {
+            auto currentTabletProgress = currentProgress->Tablets.Value(tabletIndex, New<TTabletExportProgress>());
+            RowCount += newTabletProgress->RowCount - currentTabletProgress->RowCount;
+            ChunkCount += newTabletProgress->ChunkCount - currentTabletProgress->ChunkCount;
+        }
+    }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Wrapper-class for performing a single export iteration.
@@ -118,12 +139,14 @@ public:
     TQueueExportTask(
         NNative::IClientPtr client,
         IInvokerPtr invoker,
+        TQueueExportProfilingCountersPtr profilingCounters,
         TYPath queue,
         TQueueStaticExportConfig exportConfig,
         const TLogger& logger)
         : Client_(std::move(client))
         , Connection_(Client_->GetNativeConnection())
         , Invoker_(std::move(invoker))
+        , ProfilingCounters_(std::move(profilingCounters))
         , Queue_(std::move(queue))
         , ExportConfig_(std::move(exportConfig))
         , Logger(logger.WithTag(
@@ -143,6 +166,7 @@ private:
     const NNative::IClientPtr Client_;
     const NNative::IConnectionPtr Connection_;
     const IInvokerPtr Invoker_;
+    const TQueueExportProfilingCountersPtr ProfilingCounters_;
 
     const TYPath Queue_;
     const TQueueStaticExportConfig ExportConfig_;
@@ -231,13 +255,17 @@ private:
         AttachChunks();
         EndUpload();
 
-        UpdateCypressExportProgress(currentExportProgress, newExportProgress);
+        auto diff = UpdateCypressExportProgress(currentExportProgress, newExportProgress);
 
         auto commitResultOrError = WaitFor(transaction->Commit());
         THROW_ERROR_EXCEPTION_IF_FAILED(
             commitResultOrError,
             "Error committing main export task transaction for queue %v",
             Queue_);
+
+        ProfilingCounters_->ExportedRows.Increment(diff.RowCount);
+        ProfilingCounters_->ExportedChunks.Increment(diff.ChunkCount);
+        ProfilingCounters_->ExportedTables.Increment();
 
         YT_LOG_INFO("Finished queue static export iteration");
     }
@@ -359,6 +387,7 @@ private:
         if (destinationConfig.OriginatingQueueId != QueueObject_.ObjectId) {
             THROW_ERROR_EXCEPTION(
                 "Destination config is not configured to accept exports from queue %v, configured id %v does not match queue id %v",
+                QueueObject_.GetPath(),
                 destinationConfig.OriginatingQueueId,
                 QueueObject_.ObjectId);
         }
@@ -462,7 +491,7 @@ private:
 
         if (!ExportConfig_.UseUpperBoundForTableNames) {
             unixTs -= periodInSeconds;
-        }
+    }
 
         auto instant = TInstant::Seconds(unixTs);
 
@@ -706,8 +735,8 @@ private:
         UploadTransaction_->Detach();
     }
 
-    void UpdateCypressExportProgress(
-        const TExportProgressPtr& /*currentExportProgress*/,
+    TProgressDiff UpdateCypressExportProgress(
+        const TExportProgressPtr& currentExportProgress,
         const TExportProgressPtr& newExportProgress)
     {
         TSetNodeOptions options;
@@ -718,8 +747,10 @@ private:
             options))
             .ThrowOnError();
 
-        // TODO(achulkov2): Log summary of progress difference.
-        YT_LOG_DEBUG("Updated export progress");
+
+        TProgressDiff diff{currentExportProgress, newExportProgress};
+        YT_LOG_DEBUG("Updated export progress (ExportedRows: %v, ExportedChunks: %v)", diff.RowCount, diff.ChunkCount);
+        return diff;
     }
 
     bool CanUseSchemaId() const
@@ -732,13 +763,27 @@ DEFINE_REFCOUNTED_TYPE(TQueueExportTask)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TQueueExportProfilingCounters::TQueueExportProfilingCounters(const TProfiler& profiler)
+    : ExportedRows(profiler.Counter("/exported_rows"))
+    , ExportedChunks(profiler.Counter("/exported_chunks"))
+    , ExportedTables(profiler.Counter("/exported_tables"))
+{ }
+
+////////////////////////////////////////////////////////////////////////////////
+
 TQueueExporter::TQueueExporter(
+    TString exportName,
     TClientDirectoryPtr clientDirectory,
     IInvokerPtr invoker,
+    IAlertCollectorPtr alertCollector,
+    const TProfiler& queueProfiler,
     const TLogger& logger)
-    : ClientDirectory_(std::move(clientDirectory))
+    : ExportName_(std::move(exportName))
+    , ClientDirectory_(std::move(clientDirectory))
     , Invoker_(std::move(invoker))
-    , Logger(logger)
+    , AlertCollector_(std::move(alertCollector))
+    , ProfilingCounters_(New<TQueueExportProfilingCounters>(queueProfiler.WithPrefix("/static_export").WithTag("export_name", ExportName_)))
+    , Logger(logger.WithTag("ExportName: %v", ExportName_))
 { }
 
 TFuture<void> TQueueExporter::RunExportIteration(
@@ -748,10 +793,22 @@ TFuture<void> TQueueExporter::RunExportIteration(
     auto exportTask = New<TQueueExportTask>(
         ClientDirectory_->GetClientOrThrow(queue.Cluster),
         Invoker_,
+        ProfilingCounters_,
         queue.Path,
         exportConfig,
         Logger);
-    return exportTask->Run();
+    auto exportTaskFuture = exportTask->Run();
+    exportTaskFuture.Subscribe(BIND([this, this_ = MakeStrong(this)] (const TError& error) {
+        if (!error.IsOK()) {
+            AlertCollector_->StageAlert(CreateAlert(
+                NAlerts::EErrorCode::QueueAgentQueueControllerStaticExportFailed,
+                "Failed to perform static export for queue",
+                /*tags*/ {{"export_name", ExportName_}},
+                error));
+        }
+        AlertCollector_->PublishAlerts();
+    }));
+    return exportTaskFuture;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/queue_agent/queue_static_table_exporter.h
+++ b/yt/yt/server/queue_agent/queue_static_table_exporter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <yt/yt/server/lib/alert_manager/alert_manager.h>
+
 #include <yt/yt/ytlib/api/native/config.h>
 #include <yt/yt/ytlib/api/native/connection.h>
 #include <yt/yt/ytlib/api/native/transaction.h>
@@ -13,7 +15,22 @@
 
 #include <yt/yt/library/auth/auth.h>
 
+#include <yt/yt/core/misc/error_code_counter.h>
+
 namespace NYT::NQueueAgent {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TQueueExportProfilingCounters final
+{
+    NProfiling::TCounter ExportedRows;
+    NProfiling::TCounter ExportedChunks;
+    NProfiling::TCounter ExportedTables;
+
+    explicit TQueueExportProfilingCounters(const NProfiling::TProfiler& profiler);
+};
+
+using TQueueExportProfilingCountersPtr = TIntrusivePtr<TQueueExportProfilingCounters>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -24,8 +41,11 @@ public:
     TQueueExporter() = default;
 
     TQueueExporter(
+        TString exportName,
         NHiveClient::TClientDirectoryPtr clientDirectory,
         IInvokerPtr invoker,
+        NAlertManager::IAlertCollectorPtr alertCollector,
+        const NProfiling::TProfiler& queueProfiler,
         const NLogging::TLogger& logger);
 
     TFuture<void> RunExportIteration(
@@ -33,8 +53,11 @@ public:
         const NQueueClient::TQueueStaticExportConfig& config);
 
 private:
+    const TString ExportName_;
     const NHiveClient::TClientDirectoryPtr ClientDirectory_;
     const IInvokerPtr Invoker_;
+    const NAlertManager::IAlertCollectorPtr AlertCollector_;
+    const TQueueExportProfilingCountersPtr ProfilingCounters_;
 
     const NLogging::TLogger Logger;
 };

--- a/yt/yt/server/queue_agent/queue_static_table_exporter.h
+++ b/yt/yt/server/queue_agent/queue_static_table_exporter.h
@@ -15,8 +15,6 @@
 
 #include <yt/yt/library/auth/auth.h>
 
-#include <yt/yt/core/misc/error_code_counter.h>
-
 namespace NYT::NQueueAgent {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/queue_agent/snapshot_representation.h
+++ b/yt/yt/server/queue_agent/snapshot_representation.h
@@ -8,7 +8,7 @@ namespace NYT::NQueueAgent {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void BuildQueueStatusYson(const TQueueSnapshotPtr& snapshot, NYTree::TFluentAny fluent);
+void BuildQueueStatusYson(const TQueueSnapshotPtr& snapshot, const NAlertManager::IAlertManagerPtr& alertManager, NYTree::TFluentAny fluent);
 void BuildQueuePartitionListYson(const TQueueSnapshotPtr& snapshot, NYTree::TFluentAny fluent);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/tests/integration/queues/test_queue_agent.py
+++ b/yt/yt/tests/integration/queues/test_queue_agent.py
@@ -3073,7 +3073,6 @@ class TestObjectAlertCollection(TestQueueStaticExportBase):
     @authors("achulkov2")
     def test_alert_combinations(self):
         queue_agent_orchid = QueueAgentOrchid()
-        cypress_orchid = CypressSynchronizerOrchid()
 
         export_dir_1 = "//tmp/export1"
         export_dir_2 = "//tmp/export2"

--- a/yt/yt/tests/integration/queues/test_queue_agent.py
+++ b/yt/yt/tests/integration/queues/test_queue_agent.py
@@ -2591,7 +2591,6 @@ class TestDynamicConfig(TestQueueAgentBase):
 
 class TestQueueStaticExportBase(TestQueueAgentBase):
     NUM_SECONDARY_MASTER_CELLS = 2
-    NUM_TEST_PARTITIONS = 3
     DELTA_QUEUE_AGENT_DYNAMIC_CONFIG = {
         "queue_agent": {
             "controller": {
@@ -2932,6 +2931,10 @@ class TestQueueStaticExport(TestQueueStaticExportBase):
         # The export directory is not configured to accept exports from //tmp/q, so none should have been performed.
         assert len(ls(export_dir)) == 0
 
+        alerts = queue_agent_orchid.get_queue_orchid("primary://tmp/q").get_alerts()
+        alerts.assert_matching("queue_agent_queue_controller_static_export_failed", text="does not match queue id", attributes={"export_name": "default"})
+        assert alerts.get_alert_count() == 1
+
         self.remove_export_destination(export_dir)
 
     @authors("nadya73")
@@ -3052,3 +3055,78 @@ class TestQueueStaticExportPortals(TestQueueStaticExport):
         self._check_export(export_dir, [["foo"] * 6])
 
         self.remove_export_destination(export_dir)
+
+
+class TestObjectAlertCollection(TestQueueStaticExportBase):
+    DELTA_QUEUE_AGENT_DYNAMIC_CONFIG = {
+        "queue_agent": {
+            "controller": {
+                "enable_automatic_trimming": True,
+                "enable_queue_static_export": True,
+            },
+        },
+        "cypress_synchronizer": {
+            "policy": "watching",
+        },
+    }
+
+    @authors("achulkov2")
+    def test_alert_combinations(self):
+        queue_agent_orchid = QueueAgentOrchid()
+        cypress_orchid = CypressSynchronizerOrchid()
+
+        export_dir_1 = "//tmp/export1"
+        export_dir_2 = "//tmp/export2"
+        export_dir_3 = "//tmp/export3"
+        create("map_node", export_dir_2)
+        create("map_node", export_dir_3)
+
+        queue_path = "//tmp/q"
+        _, queue_id = self._create_queue(queue_path)
+
+        # Only the third export should actually work.
+        self._create_export_destination(export_dir_3, queue_id)
+
+        set(f"{queue_path}/@static_export_config", {
+            # Destination directory does not exist.
+            "first": {
+                "export_directory": export_dir_1,
+                "export_period": 1 * 1000,
+            },
+            # Destination directory is not properly configured.
+            "second": {
+                "export_directory": export_dir_2,
+                "export_period": 1 * 1000,
+            },
+            # Everything is correct.
+            "third": {
+                "export_directory": export_dir_3,
+                "export_period": 2 * 1000,
+            },
+        })
+
+        # A single non-vital consumer with enabled trimming should trigger an alert.
+        self._create_registered_consumer("//tmp/c", "//tmp/q", vital=False)
+        set("//tmp/q/@auto_trim_config", {"enable": True})
+
+        self._wait_for_component_passes()
+
+        insert_rows(queue_path, [{"$tablet_index": 0, "data": "foo"}] * 6)
+        self._flush_table(queue_path)
+
+        self._advance_consumer("//tmp/c", "//tmp/q", 0, 3)
+
+        wait(lambda: len(ls(export_dir_3)) == 1)
+        # Nothing should be trimmed since consumer is not vital.
+        self._wait_for_row_count("//tmp/q", 0, 6)
+
+        queue_agent_orchid.get_queue_orchid("primary://tmp/q").wait_fresh_pass()
+
+        alerts = queue_agent_orchid.get_queue_orchid("primary://tmp/q").get_alerts()
+        alerts.assert_matching("queue_agent_queue_controller_static_export_failed", text="has no child with key", attributes={"export_name": "first"})
+        alerts.assert_matching("queue_agent_queue_controller_static_export_failed", text="export_destination", attributes={"export_name": "second"})
+        alerts.assert_matching("queue_agent_queue_controller_trim_failed", text="with no vital consumers")
+        assert alerts.get_alert_count() == 3
+
+        self.remove_export_destination(export_dir_2)
+        self.remove_export_destination(export_dir_3)


### PR DESCRIPTION
This PR revamps lib/alert_manager to facilitate alert aggregation across several logical components and adds multiple features related to queue agent introspection, including:
- New metrics for reporting the number of rows/chunks/tables exported into static tables.
- Per-object alerts are now collected for queues, exposing trim/static export errors to Cypress.
- Per-object alerts are reported via gauges in profiling.