### PR TITLE
unaware_nodes whitelisted check

### DIFF
--- a/yt/odin/checks/bin/unaware_nodes/__main__.py
+++ b/yt/odin/checks/bin/unaware_nodes/__main__.py
@@ -1,9 +1,19 @@
 from yt_odin_checks.lib.check_runner import main
 
 
-def find_unaware_nodes(yt_client):
+def find_unaware_nodes(yt_client, check_node_flavors):
     result = []
-    for row in yt_client.list("//sys/cluster_nodes", attributes=["rack"], read_from="cache"):
+    for row in yt_client.list("//sys/cluster_nodes", attributes=["rack", "flavors"], read_from="cache"):
+        flavors = row.attributes.get("flavors", [])
+
+        check_node_rack = False
+        for node_flavor in flavors:
+            if node_flavor in check_node_flavors:
+                check_node_rack = True
+                break
+        if not check_node_rack and len(flavors) > 0:
+            continue
+
         rack = row.attributes.get("rack", None)
         if rack is None:
             result.append(str(row))
@@ -15,7 +25,7 @@ def run_check(yt_client, logger, options, states):
     if allow_unaware_nodes:
         return states.FULLY_AVAILABLE_STATE
 
-    unaware_nodes = find_unaware_nodes(yt_client)
+    unaware_nodes = find_unaware_nodes(yt_client, ["data"])
     if unaware_nodes:
         logger.info("First ten unaware nodes: {}".format(" ".join(unaware_nodes[:10])))
         return states.UNAVAILABLE_STATE, len(unaware_nodes)

--- a/yt/odin/checks/bin/unaware_nodes/__main__.py
+++ b/yt/odin/checks/bin/unaware_nodes/__main__.py
@@ -1,5 +1,12 @@
 from yt_odin_checks.lib.check_runner import main
 
+DEFAULT_ENABLED_NODE_FLAVORS = [
+    "data",
+    "exec",
+    "tablet",
+    "chaos"
+]
+
 
 def find_unaware_nodes(yt_client, check_node_flavors):
     result = []
@@ -25,7 +32,9 @@ def run_check(yt_client, logger, options, states):
     if allow_unaware_nodes:
         return states.FULLY_AVAILABLE_STATE
 
-    unaware_nodes = find_unaware_nodes(yt_client, ["data"])
+    check_node_flavors = options.get("check_node_flavors", DEFAULT_ENABLED_NODE_FLAVORS)
+
+    unaware_nodes = find_unaware_nodes(yt_client, check_node_flavors)
     if unaware_nodes:
         logger.info("First ten unaware nodes: {}".format(" ".join(unaware_nodes[:10])))
         return states.UNAVAILABLE_STATE, len(unaware_nodes)


### PR DESCRIPTION
The proposed change allows to specify a whitelist of node flavours the rack configuration should be specified on. E.g. only data-nodes can be monitored for rack assignment.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

