### PR TITLE
stable/23.2 - Retry CRI requests when containerd is not initialized

### DIFF
--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -221,8 +221,8 @@ public:
         TCriExecutorConfigPtr config,
         IChannelFactoryPtr channelFactory)
         : Config_(std::move(config))
-        , RuntimeApi_(CreateRetryingChannel(Config_, channelFactory->CreateChannel(Config_->RuntimeEndpoint)))
-        , ImageApi_(CreateRetryingChannel(Config_, channelFactory->CreateChannel(Config_->ImageEndpoint)))
+        , RuntimeApi_(CreateRetryingChannel(Config_, channelFactory->CreateChannel(Config_->RuntimeEndpoint), GetRetryChecker()))
+        , ImageApi_(CreateRetryingChannel(Config_, channelFactory->CreateChannel(Config_->ImageEndpoint), GetRetryChecker()))
         , Attempt_(RandomNumber<ui32>())
     { }
 
@@ -725,6 +725,16 @@ private:
         if (!authConfig.RegistryToken.empty()) {
             auth->set_registry_token(authConfig.RegistryToken);
         }
+    }
+
+    static TRetryChecker GetRetryChecker()
+    {
+        static const auto Result = BIND_NO_PROPAGATE([] (const TError& error) {
+            return IsRetriableError(error) ||
+                   (error.GetCode() == NYT::EErrorCode::Generic &&
+                    error.GetMessage() == "server is not initialized yet");
+        });
+        return Result;
     }
 };
 


### PR DESCRIPTION
Containerd does not report correct error code in this case yet.
Thus we have to check error message.

Link: https://github.com/containerd/containerd/pull/9565

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/296

(cherry picked from commit 2bd7999c6c09fef0ecabfbe730bfd16ca3507144)
