### PR TITLE
Automatic update for HTTPS proxy TLS certificates

### DIFF
--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -1069,10 +1069,10 @@ def _build_http_proxy_config(proxy_dir,
                 "port": yt_config.https_proxy_ports[index] if yt_config.https_proxy_ports else next(ports_generator),
                 "credentials": {
                     "cert_chain": {
-                        "value": yt_config.https_cert,
+                        "file_name": os.path.join(proxy_dir[index], 'https.crt'),
                     },
                     "private_key": {
-                        "value": yt_config.https_cert_key,
+                        "file_name": os.path.join(proxy_dir[index], 'https.key'),
                     },
                 },
             })
@@ -1445,7 +1445,7 @@ def _build_cluster_connection_config(yt_config,
     if yt_config.ca_cert is not None:
         set_at(cluster_connection, "bus_client", {
             "ca": {
-                "value": yt_config.ca_cert,
+                "file_name": yt_config.ca_cert,
             },
             "encryption_mode": "required",
             "verification_mode": "full",
@@ -1755,10 +1755,10 @@ def init_singletons(config, yt_config, index):
         set_at(config, "bus_server", {
             "encryption_mode": "optional",
             "cert_chain": {
-                "value": yt_config.rpc_cert,
+                "file_name": yt_config.rpc_cert,
             },
             "private_key": {
-                "value": yt_config.rpc_cert_key,
+                "file_name": yt_config.rpc_cert_key,
             },
         })
 

--- a/yt/python/yt/environment/tls_helpers.py
+++ b/yt/python/yt/environment/tls_helpers.py
@@ -63,3 +63,26 @@ def verify_certificate(cert, ca_cert, name):
         [openssl_binary(), "verify", "-trusted", ca_cert, "-verify_hostname", name, cert],
         check=False)
     return proc.returncode == 0
+
+def get_server_certificate(address):
+    proc = subprocess.run(
+        [openssl_binary(), "s_client", "-connect", address],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    header, footer = b"-----BEGIN CERTIFICATE-----\n", b"-----END CERTIFICATE-----\n"
+    return proc.stdout[proc.stdout.index(header):proc.stdout.index(footer)+len(footer)]
+
+def get_certificate_fingerprint(cert=None, cert_content=None):
+    if cert is not None:
+        with open(cert, "rb") as f:
+            cert_content = f.read()
+    else:
+        assert cert_content is not None
+    proc = subprocess.run(
+        [openssl_binary(), "x509", "-noout", "-fingerprint"],
+        input=cert_content,
+        stdout=subprocess.PIPE,
+    )
+    return proc.stdout.decode().strip()

--- a/yt/python/yt/environment/yt_env.py
+++ b/yt/python/yt/environment/yt_env.py
@@ -364,32 +364,34 @@ class YTInstance(object):
         return config_paths
 
     def _prepare_certificates(self):
-        def read_content(filename):
-            with open(filename, "rb") as fin:
-                return fin.read()
-
         names = [self.yt_config.fqdn, self.yt_config.cluster_name]
 
         if self.yt_config.ca_cert is None:
-            ca_cert = os.path.join(self.path, "ca.crt")
-            ca_cert_key = os.path.join(self.path, "ca.key")
-            create_ca(ca_cert=ca_cert, ca_cert_key=ca_cert_key)
-            self.yt_config.ca_cert = read_content(ca_cert)
-            self.yt_config.ca_cert_key = read_content(ca_cert_key)
+            self.yt_config.ca_cert = os.path.join(self.path, "ca.crt")
+            self.yt_config.ca_cert_key = os.path.join(self.path, "ca.key")
+            create_ca(ca_cert=self.yt_config.ca_cert, ca_cert_key=self.yt_config.ca_cert_key)
 
         if self.yt_config.rpc_cert is None:
-            rpc_cert = os.path.join(self.path, "rpc.crt")
-            rpc_cert_key = os.path.join(self.path, "rpc.key")
-            create_certificate(ca_cert=ca_cert, ca_cert_key=ca_cert_key, cert=rpc_cert, cert_key=rpc_cert_key, names=names)
-            self.yt_config.rpc_cert = read_content(rpc_cert)
-            self.yt_config.rpc_cert_key = read_content(rpc_cert_key)
+            self.yt_config.rpc_cert = os.path.join(self.path, "rpc.crt")
+            self.yt_config.rpc_cert_key = os.path.join(self.path, "rpc.key")
+            create_certificate(
+                ca_cert=self.yt_config.ca_cert,
+                ca_cert_key=self.yt_config.ca_cert_key,
+                cert=self.yt_config.rpc_cert,
+                cert_key=self.yt_config.rpc_cert_key,
+                names=names
+            )
 
         if self.yt_config.https_cert is None and self.yt_config.http_proxy_count > 0:
-            https_cert = os.path.join(self.path, "https.crt")
-            https_cert_key = os.path.join(self.path, "https.key")
-            create_certificate(ca_cert=ca_cert, ca_cert_key=ca_cert_key, cert=https_cert, cert_key=https_cert_key, names=names)
-            self.yt_config.https_cert = read_content(https_cert)
-            self.yt_config.https_cert_key = read_content(https_cert_key)
+            self.yt_config.https_cert = os.path.join(self.path, "https.crt")
+            self.yt_config.https_cert_key = os.path.join(self.path, "https.key")
+            create_certificate(
+                ca_cert=self.yt_config.ca_cert,
+                ca_cert_key=self.yt_config.ca_cert_key,
+                cert=self.yt_config.https_cert,
+                cert_key=self.yt_config.https_cert_key,
+                names=names
+            )
 
     def _prepare_builtin_environment(self, ports_generator, modify_configs_func):
         service_infos = [
@@ -1845,6 +1847,11 @@ class YTInstance(object):
             else:
                 config = proxy_configs[i]
                 write_config(config, config_path)
+
+            if self.yt_config.https_cert is not None:
+                cred = config["https_server"]["credentials"]
+                shutil.copy(self.yt_config.https_cert, cred["cert_chain"]["file_name"])
+                shutil.copy(self.yt_config.https_cert_key, cred["private_key"]["file_name"])
 
             self.configs["http_proxy"].append(config)
             self.config_paths["http_proxy"].append(config_path)

--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -54,6 +54,24 @@ struct TSslContextImpl
 
     TSslContextImpl()
     {
+        Reset();
+    }
+
+    ~TSslContextImpl()
+    {
+        if (Ctx) {
+            SSL_CTX_free(Ctx);
+        }
+        if (ActiveCtx_) {
+            SSL_CTX_free(ActiveCtx_);
+        }
+    }
+
+    void Reset()
+    {
+        if (Ctx) {
+            SSL_CTX_free(Ctx);
+        }
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
         Ctx = SSL_CTX_new(TLS_method());
         if (!Ctx) {
@@ -77,12 +95,37 @@ struct TSslContextImpl
 #endif
     }
 
-    ~TSslContextImpl()
+    void Commit()
     {
-        if (Ctx) {
-            SSL_CTX_free(Ctx);
+        SSL_CTX* oldCtx;
+        YT_ASSERT(Ctx);
+        {
+            auto guard = WriterGuard(Lock_);
+            oldCtx = ActiveCtx_;
+            ActiveCtx_ = Ctx;
+            Ctx = nullptr;
+        }
+        if (oldCtx) {
+            SSL_CTX_free(oldCtx);
         }
     }
+
+    SSL* NewSsl()
+    {
+        auto guard = ReaderGuard(Lock_);
+        YT_ASSERT(ActiveCtx_);
+        return SSL_new(ActiveCtx_);
+    }
+
+    bool IsActive(const SSL* ssl)
+    {
+        auto guard = ReaderGuard(Lock_);
+        return SSL_get_SSL_CTX(ssl) == ActiveCtx_;
+    }
+
+private:
+    YT_DECLARE_SPIN_LOCK(NThreading::TReaderWriterSpinLock, Lock_);
+    SSL_CTX* ActiveCtx_ = nullptr;
 };
 
 DEFINE_REFCOUNTED_TYPE(TSslContextImpl)
@@ -104,7 +147,7 @@ public:
         , Invoker_(CreateSerializedInvoker(poller->GetInvoker(), "crypto_tls_connection"))
         , Underlying_(std::move(connection))
     {
-        Ssl_ = SSL_new(Ctx_->Ctx);
+        Ssl_ = Ctx_->NewSsl();
         if (!Ssl_) {
             THROW_ERROR_EXCEPTION("SSL_new failed")
                 << GetLastSslError();
@@ -557,6 +600,22 @@ private:
 TSslContext::TSslContext()
     : Impl_(New<TSslContextImpl>())
 { }
+
+void TSslContext::Reset()
+{
+    Impl_->Reset();
+}
+
+void TSslContext::Commit(TInstant time)
+{
+    CommitTime_ = time;
+    Impl_->Commit();
+}
+
+TInstant TSslContext::GetCommitTime()
+{
+    return CommitTime_;
+}
 
 void TSslContext::UseBuiltinOpenSslX509Store()
 {

--- a/yt/yt/core/crypto/tls.h
+++ b/yt/yt/core/crypto/tls.h
@@ -20,6 +20,10 @@ class TSslContext
 public:
     TSslContext();
 
+    void Reset();
+    void Commit(TInstant time = TInstant::Zero());
+    TInstant GetCommitTime();
+
     void UseBuiltinOpenSslX509Store();
 
     void SetCipherList(const TString& list);
@@ -48,6 +52,7 @@ public:
 
 private:
     const TIntrusivePtr<TSslContextImpl> Impl_;
+    TInstant CommitTime_;
 };
 
 DEFINE_REFCOUNTED_TYPE(TSslContext)

--- a/yt/yt/core/crypto/unittests/tls_ut.cpp
+++ b/yt/yt/core/crypto/unittests/tls_ut.cpp
@@ -37,6 +37,7 @@ public:
 
         Context->AddCertificate(TestCertificate);
         Context->AddPrivateKey(TestCertificate);
+        Context->Commit();
 
         Poller = CreateThreadPoolPoller(2, "TlsTest");
     }
@@ -106,6 +107,7 @@ TEST(TTlsTestWithoutFixture, LoadCertificateChain)
     auto grpcLock = NRpc::NGrpc::TDispatcher::Get()->GetLibraryLock();
     auto context = New<TSslContext>();
     context->AddCertificateChain(TestCertificateChain);
+    context->Commit();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/https/client.cpp
+++ b/yt/yt/core/https/client.cpp
@@ -120,6 +120,7 @@ IClientPtr CreateClient(
     } else {
         sslContext->UseBuiltinOpenSslX509Store();
     }
+    sslContext->Commit();
 
     auto tlsDialer = sslContext->CreateDialer(
         New<TDialerConfig>(),

--- a/yt/yt/core/https/config.cpp
+++ b/yt/yt/core/https/config.cpp
@@ -10,6 +10,8 @@ void TServerCredentialsConfig::Register(TRegistrar registrar)
         .Optional();
     registrar.Parameter("cert_chain", &TThis::CertChain)
         .Optional();
+    registrar.Parameter("update_period", &TThis::UpdatePeriod)
+        .Optional();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/https/config.h
+++ b/yt/yt/core/https/config.h
@@ -16,6 +16,7 @@ class TServerCredentialsConfig
 public:
     NCrypto::TPemBlobConfigPtr PrivateKey;
     NCrypto::TPemBlobConfigPtr CertChain;
+    TDuration UpdatePeriod;
 
     REGISTER_YSON_STRUCT(TServerCredentialsConfig);
 

--- a/yt/yt/core/https/server.cpp
+++ b/yt/yt/core/https/server.cpp
@@ -84,6 +84,7 @@ IServerPtr CreateServer(
     } else {
         YT_ABORT();
     }
+    sslContext->Commit();
 
     auto address = TNetworkAddress::CreateIPv6Any(config->Port);
     auto tlsListener = sslContext->CreateListener(address, poller, acceptor);

--- a/yt/yt/core/https/server.cpp
+++ b/yt/yt/core/https/server.cpp
@@ -2,14 +2,22 @@
 #include "config.h"
 
 #include <yt/yt/core/http/server.h>
+#include <yt/yt/core/http/private.h>
 
 #include <yt/yt/core/crypto/tls.h>
+
+#include <yt/yt/core/logging/log.h>
+
+#include <yt/yt/core/misc/fs.h>
 
 #include <yt/yt/core/net/address.h>
 
 #include <yt/yt/core/concurrency/poller.h>
+#include <yt/yt/core/concurrency/periodic_executor.h>
 
 namespace NYT::NHttps {
+
+static const auto& Logger = NHttp::HttpLogger;
 
 using namespace NNet;
 using namespace NHttp;
@@ -22,8 +30,9 @@ class TServer
     : public IServer
 {
 public:
-    explicit TServer(IServerPtr underlying)
+    explicit TServer(IServerPtr underlying, TPeriodicExecutorPtr certificateUpdater)
         : Underlying_(std::move(underlying))
+        , CertificateUpdater_(certificateUpdater)
     { }
 
     void AddHandler(
@@ -42,12 +51,18 @@ public:
     void Start() override
     {
         Underlying_->Start();
+        if (CertificateUpdater_) {
+            CertificateUpdater_->Start();
+        }
     }
 
     //! Stops the server.
     void Stop() override
     {
         Underlying_->Stop();
+        if (CertificateUpdater_) {
+            YT_UNUSED_FUTURE(CertificateUpdater_->Stop());
+        }
     }
 
     void SetPathMatcher(const IRequestPathMatcherPtr& matcher) override
@@ -62,7 +77,26 @@ public:
 
 private:
     const IServerPtr Underlying_;
+    const TPeriodicExecutorPtr CertificateUpdater_;
 };
+
+static void ApplySslConfig(const TSslContextPtr&  sslContext, const TServerCredentialsConfigPtr& sslConfig)
+{
+    if (sslConfig->CertChain->FileName) {
+        sslContext->AddCertificateChainFromFile(*sslConfig->CertChain->FileName);
+    } else if (sslConfig->CertChain->Value) {
+        sslContext->AddCertificateChain(*sslConfig->CertChain->Value);
+    } else {
+        YT_ABORT();
+    }
+    if (sslConfig->PrivateKey->FileName) {
+        sslContext->AddPrivateKeyFromFile(*sslConfig->PrivateKey->FileName);
+    } else if (sslConfig->PrivateKey->Value) {
+        sslContext->AddPrivateKey(*sslConfig->PrivateKey->Value);
+    } else {
+        YT_ABORT();
+    }
+}
 
 IServerPtr CreateServer(
     const TServerConfigPtr& config,
@@ -70,21 +104,39 @@ IServerPtr CreateServer(
     const IPollerPtr& acceptor)
 {
     auto sslContext =  New<TSslContext>();
-    if (config->Credentials->CertChain->FileName) {
-        sslContext->AddCertificateChainFromFile(*config->Credentials->CertChain->FileName);
-    } else if (config->Credentials->CertChain->Value) {
-        sslContext->AddCertificateChain(*config->Credentials->CertChain->Value);
-    } else {
-        YT_ABORT();
-    }
-    if (config->Credentials->PrivateKey->FileName) {
-        sslContext->AddPrivateKeyFromFile(*config->Credentials->PrivateKey->FileName);
-    } else if (config->Credentials->PrivateKey->Value) {
-        sslContext->AddPrivateKey(*config->Credentials->PrivateKey->Value);
-    } else {
-        YT_ABORT();
-    }
+    ApplySslConfig(sslContext, config->Credentials);
     sslContext->Commit();
+
+    auto sslConfig = config->Credentials;
+    TPeriodicExecutorPtr certificateUpdater;
+    if (sslConfig->UpdatePeriod &&
+        sslConfig->CertChain->FileName &&
+        sslConfig->PrivateKey->FileName)
+    {
+        certificateUpdater = New<TPeriodicExecutor>(
+            poller->GetInvoker(),
+            BIND([=, serverName = config->ServerName] {
+                try {
+                    auto modificationTime = Max(
+                        NFS::GetPathStatistics(*sslConfig->CertChain->FileName).ModificationTime,
+                        NFS::GetPathStatistics(*sslConfig->PrivateKey->FileName).ModificationTime);
+
+                    // Detect fresh and stable updates.
+                    if (modificationTime > sslContext->GetCommitTime() &&
+                        modificationTime + sslConfig->UpdatePeriod <= TInstant::Now())
+                    {
+                        YT_LOG_INFO("Updating TLS certificates (ServerName: %v, ModificationTime: %v)", serverName, modificationTime);
+                        sslContext->Reset();
+                        ApplySslConfig(sslContext, sslConfig);
+                        sslContext->Commit(modificationTime);
+                        YT_LOG_INFO("TLS certificates updated (ServerName: %v)", serverName);
+                    }
+                } catch (const std::exception& ex) {
+                    YT_LOG_WARNING(ex, "Unexpected exception while updating TLS certificates (ServerName: %v)", serverName);
+                }
+            }),
+            sslConfig->UpdatePeriod);
+    }
 
     auto address = TNetworkAddress::CreateIPv6Any(config->Port);
     auto tlsListener = sslContext->CreateListener(address, poller, acceptor);
@@ -93,7 +145,7 @@ IServerPtr CreateServer(
     configCopy->IsHttps = true;
     auto httpServer = NHttp::CreateServer(configCopy, tlsListener, poller, acceptor);
 
-    return New<TServer>(std::move(httpServer));
+    return New<TServer>(std::move(httpServer), std::move(certificateUpdater));
 }
 
 IServerPtr CreateServer(const TServerConfigPtr& config, const IPollerPtr& poller)


### PR DESCRIPTION
- Add methods for SSL context update
  This is required for TLS certificate rotation without downtime.
  
- Automatically update HTTPS server TLS certificates
  
- yt/environmnt: keep TLS certificates in files
  
- Add test for http proxy certificate update
  
