### PR TITLE
Cherry-picks for stable/23.2 CRI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,25 @@
-__pycache__
+# Compiled
+*.a
+*.o
+*.so
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Protobuf
+*_pb2.py
+*_pb2_grpc.py
+*_pb2.pyi
+*.pb.h
+*.pb.cc
+
+compile_commands.json
+
+# clangd cache
 .cache
+
+.idea
+.vscode
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ compile_commands.json
 .idea
 .vscode
 .DS_Store
+
+test-results

--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -827,7 +827,7 @@ def _build_node_configs(node_dirs,
             start_uid = 10000 + config["rpc_port"]
             set_at(config, "exec_node/slot_manager/job_environment/start_uid", start_uid)
         else:
-            set_at(config, "exec_node/slot_manager/do_not_set_user_id", True)
+            set_at(config, "exec_node/do_not_set_user_id", True)
 
         set_at(config, "exec_node/slot_manager/locations", [
             {"path": os.path.join(node_dirs[index], "slots"), "disk_usage_watermark": 0}

--- a/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
+++ b/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
@@ -51,10 +51,13 @@ DEPENDS(
     yt/yt/tools/yt_sudo_fixup
 )
 
-DATA(
-    sbr://5443303555 # Layers.
-    sbr://1703335903 # Rootfs.
-)
+IF (NOT OPENSOURCE)
+    # Containers images for porto tests.
+    DATA(
+        sbr://5443303555 # Layers.
+        sbr://1703335903 # Rootfs.
+    )
+ENDIF()
 
 PY_NAMESPACE(.)
 

--- a/yt/yt/tests/integration/node/test_user_job.py
+++ b/yt/yt/tests/integration/node/test_user_job.py
@@ -15,7 +15,8 @@ from yt_commands import (
     update_nodes_dynamic_config, set_node_banned, check_all_stderrs,
     assert_statistics, assert_statistics_v2, extract_statistic_v2,
     heal_exec_node, ban_node,
-    make_random_string, raises_yt_error, update_controller_agent_config, update_scheduler_config)
+    make_random_string, raises_yt_error, update_controller_agent_config, update_scheduler_config,
+    get_supported_erasure_codecs)
 
 
 import subprocess
@@ -1832,7 +1833,7 @@ class TestUserFiles(YTEnvSetup):
         ]
 
     @authors("ignat")
-    @pytest.mark.parametrize("erasure_codec", ["reed_solomon_6_3", "isa_reed_solomon_6_3"])
+    @pytest.mark.parametrize("erasure_codec", get_supported_erasure_codecs(["reed_solomon_6_3", "isa_reed_solomon_6_3"]))
     def test_erasure_user_files(self, erasure_codec):
         create("table", "//tmp/input")
         write_table("//tmp/input", {"foo": "bar"})

--- a/yt/yt/tests/library/yt_commands.py
+++ b/yt/yt/tests/library/yt_commands.py
@@ -45,6 +45,11 @@ except ImportError:  # Python 3
     from io import BytesIO
     OutputType = BytesIO
 
+try:
+    import yt_tests_settings
+except ImportError:
+    import yt_tests_opensource_settings as yt_tests_settings
+
 ###########################################################################
 
 root_logger = logging.getLogger()
@@ -3345,3 +3350,9 @@ def wait_for_node_alive_object_counts(address, type_to_expected_count):
 
 def get_connection_config(**kwargs):
     return execute_command("get_connection_config", kwargs, parse_yson=True)
+
+
+def get_supported_erasure_codecs(filter=None):
+    if filter is None:
+        return yt_tests_settings.supported_erasure_codes
+    return [codec for codec in filter if codec in yt_tests_settings.supported_erasure_codes]

--- a/yt/yt/tests/library/yt_tests_opensource_settings.py
+++ b/yt/yt/tests/library/yt_tests_opensource_settings.py
@@ -1,1 +1,4 @@
 has_tvm_service_support = False
+
+# See yt/yt/library/erasure/impl/codec_opensource.cpp
+supported_erasure_codes = ["isa_lrc_12_2_2", "reed_solomon_3_3", "isa_reed_solomon_6_3"]


### PR DESCRIPTION
- Improve .gitignore in ytsaurus repo
  (cherry picked from commit 5f7d3d90a80403398dec8415274b2c6bc6c6c582)
  
- Add "test-results" into gitignore
  No description
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/355
  
  (cherry picked from commit 38e552a2e0fd1e9bc725f27c07da5e5af8cd3f7a)
  
- Ignore sandbox artifacts not availbale in opensource
  No description
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/354
  
  (cherry picked from commit c7149dfe94de23fab0b0e7d68a91c6fb3297f501)
  
- Fix tests for unsupported erasure codecs
  Add list of supported eraseure codecs into yt/yt/tests/library/yt_tests_settings
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/344
  
  Co-authored-by: ignat <ignat@ytsaurus.tech>
  (cherry picked from commit 572021642aeca483af93e75f2ca01d151227c154)
  
- [23.2] Fix CRI tests: move "do_not_set_user_id" into correct place
  
