### PR TITLE
Wrap and attribute origin of error loaded from lock file in disabled location

### DIFF
--- a/yt/yt/server/node/data_node/disk_location.cpp
+++ b/yt/yt/server/node/data_node/disk_location.cpp
@@ -116,7 +116,8 @@ void TDiskLocation::ValidateLockFile() const
 
     auto errorData = fileInput.ReadAll();
     if (errorData.empty()) {
-        THROW_ERROR_EXCEPTION("Empty lock file found");
+        THROW_ERROR_EXCEPTION("Empty lock file found")
+            << TErrorAttribute("lock_file", lockFilePath);
     }
 
     TError error;
@@ -124,9 +125,12 @@ void TDiskLocation::ValidateLockFile() const
         error = ConvertTo<TError>(TYsonString(errorData));
     } catch (const std::exception& ex) {
         THROW_ERROR_EXCEPTION("Error parsing lock file contents")
+            << TErrorAttribute("lock_file", lockFilePath)
             << ex;
     }
-    THROW_ERROR error;
+    THROW_ERROR_EXCEPTION("Lock file found")
+        << TErrorAttribute("lock_file", lockFilePath)
+        << error;
 }
 
 void TDiskLocation::ValidateMinimumSpace() const


### PR DESCRIPTION
Currently there is no clear difference between fresh error and
error recovered from previous run.
