### PR TITLE
Add zstd to query tracker docker image

### DIFF
--- a/yt/docker/query-tracker/Dockerfile
+++ b/yt/docker/query-tracker/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   less \
   gdb \
   lsof \
+  zstd \
   strace \
   telnet \
   dnsutils \


### PR DESCRIPTION
It is required to read compressed debug logs of query tracker