### PR TITLE
Support SortColumn in run_sort method

### DIFF
--- a/yt/python/yt/wrapper/schema/table_schema.py
+++ b/yt/python/yt/wrapper/schema/table_schema.py
@@ -25,6 +25,12 @@ class SortColumn(object):
         self.name = name
         self.sort_order = sort_order
 
+    def to_yson_type(self):
+        return {
+            "name": self.name,
+            "sort_order": self.sort_order,
+        }
+
 
 class ColumnSchema(object):
     """ Class representing table column schema.

--- a/yt/python/yt/wrapper/tests/test_operations.py
+++ b/yt/python/yt/wrapper/tests/test_operations.py
@@ -185,8 +185,8 @@ class TestOperations(object):
 
         assert yt.is_sorted(table)
 
-        yt.run_sort(table, sort_by=[SortColumn("x", sort_order="descending")])
-        assert list(reversed([{"x": x, "y": y} for x, y in sorted(columns, key=lambda c: c[0])])) == list(yt.read_table(table))
+        yt.run_sort(table, sort_by=[SortColumn("x", sort_order=SortColumn.DESCENDING)])
+        assert [{"x": x, "y": y} for x, y in sorted(columns, key=lambda c: c[0], reverse=True)] == list(yt.read_table(table))
 
         assert yt.is_sorted(table)
 

--- a/yt/python/yt/wrapper/tests/test_operations.py
+++ b/yt/python/yt/wrapper/tests/test_operations.py
@@ -16,7 +16,7 @@ from yt.wrapper.py_wrapper import create_modules_archive_default, TempfilesManag
 from yt.wrapper.common import get_disk_size, MB
 from yt.wrapper.operation_commands import (
     add_failed_operation_stderrs_to_error_message, get_jobs_with_error_or_stderr, get_operation_error)
-from yt.wrapper.schema import TableSchema
+from yt.wrapper.schema import SortColumn, TableSchema
 from yt.wrapper.spec_builders import MapSpecBuilder, MapReduceSpecBuilder, VanillaSpecBuilder
 from yt.wrapper.skiff import convert_to_skiff_schema
 
@@ -182,6 +182,11 @@ class TestOperations(object):
 
         yt.run_sort(table, sort_by=["y"])
         assert [{"x": x, "y": y} for x, y in sorted(columns, key=lambda c: c[1])] == list(yt.read_table(table))
+
+        assert yt.is_sorted(table)
+
+        yt.run_sort(table, sort_by=[SortColumn("x", sort_order="descending")])
+        assert list(reversed([{"x": x, "y": y} for x, y in sorted(columns, key=lambda c: c[0])])) == list(yt.read_table(table))
 
         assert yt.is_sorted(table)
 


### PR DESCRIPTION
Without this change it is impossible to sort table in descending order without using raw specs:

```python
yt.yson.common.YsonError: Value <yt.wrapper.schema.table_schema.SortColumn object at 0x7f9f258cb450> cannot be serialized to YSON since it has unsupported type "<class 'yt.wrapper.schema.table_schema.SortColumn'>"
```