### PR TITLE
Cherrypicking Query Tracker ACO commits to 23.2

### DIFF
--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -1365,9 +1365,10 @@ type QueryTrackerOptions struct {
 }
 
 type StartQueryOptions struct {
-	Settings    any   `http:"settings,omitnil"`
-	Draft       *bool `http:"draft,omitnil"`
-	Annotations any   `http:"annotations,omitnil"`
+	Settings            any     `http:"settings,omitnil"`
+	Draft               *bool   `http:"draft,omitnil"`
+	Annotations         any     `http:"annotations,omitnil"`
+	AccessControlObject *string `http:"access_control_object,omitnil"`
 
 	*QueryTrackerOptions
 }
@@ -1415,7 +1416,8 @@ type ReadQueryResultOptions struct {
 }
 
 type AlterQueryOptions struct {
-	Annotations any `http:"annotations,omitnil"`
+	Annotations         any     `http:"annotations,omitnil"`
+	AccessControlObject *string `http:"access_control_object,omitnil"`
 
 	*QueryTrackerOptions
 }

--- a/yt/go/yt/internal/params_gen.go
+++ b/yt/go/yt/internal/params_gen.go
@@ -1014,6 +1014,10 @@ func writeStartQueryOptions(w *yson.Writer, o *yt.StartQueryOptions) {
 		w.MapKeyString("annotations")
 		w.Any(o.Annotations)
 	}
+	if o.AccessControlObject != nil {
+		w.MapKeyString("access_control_object")
+		w.Any(o.AccessControlObject)
+	}
 	writeQueryTrackerOptions(w, o.QueryTrackerOptions)
 }
 
@@ -1123,6 +1127,10 @@ func writeAlterQueryOptions(w *yson.Writer, o *yt.AlterQueryOptions) {
 	if o.Annotations != nil {
 		w.MapKeyString("annotations")
 		w.Any(o.Annotations)
+	}
+	if o.AccessControlObject != nil {
+		w.MapKeyString("access_control_object")
+		w.Any(o.AccessControlObject)
 	}
 	writeQueryTrackerOptions(w, o.QueryTrackerOptions)
 }

--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -1189,6 +1189,7 @@ def add_start_query_parser(add_parser):
     add_structured_argument(parser, "--settings", help="additional settings of a query in structured form")
     add_structured_argument(parser, "--files", help='query files, a YSON list of files, each of which is represented by a map with keys "name", "content", "type".'
                                                     'Field "type" is one of "raw_inline_data", "url"')
+    parser.add_argument("--access-control-object", type=str, help='optional access control object name')
     parser.add_argument("--stage", type=str, help='query tracker stage, defaults to "production"')
 
 

--- a/yt/python/yt/environment/init_query_tracker_state.py
+++ b/yt/python/yt/environment/init_query_tracker_state.py
@@ -312,6 +312,88 @@ TRANSFORMS[4] = [
     ),
 ]
 
+TRANSFORMS[5] = [
+    Conversion(
+        "active_queries",
+        table_info=TableInfo(
+            [
+                ("query_id", "string"),
+            ],
+            [
+                ("engine", "string", "client"),
+                ("query", "string", "client"),
+                ("files", "any", "client"),
+                ("settings", "any", "client"),
+                ("user", "string", "client"),
+                ("access_control_object", "string", "client"),
+                ("start_time", "timestamp", "client"),
+                ("filter_factors", "string", "client"),
+                ("state", "string", "common"),
+                ("incarnation", "int64", "query_tracker"),
+                ("ping_time", "timestamp", "query_tracker"),
+                ("assigned_tracker", "string", "query_tracker"),
+                ("progress", "any", "query_tracker_progress"),
+                ("error", "any", "query_tracker"),
+                ("result_count", "int64", "query_tracker"),
+                ("finish_time", "timestamp", "common"),
+                ("abort_request", "any", "client"),
+                ("annotations", "any", "client"),
+            ],
+            optimize_for="lookup",
+            attributes={
+                "tablet_cell_bundle": SYS_BUNDLE_NAME,
+            },
+        )
+    ),
+    Conversion(
+        "finished_queries",
+        table_info=TableInfo(
+            [
+                ("query_id", "string"),
+            ],
+            [
+                ("engine", "string"),
+                ("query", "string"),
+                ("files", "any"),
+                ("settings", "any"),
+                ("user", "string"),
+                ("access_control_object", "string"),
+                ("start_time", "timestamp"),
+                ("state", "string"),
+                ("progress", "any"),
+                ("error", "any"),
+                ("result_count", "int64"),
+                ("finish_time", "timestamp"),
+                ("annotations", "any"),
+            ],
+            optimize_for="lookup",
+            attributes={
+                "tablet_cell_bundle": SYS_BUNDLE_NAME,
+            },
+        ),
+    ),
+    Conversion(
+        "finished_queries_by_start_time",
+        table_info=TableInfo(
+            [
+                ("start_time", "timestamp"),
+                ("query_id", "string")
+            ],
+            [
+                ("engine", "string"),
+                ("user", "string"),
+                ("access_control_object", "string"),
+                ("state", "string"),
+                ("filter_factors", "string"),
+            ],
+            optimize_for="lookup",
+            attributes={
+                "tablet_cell_bundle": SYS_BUNDLE_NAME,
+            },
+        ),
+    ),
+]
+
 # NB(mpereskokova): don't forget to update min_required_state_version at yt/yt/server/query_tracker/config.cpp and state at yt/yt/ytlib/query_tracker_client/records/query.yaml
 
 MIGRATION = Migration(

--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -2409,7 +2409,7 @@ class YtClient(ClientState):
     def start_query(
             self,
             engine, query,
-            settings=None, files=None, stage=None):
+            settings=None, files=None, stage=None, annotations=None):
         """
         Start query.
 
@@ -2423,12 +2423,13 @@ class YtClient(ClientState):
         :type files: list or None
         :param stage: query tracker stage, defaults to "production"
         :type stage: str
-
+        :param annotations: a dictionary of annotations
+        :type stage: dict or None
         """
         return client_api.start_query(
             engine, query,
             client=self,
-            settings=settings, files=files, stage=stage)
+            settings=settings, files=files, stage=stage, annotations=annotations)
 
     def start_spark_cluster(
             self,

--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -2409,7 +2409,7 @@ class YtClient(ClientState):
     def start_query(
             self,
             engine, query,
-            settings=None, files=None, stage=None, annotations=None):
+            settings=None, files=None, stage=None, annotations=None, access_control_object=None):
         """
         Start query.
 
@@ -2425,11 +2425,14 @@ class YtClient(ClientState):
         :type stage: str
         :param annotations: a dictionary of annotations
         :type stage: dict or None
+        :param access_control_object: access control object name
+        :type access_control_object: str or None
+
         """
         return client_api.start_query(
             engine, query,
             client=self,
-            settings=settings, files=files, stage=stage, annotations=annotations)
+            settings=settings, files=files, stage=stage, annotations=annotations, access_control_object=access_control_object)
 
     def start_spark_cluster(
             self,

--- a/yt/python/yt/wrapper/query_commands.py
+++ b/yt/python/yt/wrapper/query_commands.py
@@ -7,7 +7,7 @@ from .common import datetime_to_string, set_param, get_value
 from datetime import datetime
 
 
-def start_query(engine, query, settings=None, files=None, stage=None, client=None):
+def start_query(engine, query, settings=None, files=None, stage=None, annotations=None, client=None):
     """Start query.
 
     :param engine: one of "ql", "yql".
@@ -20,14 +20,17 @@ def start_query(engine, query, settings=None, files=None, stage=None, client=Non
     :type files: list or None
     :param stage: query tracker stage, defaults to "production"
     :type stage: str
+    :param annotations: a dictionary of annotations
+    :type stage: dict or None
     """
 
     params = {
         "engine": engine,
         "query": query,
         "settings": get_value(settings, {}),
-        "files" : get_value(files, []),
+        "files": get_value(files, []),
         "stage": get_value(stage, "production"),
+        "annotations": get_value(annotations, {}),
     }
 
     response = make_formatted_request("start_query", params, format=None, client=client)

--- a/yt/python/yt/wrapper/query_commands.py
+++ b/yt/python/yt/wrapper/query_commands.py
@@ -7,7 +7,7 @@ from .common import datetime_to_string, set_param, get_value
 from datetime import datetime
 
 
-def start_query(engine, query, settings=None, files=None, stage=None, annotations=None, client=None):
+def start_query(engine, query, settings=None, files=None, stage=None, annotations=None, access_control_object=None, client=None):
     """Start query.
 
     :param engine: one of "ql", "yql".
@@ -22,6 +22,8 @@ def start_query(engine, query, settings=None, files=None, stage=None, annotation
     :type stage: str
     :param annotations: a dictionary of annotations
     :type stage: dict or None
+    :param access_control_object: access control object name
+    :type access_control_object: str or None
     """
 
     params = {
@@ -32,6 +34,8 @@ def start_query(engine, query, settings=None, files=None, stage=None, annotation
         "stage": get_value(stage, "production"),
         "annotations": get_value(annotations, {}),
     }
+
+    set_param(params, "access_control_object", access_control_object)
 
     response = make_formatted_request("start_query", params, format=None, client=client)
 

--- a/yt/yt/client/api/delegating_client.h
+++ b/yt/yt/client/api/delegating_client.h
@@ -619,6 +619,9 @@ public:
         NQueryTrackerClient::TQueryId queryId,
         const TAlterQueryOptions& options) override;
 
+    TFuture<TGetQueryTrackerInfoResult> GetQueryTrackerInfo(
+        const TGetQueryTrackerInfoOptions& options) override;
+
 protected:
     const IClientPtr Underlying_;
 };

--- a/yt/yt/client/api/query_tracker_client.cpp
+++ b/yt/yt/client/api/query_tracker_client.cpp
@@ -14,7 +14,7 @@ using namespace NYTree;
 
 void Serialize(const TQuery& query, NYson::IYsonConsumer* consumer)
 {
-    static_assert(pfr::tuple_size<TQuery>::value == 14);
+    static_assert(pfr::tuple_size<TQuery>::value == 15);
     BuildYsonFluently(consumer)
         .BeginMap()
             .OptionalItem("id", query.Id)
@@ -25,6 +25,7 @@ void Serialize(const TQuery& query, NYson::IYsonConsumer* consumer)
             .OptionalItem("finish_time", query.FinishTime)
             .OptionalItem("settings", query.Settings)
             .OptionalItem("user", query.User)
+            .OptionalItem("access_control_object", query.AccessControlObject)
             .OptionalItem("state", query.State)
             .OptionalItem("result_count", query.ResultCount)
             .OptionalItem("progress", query.Progress)

--- a/yt/yt/client/api/query_tracker_client.h
+++ b/yt/yt/client/api/query_tracker_client.h
@@ -146,6 +146,20 @@ struct TAlterQueryOptions
     std::optional<TString> AccessControlObject;
 };
 
+struct TGetQueryTrackerInfoOptions
+    : public TTimeoutOptions
+    , public TQueryTrackerOptions
+{
+    NYTree::TAttributeFilter Attributes;
+};
+
+struct TGetQueryTrackerInfoResult
+{
+    TString ClusterName;
+    NYson::TYsonString SupportedFeatures;
+    std::vector<TString> AccessControlObjects;
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct IQueryTrackerClient
@@ -178,6 +192,8 @@ struct IQueryTrackerClient
     virtual TFuture<void> AlterQuery(
         NQueryTrackerClient::TQueryId queryId,
         const TAlterQueryOptions& options = {}) = 0;
+
+    virtual TFuture<TGetQueryTrackerInfoResult> GetQueryTrackerInfo(const TGetQueryTrackerInfoOptions& options = {}) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/api/query_tracker_client.h
+++ b/yt/yt/client/api/query_tracker_client.h
@@ -48,6 +48,7 @@ struct TStartQueryOptions
     bool Draft = false;
     NYTree::IMapNodePtr Annotations;
     std::vector<TQueryFilePtr> Files;
+    std::optional<TString> AccessControlObject;
 };
 
 struct TAbortQueryOptions
@@ -107,6 +108,7 @@ struct TQuery
     std::optional<TInstant> FinishTime;
     NYson::TYsonString Settings;
     std::optional<TString> User;
+    std::optional<TString> AccessControlObject;
     std::optional<NQueryTrackerClient::EQueryState> State;
     std::optional<i64> ResultCount;
     NYson::TYsonString Progress;
@@ -141,6 +143,7 @@ struct TAlterQueryOptions
     , public TQueryTrackerOptions
 {
     NYTree::IMapNodePtr Annotations;
+    std::optional<TString> AccessControlObject;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/api/rpc_proxy/client_impl.cpp
+++ b/yt/yt/client/api/rpc_proxy/client_impl.cpp
@@ -2056,6 +2056,12 @@ TFuture<void> TClient::AlterQuery(
     ThrowUnimplemented("AlterQuery");
 }
 
+TFuture<TGetQueryTrackerInfoResult> TClient::GetQueryTrackerInfo(
+    const TGetQueryTrackerInfoOptions& /*options*/)
+{
+    ThrowUnimplemented("GetQueryTrackerInfo");
+}
+
 TFuture<void> TClient::SetUserPassword(
     const TString& /*user*/,
     const TString& /*currentPasswordSha256*/,

--- a/yt/yt/client/api/rpc_proxy/client_impl.h
+++ b/yt/yt/client/api/rpc_proxy/client_impl.h
@@ -459,6 +459,9 @@ public:
         NQueryTrackerClient::TQueryId queryId,
         const TAlterQueryOptions& options = {}) override;
 
+    TFuture<TGetQueryTrackerInfoResult> GetQueryTrackerInfo(
+        const TGetQueryTrackerInfoOptions& options = {}) override;
+
     // Authentication
 
     virtual TFuture<void> SetUserPassword(

--- a/yt/yt/client/driver/driver.cpp
+++ b/yt/yt/client/driver/driver.cpp
@@ -355,7 +355,8 @@ public:
         REGISTER    (TListQueriesCommand,                  "list_queries",                    Null,       Structured, false, false, ApiVersion4);
         REGISTER    (TGetQueryResultCommand,               "get_query_result",                Null,       Structured, false, false, ApiVersion4);
         REGISTER    (TReadQueryResultCommand,              "read_query_result",               Null,       Tabular,    false, true, ApiVersion4);
-        REGISTER    (TAlterQueryCommand,                   "alter_query",                    Null,       Tabular,    false, false, ApiVersion4);
+        REGISTER    (TAlterQueryCommand,                   "alter_query",                     Null,       Tabular,    false, false, ApiVersion4);
+        REGISTER    (TGetQueryTrackerInfoCommand,          "get_query_tracker_info",          Null,       Structured, false, false, ApiVersion4);
 
         if (Config_->EnableInternalCommands) {
             REGISTER_ALL(TReadHunksCommand,                "read_hunks",                      Null,       Structured, false,  true );

--- a/yt/yt/client/driver/query_commands.cpp
+++ b/yt/yt/client/driver/query_commands.cpp
@@ -33,6 +33,8 @@ TStartQueryCommand::TStartQueryCommand()
         .Optional();
     RegisterParameter("annotations", Options.Annotations)
         .Optional();
+    RegisterParameter("access_control_object", Options.AccessControlObject)
+        .Optional();
 }
 
 void TStartQueryCommand::DoExecute(ICommandContextPtr context)
@@ -187,6 +189,8 @@ TAlterQueryCommand::TAlterQueryCommand()
 {
     RegisterParameter("query_id", QueryId);
     RegisterParameter("annotations", Options.Annotations)
+        .Optional();
+    RegisterParameter("access_control_object", Options.AccessControlObject)
         .Optional();
 }
 

--- a/yt/yt/client/driver/query_commands.h
+++ b/yt/yt/client/driver/query_commands.h
@@ -109,4 +109,16 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////
 
+class TGetQueryTrackerInfoCommand
+    : public TTypedCommand<NApi::TGetQueryTrackerInfoOptions>
+{
+public:
+    TGetQueryTrackerInfoCommand();
+
+private:
+    void DoExecute(ICommandContextPtr context) override;
+};
+
+////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NDriver

--- a/yt/yt/client/federated/client.cpp
+++ b/yt/yt/client/federated/client.cpp
@@ -415,7 +415,7 @@ public:
     UNIMPLEMENTED_METHOD(TFuture<TQuery>, GetQuery, (NQueryTrackerClient::TQueryId, const TGetQueryOptions&));
     UNIMPLEMENTED_METHOD(TFuture<TListQueriesResult>, ListQueries, (const TListQueriesOptions&));
     UNIMPLEMENTED_METHOD(TFuture<void>, AlterQuery, (NQueryTrackerClient::TQueryId, const TAlterQueryOptions&));
-
+    UNIMPLEMENTED_METHOD(TFuture<TGetQueryTrackerInfoResult>, GetQueryTrackerInfo, (const TGetQueryTrackerInfoOptions&));
     UNIMPLEMENTED_METHOD(TFuture<ITableReaderPtr>, CreateTableReader, (const NYPath::TRichYPath&, const TTableReaderOptions&));
     UNIMPLEMENTED_METHOD(TFuture<ITableWriterPtr>, CreateTableWriter, (const NYPath::TRichYPath&, const TTableWriterOptions&));
     UNIMPLEMENTED_METHOD(TFuture<IFileReaderPtr>, CreateFileReader, (const NYPath::TYPath&, const TFileReaderOptions&));

--- a/yt/yt/client/hedging/hedging.cpp
+++ b/yt/yt/client/hedging/hedging.cpp
@@ -210,6 +210,7 @@ public:
     UNSUPPORTED_METHOD(TFuture<TQuery>, GetQuery, (NQueryTrackerClient::TQueryId, const TGetQueryOptions&));
     UNSUPPORTED_METHOD(TFuture<TListQueriesResult>, ListQueries, (const TListQueriesOptions&));
     UNSUPPORTED_METHOD(TFuture<void>, AlterQuery, (NQueryTrackerClient::TQueryId, const TAlterQueryOptions&));
+    UNSUPPORTED_METHOD(TFuture<TGetQueryTrackerInfoResult>, GetQueryTrackerInfo, (const TGetQueryTrackerInfoOptions&));
 
 private:
     THedgingExecutorPtr Executor_;

--- a/yt/yt/client/unittests/mock/client.h
+++ b/yt/yt/client/unittests/mock/client.h
@@ -620,6 +620,9 @@ public:
 
     MOCK_METHOD(TFuture<void>, AlterQuery, (
         NQueryTrackerClient::TQueryId queryId, const TAlterQueryOptions& options), (override));
+
+    MOCK_METHOD(TFuture<TGetQueryTrackerInfoResult>, GetQueryTrackerInfo, (
+        const TGetQueryTrackerInfoOptions& options), (override));
 };
 
 DEFINE_REFCOUNTED_TYPE(TMockClient)

--- a/yt/yt/server/query_tracker/config.cpp
+++ b/yt/yt/server/query_tracker/config.cpp
@@ -85,7 +85,7 @@ void TQueryTrackerDynamicConfig::Register(TRegistrar registrar)
 void TQueryTrackerServerConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("min_required_state_version", &TThis::MinRequiredStateVersion)
-        .Default(3);
+        .Default(5);
     registrar.Parameter("abort_on_unrecognized_options", &TThis::AbortOnUnrecognizedOptions)
         .Default(false);
     registrar.Parameter("user", &TThis::User);

--- a/yt/yt/server/query_tracker/query_tracker.cpp
+++ b/yt/yt/server/query_tracker/query_tracker.cpp
@@ -514,7 +514,7 @@ private:
             {
                 // We must copy all fields of active query except for incarnation, ping time, assigned query and abort request
                 // (which do not matter for finished query) and filter factors field (which goes to finished_queries_by_start_time table).
-                static_assert(TActiveQueryDescriptor::FieldCount == 18 && TFinishedQueryDescriptor::FieldCount == 13);
+                static_assert(TActiveQueryDescriptor::FieldCount == 19 && TFinishedQueryDescriptor::FieldCount == 14);
                 TFinishedQuery newRecord{
                     .Key = TFinishedQueryKey{.QueryId = queryId},
                     .Engine = activeQueryRecord->Engine,
@@ -522,6 +522,7 @@ private:
                     .Files = activeQueryRecord->Files,
                     .Settings = activeQueryRecord->Settings,
                     .User = activeQueryRecord->User,
+                    .AccessControlObject = activeQueryRecord->AccessControlObject,
                     .StartTime = activeQueryRecord->StartTime,
                     .State = finalState,
                     .Progress = activeQueryRecord->Progress,
@@ -540,11 +541,12 @@ private:
             }
 
             {
-                static_assert(TActiveQueryDescriptor::FieldCount == 18 && TFinishedQueryByStartTimeDescriptor::FieldCount == 6);
+                static_assert(TActiveQueryDescriptor::FieldCount == 19 && TFinishedQueryByStartTimeDescriptor::FieldCount == 7);
                 TFinishedQueryByStartTime newRecord{
                     .Key = TFinishedQueryByStartTimeKey{.StartTime = activeQueryRecord->StartTime, .QueryId = queryId},
                     .Engine = activeQueryRecord->Engine,
                     .User = activeQueryRecord->User,
+                    .AccessControlObject = activeQueryRecord->AccessControlObject,
                     .State = finalState,
                     .FilterFactors = activeQueryRecord->FilterFactors,
                 };

--- a/yt/yt/tests/conftest_lib/conftest_queries.py
+++ b/yt/yt/tests/conftest_lib/conftest_queries.py
@@ -1,5 +1,6 @@
 from yt_commands import (
-    create, create_user, remove_user, remove, add_member, sync_create_cells, sync_remove_tablet_cells, ls,
+    create, create_access_control_object_namespace, create_access_control_object, create_user,
+    remove_user, remove, add_member, sync_create_cells, sync_remove_tablet_cells, ls,
     set, get_connection_config, wait, get)
 from yt.environment import ExternalComponent
 
@@ -47,9 +48,13 @@ def query_tracker_environment():
     }
     set("//sys/clusters/primary/query_tracker", query_tracker_config)
     create("document", "//sys/query_tracker/config", recursive=True, force=True, attributes={"value": {}})
+    create_access_control_object_namespace("queries")
+    create_access_control_object("nobody", "queries")
     wait(lambda: get_connection_config(verbose=False)
          .get("query_tracker", {}).get("stages", {}).get("production") is not None)
     yield
+    remove("//sys/access_control_object_namespaces/queries/nobody")
+    remove("//sys/access_control_object_namespaces/queries")
     remove("//sys/clusters/primary/query_tracker")
     sync_remove_tablet_cells(ls("//sys/tablet_cells"))
     remove_user("query_tracker")

--- a/yt/yt/tests/integration/queries/test_mock.py
+++ b/yt/yt/tests/integration/queries/test_mock.py
@@ -1,12 +1,18 @@
 from yt_env_setup import YTEnvSetup
 
-from yt_commands import (authors, raises_yt_error, wait, create_user, print_debug, select_rows)
+from yt_commands import (
+    add_member, authors, create_access_control_object, remove,
+    make_ace, raises_yt_error, wait, create_user, print_debug, select_rows)
+
+from yt_error_codes import AuthorizationErrorCode, ResolveErrorCode
 
 from yt_queries import start_query, list_queries
 
 from yt.test_helpers import assert_items_equal
 
 from collections import Counter
+
+import pytest
 
 
 class TestQueriesMock(YTEnvSetup):
@@ -191,3 +197,366 @@ class TestQueriesMock(YTEnvSetup):
         q.track()
         assert q.get_result(0)["is_truncated"]
         assert not q.get_result(1)["is_truncated"]
+
+
+class TestAccessControl(YTEnvSetup):
+    NUM_TEST_PARTITIONS = 16
+
+    DELTA_DRIVER_CONFIG = {
+        "cluster_connection_dynamic_config_policy": "from_cluster_directory",
+    }
+
+    @authors("krock21")
+    def test_no_acos(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        q_u1 = start_query("mock", "u1", authenticated_user="u1")
+        q_u2 = start_query("mock", "u2", authenticated_user="u2")
+        q_u1.get(authenticated_user="u1")
+        q_u2.get(authenticated_user="u2")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.get(authenticated_user="u2")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u2.get(authenticated_user="u1")
+
+    @authors("krock21")
+    def test_aco_does_not_exist(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("superuser_u3")
+        add_member("superuser_u3", "superusers")
+        create_access_control_object(
+            "aco1",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "use"),
+                ]
+            })
+        q_u1 = start_query("mock", "run_forever", authenticated_user="u1", access_control_object="aco1")
+        with raises_yt_error(ResolveErrorCode):
+            start_query("mock", "run_forever", authenticated_user="u2", access_control_object="aco2")
+        q_u1.get(authenticated_user="u2")
+
+        # Delete ACO and verify that owner and superusers can still access it.
+        remove("//sys/access_control_object_namespaces/queries/aco1")
+        q_u1.get(authenticated_user="u1")
+        q_u1.get(authenticated_user="superuser_u3")
+        with raises_yt_error("Error while fetching access control object \"aco1\""):
+            q_u1.get(authenticated_user="u2")
+
+    @authors("krock21")
+    def test_aco_denies_author(self, query_tracker):
+        create_user("u1")
+        create_access_control_object(
+            "aco_denies_author",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("deny", "u1", "use"),
+                ]
+            })
+        q_u1 = start_query("mock", "run_forever", authenticated_user="u1", access_control_object="aco_denies_author")
+        q_u1.get(authenticated_user="u1")
+
+    @authors("krock21")
+    def test_get(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_access_control_object(
+            "aco_get",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "use"),
+                    make_ace("allow", "u3", "read"),
+                    make_ace("allow", "u3", "write"),
+                    make_ace("allow", "u3", "administer"),
+                ]
+            })
+        q_u1 = start_query("mock", "run_forever", authenticated_user="u1", access_control_object="aco_get")
+        q_u1.get(authenticated_user="u2")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.get(authenticated_user="u3")
+
+    @authors("krock21")
+    def test_abort(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_access_control_object(
+            "aco_abort",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "administer"),
+                    make_ace("allow", "u3", "read"),
+                    make_ace("allow", "u3", "write"),
+                    make_ace("allow", "u3", "use"),
+                ]
+            })
+        q_u1 = start_query("mock", "run_forever", authenticated_user="u1", access_control_object="aco_abort")
+        wait(lambda: q_u1.get_state() == "running")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.abort(authenticated_user="u3")
+        q_u1.abort(authenticated_user="u2")
+
+    @authors("krock21")
+    def test_get_query_result(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_access_control_object(
+            "aco_get_query_result",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "read"),
+                    make_ace("allow", "u3", "administer"),
+                    make_ace("allow", "u3", "write"),
+                    make_ace("allow", "u3", "use"),
+                ]
+            })
+        q_u1 = start_query("mock", "complete_after", authenticated_user="u1", access_control_object="aco_get_query_result", settings={
+            "duration": 3000,
+            "results": [
+                {"schema": [{"name": "foo", "type": "int64"}], "rows": [{"foo": 42}]},
+            ]
+        })
+        q_u1.track()
+        q_u1.get_result(0, authenticated_user="u2")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.get_result(0, authenticated_user="u3")
+
+    @authors("krock21")
+    def test_read_query_result(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_access_control_object(
+            "aco_read_query_result",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "read"),
+                    make_ace("allow", "u3", "administer"),
+                    make_ace("allow", "u3", "write"),
+                    make_ace("allow", "u3", "use"),
+                ]
+            })
+        q_u1 = start_query("mock", "complete_after", authenticated_user="u1", access_control_object="aco_read_query_result", settings={
+            "duration": 3000,
+            "results": [
+                {"schema": [{"name": "foo", "type": "int64"}], "rows": [{"foo": 42}]},
+            ]
+        })
+        q_u1.track()
+        q_u1.read_result(0, authenticated_user="u2")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.read_result(0, authenticated_user="u3")
+
+    @authors("krock21")
+    def test_alter(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_access_control_object(
+            "aco_alter",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "administer"),
+                    make_ace("allow", "u3", "read"),
+                    make_ace("allow", "u3", "write"),
+                    make_ace("allow", "u3", "use"),
+                ]
+            })
+        q_u1 = start_query("mock", "run_forever", authenticated_user="u1", access_control_object="aco_alter")
+        q_u1.alter(authenticated_user="u2", annotations={"qwe": "asd"})
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.alter(authenticated_user="u3", annotations={"qwe2": "asd3"})
+
+    @authors("krock21")
+    def test_alter_aco(self, query_tracker):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_access_control_object(
+            "aco_alter_aco",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u2", "administer"),
+                    make_ace("allow", "u3", "read"),
+                    make_ace("allow", "u3", "write"),
+                    make_ace("allow", "u3", "use"),
+                ]
+            })
+        create_access_control_object(
+            "aco_alter_aco_u3",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    make_ace("allow", "u3", "administer"),
+                ]
+            })
+        q_u1 = start_query("mock", "run_forever", authenticated_user="u1", access_control_object="aco_alter_aco")
+
+        q_u1.alter(authenticated_user="u1", access_control_object="aco_alter_aco")
+
+        q_u1.alter(authenticated_user="u2", annotations={"qwe": "asd"}, access_control_object="nobody")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.alter(authenticated_user="u2", annotations={"qwe": "asd"}, access_control_object="aco_alter_aco")
+
+        q_u1.alter(authenticated_user="u1", access_control_object="aco_alter_aco")
+
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.alter(authenticated_user="u3", access_control_object="nobody")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.alter(authenticated_user="u3", access_control_object="aco_alter_aco")
+
+        q_u1.alter(authenticated_user="u1", access_control_object="aco_alter_aco_u3")
+
+        q_u1.alter(authenticated_user="u3", access_control_object="aco_alter_aco")
+        with raises_yt_error(AuthorizationErrorCode):
+            q_u1.alter(authenticated_user="u3", access_control_object="aco_alter_aco_u3")
+
+        with raises_yt_error(ResolveErrorCode):
+            q_u1.alter(authenticated_user="u1", access_control_object="nonexistent_aco")
+
+
+# Separate list to fit 480 seconds limit for a test class.
+class TestAccessControlList(YTEnvSetup):
+    NUM_TEST_PARTITIONS = 16
+
+    DELTA_DRIVER_CONFIG = {
+        "cluster_connection_dynamic_config_policy": "from_cluster_directory",
+    }
+
+    @pytest.mark.parametrize(
+        "query_type",
+        [
+            ["mock", "fail", {}],
+            ["mock", "complete_after", {"settings": {"duration": 1000}}],
+            ["mock", "fail_by_exception", {}],
+            ["mock", "blahblah", {}],
+            ["mock", "fail_after", {"settings": {"duration": 1000}}],
+            ["mock", "run_forever", {}]
+        ])
+    @authors("krock21")
+    def test_list(self, query_tracker, query_type):
+        create_user("u1")
+        create_user("u2")
+        create_user("u3")
+        create_user("u4")
+        create_user("u5")
+        create_user("u6")
+        create_user("superuser_u7")
+        add_member("superuser_u7", "superusers")
+        create_access_control_object(
+            "aco_list_u1",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    # Allow u2, deny everyone else.
+                    make_ace("allow", "u2", "use"),
+                    make_ace("allow", "u3", "read"),
+                    make_ace("allow", "u4", "write"),
+                    make_ace("allow", "u5", "administer"),
+                ]
+            })
+        create_access_control_object(
+            "aco_list_u2",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    # Allow u3, deny everyone else.
+                    make_ace("allow", "u3", "use"),
+                    make_ace("allow", "u4", "use"),
+                    make_ace("deny", "u4", "use"),
+                    make_ace("deny", "u5", "use"),
+                ]
+            })
+        create_access_control_object(
+            "aco_list_u3",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    # Allow everyone except u6.
+                    make_ace("allow", "u1", "use"),
+                    make_ace("allow", "u2", "use"),
+                    make_ace("allow", "u4", "use"),
+                    make_ace("allow", "u5", "use"),
+                ]
+            })
+        create_access_control_object(
+            "aco_list_u4",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    # Allow everyone except u5.
+                    make_ace("allow", "u1", "use"),
+                    make_ace("allow", "u2", "use"),
+                    make_ace("allow", "u3", "use"),
+                ]
+            })
+        create_access_control_object(
+            "aco_list_u5",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    # Deny everyone implicitly.
+                ]
+            })
+
+        create_access_control_object(
+            "aco_list_u6",
+            "queries",
+            attributes={
+                "principal_acl": [
+                    # Deny everyone explicitly, even u6 themselves.
+                    make_ace("deny", "u1", "use"),
+                    make_ace("deny", "u2", "use"),
+                    make_ace("deny", "u3", "use"),
+                    make_ace("deny", "u4", "use"),
+                    make_ace("deny", "u5", "use"),
+                    make_ace("deny", "u6", "use"),
+                ]
+            })
+
+        def expect_queries(queries, list_result, incomplete=False):
+            try:
+                assert set(q.id for q in queries) == set(q["id"] for q in list_result["queries"])
+                assert list_result["incomplete"] == incomplete
+            except AssertionError:
+                timestamp = list_result["timestamp"]
+                print_debug(f"Assertion failed, dumping content of dynamic tables by timestamp {timestamp}")
+                for table in ("active_queries", "finished_queries", "finished_queries_by_start_time"):
+                    print_debug(f"{table}:")
+                    select_rows(f"* from [//sys/query_tracker/{table}]", timestamp=timestamp)
+                raise
+
+        q_u1 = start_query(query_type[0], query_type[1], **query_type[2], authenticated_user="u1", access_control_object="aco_list_u1")
+        q_u2 = start_query(query_type[0], query_type[1], **query_type[2], authenticated_user="u2", access_control_object="aco_list_u2")
+        q_u3 = start_query(query_type[0], query_type[1], **query_type[2], authenticated_user="u3", access_control_object="aco_list_u3")
+        q_u4 = start_query(query_type[0], query_type[1], **query_type[2], authenticated_user="u4", access_control_object="aco_list_u4")
+        q_u5 = start_query(query_type[0], query_type[1], **query_type[2], authenticated_user="u5", access_control_object="aco_list_u5")
+        q_u6 = start_query(query_type[0], query_type[1], **query_type[2], authenticated_user="u6", access_control_object="aco_list_u6")
+
+        if "settings" in query_type[2] and "duration" in query_type[2]["settings"]:
+            q_u1.track(raise_on_unsuccess=False)
+            q_u2.track(raise_on_unsuccess=False)
+            q_u3.track(raise_on_unsuccess=False)
+            q_u4.track(raise_on_unsuccess=False)
+            q_u5.track(raise_on_unsuccess=False)
+            q_u6.track(raise_on_unsuccess=False)
+
+        expect_queries([q_u1, q_u2, q_u3, q_u4, q_u5, q_u6], list_queries(cursor_direction="future"))  # Root user sees everything.
+        expect_queries([q_u1, q_u2, q_u3, q_u4, q_u5, q_u6], list_queries(cursor_direction="future", authenticated_user="superuser_u7"))  # Superuser sees everything.
+        expect_queries([q_u1, q_u3, q_u4], list_queries(cursor_direction="future", authenticated_user="u1"))
+        expect_queries([q_u1, q_u2, q_u3, q_u4], list_queries(cursor_direction="future", authenticated_user="u2"))
+        expect_queries([q_u2, q_u3, q_u4], list_queries(cursor_direction="future", authenticated_user="u3"))
+        expect_queries([q_u3, q_u4], list_queries(cursor_direction="future", authenticated_user="u4"))
+        expect_queries([q_u3, q_u5], list_queries(cursor_direction="future", authenticated_user="u5"))
+        expect_queries([q_u6], list_queries(cursor_direction="future", authenticated_user="u6"))

--- a/yt/yt/tests/library/yt_queries.py
+++ b/yt/yt/tests/library/yt_queries.py
@@ -108,3 +108,7 @@ def abort_query(id, **kwargs):
 def alter_query(id, **kwargs):
     kwargs["query_id"] = id
     execute_command("alter_query", kwargs)
+
+
+def get_query_tracker_info(**kwargs):
+    return execute_command("get_query_tracker_info", kwargs, parse_yson=True)

--- a/yt/yt/ytlib/api/native/client_impl.h
+++ b/yt/yt/ytlib/api/native/client_impl.h
@@ -327,6 +327,9 @@ public:
         NQueryTrackerClient::TQueryId queryId,
         const TAlterQueryOptions& options = {}),
         (queryId, options))
+    IMPLEMENT_METHOD(TGetQueryTrackerInfoResult, GetQueryTrackerInfo, (
+        const TGetQueryTrackerInfoOptions& options = {}),
+        (options))
 
     IMPLEMENT_METHOD(NYson::TYsonString, GetNode, (
         const NYPath::TYPath& path,
@@ -1764,6 +1767,8 @@ private:
     void DoAlterQuery(
         NQueryTrackerClient::TQueryId queryId,
         const TAlterQueryOptions& options);
+    TGetQueryTrackerInfoResult DoGetQueryTrackerInfo(
+        const TGetQueryTrackerInfoOptions& options);
 
     //
     // Authentication

--- a/yt/yt/ytlib/api/native/client_queries.cpp
+++ b/yt/yt/ytlib/api/native/client_queries.cpp
@@ -173,7 +173,10 @@ NSecurityClient::ESecurityAction CheckAccessControl(
         if (userSubjects.contains(NSecurityClient::SuperusersGroupName)) {
             return NSecurityClient::ESecurityAction::Allow;
         }
-        THROW_ERROR_EXCEPTION("Error while fetching access control object %Qv", actualAccessControlObject)
+        THROW_ERROR_EXCEPTION(
+            "Error while fetching access control object queries/%v. "
+            "Please make sure it exists",
+            actualAccessControlObject)
             << aclOrError;
     }
     return WaitFor(client->CheckPermissionByAcl(user, permission, ConvertToNode(aclOrError.Value())))
@@ -274,7 +277,9 @@ std::vector<TString> GetAcosForSubjects(const THashSet<TString>& subjects, const
     auto allAcosOrError = WaitFor(client->GetNode("//sys/access_control_object_namespaces/queries", options));
 
     if (!allAcosOrError.IsOK()) {
-        THROW_ERROR_EXCEPTION("Error while fetching all access control objects in the namespace \"queries\"")
+        THROW_ERROR_EXCEPTION(
+            "Error while fetching all access control objects in the namespace \"queries\". "
+            "Please make sure that the namespace exists")
             << allAcosOrError;
     }
 

--- a/yt/yt/ytlib/api/native/client_queries.cpp
+++ b/yt/yt/ytlib/api/native/client_queries.cpp
@@ -43,6 +43,9 @@ namespace NDetail {
 // Applies when a query doesn't have an access control object.
 constexpr TStringBuf DefaultAccessControlObject = "nobody";
 
+// Path to access control object namespace for QT.
+constexpr TStringBuf QueriesAcoNamespacePath = "//sys/access_control_object_namespaces/queries";
+
 TQuery PartialRecordToQuery(const auto& partialRecord)
 {
     static_assert(pfr::tuple_size<TQuery>::value == 15);
@@ -163,8 +166,9 @@ NSecurityClient::ESecurityAction CheckAccessControl(
     }
     auto actualAccessControlObject = accessControlObject.value_or(TString(DefaultAccessControlObject));
     auto aclOrError = WaitFor(client->GetNode(Format(
-        "//sys/access_control_object_namespaces/queries/%v/@principal_acl",
-        actualAccessControlObject)));
+        "%v/%v/@principal_acl",
+        QueriesAcoNamespacePath,
+        NYPath::ToYPathLiteral(actualAccessControlObject))));
     if (!aclOrError.IsOK()) {
         YT_LOG_WARNING(aclOrError,
             "Error while fetching access control object queries/%v",
@@ -274,7 +278,7 @@ std::vector<TString> GetAcosForSubjects(const THashSet<TString>& subjects, const
     };
     options.ReadFrom = EMasterChannelKind::Cache;
 
-    auto allAcosOrError = WaitFor(client->GetNode("//sys/access_control_object_namespaces/queries", options));
+    auto allAcosOrError = WaitFor(client->GetNode(TString(QueriesAcoNamespacePath), options));
 
     if (!allAcosOrError.IsOK()) {
         THROW_ERROR_EXCEPTION(
@@ -332,7 +336,10 @@ std::vector<TString> GetAcosForSubjects(const THashSet<TString>& subjects, const
 
 void VerifyAccessControlObjectExists(const TString& accessControlObject, const IClientPtr& client)
 {
-    auto error = WaitFor(client->NodeExists("//sys/access_control_object_namespaces/queries/" + accessControlObject));
+    auto error = WaitFor(client->NodeExists(Format(
+        "%v/%v",
+        QueriesAcoNamespacePath,
+        NYPath::ToYPathLiteral(accessControlObject))));
 
     if (!error.IsOK()) {
         THROW_ERROR_EXCEPTION("Failed to check whether access control object %Qv exists", accessControlObject)
@@ -1067,6 +1074,60 @@ void TClient::DoAlterQuery(TQueryId queryId, const TAlterQueryOptions& options)
 
     WaitFor(transaction->Commit())
         .ThrowOnError();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TGetQueryTrackerInfoResult TClient::DoGetQueryTrackerInfo(const TGetQueryTrackerInfoOptions& options)
+{
+    IClientPtr client;
+    TString root;
+    std::tie(client, root) = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+
+    YT_LOG_DEBUG(
+        "Getting query tracker information (Attributes: %v)",
+        options.Attributes);
+
+    auto attributes = options.Attributes;
+
+    attributes.ValidateKeysOnly();
+
+    TString clusterName = "";
+
+    if (attributes.AdmitsKeySlow("cluster_name")) {
+        YT_LOG_DEBUG("Getting cluster name");
+        clusterName = client->GetClusterName().value_or("");
+    }
+
+    TNodeExistsOptions nodeExistsOptions;
+    nodeExistsOptions.ReadFrom = EMasterChannelKind::Cache;
+    bool accessControlSupported = WaitFor(client->NodeExists(TString(QueriesAcoNamespacePath), nodeExistsOptions))
+        .ValueOrThrow();
+
+    static const TYsonString EmptyMap = TYsonString(TString("{}"));
+    TYsonString supportedFeatures = EmptyMap;
+    if (attributes.AdmitsKeySlow("supported_features")) {
+        supportedFeatures = BuildYsonStringFluently()
+            .BeginMap()
+                .Item("access_control").Value(accessControlSupported)
+            .EndMap();
+    }
+
+    std::vector<TString> accessControlObjects;
+    if (accessControlSupported && attributes.AdmitsKeySlow("access_control_objects")) {
+        YT_LOG_DEBUG("Getting access control objects");
+        TListNodeOptions listOptions;
+        listOptions.ReadFrom = EMasterChannelKind::Cache;
+        auto allAcos = WaitFor(client->ListNode(TString(QueriesAcoNamespacePath), listOptions))
+            .ValueOrThrow();
+        accessControlObjects = ConvertTo<std::vector<TString>>(allAcos);
+    }
+
+    return TGetQueryTrackerInfoResult{
+        .ClusterName = std::move(clusterName),
+        .SupportedFeatures = std::move(supportedFeatures),
+        .AccessControlObjects = std::move(accessControlObjects),
+    };
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/helpers.cpp
+++ b/yt/yt/ytlib/query_tracker_client/helpers.cpp
@@ -14,17 +14,26 @@ using namespace NYson;
 
 TString GetFilterFactors(const TActiveQueryPartial& record)
 {
-    return Format("%v %v", record.Query, *record.Annotations ? ConvertToYsonString(*record.Annotations, EYsonFormat::Text).ToString() : "");
+    return Format("%v %v aco:%v",
+        record.Query,
+        (record.Annotations && *record.Annotations) ? ConvertToYsonString(*record.Annotations, EYsonFormat::Text).ToString() : "",
+        (record.AccessControlObject && *record.AccessControlObject) ? **record.AccessControlObject : "");
 }
 
 TString GetFilterFactors(const TFinishedQueryPartial& record)
 {
-    return Format("%v %v", record.Query, record.Annotations ? ConvertToYsonString(*record.Annotations, EYsonFormat::Text).ToString() : "");
+    return Format("%v %v aco:%v",
+        record.Query,
+        (record.Annotations && *record.Annotations) ? ConvertToYsonString(*record.Annotations, EYsonFormat::Text).ToString() : "",
+        (record.AccessControlObject && *record.AccessControlObject) ? **record.AccessControlObject : "");
 }
 
-TString GetFilterFactors(const NRecords::TFinishedQuery& record)
+TString GetFilterFactors(const TFinishedQuery& record)
 {
-    return Format("%v %v", record.Query, record.Annotations ? ConvertToYsonString(record.Annotations, EYsonFormat::Text).ToString() : "");
+    return Format("%v %v aco:%v",
+        record.Query,
+        record.Annotations ? ConvertToYsonString(record.Annotations, EYsonFormat::Text).ToString() : "",
+        record.AccessControlObject ? *record.AccessControlObject : "");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/records/query.yaml
+++ b/yt/yt/ytlib/query_tracker_client/records/query.yaml
@@ -47,6 +47,12 @@ types:
         column_type: String
         lock: client
 
+      - cpp_name: AccessControlObject
+        cpp_type: std::optional<TString>
+        column_name: access_control_object
+        column_type: String
+        lock: client
+
       - cpp_name: StartTime
         cpp_type: TInstant
         column_name: start_time
@@ -168,6 +174,11 @@ types:
         column_name: user
         column_type: String
 
+      - cpp_name: AccessControlObject
+        cpp_type: std::optional<TString>
+        column_name: access_control_object
+        column_type: String
+
       - cpp_name: StartTime
         cpp_type: TInstant
         column_name: start_time
@@ -230,6 +241,11 @@ types:
       - cpp_name: User
         cpp_type: TString
         column_name: user
+        column_type: String
+
+      - cpp_name: AccessControlObject
+        cpp_type: std::optional<TString>
+        column_name: access_control_object
         column_type: String
 
       - cpp_name: State


### PR DESCRIPTION
Cherrypicking Query Tracker ACO commits to 23.2
I had to manually fix conflicts in first and last commit(marked with [23.2]) because they were created on top of some refactorings