### PR TITLE
Fix fd leak

### DIFF
--- a/yt/python/yt/wrapper/default_config.py
+++ b/yt/python/yt/wrapper/default_config.py
@@ -891,7 +891,8 @@ def _update_from_file(config):
                 config_path = home_config_path
 
         try:
-            open(config_path, "r")
+            with open(config_path, "r"):
+                pass
         except IOError:
             config_path = None
 
@@ -905,7 +906,8 @@ def _update_from_file(config):
         else:
             raise common.YtError("Incorrect config_format '%s'" % format)
         try:
-            common.update_inplace(config, load_func(open(config_path, "rb")))
+            with open(config_path, "rb") as f:
+                common.update_inplace(config, load_func(f))
         except Exception:
             print("Failed to parse YT config from " + config_path, file=sys.stderr)
             raise


### PR DESCRIPTION
Fixes:
```shell
yt/python/yt/wrapper/default_config.py:894: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/echunaev/.yt/config' mode='r' encoding='UTF-8'>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
yt/python/yt/wrapper/default_config.py:908: ResourceWarning: unclosed file <_io.BufferedReader name='/home/echunaev/.yt/config'>
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```