### PR TITLE
Support for temporary tokens in yql_agent

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ydb-platform/ydb
-          ref: 143a9259fef4d867a95c303b086a0782e67165f9
+          ref: 80ed6f7379cd81d696cc71d6f0ea32cdc9861c57
           path: ydb
 
   build:

--- a/.github/workflows/query_tracker_release.yaml
+++ b/.github/workflows/query_tracker_release.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ydb-platform/ydb
-          ref: 143a9259fef4d867a95c303b086a0782e67165f9
+          ref: 80ed6f7379cd81d696cc71d6f0ea32cdc9861c57
           path: ydb
 
   build:

--- a/.github/workflows/ya_make.yaml
+++ b/.github/workflows/ya_make.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: ydb-platform/ydb
-          ref: 143a9259fef4d867a95c303b086a0782e67165f9
+          ref: 80ed6f7379cd81d696cc71d6f0ea32cdc9861c57
           path: ydb
 
   build:

--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -319,6 +319,8 @@ void TYqlAgentConfig::Register(TRegistrar registrar)
         .Default(TDuration::Minutes(20));
     registrar.Parameter("refresh_token_period", &TThis::RefreshTokenPeriod)
         .Default(TDuration::Minutes(10));
+    registrar.Parameter("issue_token_attempts", &TThis::IssueTokenAttempts)
+        .Default(10);
     registrar.Parameter("bus_client", &TThis::BusClient)
         .DefaultNew();
     registrar.Parameter("yql_thread_count", &TThis::YqlThreadCount)

--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -250,7 +250,7 @@ void TYqlPluginConfig::Register(TRegistrar registrar)
     registrar.Parameter("operation_attributes", &TThis::OperationAttributes)
         .Default(GetEphemeralNodeFactory()->CreateMap());
     registrar.Parameter("yt_token_path", &TThis::YTTokenPath)
-        .Default();
+        .IsRequired();
     registrar.Parameter("yql_plugin_shared_library", &TThis::YqlPluginSharedLibrary)
         .Default();
     registrar.Parameter("dq_manager_config", &TThis::DqManagerConfig)
@@ -315,6 +315,10 @@ void TYqlPluginConfig::Register(TRegistrar registrar)
 
 void TYqlAgentConfig::Register(TRegistrar registrar)
 {
+    registrar.Parameter("token_expiration_timeout", &TThis::TokenExpirationTimeout)
+        .Default(TDuration::Minutes(20));
+    registrar.Parameter("refresh_token_period", &TThis::RefreshTokenPeriod)
+        .Default(TDuration::Minutes(10));
     registrar.Parameter("bus_client", &TThis::BusClient)
         .DefaultNew();
     registrar.Parameter("yql_thread_count", &TThis::YqlThreadCount)

--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -250,7 +250,7 @@ void TYqlPluginConfig::Register(TRegistrar registrar)
     registrar.Parameter("operation_attributes", &TThis::OperationAttributes)
         .Default(GetEphemeralNodeFactory()->CreateMap());
     registrar.Parameter("yt_token_path", &TThis::YTTokenPath)
-        .IsRequired();
+        .Default();
     registrar.Parameter("yql_plugin_shared_library", &TThis::YqlPluginSharedLibrary)
         .Default();
     registrar.Parameter("dq_manager_config", &TThis::DqManagerConfig)

--- a/yt/yql/agent/config.h
+++ b/yt/yql/agent/config.h
@@ -144,6 +144,9 @@ class TYqlAgentConfig
     : public TYqlPluginConfig
 {
 public:
+    TDuration TokenExpirationTimeout;
+    TDuration RefreshTokenPeriod;
+
     //! Used to create channels to other queue agents.
     NBus::TBusConfigPtr BusClient;
 

--- a/yt/yql/agent/config.h
+++ b/yt/yql/agent/config.h
@@ -146,6 +146,7 @@ class TYqlAgentConfig
 public:
     TDuration TokenExpirationTimeout;
     TDuration RefreshTokenPeriod;
+    int IssueTokenAttempts;
 
     //! Used to create channels to other queue agents.
     NBus::TBusConfigPtr BusClient;

--- a/yt/yql/plugin/bridge/interface.h
+++ b/yt/yql/plugin/bridge/interface.h
@@ -73,6 +73,15 @@ struct TBridgeQueryResult
     ssize_t YsonErrorLength = 0;
 };
 
+struct TBridgeClustersResult
+{
+    const char** Clusters = nullptr;
+    ssize_t ClusterCount = 0;
+
+    const char* YsonError = nullptr;
+    ssize_t YsonErrorLength = 0;
+};
+
 enum EQueryFileContentType
 {
     RawInlineData,
@@ -97,16 +106,25 @@ struct TBridgeAbortResult
 };
 
 using TFuncBridgeFreeQueryResult = void(TBridgeQueryResult* result);
+using TFuncBridgeFreeClustersResult = void(TBridgeClustersResult* result);
 using TFuncBridgeRun = TBridgeQueryResult*(
     TBridgeYqlPlugin* plugin,
     const char* queryId,
-    const char* impersonationUser,
+    const char* user,
+    const char* token,
     const char* queryText,
     const char* settings,
     int settingsLength,
     const TBridgeQueryFile* files,
     int fileCount,
     int executeMode);
+using TFuncBridgeGetUsedClusters = TBridgeClustersResult*(
+    TBridgeYqlPlugin* plugin,
+    const char* queryText,
+    const char* settings,
+    int settingsLength,
+    const TBridgeQueryFile* files,
+    int fileCount);
 using TFuncBridgeGetProgress = TBridgeQueryResult*(TBridgeYqlPlugin* plugin, const char* queryId);
 using TFuncBridgeAbort = TBridgeAbortResult*(TBridgeYqlPlugin* plugin, const char* queryId);
 using TFuncBridgeFreeAbortResult = void(TBridgeAbortResult* result);
@@ -118,7 +136,9 @@ using TFuncBridgeFreeAbortResult = void(TBridgeAbortResult* result);
     XX(BridgeStartYqlPlugin) \
     XX(BridgeFreeYqlPlugin) \
     XX(BridgeFreeQueryResult) \
+    XX(BridgeFreeClustersResult) \
     XX(BridgeRun) \
+    XX(BridgeGetUsedClusters) \
     XX(BridgeGetProgress) \
     XX(BridgeGetAbiVersion) \
     XX(BridgeAbort) \

--- a/yt/yql/plugin/plugin.h
+++ b/yt/yql/plugin/plugin.h
@@ -11,8 +11,6 @@
 #include <util/generic/hash.h>
 #include <util/generic/string.h>
 
-#include <optional>
-
 namespace NYT::NYqlPlugin {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,6 +48,14 @@ struct TQueryResult
     std::optional<TString> YsonError;
 };
 
+struct TClustersResult
+{
+    std::vector<TString> Clusters;
+
+    //! YSON representation of a YT error.
+    std::optional<TString> YsonError;
+};
+
 struct TQueryFile
 {
     TStringBuf Name;
@@ -74,13 +80,20 @@ struct IYqlPlugin
 {
     virtual void Start() = 0;
 
+    virtual TClustersResult GetUsedClusters(
+        TString queryText,
+        NYson::TYsonString settings,
+        std::vector<TQueryFile> files) noexcept = 0;
+
     virtual TQueryResult Run(
         TQueryId queryId,
-        TString impersonationUser,
+        TString user,
+        TString token,
         TString queryText,
         NYson::TYsonString settings,
         std::vector<TQueryFile> files,
         int executeMode) noexcept = 0;
+
     virtual TQueryResult GetProgress(TQueryId queryId) noexcept = 0;
 
     virtual TAbortResult Abort(TQueryId queryId) noexcept = 0;

--- a/yt/yql/tests/conftest.py
+++ b/yt/yql/tests/conftest.py
@@ -23,6 +23,8 @@ class YqlAgent(ExternalComponent):
     def __init__(self, env, count):
         super().__init__(env, count)
 
+        create_user("yql_agent")
+        add_member("yql_agent", "superusers")
         yql_agent_token, _ = issue_token("yql_agent")
         with open(self.token_path, "w") as file:
             file.write(yql_agent_token)

--- a/yt/yt/ytlib/api/native/client.h
+++ b/yt/yt/ytlib/api/native/client.h
@@ -113,6 +113,12 @@ struct IClient
 
     virtual bool DoesOperationsArchiveExist() = 0;
 
+    virtual TFuture<TIssueTokenResult> IssueSpecificTemporaryToken(
+        const TString& user,
+        const TString& token,
+        const NYTree::IAttributeDictionaryPtr& attributes,
+        const TIssueTemporaryTokenOptions& options) = 0;
+
     virtual TFuture<TIssueTokenResult> IssueTemporaryToken(
         const TString& user,
         const NYTree::IAttributeDictionaryPtr& attributes,

--- a/yt/yt/ytlib/api/native/client_impl.h
+++ b/yt/yt/ytlib/api/native/client_impl.h
@@ -787,6 +787,12 @@ public: \
         const TString& passwordSha256,
         const TIssueTokenOptions& options),
         (user, passwordSha256, options))
+    IMPLEMENT_METHOD(TIssueTokenResult, IssueSpecificTemporaryToken, (
+        const TString& user,
+        const TString& token,
+        const NYTree::IAttributeDictionaryPtr& attributes,
+        const TIssueTemporaryTokenOptions& options),
+        (user, token, attributes, options))
     IMPLEMENT_METHOD(TIssueTokenResult, IssueTemporaryToken, (
         const TString& user,
         const NYTree::IAttributeDictionaryPtr& attributes,
@@ -1363,6 +1369,7 @@ private:
 
     TIssueTokenResult DoIssueTokenImpl(
         const TString& user,
+        const TString& token,
         const NYTree::IAttributeDictionaryPtr& attributes,
         const TIssueTokenOptions& options);
 


### PR DESCRIPTION
In this pull request, I am changing the authorization method in yql QT requests. Temporary tokens will be used instead of impersonation.

The algorithm for generating temporary tokens is:
1) We get all used clusters from the query (in yql_plugin)
2) Generating a temporary token on all clusters (in yql_agent)
3) Run the query (in yql_agent)

yql_plugin PR: https://github.com/ydb-platform/ydb/pull/2356