### PR TITLE
build(docker): add master-cache component

### DIFF
--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -9,6 +9,7 @@ COPY ./ytserver-all /usr/bin/ytserver-all
 
 # If this list changes, also update yt_nightly/Dockerfile
 RUN ln -s /usr/bin/ytserver-all /usr/bin/ytserver-master && \
+    ln -s /usr/bin/ytserver-all /usr/bin/ytserver-master-cache && \
     ln -s /usr/bin/ytserver-all /usr/bin/ytserver-clock && \
     ln -s /usr/bin/ytserver-all /usr/bin/ytserver-discovery && \
     ln -s /usr/bin/ytserver-all /usr/bin/ytserver-node && \


### PR DESCRIPTION
Ref: https://github.com/ytsaurus/yt-k8s-operator/issues/94
Cherry-pick of master-cache adding to the stable/23.2 branch
---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/373

