### PR TITLE
[styleguide] Fix link to property.h

### DIFF
--- a/yt/styleguide/cpp.md
+++ b/yt/styleguide/cpp.md
@@ -182,7 +182,7 @@ public:
 };
 ```
 
-See more complex property macros in [property.h](library/cpp/yt/misc/property.h).
+See more complex property macros in [property.h](/library/cpp/yt/misc/property.h).
 
 <!------------------------------------------------------------------------------------>
 


### PR DESCRIPTION
### What

Link to `property.h` in the C++ style guide doc is relative, so it's resolved to `https://github.com/ytsaurus/ytsaurus/blob/main/yt/styleguide/library/cpp/yt/misc/property.h` that returns 404:
<img width="1110" alt="image" src="https://github.com/artsiukhou/ytsaurus/assets/1358483/f7a8b7ad-ed21-473c-a919-c3038e61448d">

### How

Making the link absolute, so it's resolved to `https://github.com/ytsaurus/ytsaurus/blob/main/library/cpp/yt/misc/property.h`. 

### How tested

Looking at "rich diff" and clicking at the link

### Other
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en