### PR TITLE
Introduce batch_row_count for ordered map/merge

### DIFF
--- a/yt/chyt/server/job_size_constraints.cpp
+++ b/yt/chyt/server/job_size_constraints.cpp
@@ -54,18 +54,19 @@ IJobSizeConstraintsPtr CreateClickHouseJobSizeConstraints(
     }
 
     return CreateExplicitJobSizeConstraints(
-        false /*canAdjustDataWeightPerJob*/,
-        true /*isExplicitJobCount*/,
+        /*canAdjustDataWeightPerJob*/ false,
+        /*isExplicitJobCount*/ true,
         jobCount,
         dataWeightPerJob,
-        1024 * 1024 * 1_TB /*primaryDataWeightPerJob*/,
-        1'000'000'000'000ll /*maxDataSlicesPerJob*/,
-        1024 * 1024 * 1_TB /*maxDataWeightPerJob*/,
-        1024 * 1024 * 1_TB /*primaryMaxDataWeightPerJob*/,
-        inputSliceDataWeight /*inputSliceDataWeight*/,
-        std::max<i64>(1, totalRowCount / jobCount) /*inputSliceRowCount*/,
-        0 /*foreignSliceDataWeight*/,
-        std::nullopt /*samplingRate*/);
+        /*primaryDataWeightPerJob*/ 1_EB,
+        /*maxDataSlicesPerJob*/ 1'000'000'000'000ll,
+        /*maxDataWeightPerJob*/ 1_EB,
+        /*primaryMaxDataWeightPerJob*/ 1_EB,
+        /*inputSliceDataWeight*/ inputSliceDataWeight,
+        /*inputSliceRowCount*/ std::max<i64>(1, totalRowCount / jobCount),
+        /*batchRowCount*/ {},
+        /*foreignSliceDataWeight*/ 0,
+        /*samplingRate*/ std::nullopt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/controller_agent/controllers/auto_merge_task.cpp
+++ b/yt/yt/server/controller_agent/controllers/auto_merge_task.cpp
@@ -44,7 +44,7 @@ TAutoMergeChunkPoolAdapter::TAutoMergeChunkPoolAdapter(
 
 IChunkPoolInput::TCookie TAutoMergeChunkPoolAdapter::AddWithKey(TChunkStripePtr stripe, TChunkStripeKey key)
 {
-    Task_->GetTaskHost()->GetAutoMergeDirector()->AccountMergeInputChunks(stripe->GetChunkCount() /*intermediateChunkCount*/);
+    Task_->GetTaskHost()->GetAutoMergeDirector()->AccountMergeInputChunks(/*intermediateChunkCount*/ stripe->GetChunkCount());
 
     Task_->CurrentChunkCounts_[PoolIndex_] += stripe->GetChunkCount();
 
@@ -154,18 +154,19 @@ TAutoMergeTask::TAutoMergeTask(
     CurrentChunkCounts_.resize(OutputStreamDescriptors_.size(), 0);
     for (int poolIndex = 0; poolIndex < std::ssize(OutputStreamDescriptors_); ++poolIndex) {
         auto autoMergeJobSizeConstraints = CreateExplicitJobSizeConstraints(
-            false /*canAdjustDataSizePerJob*/,
-            false /*isExplicitJobCount*/,
-            1 /*jobCount*/,
-            dataWeightPerJob /*dataWeightPerJob*/,
-            std::numeric_limits<i64>::max() / 4 /*primaryDataWeightPerJob*/,
-            maxChunksPerJob /*maxDataSlicesPerJob*/,
-            std::numeric_limits<i64>::max() / 4 /*maxDataWeightPerJob*/,
-            std::numeric_limits<i64>::max() / 4 /*primaryMaxDataWeightPerJob*/,
-            std::numeric_limits<i64>::max() / 4 /*inputSliceDataSize*/,
-            std::numeric_limits<i64>::max() / 4 /*inputSliceRowCount*/,
-            0 /*foreignSliceDataWeight*/,
-            std::nullopt /*samplingRate*/);
+            /*canAdjustDataSizePerJob*/ false,
+            /*isExplicitJobCount*/ false,
+            /*jobCount*/ 1,
+            /*dataWeightPerJob*/ dataWeightPerJob,
+            /*primaryDataWeightPerJob*/ std::numeric_limits<i64>::max() / 4,
+            /*maxDataSlicesPerJob*/ maxChunksPerJob,
+            /*maxDataWeightPerJob*/ std::numeric_limits<i64>::max() / 4,
+            /*primaryMaxDataWeightPerJob*/ std::numeric_limits<i64>::max() / 4,
+            /*inputSliceDataSize*/ std::numeric_limits<i64>::max() / 4,
+            /*inputSliceRowCount*/ std::numeric_limits<i64>::max() / 4,
+            /*batchRowCount*/ {},
+            /*foreignSliceDataWeight*/ 0,
+            /*samplingRate*/ std::nullopt);
 
         TUnorderedChunkPoolOptions options;
         options.RowBuffer = TaskHost_->GetRowBuffer();
@@ -383,7 +384,7 @@ TJobFinishedResult TAutoMergeTask::OnJobAborted(TJobletPtr joblet, const TAborte
         }
     }
 
-    TaskHost_->GetAutoMergeDirector()->OnMergeJobFinished(0 /*unregisteredIntermediateChunkCount*/);
+    TaskHost_->GetAutoMergeDirector()->OnMergeJobFinished(/*unregisteredIntermediateChunkCount*/ 0);
 
     return result;
 }
@@ -410,7 +411,7 @@ TJobFinishedResult TAutoMergeTask::OnJobFailed(TJobletPtr joblet, const TFailedJ
     int poolIndex = *joblet->InputStripeList->PartitionTag;
     CurrentChunkCounts_[poolIndex] += joblet->InputStripeList->TotalChunkCount;
 
-    TaskHost_->GetAutoMergeDirector()->OnMergeJobFinished(0 /*unregisteredIntermediateChunkCount*/);
+    TaskHost_->GetAutoMergeDirector()->OnMergeJobFinished(/*unregisteredIntermediateChunkCount*/ 0);
 
     return result;
 }

--- a/yt/yt/server/controller_agent/controllers/ordered_controller.cpp
+++ b/yt/yt/server/controller_agent/controllers/ordered_controller.cpp
@@ -287,6 +287,11 @@ protected:
                 return false;
             }
 
+            // Setting batch_row_count disables interrupts since they make it much harder to fullfil the divisibility conditions.
+            if (Controller_->JobSizeConstraints_->GetBatchRowCount()) {
+                return false;
+            }
+
             if (Controller_->JobSizeConstraints_->ForceAllowJobInterruption()) {
                 return true;
             }

--- a/yt/yt/server/controller_agent/job_size_constraints.cpp
+++ b/yt/yt/server/controller_agent/job_size_constraints.cpp
@@ -56,14 +56,21 @@ public:
     {
         YT_VERIFY(ForeignInputDataWeight_ >= 0);
 
-        if (SamplingConfig_ && SamplingConfig_->SamplingRate) {
+        if (GetSamplingRateImpl()) {
             InitializeSampling();
         }
     }
 
-    std::optional<double> GetSamplingRate() const override
+    // NB: Helper method to avoid calling virtual method from constructor.
+    // Even though it should be technically fine in this case.
+    std::optional<double> GetSamplingRateImpl() const
     {
         return SamplingConfig_ ? SamplingConfig_->SamplingRate : std::nullopt;
+    }
+
+    std::optional<double> GetSamplingRate() const override
+    {
+        return GetSamplingRateImpl();
     }
 
     i64 GetSamplingDataWeightPerJob() const override
@@ -90,7 +97,7 @@ public:
 
     i64 GetInputSliceDataWeight() const override
     {
-        auto dataWeightPerJob = (SamplingConfig_ && SamplingConfig_->SamplingRate)
+        auto dataWeightPerJob = GetSamplingRate()
             ? GetSamplingDataWeightPerJob()
             : GetDataWeightPerJob();
 
@@ -139,6 +146,11 @@ public:
         return JobCount_ > 0
             ? DivCeil(InputRowCount_, JobCount_)
             : 1;
+    }
+
+    std::optional<i64> GetBatchRowCount() const override
+    {
+        return Spec_->BatchRowCount;
     }
 
     int GetJobCount() const override
@@ -454,7 +466,7 @@ public:
             spec,
             options,
             logger,
-            std::numeric_limits<i64>::max() / 4 /*inputRowCount*/,
+            /*inputRowCount*/ std::numeric_limits<i64>::max() / 4,
             inputChunkCount,
             mergeInputTableCount,
             mergePrimaryInputTableCount,
@@ -662,9 +674,9 @@ public:
             options,
             logger,
             inputRowCount,
-            std::numeric_limits<i64>::max() / 4 /*inputChunkCount*/,
-            1 /*mergeInputTableCount*/,
-            1 /*primaryMergeInputTableCount*/,
+            /*inputChunkCount*/ std::numeric_limits<i64>::max() / 4,
+            /*mergeInputTableCount*/ 1,
+            /*primaryMergeInputTableCount*/ 1,
             spec->Sampling)
         , Spec_(spec)
         , Options_(options)
@@ -846,18 +858,19 @@ IJobSizeConstraintsPtr CreatePartitionBoundSortedJobSizeConstraints(
     i64 dataWeightPerJob = std::max(minDataWeightPerJob, spec->DataWeightPerSortedJob.value_or(spec->DataWeightPerShuffleJob));
 
     return CreateExplicitJobSizeConstraints(
-        false /*canAdjustDataSizePerJob*/,
-        false /*isExplicitJobCount*/,
-        0 /*jobCount*/,
-        dataWeightPerJob /*dataWeightPerJob*/,
-        dataWeightPerJob /*primaryDataWeightPerJob*/,
+        /*canAdjustDataSizePerJob*/ false,
+        /*isExplicitJobCount*/ false,
+        /*jobCount*/ 0,
+        /*dataWeightPerJob*/ dataWeightPerJob,
+        /*primaryDataWeightPerJob*/ dataWeightPerJob,
         options->MaxDataSlicesPerJob,
         spec->MaxDataWeightPerJob,
         spec->MaxPrimaryDataWeightPerJob,
-        std::numeric_limits<i64>::max() / 4 /*inputSliceDataSize*/,
-        std::numeric_limits<i64>::max() / 4 /*inputSliceRowCount*/,
-        0 /*foreignSliceDataWeight*/,
-        std::nullopt /*samplingRate*/);
+        /*inputSliceDataSize*/ std::numeric_limits<i64>::max() / 4,
+        /*inputSliceRowCount*/ std::numeric_limits<i64>::max() / 4,
+        /*batchRowCount*/ {},
+        /*foreignSliceDataWeight*/ 0,
+        /*samplingRate*/ std::nullopt);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/chunk_pools/chunk_pool_factory.cpp
+++ b/yt/yt/server/lib/chunk_pools/chunk_pool_factory.cpp
@@ -99,6 +99,11 @@ public:
         return InfiniteCount;
     }
 
+    std::optional<i64> GetBatchRowCount() const override
+    {
+        return {};
+    }
+
     i64 GetForeignSliceDataWeight() const override
     {
         return 0;

--- a/yt/yt/server/lib/chunk_pools/legacy_sorted_chunk_pool.cpp
+++ b/yt/yt/server/lib/chunk_pools/legacy_sorted_chunk_pool.cpp
@@ -701,6 +701,7 @@ private:
             JobSizeConstraints_->GetMaxPrimaryDataWeightPerJob(),
             JobSizeConstraints_->GetInputSliceDataWeight(),
             JobSizeConstraints_->GetInputSliceRowCount(),
+            JobSizeConstraints_->GetBatchRowCount(),
             JobSizeConstraints_->GetForeignSliceDataWeight(),
             std::nullopt /*samplingRate*/);
 

--- a/yt/yt/server/lib/chunk_pools/new_sorted_chunk_pool.cpp
+++ b/yt/yt/server/lib/chunk_pools/new_sorted_chunk_pool.cpp
@@ -741,6 +741,7 @@ private:
             JobSizeConstraints_->GetMaxPrimaryDataWeightPerJob(),
             JobSizeConstraints_->GetInputSliceDataWeight(),
             JobSizeConstraints_->GetInputSliceRowCount(),
+            JobSizeConstraints_->GetBatchRowCount(),
             JobSizeConstraints_->GetForeignSliceDataWeight(),
             std::nullopt /*samplingRate*/);
 

--- a/yt/yt/server/lib/chunk_pools/ordered_chunk_pool.cpp
+++ b/yt/yt/server/lib/chunk_pools/ordered_chunk_pool.cpp
@@ -89,11 +89,12 @@ public:
         }
 
         YT_LOG_DEBUG("Ordered chunk pool created (DataWeightPerJob: %v, MaxDataSlicesPerJob: %v, "
-            "InputSliceDataWeight: %v, InputSliceRowCount: %v, SingleJob: %v)",
-            JobSizeConstraints_->GetDataWeightPerJob(),
+            "InputSliceDataWeight: %v, InputSliceRowCount: %v, BatchRowCount: %v, SingleJob: %v)",
+            GetDataWeightPerJob(),
             JobSizeConstraints_->GetMaxDataSlicesPerJob(),
             JobSizeConstraints_->GetInputSliceDataWeight(),
             JobSizeConstraints_->GetInputSliceRowCount(),
+            JobSizeConstraints_->GetBatchRowCount(),
             SingleJob_);
     }
 
@@ -239,6 +240,8 @@ private:
 
     TOutputOrderPtr OutputOrder_ = nullptr;
 
+    i64 RowCountUntilJobSplit_ = 0;
+    i64 JobCarryOverDataWeight_ = 0;
     std::unique_ptr<TNewJobStub> CurrentJob_;
 
     int JobIndex_ = 0;
@@ -265,6 +268,23 @@ private:
         } else {
             return TPeriodicYielder();
         }
+    }
+
+    bool IsTeleportable(const TLegacyDataSlicePtr& dataSlice) const
+    {
+        if (dataSlice->Type != EDataSourceType::UnversionedTable) {
+            return false;
+        }
+
+        if (SingleJob_ || JobSizeConstraints_->GetBatchRowCount()) {
+            return false;
+        }
+
+        if (!InputStreamDirectory_.GetDescriptor(dataSlice->GetInputStreamIndex()).IsTeleportable()) {
+            return false;
+        }
+
+        return dataSlice->GetSingleUnversionedChunk()->IsLargeCompleteChunk(MinTeleportChunkSize_);
     }
 
     void BuildJobsAndFindTeleportChunks()
@@ -297,47 +317,31 @@ private:
             const auto& stripe = Stripes_[inputCookie].GetStripe();
             for (const auto& dataSlice : stripe->DataSlices) {
                 yielder.TryYield();
-                if (dataSlice->Type == EDataSourceType::UnversionedTable) {
-                    auto inputChunk = dataSlice->GetSingleUnversionedChunk();
-                    if (InputStreamDirectory_.GetDescriptor(stripe->GetInputStreamIndex()).IsTeleportable() &&
-                        inputChunk->IsLargeCompleteChunk(MinTeleportChunkSize_) &&
-                        !SingleJob_)
-                    {
-                        if (Sampler_.Sample()) {
-                            EndJob();
+                if (IsTeleportable(dataSlice)) {
+                    if (Sampler_.Sample()) {
+                        EndJob();
 
-                            // Add barrier.
-                            CurrentJob()->SetIsBarrier(true);
-                            JobManager_->AddJob(std::move(CurrentJob()));
+                        // Add barrier.
+                        CurrentJob()->SetIsBarrier(true);
+                        JobManager_->AddJob(std::move(CurrentJob()));
 
-                            ChunkTeleported_.Fire(inputChunk, /*tag=*/std::any{});
-                            ++chunksTeleported;
+                        auto inputChunk = dataSlice->GetSingleUnversionedChunk();
+                        ChunkTeleported_.Fire(inputChunk, /*tag*/ std::any{});
+                        ++chunksTeleported;
 
-                            if (OutputOrder_) {
-                                OutputOrder_->Push(TOutputOrder::TEntry(inputChunk));
-                            }
-                        } else {
-                            // This teleport chunk goes to /dev/null.
-                            ++droppedTeleportChunkCount;
+                        if (OutputOrder_) {
+                            OutputOrder_->Push(TOutputOrder::TEntry(inputChunk));
                         }
-                        continue;
+                    } else {
+                        // This teleport chunk goes to /dev/null.
+                        ++droppedTeleportChunkCount;
                     }
+
+                    continue;
                 }
 
-                std::vector<TLegacyDataSlicePtr> slicedDataSlices;
                 YT_VERIFY(!dataSlice->IsLegacy);
-                if (dataSlice->Type == EDataSourceType::UnversionedTable && ShouldSliceByRowIndices_) {
-                    auto chunkSliceCopy = CreateInputChunkSlice(*dataSlice->ChunkSlices[0]);
-                    auto chunkSlices = chunkSliceCopy
-                        ->SliceEvenly(JobSizeConstraints_->GetInputSliceDataWeight(), JobSizeConstraints_->GetInputSliceRowCount());
-                    for (const auto& chunkSlice : chunkSlices) {
-                        auto smallerDataSlice = CreateUnversionedInputDataSlice(chunkSlice);
-                        smallerDataSlice->CopyPayloadFrom(*dataSlice);
-                        AddPrimaryDataSlice(smallerDataSlice, inputCookie, JobSizeConstraints_->GetDataWeightPerJob());
-                    }
-                } else {
-                    AddPrimaryDataSlice(dataSlice, inputCookie, JobSizeConstraints_->GetDataWeightPerJob());
-                }
+                AddPrimaryDataSlice(dataSlice, inputCookie, GetDataWeightPerJob());
             }
         }
         EndJob();
@@ -349,7 +353,7 @@ private:
 
         if (JobSizeConstraints_->GetSamplingRate()) {
             JobManager_->Enlarge(
-                JobSizeConstraints_->GetDataWeightPerJob(),
+                GetDataWeightPerJob(),
                 JobSizeConstraints_->GetPrimaryDataWeightPerJob());
         }
 
@@ -381,7 +385,7 @@ private:
         std::vector<IChunkPoolOutput::TCookie> childCookies;
         for (const auto& dataSlice : unreadInputDataSlices) {
             int inputCookie = *dataSlice->Tag;
-            auto outputCookie = AddPrimaryDataSlice(dataSlice, inputCookie, dataSizePerJob);
+            auto outputCookie = AddUnsplittablePrimaryDataSlice(dataSlice, inputCookie, dataSizePerJob);
             if (outputCookie != IChunkPoolOutput::NullCookie) {
                 childCookies.push_back(outputCookie);
             }
@@ -401,28 +405,158 @@ private:
     {
         return
             JobSizeConstraints_->GetSamplingRate()
-            ? JobSizeConstraints_->GetSamplingDataWeightPerJob()
+            ? std::max(JobSizeConstraints_->GetDataWeightPerJob(), JobSizeConstraints_->GetSamplingDataWeightPerJob())
             : JobSizeConstraints_->GetDataWeightPerJob();
     }
 
-    IChunkPoolOutput::TCookie AddPrimaryDataSlice(
+    i64 GetCurrentJobDataWeight()
+    {
+        return JobCarryOverDataWeight_ + CurrentJob()->GetDataWeight();
+    }
+
+    IChunkPoolOutput::TCookie AddUnsplittablePrimaryDataSlice(
         const TLegacyDataSlicePtr& dataSlice,
         IChunkPoolInput::TCookie cookie,
         i64 dataSizePerJob)
     {
         YT_VERIFY(!dataSlice->IsLegacy);
-        bool jobIsLargeEnough =
-            CurrentJob()->GetPreliminarySliceCount() + 1 > JobSizeConstraints_->GetMaxDataSlicesPerJob() ||
-            CurrentJob()->GetDataWeight() >= dataSizePerJob;
+
+        RowCountUntilJobSplit_ = 0;
+        JobCarryOverDataWeight_ = 0;
+
         IChunkPoolOutput::TCookie result = IChunkPoolOutput::NullCookie;
+
+        bool jobIsLargeEnough =
+            CurrentJob()->GetPreliminarySliceCount() >= JobSizeConstraints_->GetMaxDataSlicesPerJob() ||
+            GetCurrentJobDataWeight() >= dataSizePerJob;
         if (jobIsLargeEnough && !SingleJob_) {
             result = EndJob();
         }
+
         auto dataSliceCopy = CreateInputDataSlice(dataSlice);
         dataSliceCopy->Tag = cookie;
-        dataSlice->CopyPayloadFrom(*dataSlice);
-        CurrentJob()->AddDataSlice(dataSliceCopy, cookie, true /*isPrimary*/);
+        CurrentJob()->AddDataSlice(dataSliceCopy, cookie, /*isPrimary*/ true);
         return result;
+    }
+
+    bool IsDataSliceSplittable(const TLegacyDataSlicePtr& dataSlice) const
+    {
+        if (dataSlice->Type != EDataSourceType::UnversionedTable) {
+            return false;
+        }
+
+        // Unbounded dynamic store cannot be split.
+        if (dataSlice->GetSingleUnversionedChunkSlice()->GetInputChunk()->IsOrderedDynamicStore() &&
+            !dataSlice->GetSingleUnversionedChunkSlice()->UpperLimit().RowIndex) {
+            return false;
+        }
+
+        return ShouldSliceByRowIndices_;
+    }
+
+    void AddPrimaryDataSlice(
+        const TLegacyDataSlicePtr& dataSlice,
+        IChunkPoolInput::TCookie cookie,
+        i64 dataSizePerJob)
+    {
+        if (IsDataSliceSplittable(dataSlice)) {
+            AddSplittablePrimaryDataSlice(dataSlice, cookie, dataSizePerJob);
+        } else {
+            AddUnsplittablePrimaryDataSlice(dataSlice, cookie, dataSizePerJob);
+        }
+    }
+
+    // Adding slices via this method essentially circles between multiple stages.
+    // First, we add slices while none of the limits (data weight / slice count) are violated.
+    // The job slice limit is considered hard: whenever it is hit, we just end the current job.
+    // Once we reach a slice adding which would violate the data weight limit, we break into multiple cases:
+    //   - First, we compute the ideal split index by data weight.
+    //   - Then, if batch row count is not set, we try to split the job by the index above.
+    //   - Otherwise, we compute the next split that would make the number of rows in the job divisible by batch row count and store it for the next iteration.
+    // Next iterations operate on a data weight "discount", decrementing the stored row count until next split.
+    void AddSplittablePrimaryDataSlice(
+        const TLegacyDataSlicePtr& dataSlice,
+        IChunkPoolInput::TCookie cookie,
+        i64 dataSizePerJob)
+    {
+        YT_VERIFY(IsDataSliceSplittable(dataSlice));
+
+        auto chunkSlices = dataSlice->GetSingleUnversionedChunkSlice()
+            ->SliceEvenly(JobSizeConstraints_->GetInputSliceDataWeight(), JobSizeConstraints_->GetInputSliceRowCount());
+
+        auto batchRowCount = JobSizeConstraints_->GetBatchRowCount();
+
+        TInputChunkSlicePtr pocket;
+        int chunkSliceIndex = 0;
+        while (chunkSliceIndex < std::ssize(chunkSlices) || pocket) {
+            auto chunkSlice = pocket ? pocket : chunkSlices[chunkSliceIndex];
+            pocket = nullptr;
+
+            if (!chunkSlice->GetRowCount()) {
+                ++chunkSliceIndex;
+                continue;
+            }
+
+            // NB: Hitting this limit means we cannot take more than one slice.
+            // In this case the final row count of this job might not be divisible by batch row count.
+            // NB: We need >= instead of == to handle the case of an explicit single job.
+            if (CurrentJob()->GetPreliminarySliceCount() + 1 >= JobSizeConstraints_->GetMaxDataSlicesPerJob()) {
+                RowCountUntilJobSplit_ = chunkSlice->GetRowCount();
+                // This will lead to the carry-over value being zero after adding `chunkSliceToAdd->GetDataWeight()`.
+                JobCarryOverDataWeight_ = -chunkSlice->GetDataWeight();
+            }
+
+            if (RowCountUntilJobSplit_ == 0 && GetCurrentJobDataWeight() + chunkSlice->GetDataWeight() >= dataSizePerJob) {
+                // Taking this maximum is needed if jobs of batch row count rows are significantly larger than data size per job.
+                // In these cases we simply try to end the jobs as soon as we can hit an acceptable split.
+                auto dataWeightUntilSplit = std::max<i64>(dataSizePerJob - GetCurrentJobDataWeight(), 0);
+
+                RowCountUntilJobSplit_ = DivCeil(dataWeightUntilSplit * chunkSlice->GetRowCount(), chunkSlice->GetDataWeight());
+                YT_VERIFY(RowCountUntilJobSplit_ <= chunkSlice->GetRowCount());
+
+                // We only carry-over from one previous job.
+                // NB: We use splitting here in order to get the exact same data weight we would get later on in the process.
+                JobCarryOverDataWeight_ = RowCountUntilJobSplit_ ? -chunkSlice->SplitByRowIndex(RowCountUntilJobSplit_).first->GetDataWeight() : 0;
+
+                // If batch row count is zero, there should never be any carry-over data weight,
+                // so the second value cannot be zero for non-empty slices.
+                YT_VERIFY(batchRowCount || RowCountUntilJobSplit_ > 0);
+
+                if (batchRowCount) {
+                    YT_VERIFY(*batchRowCount > 0);
+                    // Zero rows until split force us to look for the next acceptable split (even when batchRowCountRemainder = 0) since it usually means that a job just ended.
+                    if (auto batchRowCountRemainder = (CurrentJob()->GetRowCount() + RowCountUntilJobSplit_) % *batchRowCount; !RowCountUntilJobSplit_ || batchRowCountRemainder) {
+                        RowCountUntilJobSplit_ += *batchRowCount - batchRowCountRemainder;
+                    }
+                }
+            }
+
+            auto chunkSliceToAdd = chunkSlice;
+
+            bool endJob = RowCountUntilJobSplit_ > 0 && RowCountUntilJobSplit_ <= chunkSlice->GetRowCount();
+            if (endJob && RowCountUntilJobSplit_ < chunkSlice->GetRowCount()) {
+                std::tie(chunkSliceToAdd, pocket) = chunkSlice->SplitByRowIndex(RowCountUntilJobSplit_);
+            }
+
+            if (RowCountUntilJobSplit_ > 0) {
+                RowCountUntilJobSplit_ -= chunkSliceToAdd->GetRowCount();
+                JobCarryOverDataWeight_ += chunkSliceToAdd->GetDataWeight();
+            }
+
+            auto dataSliceToAdd = CreateUnversionedInputDataSlice(chunkSliceToAdd);
+            dataSliceToAdd->CopyPayloadFrom(*dataSlice);
+            dataSliceToAdd->Tag = cookie;
+
+            CurrentJob()->AddDataSlice(dataSliceToAdd, cookie, /*isPrimary*/ true);
+            if (endJob && !SingleJob_) {
+                YT_VERIFY(RowCountUntilJobSplit_ == 0);
+                EndJob();
+            }
+
+            if (!pocket) {
+                ++chunkSliceIndex;
+            }
+        }
     }
 
     IChunkPoolOutput::TCookie EndJob()

--- a/yt/yt/server/lib/chunk_pools/unittests/ordered_chunk_pool_ut.cpp
+++ b/yt/yt/server/lib/chunk_pools/unittests/ordered_chunk_pool_ut.cpp
@@ -21,6 +21,8 @@
 #include <yt/yt/core/misc/blob_output.h>
 #include <yt/yt/core/misc/phoenix.h>
 
+#include <library/cpp/iterator/zip.h>
+
 #include <util/generic/cast.h>
 
 #include <util/stream/null.h>
@@ -68,17 +70,18 @@ protected:
     void InitJobConstraints()
     {
         Options_.JobSizeConstraints = CreateExplicitJobSizeConstraints(
-            false /*canAdjustDataSizePerJob*/,
-            static_cast<bool>(ExplicitJobCount_) /*isExplicitJobCount*/,
-            ExplicitJobCount_.value_or(0) /*jobCount*/,
+            /*canAdjustDataSizePerJob*/ false,
+            /*isExplicitJobCount*/ static_cast<bool>(ExplicitJobCount_),
+            /*jobCount*/ ExplicitJobCount_.value_or(0),
             DataSizePerJob_,
             Inf64,
             MaxDataSlicesPerJob_,
-            0 /*maxDataSizePerJob_*/,
-            0 /*maxPrimaryDataWeightPerJob_*/,
+            /*maxDataSizePerJob_*/ 0,
+            /*maxPrimaryDataWeightPerJob*/ 0,
             InputSliceDataSize_,
             InputSliceRowCount_,
-            0 /*foreignSliceDataWeight*/,
+            BatchRowCount_,
+            /*foreignSliceDataWeight*/ 0,
             SamplingRate_);
     }
 
@@ -106,7 +109,7 @@ protected:
     {
         YT_VERIFY(isTeleportable.size() == isVersioned.size() && isVersioned.size() > 0);
         for (int index = 0; index < std::ssize(isVersioned); ++index) {
-            InputTables_.emplace_back(isTeleportable[index], true /*isPrimary*/, isVersioned[index]);
+            InputTables_.emplace_back(isTeleportable[index], /*isPrimary*/ true, isVersioned[index]);
         }
         UnversionedTableRowCounts_.resize(InputTables_.size(), 0);
     }
@@ -117,7 +120,7 @@ protected:
             Options_,
             useGenericInputStreamDirectory ? IntermediateInputStreamDirectory : TInputStreamDirectory(InputTables_));
         ChunkPool_->SubscribeChunkTeleported(
-            BIND([this] (TInputChunkPtr teleportChunk, std::any /*tag*/) {
+            BIND([this] (TInputChunkPtr teleportChunk, /*tag*/ std::any) {
                 TeleportChunks_.push_back(std::move(teleportChunk));
             }));
     }
@@ -133,6 +136,8 @@ protected:
 
     IChunkPoolInput::TCookie AddChunk(const TInputChunkPtr& chunk)
     {
+        MaxChunkRowDataWeight_ = std::max(MaxChunkRowDataWeight_, DivCeil(chunk->GetDataWeight(), chunk->GetRowCount()));
+
         auto dataSlice = BuildDataSliceByChunk(chunk);
         ActiveChunks_.insert(chunk->GetChunkId());
         OriginalChunks_.push_back(chunk->GetChunkId());
@@ -193,7 +198,7 @@ protected:
         TLoadContext loadContext(&input, RowBuffer_, GetCurrentSnapshotVersion());
         Load(loadContext, ChunkPool_);
         ChunkPool_->SubscribeChunkTeleported(
-            BIND([this] (TInputChunkPtr teleportChunk, std::any /*tag*/) {
+            BIND([this] (TInputChunkPtr teleportChunk, /*tag*/ std::any) {
                 TeleportChunks_.push_back(std::move(teleportChunk));
             }));
     }
@@ -292,6 +297,48 @@ protected:
         }
     }
 
+    void CheckEntryForBatchRowCountAcceptability(const TOutputOrder::TEntry& entry)
+    {
+        EXPECT_TRUE(entry.IsCookie());
+
+        auto stripeList = ChunkPool_->GetStripeList(entry.GetCookie());
+        EXPECT_TRUE(stripeList->TotalRowCount % *BatchRowCount_ == 0);
+        EXPECT_LE(std::abs(stripeList->TotalDataWeight - DataSizePerJob_), *BatchRowCount_ * MaxChunkRowDataWeight_);
+    }
+
+    void CheckBatchRowCount()
+    {
+        ASSERT_TRUE(Options_.KeepOutputOrder);
+
+        auto order = ChunkPool_->GetOutputOrder();
+        ASSERT_TRUE(order);
+
+        auto entries = order->ToEntryVector();
+        for (int index = 0; index + 1 < std::ssize(entries); ++index) {
+            CheckEntryForBatchRowCountAcceptability(entries[index]);
+        }
+    }
+
+    void CheckExplicitRowCounts(std::vector<i64> rowCounts)
+    {
+        ASSERT_TRUE(Options_.KeepOutputOrder);
+
+        auto order = ChunkPool_->GetOutputOrder();
+        ASSERT_TRUE(order);
+
+        auto entries = order->ToEntryVector();
+        EXPECT_EQ(std::ssize(entries), std::ssize(rowCounts));
+
+        for (const auto& [entry, rowCount] : Zip(entries, rowCounts)) {
+            if (entry.IsTeleportChunk()) {
+                EXPECT_EQ(entry.GetTeleportChunk()->GetRowCount(), rowCount);
+            } else {
+                EXPECT_TRUE(entry.IsCookie());
+                EXPECT_EQ(ChunkPool_->GetStripeList(entry.GetCookie())->TotalRowCount, rowCount);
+            }
+        }
+    }
+
     std::vector<TChunkId> OriginalChunks_;
 
     IPersistentChunkPoolPtr ChunkPool_;
@@ -300,6 +347,8 @@ protected:
     THashSet<TInputChunkPtr> CreatedUnversionedPrimaryChunks_;
     //! Set containing all chunks that are added to the pool without being suspended.
     THashSet<TChunkId> ActiveChunks_;
+
+    i64 MaxChunkRowDataWeight_ = 0;
 
     std::vector<TInputStreamDescriptor> InputTables_;
 
@@ -319,6 +368,8 @@ protected:
 
     i64 InputSliceRowCount_;
 
+    std::optional<i64> BatchRowCount_;
+
     std::optional<i32> ExplicitJobCount_;
 
     std::optional<double> SamplingRate_;
@@ -335,8 +386,8 @@ protected:
 TEST_F(TOrderedChunkPoolTest, OrderedMergeSimple)
 {
     InitTables(
-        {true, true, true} /*isTeleportable*/,
-        {false, false, false} /*isVersioned*/
+        /*isTeleportable*/ {true, true, true},
+        /*isVersioned*/ {false, false, false}
     );
 
     DataSizePerJob_ = 2_KB;
@@ -368,11 +419,167 @@ TEST_F(TOrderedChunkPoolTest, OrderedMergeSimple)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TEST_F(TOrderedChunkPoolTest, LargeChunksPreciseSlicing)
+{
+    InitTables(
+        /*isTeleportable*/ {true, true, true},
+        /*isVersioned*/ {false, false, false}
+    );
+
+    DataSizePerJob_ = 2_KB;
+
+    InitJobConstraints();
+
+    auto chunkA1 = CreateChunk(0, 10_KB);
+    auto chunkA2 = CreateChunk(0, 22_KB);
+    auto chunkB = CreateChunk(1, 23_KB);
+    auto chunkC = CreateChunk(2, 3_KB);
+
+    CreateChunkPool();
+
+    AddChunk(chunkA1);
+    AddChunk(chunkA2);
+    AddChunk(chunkB);
+    AddChunk(chunkC);
+
+    ChunkPool_->Finish();
+
+    ExtractOutputCookiesWhilePossible();
+    auto stripeLists = GetAllStripeLists();
+
+    EXPECT_THAT(TeleportChunks_, IsEmpty());
+    EXPECT_EQ(29u, stripeLists.size());
+
+    CheckEverything(stripeLists);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(TOrderedChunkPoolTest, BatchRowCountBasic)
+{
+    InitTables(
+        /*isTeleportable*/ {true, true, true},
+        /*isVersioned*/ {false, false, false}
+    );
+
+    Options_.KeepOutputOrder = true;
+    // This should have no effect!
+    Options_.MinTeleportChunkSize = 2_KB;
+
+    // Nor this!
+    SamplingRate_ = 0.3;
+    BatchRowCount_ = 42;
+    DataSizePerJob_ = 2_KB;
+
+    InitJobConstraints();
+
+    auto chunkA1 = CreateChunk(0, 10_KB, 1234);
+    auto chunkA2 = CreateChunk(0, 22_KB, 2435);
+    auto chunkB = CreateChunk(1, 23_KB, 3434);
+    auto chunkC = CreateChunk(2, 3_KB, 333);
+
+    CreateChunkPool();
+
+    AddChunk(chunkA1);
+    AddChunk(chunkA2);
+    AddChunk(chunkB);
+    AddChunk(chunkC);
+
+    ChunkPool_->Finish();
+
+    ExtractOutputCookiesWhilePossible();
+
+    CheckBatchRowCount();
+    CheckEverything(GetAllStripeLists());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(TOrderedChunkPoolTest, BatchRowCountDoesNotFailWithVersionedChunks)
+{
+    InitTables(
+        /*isTeleportable*/ {true, true, true},
+        /*isVersioned*/ {false, true, false}
+    );
+
+    Options_.KeepOutputOrder = true;
+    // This should have no effect!
+    Options_.MinTeleportChunkSize = 2_KB;
+    // Nor this!
+    SamplingRate_ = 0.3;
+    BatchRowCount_ = 42;
+    DataSizePerJob_ = 2_KB;
+
+    InitJobConstraints();
+
+    auto chunkA1 = CreateChunk(0, 10_KB, 1234);
+    auto chunkA2 = CreateChunk(0, 22_KB, 2435);
+    auto chunkB = CreateChunk(1, 23_KB, 3434);
+    auto chunkC = CreateChunk(2, 3_KB, 333);
+
+    CreateChunkPool();
+
+    AddChunk(chunkA1);
+    AddChunk(chunkA2);
+    AddChunk(chunkB);
+    AddChunk(chunkC);
+
+    ChunkPool_->Finish();
+
+    ExtractOutputCookiesWhilePossible();
+
+    CheckEverything(GetAllStripeLists());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST_F(TOrderedChunkPoolTest, BatchRowCountBigBatchesSmallDataSizePerJob)
+{
+    InitTables(
+        /*isTeleportable*/ {true, true, true},
+        /*isVersioned*/ {false, false, false}
+    );
+
+    Options_.KeepOutputOrder = true;
+    // This should have no effect!
+    Options_.MinTeleportChunkSize = 2_KB;
+    BatchRowCount_ = 20;
+    DataSizePerJob_ = 2_KB;
+
+    InitJobConstraints();
+
+    auto chunkA1 = CreateChunk(0, 10_KB, 10);
+    auto chunkA2 = CreateChunk(0, 30_KB, 5);
+    auto chunkB = CreateChunk(1, 60_KB, 30);
+    auto chunkC = CreateChunk(2, 3_KB, 6);
+
+    CreateChunkPool();
+
+    AddChunk(chunkA1);
+    AddChunk(chunkA2);
+    AddChunk(chunkB);
+    AddChunk(chunkC);
+
+    ChunkPool_->Finish();
+
+    ExtractOutputCookiesWhilePossible();
+
+    CheckBatchRowCount();
+
+    auto stripeLists = GetAllStripeLists();
+    EXPECT_EQ(std::ssize(stripeLists), 3);
+    CheckExplicitRowCounts({20, 20, 11});
+
+    CheckEverything(GetAllStripeLists());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 TEST_F(TOrderedChunkPoolTest, OrderedMergeOrderedOutput)
 {
     InitTables(
-        {true, true, true} /*isTeleportable*/,
-        {false, false, false} /*isVersioned*/
+        /*isTeleportable*/ {true, true, true},
+        /*isVersioned*/ {false, false, false}
     );
 
     Options_.KeepOutputOrder = true;
@@ -455,8 +662,8 @@ TEST_F(TOrderedChunkPoolTest, OrderedMergeOrderedOutput)
 TEST_F(TOrderedChunkPoolTest, OrderedMergeSliceLargeChunks)
 {
     InitTables(
-        {false} /*isTeleportable*/,
-        {false} /*isVersioned*/
+        /*isTeleportable*/ {false},
+        /*isVersioned*/ {false}
     );
 
     DataSizePerJob_ = 2_KB;
@@ -465,7 +672,7 @@ TEST_F(TOrderedChunkPoolTest, OrderedMergeSliceLargeChunks)
 
     InitJobConstraints();
 
-    auto chunkA = CreateChunk(0, 20_KB, 1000 /*rowCount*/);
+    auto chunkA = CreateChunk(0, 20_KB, /*rowCount*/ 1000);
 
     CreateChunkPool();
 
@@ -488,8 +695,8 @@ TEST_F(TOrderedChunkPoolTest, OrderedMergeSliceLargeChunks)
 TEST_F(TOrderedChunkPoolTest, ExplicitSingleJob)
 {
     InitTables(
-        {true} /*isTeleportable*/,
-        {false} /*isVersioned*/
+        /*isTeleportable*/ {true},
+        /*isVersioned*/ {false}
     );
 
     ExplicitJobCount_ = 1;
@@ -502,8 +709,8 @@ TEST_F(TOrderedChunkPoolTest, ExplicitSingleJob)
 
     // We have many data slices, large data weight and teleportable chunks.
     // So many reasons to create two jobs.
-    auto chunkA = CreateChunk(0, 10_KB, 1000 /*rowCount*/);
-    auto chunkB = CreateChunk(0, 10_KB, 1000 /*rowCount*/);
+    auto chunkA = CreateChunk(0, 10_KB, /*rowCount*/ 1000);
+    auto chunkB = CreateChunk(0, 10_KB, /*rowCount*/ 1000);
 
     CreateChunkPool();
 
@@ -542,8 +749,8 @@ static constexpr int NumberOfRepeats = 15;
 TEST_P(TOrderedChunkPoolTestRandomized, VariousOperationsWithPoolTest)
 {
     InitTables(
-        {false} /*isTeleportable*/,
-        {false} /*isVersioned*/
+        /*isTeleportable*/ {false},
+        /*isVersioned*/ {false}
     );
     DataSizePerJob_ = 1_KB;
     InitJobConstraints();

--- a/yt/yt/server/lib/chunk_pools/unittests/sorted_chunk_pool_new_keys_ut.cpp
+++ b/yt/yt/server/lib/chunk_pools/unittests/sorted_chunk_pool_new_keys_ut.cpp
@@ -109,6 +109,7 @@ protected:
             MaxPrimaryDataWeightPerJob_,
             InputSliceDataWeight_,
             Inf64 /*inputSliceRowCount*/,
+            {} /*batchRowCount*/,
             InputSliceDataWeight_,
             SamplingRate_,
             SamplingDataWeightPerJob_,

--- a/yt/yt/server/lib/chunk_pools/unittests/sorted_chunk_pool_ut.cpp
+++ b/yt/yt/server/lib/chunk_pools/unittests/sorted_chunk_pool_ut.cpp
@@ -85,6 +85,7 @@ protected:
             MaxPrimaryDataWeightPerJob_,
             InputSliceDataWeight_,
             Inf64 /*inputSliceRowCount*/,
+            {} /*batchRowCount*/,
             InputSliceDataWeight_,
             SamplingRate_,
             SamplingDataWeightPerJob_,

--- a/yt/yt/server/lib/chunk_pools/unittests/unordered_chunk_pool_ut.cpp
+++ b/yt/yt/server/lib/chunk_pools/unittests/unordered_chunk_pool_ut.cpp
@@ -74,6 +74,7 @@ protected:
             0 /*maxPrimaryDataWeightPerJob*/,
             InputSliceDataSize_,
             InputSliceRowCount_,
+            {} /*batchRowCount*/,
             0 /*foreignSliceDataWeight*/,
             SamplingRate_);
     }

--- a/yt/yt/server/lib/controller_agent/job_size_constraints.cpp
+++ b/yt/yt/server/lib/controller_agent/job_size_constraints.cpp
@@ -23,6 +23,7 @@ public:
         i64 maxPrimaryDataWeightPerJob,
         i64 inputSliceDataWeight,
         i64 inputSliceRowCount,
+        std::optional<i64> batchRowCount,
         i64 foreignSliceDataWeight,
         std::optional<double> samplingRate,
         i64 samplingDataWeightPerJob,
@@ -41,6 +42,7 @@ public:
         , MaxPrimaryDataWeightPerJob_(maxPrimaryDataWeightPerJob)
         , InputSliceDataWeight_(inputSliceDataWeight)
         , InputSliceRowCount_(inputSliceRowCount)
+        , BatchRowCount_(batchRowCount)
         , ForeignSliceDataWeight_(foreignSliceDataWeight)
         , SamplingRate_(samplingRate)
         , SamplingDataWeightPerJob_(samplingDataWeightPerJob)
@@ -110,6 +112,11 @@ public:
         return InputSliceRowCount_;
     }
 
+    std::optional<i64> GetBatchRowCount() const override
+    {
+        return BatchRowCount_;
+    }
+
     i64 GetForeignSliceDataWeight() const override
     {
         return ForeignSliceDataWeight_;
@@ -165,6 +172,12 @@ public:
         Persist(context, MaxPrimaryDataWeightPerJob_);
         Persist(context, InputSliceDataWeight_);
         Persist(context, InputSliceRowCount_);
+        // NB: ESnapshotVersion::BumpTo_24_1 is the first 24.1 snapshot version.
+        if ((context.GetVersion() >= ESnapshotVersion::BatchRowCount_23_2 && context.GetVersion() < ESnapshotVersion::BumpTo_24_1) ||
+            context.GetVersion() >= ESnapshotVersion::BatchRowCount_24_1)
+        {
+            Persist(context, BatchRowCount_);
+        }
         Persist(context, ForeignSliceDataWeight_);
         Persist(context, SamplingRate_);
         Persist(context, SamplingDataWeightPerJob_);
@@ -202,6 +215,7 @@ private:
     i64 MaxPrimaryDataWeightPerJob_;
     i64 InputSliceDataWeight_;
     i64 InputSliceRowCount_;
+    std::optional<i64> BatchRowCount_;
     i64 ForeignSliceDataWeight_;
     std::optional<double> SamplingRate_;
     i64 SamplingDataWeightPerJob_;
@@ -226,6 +240,7 @@ IJobSizeConstraintsPtr CreateExplicitJobSizeConstraints(
     i64 maxPrimaryDataWeightPerJob,
     i64 inputSliceDataWeight,
     i64 inputSliceRowCount,
+    std::optional<i64> batchRowCount,
     i64 foreignSliceDataWeight,
     std::optional<double> samplingRate,
     i64 samplingDataWeightPerJob,
@@ -245,6 +260,7 @@ IJobSizeConstraintsPtr CreateExplicitJobSizeConstraints(
         maxPrimaryDataWeightPerJob,
         inputSliceDataWeight,
         inputSliceRowCount,
+        batchRowCount,
         foreignSliceDataWeight,
         samplingRate,
         samplingDataWeightPerJob,

--- a/yt/yt/server/lib/controller_agent/job_size_constraints.h
+++ b/yt/yt/server/lib/controller_agent/job_size_constraints.h
@@ -40,6 +40,10 @@ struct IJobSizeConstraints
     virtual i64 GetInputSliceDataWeight() const = 0;
     virtual i64 GetInputSliceRowCount() const = 0;
 
+    //! A recommendation for the number of rows fed to each job to be divisible by this number.
+    //! Disables job interrupts, chunk teleportation and sampling.
+    virtual std::optional<i64> GetBatchRowCount() const = 0;
+
     //! Approximate size of a foreign data slice. Has meaning only in context of sorted operation.
     virtual i64 GetForeignSliceDataWeight() const = 0;
 
@@ -85,6 +89,7 @@ IJobSizeConstraintsPtr CreateExplicitJobSizeConstraints(
     i64 maxPrimaryDataWeightPerJob,
     i64 inputSliceDataWeight,
     i64 inputSliceRowCount,
+    std::optional<i64> batchRowCount,
     i64 foreignSliceDataWeight,
     std::optional<double> samplingRate,
     i64 samplingDataWeightPerJob = -1,

--- a/yt/yt/server/lib/controller_agent/serialize.h
+++ b/yt/yt/server/lib/controller_agent/serialize.h
@@ -41,12 +41,14 @@ DEFINE_ENUM(ESnapshotVersion,
     // 23.2 continues here (YT-21342)
     ((NodeJobStartTimeInJoblet)             (301408))
     ((JobAbortsUntilOperationFailure)       (301409))
+    ((BatchRowCount_23_2)                   (301410))
     // 24.1 starts here
     ((BumpTo_24_1)                          (301500))
     ((InterruptionReasonInJoblet)           (301501))
     ((PersistMonitoringCounts)              (301502))
     ((WaitingForResourcesDuration)          (301503))
     ((ForceAllowJobInterruption)            (301504))
+    ((BatchRowCount_24_1)                   (301505))
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/tests/integration/controller/test_merge_operation.py
+++ b/yt/yt/tests/integration/controller/test_merge_operation.py
@@ -309,6 +309,82 @@ class TestSchedulerMergeCommands(YTEnvSetup):
         assert read_table("//tmp/t_out") == self.v1 + self.v2
         assert get("//tmp/t_out/@chunk_count") == 1
 
+    @authors("achulkov2")
+    def test_ordered_batch_row_count(self):
+        # TODO(achulkov2): Lower/remove after cherry-picks.
+        if self.Env.get_component_version("ytserver-controller-agent").abi <= (24, 1):
+            pytest.skip()
+
+        create("table", "//tmp/t_in")
+        create("table", "//tmp/t_out")
+
+        batch_row_count = 33
+
+        input_rows = []
+        input_rows += [[{"value": "smol"} for i in range(3)] for i in range(15)]
+        input_rows += [[{"value": "bighumongouslargefatenormousobeseoverweightoverflowing"} for i in range(11)] for i in range(43)]
+        input_rows += [[{"value": "w.e.f.a.latfnltih.tecwtfna"} for i in range(5)] for i in range(2)]
+
+        for row_batch in input_rows:
+            write_table("<append=true>//tmp/t_in", row_batch)
+
+        merge(
+            combine_chunks=False,
+            mode="ordered",
+            in_=["//tmp/t_in"],
+            out="//tmp/t_out",
+            spec={"data_size_per_job": 26, "batch_row_count": batch_row_count}
+        )
+
+        assert read_table("//tmp/t_out") == sum(input_rows, start=[])
+
+        out_chunk_ids = get("//tmp/t_out/@chunk_ids")
+        for out_chunk in out_chunk_ids:
+            assert get(f"#{out_chunk}/@row_count") % batch_row_count == 0
+
+    @authors("achulkov2")
+    def test_ordered_batch_row_count_disables_teleports_and_sampling(self):
+        # TODO(achulkov2): Lower/remove after cherry-picks.
+        if self.Env.get_component_version("ytserver-controller-agent").abi <= (24, 1):
+            pytest.skip()
+
+        create("table", "//tmp/t_in")
+        create("table", "//tmp/t_out")
+
+        chunk_count = 10
+
+        rows = [{"value": i} for i in range(3)]
+        for i in range(chunk_count):
+            write_table("<append=true>//tmp/t_in", rows)
+
+        with pytest.raises(YtError):
+            merge(
+                combine_chunks=False,
+                mode="ordered",
+                in_=["//tmp/t_in"],
+                out="//tmp/t_out",
+                spec={"data_size_per_job": 1, "batch_row_count": 3, "sampling": {"sampling_rate": 0.2}}
+            )
+
+        merge(
+            combine_chunks=False,
+            mode="ordered",
+            in_=["//tmp/t_in"],
+            out="//tmp/t_out",
+            spec={"data_size_per_job": 1, "batch_row_count": 3}
+        )
+
+        assert read_table("//tmp/t_out") == rows * chunk_count
+
+        in_chunk_ids = get("//tmp/t_in/@chunk_ids")
+        out_chunk_ids = get("//tmp/t_out/@chunk_ids")
+
+        assert len(in_chunk_ids) == len(out_chunk_ids)
+        for in_chunk, out_chunk in zip(in_chunk_ids, out_chunk_ids):
+            # Rows should be the same, but none of the chunks should have been teleported!
+            assert get(f"#{in_chunk}/@row_count") == get(f"#{out_chunk}/@row_count")
+            assert in_chunk != out_chunk
+
     @authors("ignat")
     @pytest.mark.parametrize("sort_order", ["ascending", "descending"])
     @pytest.mark.parametrize("combine_chunks", [False, True])

--- a/yt/yt/ytlib/chunk_client/legacy_data_slice.cpp
+++ b/yt/yt/ytlib/chunk_client/legacy_data_slice.cpp
@@ -129,9 +129,14 @@ int TLegacyDataSlice::GetRangeIndex() const
 
 TInputChunkPtr TLegacyDataSlice::GetSingleUnversionedChunk() const
 {
+    return GetSingleUnversionedChunkSlice()->GetInputChunk();
+}
+
+TInputChunkSlicePtr TLegacyDataSlice::GetSingleUnversionedChunkSlice() const
+{
     YT_VERIFY(IsTrivial());
 
-    return ChunkSlices[0]->GetInputChunk();
+    return ChunkSlices[0];
 }
 
 bool TLegacyDataSlice::IsTrivial() const

--- a/yt/yt/ytlib/chunk_client/legacy_data_slice.h
+++ b/yt/yt/ytlib/chunk_client/legacy_data_slice.h
@@ -70,6 +70,7 @@ public:
     void CopyPayloadFrom(const TLegacyDataSlice& dataSlice);
 
     TInputChunkPtr GetSingleUnversionedChunk() const;
+    TInputChunkSlicePtr GetSingleUnversionedChunkSlice() const;
 
     std::pair<TLegacyDataSlicePtr, TLegacyDataSlicePtr> SplitByRowIndex(i64 splitRow) const;
 

--- a/yt/yt/ytlib/scheduler/config.cpp
+++ b/yt/yt/ytlib/scheduler/config.cpp
@@ -805,6 +805,9 @@ void TOperationSpecBase::Register(TRegistrar registrar)
     registrar.Parameter("adjust_dynamic_table_data_slices", &TThis::AdjustDynamicTableDataSlices)
         .Default(false);
 
+    registrar.Parameter("batch_row_count", &TThis::BatchRowCount)
+        .Default();
+
     registrar.Parameter("bypass_hunk_remote_copy_prohibition", &TThis::BypassHunkRemoteCopyProhibition)
         .Default();
 
@@ -857,6 +860,11 @@ void TOperationSpecBase::Register(TRegistrar registrar)
         if (spec->UseColumnarStatistics) {
             spec->InputTableColumnarStatistics->Enabled = true;
             spec->UserFileColumnarStatistics->Enabled = true;
+        }
+
+        if (spec->BatchRowCount) {
+            THROW_ERROR_EXCEPTION_IF(*spec->BatchRowCount <= 0, "Value of \"batch_row_count\" of must be positive");
+            THROW_ERROR_EXCEPTION_IF(spec->Sampling && spec->Sampling->SamplingRate, "Option \"batch_row_count\" cannot be used with input sampling");
         }
     });
 }

--- a/yt/yt/ytlib/scheduler/config.h
+++ b/yt/yt/ytlib/scheduler/config.h
@@ -1101,6 +1101,11 @@ public:
 
     bool AdjustDynamicTableDataSlices;
 
+    //! If set, the operation tries to run jobs with row counts divisible by this number.
+    //! Generic, but only supported by operations for which you can specify ordered=%true (Map, Merge, MapReduce, Erase).
+    //! NB: Disables job interrupts and chunk teleportation. Cannot be used together with input sampling.
+    std::optional<i64> BatchRowCount;
+
     //! If explicitly true, allow remote copy of tables with hunk columns.
     std::optional<bool> BypassHunkRemoteCopyProhibition;
 


### PR DESCRIPTION
This PR imlements #375, adding the ability to request jobs with sizes divisible by a certain batch_row_count.
Additionally, it enhances ordered chunk pools to perform chunk splits based on estimated data weight to form jobs with weights almost exactly to equal to data_size_per_job, which was previously only achieved with a certain margin.

Also refactored some of the comments in the touched files into YT style. Left comments in some of the chunk pool unittests unchanged, as there are too many lines.