### PR TITLE
Cleanup memory accounting

### DIFF
--- a/yt/yt/library/containers/cgroup.cpp
+++ b/yt/yt/library/containers/cgroup.cpp
@@ -641,7 +641,7 @@ TMemory::TStatistics TMemory::GetStatistics() const
             const auto& type = values[2 * lineNumber];
             const auto& unparsedValue = values[2 * lineNumber + 1];
             if (type == "rss") {
-                result.Rss = FromString<i64>(unparsedValue);
+                result.ResidentAnon = FromString<i64>(unparsedValue);
             }
             if (type == "mapped_file") {
                 result.MappedFile = FromString<i64>(unparsedValue);

--- a/yt/yt/library/containers/cgroup.h
+++ b/yt/yt/library/containers/cgroup.h
@@ -214,7 +214,7 @@ public:
 
     struct TStatistics
     {
-        TErrorOr<i64> Rss;
+        TErrorOr<i64> ResidentAnon;
         TErrorOr<i64> MappedFile;
         TErrorOr<i64> MinorPageFaults;
         TErrorOr<i64> MajorPageFaults;

--- a/yt/yt/library/containers/cgroup.h
+++ b/yt/yt/library/containers/cgroup.h
@@ -215,6 +215,7 @@ public:
     struct TStatistics
     {
         TErrorOr<i64> ResidentAnon;
+        TErrorOr<i64> TmpfsUsage;
         TErrorOr<i64> MappedFile;
         TErrorOr<i64> MinorPageFaults;
         TErrorOr<i64> MajorPageFaults;

--- a/yt/yt/library/containers/cgroups_new.cpp
+++ b/yt/yt/library/containers/cgroups_new.cpp
@@ -50,6 +50,7 @@ TMemoryStatistics GetMemoryStatisticsV1(const TString& cgroup)
     // NB: Statistics name "rss" isn't correct - it accounts only anonymous pages.
     return TMemoryStatistics{
         .ResidentAnon = statistics["total_rss"],
+        .TmpfsUsage = statistics["total_shmem"],
         .MappedFile = statistics["total_mapped_file"],
         .MajorPageFaults = statistics["total_pgmajfault"],
     };
@@ -63,6 +64,7 @@ TMemoryStatistics GetMemoryStatisticsV2(const TString& cgroup)
     // Swap and swap-cache are are not accounted. In kernel it is called "NR_ANON_MAPPED".
     return TMemoryStatistics{
         .ResidentAnon = statistics["anon"],
+        .TmpfsUsage = statistics["shmem"],
         .MappedFile = statistics["mapped_file"],
         .MajorPageFaults = statistics["pgmajfault"],
     };

--- a/yt/yt/library/containers/cgroups_new.cpp
+++ b/yt/yt/library/containers/cgroups_new.cpp
@@ -198,15 +198,7 @@ TSelfCGroupsStatisticsFetcher::TSelfCGroupsStatisticsFetcher()
 
 TMemoryStatistics TSelfCGroupsStatisticsFetcher::GetMemoryStatistics() const
 {
-    auto statistics = IsV2_ ? GetMemoryStatisticsV2(CGroup_) : GetMemoryStatisticsV1(CGroup_);
-
-    {
-        auto guard = Guard(SpinLock_);
-        PeakResidentAnon_ = std::max(PeakResidentAnon_, statistics.ResidentAnon);
-        statistics.PeakResidentAnon = PeakResidentAnon_;
-    }
-
-    return statistics;
+    return IsV2_ ? GetMemoryStatisticsV2(CGroup_) : GetMemoryStatisticsV1(CGroup_);
 }
 
 TCpuStatistics TSelfCGroupsStatisticsFetcher::GetCpuStatistics() const

--- a/yt/yt/library/containers/cgroups_new.h
+++ b/yt/yt/library/containers/cgroups_new.h
@@ -9,6 +9,7 @@ namespace NYT::NContainers::NCGroups {
 struct TMemoryStatistics
 {
     i64 ResidentAnon = 0;
+    i64 TmpfsUsage = 0;
     i64 MappedFile = 0;
     i64 MajorPageFaults = 0;
 };

--- a/yt/yt/library/containers/cgroups_new.h
+++ b/yt/yt/library/containers/cgroups_new.h
@@ -8,8 +8,8 @@ namespace NYT::NContainers::NCGroups {
 
 struct TMemoryStatistics
 {
-    i64 Rss = 0;
-    i64 PeakRss = 0;
+    i64 ResidentAnon = 0;
+    i64 PeakResidentAnon = 0;
     i64 MappedFile = 0;
     i64 MajorPageFaults = 0;
 };
@@ -44,7 +44,7 @@ private:
     TString CGroup_;
     bool IsV2_;
 
-    mutable i64 PeakRss_ = 0;
+    mutable i64 PeakResidentAnon_ = 0;
 
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, SpinLock_);
 

--- a/yt/yt/library/containers/cgroups_new.h
+++ b/yt/yt/library/containers/cgroups_new.h
@@ -9,7 +9,6 @@ namespace NYT::NContainers::NCGroups {
 struct TMemoryStatistics
 {
     i64 ResidentAnon = 0;
-    i64 PeakResidentAnon = 0;
     i64 MappedFile = 0;
     i64 MajorPageFaults = 0;
 };
@@ -43,10 +42,6 @@ public:
 private:
     TString CGroup_;
     bool IsV2_;
-
-    mutable i64 PeakResidentAnon_ = 0;
-
-    YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, SpinLock_);
 
     void DetectSelfCGroup();
 };

--- a/yt/yt/library/containers/instance.cpp
+++ b/yt/yt/library/containers/instance.cpp
@@ -125,6 +125,7 @@ const THashMap<EStatField, TPortoStatRule> PortoStatRules = {
     {EStatField::CpuLimit, {"cpu_limit_bound", CoreNsPerSecondExtractor}},
     {EStatField::CpuGuarantee, {"cpu_guarantee_bound", CoreNsPerSecondExtractor}},
     {EStatField::ResidentAnon, {"memory.stat", GetStatByKeyExtractor("total_rss")}},
+    {EStatField::TmpfsUsage, {"memory.stat", GetStatByKeyExtractor("total_shmem")}},
     {EStatField::MappedFile, {"memory.stat", GetStatByKeyExtractor("total_mapped_file")}},
     {EStatField::MinorPageFaults, {"minor_faults", LongExtractor}},
     {EStatField::MajorPageFaults, {"major_faults", LongExtractor}},

--- a/yt/yt/library/containers/instance.cpp
+++ b/yt/yt/library/containers/instance.cpp
@@ -124,7 +124,7 @@ const THashMap<EStatField, TPortoStatRule> PortoStatRules = {
     {EStatField::ThreadCount, {"thread_count", LongExtractor}},
     {EStatField::CpuLimit, {"cpu_limit_bound", CoreNsPerSecondExtractor}},
     {EStatField::CpuGuarantee, {"cpu_guarantee_bound", CoreNsPerSecondExtractor}},
-    {EStatField::Rss, {"memory.stat", GetStatByKeyExtractor("total_rss")}},
+    {EStatField::ResidentAnon, {"memory.stat", GetStatByKeyExtractor("total_rss")}},
     {EStatField::MappedFile, {"memory.stat", GetStatByKeyExtractor("total_mapped_file")}},
     {EStatField::MinorPageFaults, {"minor_faults", LongExtractor}},
     {EStatField::MajorPageFaults, {"major_faults", LongExtractor}},

--- a/yt/yt/library/containers/instance.h
+++ b/yt/yt/library/containers/instance.h
@@ -23,6 +23,7 @@ const std::vector<EStatField> InstanceStatFields{
     EStatField::CpuGuarantee,
 
     EStatField::ResidentAnon,
+    EStatField::TmpfsUsage,
     EStatField::MappedFile,
     EStatField::MajorPageFaults,
     EStatField::MinorPageFaults,

--- a/yt/yt/library/containers/instance.h
+++ b/yt/yt/library/containers/instance.h
@@ -22,7 +22,7 @@ const std::vector<EStatField> InstanceStatFields{
     EStatField::CpuLimit,
     EStatField::CpuGuarantee,
 
-    EStatField::Rss,
+    EStatField::ResidentAnon,
     EStatField::MappedFile,
     EStatField::MajorPageFaults,
     EStatField::MinorPageFaults,

--- a/yt/yt/library/containers/instance_limits_tracker.cpp
+++ b/yt/yt/library/containers/instance_limits_tracker.cpp
@@ -81,7 +81,7 @@ void TInstanceLimitsTracker::DoUpdateLimits()
         auto netStatistics = RootTracker_->GetNetworkStatistics();
         auto cpuStatistics = SelfTracker_->GetCpuStatistics();
 
-        setIfOk(&MemoryUsage_, memoryStatistics.Rss, "MemoryRss");
+        setIfOk(&MemoryUsage_, memoryStatistics.ResidentAnon, "ResidentAnon");
 
         TDuration cpuGuarantee;
         TDuration cpuLimit;

--- a/yt/yt/library/containers/porto_resource_tracker.cpp
+++ b/yt/yt/library/containers/porto_resource_tracker.cpp
@@ -134,6 +134,7 @@ TMemoryStatistics TPortoResourceTracker::ExtractMemoryStatistics(const TResource
 {
     return TMemoryStatistics{
         .ResidentAnon = GetFieldOrError(resourceUsage, EStatField::ResidentAnon),
+        .TmpfsUsage = GetFieldOrError(resourceUsage, EStatField::TmpfsUsage),
         .MappedFile = GetFieldOrError(resourceUsage, EStatField::MappedFile),
         .MinorPageFaults = GetFieldOrError(resourceUsage, EStatField::MinorPageFaults),
         .MajorPageFaults = GetFieldOrError(resourceUsage, EStatField::MajorPageFaults),

--- a/yt/yt/library/containers/porto_resource_tracker.cpp
+++ b/yt/yt/library/containers/porto_resource_tracker.cpp
@@ -133,7 +133,7 @@ TCpuStatistics TPortoResourceTracker::ExtractCpuStatistics(const TResourceUsage&
 TMemoryStatistics TPortoResourceTracker::ExtractMemoryStatistics(const TResourceUsage& resourceUsage) const
 {
     return TMemoryStatistics{
-        .Rss = GetFieldOrError(resourceUsage, EStatField::Rss),
+        .ResidentAnon = GetFieldOrError(resourceUsage, EStatField::ResidentAnon),
         .MappedFile = GetFieldOrError(resourceUsage, EStatField::MappedFile),
         .MinorPageFaults = GetFieldOrError(resourceUsage, EStatField::MinorPageFaults),
         .MajorPageFaults = GetFieldOrError(resourceUsage, EStatField::MajorPageFaults),

--- a/yt/yt/library/containers/public.h
+++ b/yt/yt/library/containers/public.h
@@ -93,6 +93,7 @@ DEFINE_ENUM(EStatField,
 
     // Memory
     (ResidentAnon)
+    (TmpfsUsage)
     (MappedFile)
     (MajorPageFaults)
     (MinorPageFaults)

--- a/yt/yt/library/containers/public.h
+++ b/yt/yt/library/containers/public.h
@@ -92,7 +92,7 @@ DEFINE_ENUM(EStatField,
     (CpuGuarantee)
 
     // Memory
-    (Rss)
+    (ResidentAnon)
     (MappedFile)
     (MajorPageFaults)
     (MinorPageFaults)

--- a/yt/yt/server/job_proxy/environment.cpp
+++ b/yt/yt/server/job_proxy/environment.cpp
@@ -1032,10 +1032,8 @@ private:
     std::optional<TJobEnvironmentMemoryStatistics> DoGetJobMemoryStatistics() const
     {
         auto statistics = StatisticsFetcher_.GetMemoryStatistics();
-        // NB: PeakResidentAnon usage is intentional here, to make statistics more sane.
-        // FIXME(khlebnikov): move PeakResidentAnon logic into memory-tracker.
         return TJobEnvironmentMemoryStatistics{
-            .ResidentAnon = statistics.PeakResidentAnon,
+            .ResidentAnon = statistics.ResidentAnon,
             .MappedFile = statistics.MappedFile,
             .MajorPageFaults = statistics.MajorPageFaults,
         };

--- a/yt/yt/server/job_proxy/environment.cpp
+++ b/yt/yt/server/job_proxy/environment.cpp
@@ -89,9 +89,10 @@ TErrorOr<TJobEnvironmentCpuStatistics> ExtractJobEnvironmentCpuStatistics(const 
 
 void Serialize(const TJobEnvironmentMemoryStatistics& statistics, NYson::IYsonConsumer* consumer)
 {
+    //FIXME(khlebnikov): Give "rss" proper name.
     NYTree::BuildYsonFluently(consumer)
         .BeginMap()
-            .Item("rss").Value(statistics.Rss)
+            .Item("rss").Value(statistics.ResidentAnon)
             .Item("mapped_file").Value(statistics.MappedFile)
             .Item("major_page_faults").Value(statistics.MajorPageFaults)
         .EndMap();
@@ -101,7 +102,7 @@ TErrorOr<TJobEnvironmentMemoryStatistics> ExtractJobEnvironmentMemoryStatistics(
 {
     try {
         return TJobEnvironmentMemoryStatistics {
-            .Rss = statistics.Rss.ValueOrThrow(),
+            .ResidentAnon = statistics.ResidentAnon.ValueOrThrow(),
             .MappedFile = statistics.MappedFile.ValueOrThrow(),
             .MajorPageFaults = statistics.MajorPageFaults.ValueOrThrow()
         };
@@ -1031,9 +1032,10 @@ private:
     std::optional<TJobEnvironmentMemoryStatistics> DoGetJobMemoryStatistics() const
     {
         auto statistics = StatisticsFetcher_.GetMemoryStatistics();
-        // NB: PeakRss usage is intentional here, to make statistics more sane.
+        // NB: PeakResidentAnon usage is intentional here, to make statistics more sane.
+        // FIXME(khlebnikov): move PeakResidentAnon logic into memory-tracker.
         return TJobEnvironmentMemoryStatistics{
-            .Rss = statistics.PeakRss,
+            .ResidentAnon = statistics.PeakResidentAnon,
             .MappedFile = statistics.MappedFile,
             .MajorPageFaults = statistics.MajorPageFaults,
         };

--- a/yt/yt/server/job_proxy/environment.cpp
+++ b/yt/yt/server/job_proxy/environment.cpp
@@ -1034,6 +1034,7 @@ private:
         auto statistics = StatisticsFetcher_.GetMemoryStatistics();
         return TJobEnvironmentMemoryStatistics{
             .ResidentAnon = statistics.ResidentAnon,
+            .TmpfsUsage = statistics.TmpfsUsage,
             .MappedFile = statistics.MappedFile,
             .MajorPageFaults = statistics.MajorPageFaults,
         };

--- a/yt/yt/server/job_proxy/environment.h
+++ b/yt/yt/server/job_proxy/environment.h
@@ -36,7 +36,7 @@ void Serialize(const TJobEnvironmentCpuStatistics& statistics, NYson::IYsonConsu
 
 struct TJobEnvironmentMemoryStatistics
 {
-    i64 Rss = 0;
+    i64 ResidentAnon = 0;
     i64 MappedFile = 0;
     i64 MajorPageFaults = 0;
 };

--- a/yt/yt/server/job_proxy/environment.h
+++ b/yt/yt/server/job_proxy/environment.h
@@ -37,6 +37,7 @@ void Serialize(const TJobEnvironmentCpuStatistics& statistics, NYson::IYsonConsu
 struct TJobEnvironmentMemoryStatistics
 {
     i64 ResidentAnon = 0;
+    i64 TmpfsUsage = 0;
     i64 MappedFile = 0;
     i64 MajorPageFaults = 0;
 };

--- a/yt/yt/server/job_proxy/memory_tracker.cpp
+++ b/yt/yt/server/job_proxy/memory_tracker.cpp
@@ -53,6 +53,7 @@ void TMemoryTracker::DumpMemoryUsageStatistics(TStatistics* statistics, const TS
     statistics->AddSample(Format("%v/current_memory", path), GetMemoryStatistics()->Total);
     statistics->AddSample(Format("%v/max_memory", path), MaxMemoryUsage_);
     statistics->AddSample(Format("%v/cumulative_memory_mb_sec", path), CumulativeMemoryUsageMBSec_);
+    statistics->AddSample(Format("%v/peak_resident_anon", path), PeakResidentAnon_);
 }
 
 i64 TMemoryTracker::GetMemoryUsage()
@@ -187,6 +188,8 @@ TJobMemoryStatisticsPtr TMemoryTracker::GetMemoryStatistics()
             }
         }
     }
+
+    PeakResidentAnon_ = std::max<i64>(PeakResidentAnon_, jobMemoryStatistics->Total.ResidentAnon);
 
     auto memoryUsage = jobMemoryStatistics->Total.ResidentAnon + jobMemoryStatistics->Total.MappedFile;
     MaxMemoryUsage_ = std::max<i64>(MaxMemoryUsage_, memoryUsage);

--- a/yt/yt/server/job_proxy/memory_tracker.h
+++ b/yt/yt/server/job_proxy/memory_tracker.h
@@ -66,6 +66,7 @@ private:
 
     std::atomic<i64> CumulativeMemoryUsageMBSec_ = 0;
     std::atomic<i64> MaxMemoryUsage_ = 0;
+    std::atomic<i64> PeakResidentAnon_ = 0;
 
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, MemoryStatisticsLock_);
 

--- a/yt/yt/server/job_proxy/memory_tracker.h
+++ b/yt/yt/server/job_proxy/memory_tracker.h
@@ -35,7 +35,6 @@ struct TJobMemoryStatistics
 {
     TJobEnvironmentMemoryStatistics Total;
     std::vector<TProcessMemoryStatisticsPtr> ProcessesStatistics;
-    i64 TmpfsUsage = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(TJobMemoryStatistics)

--- a/yt/yt/server/job_proxy/user_job.cpp
+++ b/yt/yt/server/job_proxy/user_job.cpp
@@ -1616,7 +1616,7 @@ private:
                 "Memory limit exceeded")
                 << TErrorAttribute("usage", memoryUsage)
                 << TErrorAttribute("limit", memoryLimit)
-                << TErrorAttribute("tmpfs_usage", memoryStatistics->TmpfsUsage)
+                << TErrorAttribute("tmpfs_usage", memoryStatistics->Total.TmpfsUsage)
                 << TErrorAttribute("processes", processesStatistics);
             JobErrorPromise_.TrySet(error);
             CleanupUserProcesses();


### PR DESCRIPTION
- Rename misnamed "Rss" into "ResidentAnon" and fix collecting from cgroup v2
  This kind of memory usually represents heap area allocated by malloc() by
  brk() or mmap(MAP_PRIVATE|MAP_ANONYMOUS).
  
  Copy-on-write part of mmap(MAP_PRIVATE|MAP_FILE) also accounted here.
  
  Usually it is called "resident anonymous memory", "RssAnon", "AnonPages",
  "nr_anon_pages", "NR_ANON_MAPPED", "private", "anon", or (wrongly) "rss".
  
- Add common statistics PeakResidentAnon
  
- Fetch tmpfs usage from cgroup
  Cgroup has accounting for shmem/tmpfs memory.
  
