### PR TITLE
Convert binary exceptions into YSON text

### DIFF
--- a/yt/yt/client/table_client/helpers.cpp
+++ b/yt/yt/client/table_client/helpers.cpp
@@ -740,7 +740,8 @@ void ToUnversionedValue(
     int id,
     EValueFlags flags)
 {
-    auto errorYson = ConvertToYsonString(value);
+    // Save error in text format in order to escape non-text characters and make errors human-readable
+    auto errorYson = ConvertToYsonString(value, EYsonFormat::Text);
     *unversionedValue = rowBuffer->CaptureValue(MakeUnversionedAnyValue(errorYson.AsStringBuf(), id, flags));
 }
 

--- a/yt/yt/core/misc/error.cpp
+++ b/yt/yt/core/misc/error.cpp
@@ -379,7 +379,7 @@ TError::TErrorOr(const std::exception& ex)
     } else if (const auto* errorEx = dynamic_cast<const TErrorException*>(&ex)) {
         *this = errorEx->Error();
     } else {
-        *this = TError(NYT::EErrorCode::Generic, ex.what());
+        *this = TError(NYT::EErrorCode::Generic, ConvertToYsonString(ex.what(), EYsonFormat::Text).ToString());
     }
     YT_VERIFY(!IsOK());
 }


### PR DESCRIPTION
Starting issue: https://github.com/ytsaurus/ytsaurus-ui/issues/405

Issue:

CHYT converts [clickhouse-thrown std::exception into YT TError](https://github.com/ytsaurus/ytsaurus/blob/20b88833ddafbbff57c7591e03bc94bea3243a87/yt/chyt/server/query_service.cpp#L78) directly, in [binary format (using exception.what())](https://github.com/ytsaurus/ytsaurus/blob/f09b069b1af8b50a602683a37191acb650a5cfac/yt/yt/core/misc/error.cpp#L382)

Then it is stored in dynamic table in binary format:
```
"inner_errors" = [
        {
            "attributes" = {
                "datetime" = "2024-03-08T17:27:47.033681Z";
                "fid" = 0u;
                "host" = "our-host.net";
                "pid" = 3673;
                "thread" = "ThreadPool";
                "tid" = 7905737751553949491u
            };
            "code" = 1;
            "message" = 53 79 6e 74 61 78 20 65 72 72 6f 72 3a 20 66 61 69 6c 65 64 20 61 74 20 70 6f 73 69 74 69 6f 6e 20 31 20 28 27 d0 27 29 3a 20 d0 be d1 88 d0 b8 d0 b1 d0 ba d0 b0 31 2e 20 55 6e 72 65 63 6f 67 6e 69 7a 65 64 20 74 6f 6b 65 6e 3a 20 27 d0 27
        }
```
This can't be decoded into UTF8 json on server side, resulting in failure in `get_query(id, format='<encode_utf8=%false>json'`.
Table reader (`read_query_result`) uses `web_json` format and somehow fixes it. `web_json` is not available for `get_query`

Solution:

In this PR I make 2 changes:
1. Convert clickhouse's exception.what() into text YSON string
2. Convert all TErrors before writing to the table into text YSON string
[The format](https://github.com/ytsaurus/ytsaurus/blob/f09b069b1af8b50a602683a37191acb650a5cfac/library/cpp/yt/yson_string/public.h#L18-L19) says it escapes non-text characters

Feel free to propose a different solution or leave only one of two changes

I wasn't able to write tests for it. Please help me find a correct place for a new test

