### PR TITLE
Truncate and improve samples of composite values

### DIFF
--- a/yt/yt/client/table_client/composite_compare.h
+++ b/yt/yt/client/table_client/composite_compare.h
@@ -13,6 +13,17 @@ namespace NYT::NTableClient {
 int CompareCompositeValues(NYson::TYsonStringBuf lhs, NYson::TYsonStringBuf rhs);
 TFingerprint CompositeFarmHash(NYson::TYsonStringBuf compositeValue);
 
+//! Returns a new yson value containing a truncated expression which can be compared with the original value
+//! by using the comparison function above.
+//! Returns null if the result is empty, since empty values are not suported in YSON.
+//! Effectively, it returns a prefix of the original value up to the first uncomparable item, such as a map or yson attributes,
+//! or up until the point when the size limit is hit.
+//! The size parameter limits the binary size of the output, i.e. the length of the returned string.
+//!
+//! NB: The current implementation guarantees that the size of the returned string is not larger then the provided limit. However,
+//! this might be hard to maintain and is not something one should rely on. It is better to think of this function as an approximate one.
+std::optional<NYson::TYsonString> TruncateCompositeValue(NYson::TYsonStringBuf value, i64 size);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NYT::NTableClient

--- a/yt/yt/client/table_client/helpers.cpp
+++ b/yt/yt/client/table_client/helpers.cpp
@@ -1599,7 +1599,7 @@ TUnversionedValueRangeTruncationResult TruncateUnversionedValues(
         if (clipped || value.Type == EValueType::Any) {
             truncatedValue = MakeUnversionedNullValue(value.Id, value.Flags);
         } else if (value.Type == EValueType::Composite) {
-            if (auto truncatedCompositeValue = TruncateCompositeValue(TYsonStringBuf{value.AsStringBuf()}, maxSizePerValue)) {
+            if (auto truncatedCompositeValue = TruncateCompositeValue(TYsonStringBuf(value.AsStringBuf()), maxSizePerValue)) {
                 truncatedValue = rowBuffer->CaptureValue(MakeUnversionedCompositeValue(truncatedCompositeValue->AsStringBuf(), value.Id, value.Flags));
             } else {
                 truncatedValue = MakeUnversionedNullValue(value.Id, value.Flags);
@@ -1621,7 +1621,7 @@ TUnversionedValueRangeTruncationResult TruncateUnversionedValues(
         }
     }
 
-    return {MakeSharedRange(truncatedValues, rowBuffer), resultSize, clipped};
+    return {MakeSharedRange(std::move(truncatedValues), rowBuffer), resultSize, clipped};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/table_client/helpers.h
+++ b/yt/yt/client/table_client/helpers.h
@@ -342,6 +342,26 @@ TUnversionedValue TryDecodeUnversionedAnyValue(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TUnversionedValueRangeTruncationResult
+{
+    //! Resulting values, which are captured in the underlying row buffer.
+    TSharedRange<TUnversionedValue> Values;
+    //! Estimation of the total size based on the binary representation of unversioned values.
+    i64 Size;
+    //! Signifies whether resulting value range is actually equal to the input value range.
+    bool Incomplete;
+};
+//! Captures and returns a new list of values of the same length.
+//! The values are truncated to roughly fit the provided size and form a comparable prefix.
+//! I.e. if rangeA is smaller than rangeB, then truncatedRangeA <= truncatedRangeB.
+//! Values truncated completely are replaced by values of type Null.
+//! NB: Comparability implies that values of type Any and any uncomparable parts of values of type Composite are truncated and replaced by Null values.
+//! NB: The resulting size can be slightly larger than the provided limit, since we need to form a range of exactly the same size
+//! and each filler value of type Null takes up some space for the value id and type.
+TUnversionedValueRangeTruncationResult TruncateUnversionedValues(TUnversionedValueRange values, i64 size);
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NTableClient
 
 #define HELPERS_INL_H_

--- a/yt/yt/client/unittests/composite_compare_ut.cpp
+++ b/yt/yt/client/unittests/composite_compare_ut.cpp
@@ -75,11 +75,11 @@ TEST(TCompositeCompare, CompositeFingerprint)
 TEST(TCompositeCompare, TruncateCompositeValue)
 {
     auto normalizeYson = [] (TStringBuf yson) {
-        return yson.empty() ? TString{yson} : ConvertToYsonString(TYsonString{yson}, EYsonFormat::Binary).ToString();
+        return yson.empty() ? TString(yson) : ConvertToYsonString(TYsonString(yson), EYsonFormat::Binary).ToString();
     };
 
     auto getTruncatedYson = [&] (TStringBuf original, i64 size) {
-        auto truncatedCompositeValue = TruncateCompositeValue(TYsonString{original}, size);
+        auto truncatedCompositeValue = TruncateCompositeValue(TYsonString(original), size);
         return truncatedCompositeValue ? truncatedCompositeValue->ToString() : "";
     };
 
@@ -134,7 +134,7 @@ TEST(TCompositeCompare, TruncateCompositeValue)
     checkTruncatedYson("[please; [take; [me; ha;];];]", "[please; [take; [me; haha; too; late]]]", 34);
     // The actual size of the resulting yson is only 4 bytes, but during truncation it is too hard to account for the fact that longer strings
     // take up more bytes for their length, since it is represented as a varint.
-    checkTruncatedYson("aa", TString{1000, 'a'}, 5);
+    checkTruncatedYson("aa", TString(1000, 'a'), 5);
     checkTruncatedYson("\"\"", "erase-me", 2);
 
     checkTruncatedYson("[[5; 7]; [1; 5; 4; 3]; [];]", "[[5; 7]; [1; 5; 4; 3]; [{hello=darkness}; 0; 0; 7]]", 10000);

--- a/yt/yt/client/unittests/composite_compare_ut.cpp
+++ b/yt/yt/client/unittests/composite_compare_ut.cpp
@@ -101,7 +101,7 @@ TEST(TCompositeCompare, TruncateCompositeValue)
 
     checkFullStringIdempotence("[[5; 7]; [1; 5];]");
     checkFullStringIdempotence("[[5; 7]; [1; 5; 4; 3]; [2; 0; 0; 7]]");
-    checkFullStringIdempotence("[[5; 7]; [1; 5; 4; 3; [f; #; c; k]]; [%true; [%false; 0;];]; [2; 0; 0; 7]]");
+    checkFullStringIdempotence("[[5; 7]; [1; 5; 4; 3; [g; r; i; t; #; k; #; n]]; [%true; [%false; 0;];]; [2; 0; 0; 7]]");
     checkFullStringIdempotence("this-string-desperately-wants-to-be-filled-with-some-funny-references-but-i-have-no-ideas");
     checkFullStringIdempotence("%true");
     checkFullStringIdempotence("#");

--- a/yt/yt/client/unittests/composite_compare_ut.cpp
+++ b/yt/yt/client/unittests/composite_compare_ut.cpp
@@ -8,12 +8,14 @@
 namespace NYT::NTableClient {
 namespace {
 
+using namespace NYson;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 TEST(TCompositeCompare, Simple)
 {
     auto compare = [] (TStringBuf lhs, TStringBuf rhs) {
-        return CompareCompositeValues(NYson::TYsonStringBuf(lhs), NYson::TYsonStringBuf(rhs));
+        return CompareCompositeValues(TYsonStringBuf(lhs), TYsonStringBuf(rhs));
     };
 
     EXPECT_EQ(-1, compare("-4", "42"));
@@ -59,7 +61,7 @@ TEST(TCompositeCompare, Simple)
 TEST(TCompositeCompare, CompositeFingerprint)
 {
     auto getFarmHash = [] (TStringBuf value) {
-        return CompositeFarmHash(NYson::TYsonStringBuf(value));
+        return CompositeFarmHash(TYsonStringBuf(value));
     };
 
     EXPECT_EQ(getFarmHash("-42"), GetFarmFingerprint(MakeUnversionedInt64Value(-42)));
@@ -68,6 +70,75 @@ TEST(TCompositeCompare, CompositeFingerprint)
     EXPECT_EQ(getFarmHash("%true"), GetFarmFingerprint(MakeUnversionedBooleanValue(true)));
     EXPECT_EQ(getFarmHash("%false"), GetFarmFingerprint(MakeUnversionedBooleanValue(false)));
     EXPECT_EQ(getFarmHash("#"), GetFarmFingerprint(MakeUnversionedNullValue()));
+}
+
+TEST(TCompositeCompare, TruncateCompositeValue)
+{
+    auto normalizeYson = [] (TStringBuf yson) {
+        return yson.empty() ? TString{yson} : ConvertToYsonString(TYsonString{yson}, EYsonFormat::Binary).ToString();
+    };
+
+    auto getTruncatedYson = [&] (TStringBuf original, i64 size) {
+        auto truncatedCompositeValue = TruncateCompositeValue(TYsonString{original}, size);
+        return truncatedCompositeValue ? truncatedCompositeValue->ToString() : "";
+    };
+
+    // When we rebuild the whole string during truncation, we should produce the correct normalized binary YSON version of the string as output.
+    auto checkFullStringIdempotence = [&] (TStringBuf yson) {
+        auto normalizedYson = normalizeYson(yson);
+        EXPECT_EQ(normalizedYson, getTruncatedYson(yson, std::numeric_limits<i64>::max()));
+        EXPECT_EQ(normalizedYson, getTruncatedYson(yson, std::ssize(normalizedYson)));
+    };
+
+    auto checkTruncatedYson = [&] (TStringBuf expectedTruncatedYson, TStringBuf originalYson, i64 size) {
+        auto normalizedExpectedTruncatedYson = normalizeYson(expectedTruncatedYson);
+        auto truncatedYson = getTruncatedYson(originalYson, size);
+
+        // For easier debugging.
+        EXPECT_EQ(normalizedExpectedTruncatedYson.size(), truncatedYson.size());
+        EXPECT_EQ(normalizedExpectedTruncatedYson, truncatedYson);
+    };
+
+    checkFullStringIdempotence("[[5; 7]; [1; 5];]");
+    checkFullStringIdempotence("[[5; 7]; [1; 5; 4; 3]; [2; 0; 0; 7]]");
+    checkFullStringIdempotence("[[5; 7]; [1; 5; 4; 3; [f; #; c; k]]; [%true; [%false; 0;];]; [2; 0; 0; 7]]");
+    checkFullStringIdempotence("this-string-desperately-wants-to-be-filled-with-some-funny-references-but-i-have-no-ideas");
+    checkFullStringIdempotence("%true");
+    checkFullStringIdempotence("#");
+    checkFullStringIdempotence("\"\"");
+
+    checkTruncatedYson("[[5; 7]; [1; 5];]", "[[5; 7]; [1; 5; 4; 3]; [2; 0; 0; 7]]", 20);
+    checkTruncatedYson("[[5; 7]; [1; 5];]", "[[5; 7]; [1; 5; 4; 3]; [2; 0; 0; 7]]", 21);
+    checkTruncatedYson("[[5; 7]; [1; 5];]", "[[5; 7]; [1; 5; 4; 3]; [2; 0; 0; 7]]", 22);
+    // We need 3 more bytes for the next integer: 1 for the type flag, 1 for the varint, 1 for the item separator.
+    checkTruncatedYson("[[5; 7]; [1; 5; 4;];]", "[[5; 7]; [1; 5; 4; 3]; [2; 0; 0; 7]]", 23);
+    // The value 1543 takes up 4 extra bytes, since it is represented as 2 varint bytes.
+    checkTruncatedYson("[[5; 7]; [1; 5; 4; 1543];]", "[[5; 7]; [1; 5; 4; 1543]; [2; 0; 0; 7]]", 27);
+
+    checkTruncatedYson("[[#; 0;];]", "[[#; 0; %true; x; #]; 1;]", 10);
+    // We need 2 more bytes for the boolean: 1 for the type flag which encodes the value itself, 1 for the item serpator.
+    checkTruncatedYson("[[#; 0; %true];]", "[[#; 0; %true; #; x]; 1;]", 12);
+    // Same for entities.
+    checkTruncatedYson("[[#; 0; %true; #;];]", "[[#; 0; %true; #; x]; 1;]", 14);
+
+    // NB: "" is actually std::nullopt returned from the function, it is just easier to visualize this way.
+    checkTruncatedYson("", "abacaba", 1);
+    checkTruncatedYson("", "1", 1);
+    checkTruncatedYson("", "[]", 1);
+    // Entity takes up only 1 byte!
+    checkTruncatedYson("#", "#", 1);
+
+    checkTruncatedYson("this-string", "this-string-desperately-wants-to-be-filled-with-some-funny-references-but-i-have-no-ideas", 14);
+    checkTruncatedYson("this-string-", "this-string-desperately-wants-to-be-filled-with-some-funny-references-but-i-have-no-ideas", 15);
+    checkTruncatedYson("this-string-desperatel", "this-string-desperately-wants-to-be-filled-with-some-funny-references-but-i-have-no-ideas", 25);
+    checkTruncatedYson("[please; [take; [me; ha;];];]", "[please; [take; [me; haha; too; late]]]", 34);
+    // The actual size of the resulting yson is only 4 bytes, but during truncation it is too hard to account for the fact that longer strings
+    // take up more bytes for their length, since it is represented as a varint.
+    checkTruncatedYson("aa", TString{1000, 'a'}, 5);
+    checkTruncatedYson("\"\"", "erase-me", 2);
+
+    checkTruncatedYson("[[5; 7]; [1; 5; 4; 3]; [];]", "[[5; 7]; [1; 5; 4; 3]; [{hello=darkness}; 0; 0; 7]]", 10000);
+    checkTruncatedYson("[[5; 7];]", "[[5; 7]; <my-name=borat>[1; 5; 4; 3]; [{greetings=xoxo}; 0; 0; 7]]", 10000);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/yson/pull_parser-inl.h
+++ b/yt/yt/core/yson/pull_parser-inl.h
@@ -170,6 +170,8 @@ i64 TYsonItem::GetBinarySize() const
             result += WriteVarInt32(buffer.data(), UncheckedAsString().size());
             result += UncheckedAsString().size();
             break;
+        default:
+            YT_ABORT();
     }
 
     return result;

--- a/yt/yt/core/yson/pull_parser-inl.h
+++ b/yt/yt/core/yson/pull_parser-inl.h
@@ -133,6 +133,48 @@ bool TYsonItem::IsEndOfStream() const
     return GetType() == EYsonItemType::EndOfStream;
 }
 
+// NB: Keep in sync with yson token writer.
+i64 TYsonItem::GetBinarySize() const
+{
+    // Temporary buffer for calculating actual size of varints.
+    std::array<char, MaxVarUint64Size> buffer;
+
+    // Each token requires at least 1 byte for the marker.
+    i64 result = 1;
+    switch (GetType()) {
+        case EYsonItemType::EndOfStream:
+            // This isn't a real token.
+            return 0;
+        case EYsonItemType::BeginList:
+        case EYsonItemType::EndList:
+        case EYsonItemType::BeginMap:
+        case EYsonItemType::EndMap:
+        case EYsonItemType::BeginAttributes:
+        case EYsonItemType::EndAttributes:
+            // These system values are represented solely by the marker.
+            break;
+        case EYsonItemType::EntityValue:
+        case EYsonItemType::BooleanValue:
+            // These values are represented solely by the marker.
+            break;
+        case EYsonItemType::Int64Value:
+            result += WriteVarInt64(buffer.data(), UncheckedAsInt64());
+            break;
+        case EYsonItemType::Uint64Value:
+            result += WriteVarUint64(buffer.data(), UncheckedAsUint64());
+            break;
+        case EYsonItemType::DoubleValue:
+            result += sizeof(double);
+            break;
+        case EYsonItemType::StringValue:
+            result += WriteVarInt32(buffer.data(), UncheckedAsString().size());
+            result += UncheckedAsString().size();
+            break;
+    }
+
+    return result;
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 void NDetail::TZeroCopyInputStreamReader::RefreshBlock()

--- a/yt/yt/core/yson/pull_parser.h
+++ b/yt/yt/core/yson/pull_parser.h
@@ -36,6 +36,7 @@ public:
     template <typename T>
     Y_FORCE_INLINE T UncheckedAs() const;
     Y_FORCE_INLINE bool IsEndOfStream() const;
+    Y_FORCE_INLINE i64 GetBinarySize() const;
 
 private:
     TYsonItem() = default;

--- a/yt/yt/tests/integration/controller/test_map_operation.py
+++ b/yt/yt/tests/integration/controller/test_map_operation.py
@@ -830,7 +830,8 @@ print row + table_index
         create("table", "//tmp/t_out", attributes={"schema": schema})
 
         # The last two strings are pretty big and definitely shouldn't be in the sample.
-        data = [{"data": ["is", 42, ["the", "answer", "to", "life" * (max_sample_size // 8), "the" * (max_sample_size // 9), "universe" * (max_sample_size // 32), "and" , "everything" * (big_size // 10)]]}]
+        data = [{"data": ["is", 42, ["the", "answer", "to", "life" * (max_sample_size // 8), "the" * (max_sample_size // 9),
+                                     "universe" * (max_sample_size // 32), "and" , "everything" * (big_size // 10)]]}]
 
         write_table("//tmp/t_in", data, verbose=False)
         map(in_="//tmp/t_in", out="//tmp/t_out", command="cat", spec={"max_failed_job_count": 1})
@@ -840,7 +841,6 @@ print row + table_index
         chunk_ids = get("//tmp/t_out/@chunk_ids")
         assert len(chunk_ids) == 1
 
-        # Previously the whole string would end up in the sample, which would make a 10+ megabyte-sized meta.
         assert get(f"#{chunk_ids[0]}/@meta_size") < 2 * max_sample_size
 
 

--- a/yt/yt/tests/integration/controller/test_map_operation.py
+++ b/yt/yt/tests/integration/controller/test_map_operation.py
@@ -821,6 +821,10 @@ print row + table_index
 
     @authors("achulkov2")
     def test_truncate_composite_partitioning_sample(self):
+        # TODO(achulkov2): Lower/remove after cherry-picks.
+        if self.Env.get_component_version("ytserver-controller-agent").abi <= (24, 1):
+            pytest.skip()
+
         max_sample_size = 64 * 1024  # 64KiB
         big_size = 15 * 1024 * 1024  # 15MiB, a bit smaller than the default row limit.
 

--- a/yt/yt/tests/integration/controller/test_map_operation.py
+++ b/yt/yt/tests/integration/controller/test_map_operation.py
@@ -821,8 +821,8 @@ print row + table_index
 
     @authors("achulkov2")
     def test_truncate_composite_partitioning_sample(self):
-        max_sample_size = 64 * 1024 # 64KiB
-        big_size = 15 * 1024 * 1024 # 15MiB, a bit smaller than the default row limit.
+        max_sample_size = 64 * 1024  # 64KiB
+        big_size = 15 * 1024 * 1024  # 15MiB, a bit smaller than the default row limit.
 
         schema = [{"name": "data", "type_v3": tuple_type(["string", optional_type("int64"), list_type("string")])}]
 
@@ -842,7 +842,6 @@ print row + table_index
         assert len(chunk_ids) == 1
 
         assert get(f"#{chunk_ids[0]}/@meta_size") < 2 * max_sample_size
-
 
     @authors("psushin")
     @pytest.mark.parametrize("ordered", [False, True])

--- a/yt/yt/tests/integration/controller/test_sort_operation.py
+++ b/yt/yt/tests/integration/controller/test_sort_operation.py
@@ -7,7 +7,7 @@ from yt_commands import (
     sync_create_cells, sync_mount_table, sync_unmount_table, get_singular_chunk_id, create_dynamic_table)
 
 from yt_helpers import skip_if_no_descending
-from yt_type_helpers import make_schema, normalize_schema, normalize_schema_v3, list_type, optional_type, tuple_type
+from yt_type_helpers import make_schema, normalize_schema, normalize_schema_v3, list_type, optional_type
 
 from yt.environment.helpers import assert_items_equal
 from yt.common import YtError

--- a/yt/yt/tests/integration/controller/test_sort_operation.py
+++ b/yt/yt/tests/integration/controller/test_sort_operation.py
@@ -2012,12 +2012,12 @@ class TestSchedulerSortCommands(YTEnvSetup):
                 "schema": [{"name": "key", "type_v3": type_v3}],
             },
         )
-        write_table("//tmp/in", [{"key": d} for d in data])
+        write_table("//tmp/in", [{"key": d} for d in data], verbose=False)
 
         create("table", "//tmp/out")
         sort_func("//tmp/in", "//tmp/out", sort_by="key")
 
-        out_data = [r["key"] for r in read_table("//tmp/out")]
+        out_data = [r["key"] for r in read_table("//tmp/out", verbose=False)]
         assert out_data == expected_data
 
     @authors("ermolovd")
@@ -2060,7 +2060,6 @@ class TestSchedulerSortCommands(YTEnvSetup):
 
         def expand_string(sample, size):
             return (sample * (size // len(sample) + 1))[:size]
-
 
         self.run_test_complex_sort(
             lambda *args, **kwargs: simple_sort_1_phase(*args, **kwargs, spec={"merge_job_io": {"table_writer": {"max_key_weight": 250 * 1024}}}),

--- a/yt/yt/tests/integration/controller/test_sort_operation.py
+++ b/yt/yt/tests/integration/controller/test_sort_operation.py
@@ -41,6 +41,7 @@ def check_operation_tasks(op, expected):
 
 
 def simple_sort_1_phase(in_, out, sort_by, spec=None):
+    spec = spec or {}
     op = sort(in_=in_, out=out, sort_by=sort_by, spec=spec)
     op.track()
     assert builtins.set(get_operation_job_types(op.id)) == {"simple_sort"}

--- a/yt/yt/ytlib/table_client/schemaless_chunk_writer.cpp
+++ b/yt/yt/ytlib/table_client/schemaless_chunk_writer.cpp
@@ -443,6 +443,7 @@ private:
     TRandomGenerator RandomGenerator_;
     const ui64 SamplingThreshold_;
 
+    TRowBufferPtr TruncatedSampleValueBuffer_ = New<TRowBuffer>();
     TUnversionedOwningRow Sample_;
     NProto::TSamplesExt SamplesExt_;
     i64 SamplesExtSize_ = 0;
@@ -511,7 +512,7 @@ private:
 
     void EmitSample(TUnversionedRow row)
     {
-        auto sampleValues = TruncateUnversionedValues(row.Elements(), MaxSampleSize);
+        auto sampleValues = TruncateUnversionedValues(row.Elements(), TruncatedSampleValueBuffer_, {.ClipAfterOverflow = false, .MaxTotalSize = MaxSampleSize});
 
         auto entry = SerializeToString(sampleValues.Values);
         SamplesExt_.add_entries(entry);

--- a/yt/yt/ytlib/table_client/schemaless_chunk_writer.cpp
+++ b/yt/yt/ytlib/table_client/schemaless_chunk_writer.cpp
@@ -53,6 +53,7 @@
 #include <yt/yt/client/table_client/row_buffer.h>
 #include <yt/yt/client/table_client/schemaless_row_reorderer.h>
 #include <yt/yt/client/table_client/check_schema_compatibility.h>
+#include <yt/yt/client/table_client/composite_compare.h>
 
 #include <yt/yt/client/api/client.h>
 #include <yt/yt/client/api/transaction.h>
@@ -510,24 +511,11 @@ private:
 
     void EmitSample(TUnversionedRow row)
     {
-        TCompactVector<TUnversionedValue, TypicalColumnCount> sampleValues;
-        int weight = 0;
-        for (auto it = row.Begin(); it != row.End(); ++it) {
-            sampleValues.push_back(*it);
-            auto& value = sampleValues.back();
-            weight += NTableClient::GetDataWeight(value);
+        auto sampleValues = TruncateUnversionedValues(row.Elements(), MaxSampleSize);
 
-            if (value.Type == EValueType::Any) {
-                // Composite types are non-comparable, so we don't store it inside samples.
-                value.Length = 0;
-            } else if (value.Type == EValueType::String) {
-                value.Length = std::min(static_cast<int>(value.Length), MaxSampleSize);
-            }
-        }
-
-        auto entry = SerializeToString(MakeRange(sampleValues));
+        auto entry = SerializeToString(sampleValues.Values);
         SamplesExt_.add_entries(entry);
-        SamplesExt_.add_weights(weight);
+        SamplesExt_.add_weights(sampleValues.Size);
         SamplesExtSize_ += entry.length();
     }
 };


### PR DESCRIPTION
This PR fixes #405. Composite values are now truncated while maintaining comparability with the original value. 
Also generalized some code working with samples, since the differences in size accounting and truncation approaches could have produced less usable samples.