### PR TITLE
Support building yt/cpp and yt/yt/core with vanilla protobuf

### DIFF
--- a/yt/cpp/mapreduce/client/retryful_writer_v2.cpp
+++ b/yt/cpp/mapreduce/client/retryful_writer_v2.cpp
@@ -25,7 +25,7 @@ public:
     TSentBuffer() = default;
     TSentBuffer(const TSentBuffer& ) = delete;
 
-    std::pair<std::shared_ptr<char[]>, ssize_t> Snapshot() const
+    std::pair<std::shared_ptr<std::string>, ssize_t> Snapshot() const
     {
         return {Buffer_, Size_};
     }
@@ -49,7 +49,8 @@ public:
             // Closest power of 2 exceeding new size
             auto newCapacity = 1 << (MostSignificantBit(newSize) + 1);
             newCapacity = Max<ssize_t>(64, newCapacity);
-            auto newBuffer = std::make_shared<char[]>(newCapacity);
+            auto newBuffer = std::make_shared<std::string>();
+            newBuffer->resize(newCapacity);
             memcpy(newBuffer.get(), Buffer_.get(), Size_);
             memcpy(newBuffer.get() + Size_, data, size);
             Buffer_ = newBuffer;
@@ -59,7 +60,7 @@ public:
     }
 
 private:
-    std::shared_ptr<char[]> Buffer_ = nullptr;
+    std::shared_ptr<std::string> Buffer_ = nullptr;
     ssize_t Size_ = 0;
     ssize_t Capacity_ = 0;
 };
@@ -210,7 +211,7 @@ private:
                     retrier = MakeHolder<THeavyRequestRetrier>(*currentParameters);
                 }
                 retrier->Update([task=task] {
-                    return MakeHolder<TMemoryInput>(task.Data.get(), task.Size);
+                    return MakeHolder<TMemoryInput>(task.Data->data(), task.Size);
                 });
                 if (task.BufferComplete) {
                     retrier->Finish();
@@ -245,7 +246,7 @@ private:
     struct TWriteTask
     {
         NThreading::TPromise<void> SendingComplete;
-        std::shared_ptr<char[]> Data;
+        std::shared_ptr<std::string> Data;
         ssize_t Size = 0;
         bool BufferComplete = false;
     };

--- a/yt/cpp/mapreduce/client/retryful_writer_v2.cpp
+++ b/yt/cpp/mapreduce/client/retryful_writer_v2.cpp
@@ -44,15 +44,15 @@ public:
     {
         auto newSize = Size_ + size;
         if (newSize < Capacity_) {
-            memcpy(Buffer_.get() + Size_, data, size);
+            memcpy(Buffer_->data() + Size_, data, size);
         } else {
             // Closest power of 2 exceeding new size
             auto newCapacity = 1 << (MostSignificantBit(newSize) + 1);
             newCapacity = Max<ssize_t>(64, newCapacity);
             auto newBuffer = std::make_shared<std::string>();
             newBuffer->resize(newCapacity);
-            memcpy(newBuffer.get(), Buffer_.get(), Size_);
-            memcpy(newBuffer.get() + Size_, data, size);
+            memcpy(newBuffer->data(), Buffer_->data(), Size_);
+            memcpy(newBuffer->data() + Size_, data, size);
             Buffer_ = newBuffer;
             Capacity_ = newCapacity;
         }

--- a/yt/cpp/mapreduce/examples/tutorial/mapreduce_lambda/data.proto
+++ b/yt/cpp/mapreduce/examples/tutorial/mapreduce_lambda/data.proto
@@ -2,12 +2,12 @@ import "yt/yt_proto/yt/formats/extension.proto";
 
 message TLoginRecord
 {
-    optional string Name = 1 [(NYT.column_name) = "name"];
-    optional string Login = 2 [(NYT.column_name) = "login"];
+    optional string name = 1 [(NYT.column_name) = "name"];
+    optional string login = 2 [(NYT.column_name) = "login"];
 }
 
 message TNameStatistics
 {
-    optional string Name = 1 [(NYT.column_name) = "name"];
-    optional uint64 Count = 2 [(NYT.column_name) = "count"];
+    optional string name = 1 [(NYT.column_name) = "name"];
+    optional uint64 count = 2 [(NYT.column_name) = "count"];
 }

--- a/yt/cpp/mapreduce/examples/tutorial/mapreduce_lambda/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/mapreduce_lambda/main.cpp
@@ -24,16 +24,16 @@ int main() {
         outputTable,
         {"name"}, // список ключей, по которым мы будем редьюсить
         [](auto& src, auto& dst) { // mapper
-            dst.SetName(ToLowerUTF8(src.GetName()));
+            dst.set_name(ToLowerUTF8(TString(src.name())));
             return true;
         },
         [](auto& /*src*/, auto& dst) { // reducer
-            // dst.SetName() не вызываем, т.к. когда по
+            // dst.set_count() не вызываем, т.к. когда по
             // "name" редьюсим, это поле уже заполнено.
 
             // так можно делать, т.к. конструктор протобуфа dst
             // проинициализирует .Count в 0 (по умолчанию):
-            dst.SetCount(dst.GetCount() + 1);
+            dst.set_count(dst.count() + 1);
         });
 
     Cout << "Output table: https://yt.yandex-team.ru/freud/#page=navigation&offsetMode=row&path=" << outputTable << Endl;

--- a/yt/cpp/mapreduce/examples/tutorial/mapreduce_protobuf/data.proto
+++ b/yt/cpp/mapreduce/examples/tutorial/mapreduce_protobuf/data.proto
@@ -2,12 +2,12 @@ import "yt/yt_proto/yt/formats/extension.proto";
 
 message TLoginRecord
 {
-    optional string Name = 1 [(NYT.column_name) = "name"];
-    optional string Login = 2 [(NYT.column_name) = "login"];
+    optional string name = 1 [(NYT.column_name) = "name"];
+    optional string login = 2 [(NYT.column_name) = "login"];
 }
 
 message TNameStatistics
 {
-    optional string Name = 1 [(NYT.column_name) = "name"];
-    optional uint64 Count = 2 [(NYT.column_name) = "count"];
+    optional string name = 1 [(NYT.column_name) = "name"];
+    optional uint64 count = 2 [(NYT.column_name) = "count"];
 }

--- a/yt/cpp/mapreduce/examples/tutorial/mapreduce_protobuf/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/mapreduce_protobuf/main.cpp
@@ -23,7 +23,7 @@ public:
     {
         for (auto& cursor : *reader) {
             auto row = cursor.GetRow();
-            row.SetName(ToLowerUTF8(row.GetName()));
+            row.set_name(ToLowerUTF8(TString(row.name())));
             writer->AddRow(row);
         }
     }
@@ -41,12 +41,12 @@ public:
         ui64 count = 0;
         for (auto& cursor : *reader) {
             const auto& row = cursor.GetRow();
-            if (!result.HasName()) {
-                result.SetName(row.GetName());
+            if (!result.has_name()) {
+                result.set_name(row.name());
             }
             ++count;
         }
-        result.SetCount(count);
+        result.set_count(count);
         writer->AddRow(result);
     }
 };

--- a/yt/cpp/mapreduce/examples/tutorial/multiple_input_multiple_output_reduce_protobuf/data.proto
+++ b/yt/cpp/mapreduce/examples/tutorial/multiple_input_multiple_output_reduce_protobuf/data.proto
@@ -1,23 +1,23 @@
 import "yt/yt_proto/yt/formats/extension.proto";
 
 message TUserRecord {
-    optional int64 Uid = 1    [(NYT.column_name) = "uid"];
-    optional string Name = 2  [(NYT.column_name) = "name"];
-    optional string Login = 3 [(NYT.column_name) = "login"];
+    optional int64 uid = 1    [(NYT.column_name) = "uid"];
+    optional string name = 2  [(NYT.column_name) = "name"];
+    optional string login = 3 [(NYT.column_name) = "login"];
 }
 
 message TIsRobotRecord {
-    optional int64 Uid = 1    [(NYT.column_name) = "uid"];
-    optional bool IsRobot = 2 [(NYT.column_name) = "is_robot"];
+    optional int64 uid = 1    [(NYT.column_name) = "uid"];
+    optional bool is_robot = 2 [(NYT.column_name) = "is_robot"];
 }
 
 message THumanRecord {
-    optional string Name = 1  [(NYT.column_name) = "name"];
-    optional string Email = 2 [(NYT.column_name) = "email"];
-    optional string Login = 3 [(NYT.column_name) = "login"];
+    optional string name = 1  [(NYT.column_name) = "name"];
+    optional string email = 2 [(NYT.column_name) = "email"];
+    optional string login = 3 [(NYT.column_name) = "login"];
 }
 
 message TRobotRecord {
-    optional int64 Uid = 1    [(NYT.column_name) = "uid"];
-    optional string Login = 2 [(NYT.column_name) = "login"];
+    optional int64 uid = 1    [(NYT.column_name) = "uid"];
+    optional string login = 2 [(NYT.column_name) = "login"];
 }

--- a/yt/cpp/mapreduce/examples/tutorial/multiple_input_multiple_output_reduce_protobuf/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/multiple_input_multiple_output_reduce_protobuf/main.cpp
@@ -27,7 +27,7 @@ public:
                 userRecord = cursor.GetRow<TUserRecord>();
             } else if (tableIndex == 1) {
                 const auto& isRobotRecord = cursor.GetRow<TIsRobotRecord>();
-                isRobot = isRobotRecord.GetIsRobot();
+                isRobot = isRobotRecord.is_robot();
             } else {
                 Y_ABORT();
             }
@@ -36,14 +36,14 @@ public:
         // В AddRow мы можем передавать как TRobotRecord так и THumanRecord.
         if (isRobot) {
             TRobotRecord robotRecord;
-            robotRecord.SetUid(userRecord.GetUid());
-            robotRecord.SetLogin(userRecord.GetLogin());
+            robotRecord.set_uid(userRecord.uid());
+            robotRecord.set_login(userRecord.login());
             writer->AddRow(robotRecord, 0);
         } else {
             THumanRecord humanRecord;
-            humanRecord.SetName(userRecord.GetName());
-            humanRecord.SetLogin(userRecord.GetLogin());
-            humanRecord.SetEmail(userRecord.GetLogin() + "@yandex-team.ru");
+            humanRecord.set_name(userRecord.name());
+            humanRecord.set_login(userRecord.login());
+            humanRecord.set_email(userRecord.login() + "@yandex-team.ru");
             writer->AddRow(humanRecord, 1);
         }
     }

--- a/yt/cpp/mapreduce/examples/tutorial/prepare_operation/grepper.proto
+++ b/yt/cpp/mapreduce/examples/tutorial/prepare_operation/grepper.proto
@@ -2,6 +2,6 @@ import "yt/yt_proto/yt/formats/extension.proto";
 
 message TGrepperRecord
 {
-    optional string Key = 1;
-    optional bytes Other = 2 [(NYT.flags) = OTHER_COLUMNS];
+    optional string key = 1;
+    optional bytes other = 2 [(NYT.flags) = OTHER_COLUMNS];
 };

--- a/yt/cpp/mapreduce/examples/tutorial/prepare_operation/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/prepare_operation/main.cpp
@@ -23,7 +23,7 @@ public:
     {
         for (const auto& cursor : *reader) {
             auto row = cursor.GetRow();
-            if (row.GetKey() == Pattern_) {
+            if (row.key() == Pattern_) {
                 writer->AddRow(row);
             }
         }

--- a/yt/cpp/mapreduce/examples/tutorial/protobuf_complex_types/data.proto
+++ b/yt/cpp/mapreduce/examples/tutorial/protobuf_complex_types/data.proto
@@ -1,13 +1,13 @@
 import "yt/yt_proto/yt/formats/extension.proto";
 
 message TUrl {
-    optional string Host = 1 [(NYT.column_name) = "Host"];
-    optional int32 Port = 2 [(NYT.column_name) = "Port"];
-    optional string Path = 3 [(NYT.column_name) = "Path"];
+    optional string host = 1 [(NYT.column_name) = "Host"];
+    optional int32 port = 2 [(NYT.column_name) = "Port"];
+    optional string path = 3 [(NYT.column_name) = "Path"];
 }
 
 message TExtraInfo {
-    optional uint32 TotalOccurrenceCount = 1;
+    optional uint32 total_occurrence_count = 1;
 }
 
 message TDoc {
@@ -16,18 +16,18 @@ message TDoc {
     // с соответствующими (возможно, сложными) типами.
     option (NYT.default_field_flags) = SERIALIZATION_YT;
 
-    optional string Title = 1            [(NYT.key_column_name) = "Title"];
-    repeated TUrl Links = 2              [(NYT.column_name) = "Links"];
-    repeated uint32 OccurrenceCounts = 3 [(NYT.column_name) = "UpdateTimes"];
+    optional string title = 1            [(NYT.key_column_name) = "Title"];
+    repeated TUrl links = 2              [(NYT.column_name) = "Links"];
+    repeated uint32 occurrence_count = 3 [(NYT.column_name) = "UpdateTimes"];
 
     // Данное поле специально помечено как сериализуемое в бинарном (PROTOBUF) режиме.
     // В таблице эта колонка будет иметь тип "string".
-    optional TExtraInfo ExtraInfo = 4    [(NYT.column_name) = "ExtraInfo", (NYT.flags) = SERIALIZATION_PROTOBUF];
+    optional TExtraInfo extra_info = 4    [(NYT.column_name) = "ExtraInfo", (NYT.flags) = SERIALIZATION_PROTOBUF];
 }
 
 message TLinkEntry {
     option (NYT.default_field_flags) = SERIALIZATION_YT;
-    optional string DocTitle = 1        [(NYT.column_name) = "DocTitle"];
-    optional TUrl Link = 2              [(NYT.column_name) = "Link"];
-    optional uint32 OccurrenceCount = 3 [(NYT.column_name) = "OccurrenceCount"];
+    optional string doc_title = 1        [(NYT.column_name) = "DocTitle"];
+    optional TUrl link = 2              [(NYT.column_name) = "Link"];
+    optional uint32 occurrence_count = 3 [(NYT.column_name) = "OccurrenceCount"];
 }

--- a/yt/cpp/mapreduce/examples/tutorial/protobuf_complex_types/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/protobuf_complex_types/main.cpp
@@ -18,13 +18,13 @@ public:
         TDoc doc;
         for (auto& cursor : *reader) {
             auto entry = cursor.MoveRow();
-            if (!doc.HasTitle()) {
-                doc.SetTitle(entry.GetDocTitle());
+            if (!doc.has_title()) {
+                doc.set_title(entry.doc_title());
             }
-            doc.AddLinks()->Swap(entry.MutableLink());
-            doc.AddOccurrenceCounts(entry.GetOccurrenceCount());
-            auto newCount = doc.GetExtraInfo().GetTotalOccurrenceCount() + entry.GetOccurrenceCount();
-            doc.MutableExtraInfo()->SetTotalOccurrenceCount(newCount);
+            doc.add_links()->Swap(entry.mutable_link());
+            doc.add_occurrence_count(entry.occurrence_count());
+            auto newCount = doc.extra_info().total_occurrence_count() + entry.occurrence_count();
+            doc.mutable_extra_info()->set_total_occurrence_count(newCount);
         }
         writer->AddRow(doc);
     }

--- a/yt/cpp/mapreduce/examples/tutorial/simple_map_lambda/data.proto
+++ b/yt/cpp/mapreduce/examples/tutorial/simple_map_lambda/data.proto
@@ -2,12 +2,12 @@ import "yt/yt_proto/yt/formats/extension.proto";
 
 message TLoginRecord
 {
-    optional string Name = 1 [(NYT.column_name) = "name"];
-    optional string Login = 2 [(NYT.column_name) = "login"];
+    optional string name = 1 [(NYT.column_name) = "name"];
+    optional string login = 2 [(NYT.column_name) = "login"];
 }
 
 message TEmailRecord
 {
-    optional string Name = 1 [(NYT.column_name) = "name"];
-    optional string Email = 2 [(NYT.column_name) = "email"];
+    optional string name = 1 [(NYT.column_name) = "name"];
+    optional string email = 2 [(NYT.column_name) = "email"];
 }

--- a/yt/cpp/mapreduce/examples/tutorial/simple_map_lambda/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/simple_map_lambda/main.cpp
@@ -31,8 +31,8 @@ int main() {
         "//home/tutorial/staff_unsorted",
         outputTable,
         [](auto& src, auto& dst) {
-            dst.SetName(src.GetName());
-            dst.SetEmail(src.GetLogin() + GlobalSettings.MailSuffix);
+            dst.set_name(src.name());
+            dst.set_email(src.login() + GlobalSettings.MailSuffix);
             return true;
         });
 

--- a/yt/cpp/mapreduce/examples/tutorial/simple_map_protobuf/main.cpp
+++ b/yt/cpp/mapreduce/examples/tutorial/simple_map_protobuf/main.cpp
@@ -18,8 +18,8 @@ public:
             const auto& loginRecord = cursor.GetRow();
 
             TEmailRecord emailRecord;
-            emailRecord.SetName(loginRecord.GetName());
-            emailRecord.SetEmail(loginRecord.GetLogin() + "@yandex-team.ru");
+            emailRecord.set_name(loginRecord.name());
+            emailRecord.set_email(loginRecord.login() + "@yandex-team.ru");
 
             writer->AddRow(emailRecord);
         }

--- a/yt/cpp/mapreduce/interface/CMakeLists.txt
+++ b/yt/cpp/mapreduce/interface/CMakeLists.txt
@@ -78,6 +78,7 @@ target_link_libraries(cpp-mapreduce-interface PUBLIC
   mapreduce-interface-logging
   yt_proto-yt-formats
   yt-library-tvm
+  yt-yt-core
   tools-enum_parser-enum_serialization_runtime
 )
 target_sources(cpp-mapreduce-interface PRIVATE

--- a/yt/cpp/mapreduce/interface/format.cpp
+++ b/yt/cpp/mapreduce/interface/format.cpp
@@ -4,7 +4,6 @@
 #include "errors.h"
 
 #include <google/protobuf/descriptor.h>
-#include <google/protobuf/messagext.h>
 
 namespace NYT {
 

--- a/yt/cpp/mapreduce/interface/ya.make
+++ b/yt/cpp/mapreduce/interface/ya.make
@@ -29,6 +29,7 @@ PEERDIR(
     yt/cpp/mapreduce/interface/logging
     yt/yt_proto/yt/formats
     yt/yt/library/tvm
+    yt/yt/core
 )
 
 GENERATE_ENUM_SERIALIZATION(client_method_options.h)

--- a/yt/cpp/mapreduce/io/CMakeLists.txt
+++ b/yt/cpp/mapreduce/io/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(cpp-mapreduce-io PUBLIC
   cpp-mapreduce-interface
   mapreduce-interface-logging
   yt_proto-yt-formats
+  yt-yt-core
   cpp-yson-node
   cpp-mapreduce-skiff
 )

--- a/yt/cpp/mapreduce/io/proto_helpers.cpp
+++ b/yt/cpp/mapreduce/io/proto_helpers.cpp
@@ -22,7 +22,6 @@ using ::google::protobuf::Descriptor;
 using ::google::protobuf::DescriptorPool;
 
 using ::google::protobuf::io::CodedInputStream;
-using ::google::protobuf::io::CopyingInputStreamAdaptor;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/cpp/mapreduce/io/proto_helpers.cpp
+++ b/yt/cpp/mapreduce/io/proto_helpers.cpp
@@ -1,5 +1,7 @@
 #include "proto_helpers.h"
 
+#include <yt/yt/core/misc/protobuf_helpers.h>
+
 #include <yt/cpp/mapreduce/interface/io.h>
 #include <yt/cpp/mapreduce/interface/fluent.h>
 
@@ -7,7 +9,6 @@
 
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
-#include <google/protobuf/messagext.h>
 #include <google/protobuf/io/coded_stream.h>
 
 #include <util/stream/str.h>
@@ -21,7 +22,7 @@ using ::google::protobuf::Descriptor;
 using ::google::protobuf::DescriptorPool;
 
 using ::google::protobuf::io::CodedInputStream;
-using ::google::protobuf::io::TCopyingInputStreamAdaptor;
+using ::google::protobuf::io::CopyingInputStreamAdaptor;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -87,7 +88,7 @@ void ValidateProtoDescriptor(
 void ParseFromArcadiaStream(IInputStream* stream, Message& row, ui32 length)
 {
     TLengthLimitedInput input(stream, length);
-    TCopyingInputStreamAdaptor adaptor(&input);
+    TProtobufInputStreamAdaptor adaptor(&input);
     CodedInputStream codedStream(&adaptor);
     codedStream.SetTotalBytesLimit(length + 1);
     bool parsedOk = row.ParseFromCodedStream(&codedStream);

--- a/yt/cpp/mapreduce/io/proto_table_reader.cpp
+++ b/yt/cpp/mapreduce/io/proto_table_reader.cpp
@@ -4,6 +4,8 @@
 
 #include "proto_helpers.h"
 
+#include <yt/yt/core/misc/protobuf_helpers.h>
+
 #include <yt/yt_proto/yt/formats/extension.pb.h>
 
 #include <util/string/escape.h>
@@ -15,16 +17,19 @@ using ::google::protobuf::Descriptor;
 using ::google::protobuf::FieldDescriptor;
 using ::google::protobuf::EnumValueDescriptor;
 
-const TString& GetFieldColumnName(const FieldDescriptor* fieldDesc) {
-    const auto& columnName = fieldDesc->options().GetExtension(column_name);
+using NYT::FromProto;
+
+TString GetFieldColumnName(const FieldDescriptor* fieldDesc)
+{
+    auto columnName = FromProto<TString>(fieldDesc->options().GetExtension(column_name));
     if (!columnName.empty()) {
         return columnName;
     }
-    const auto& keyColumnName = fieldDesc->options().GetExtension(key_column_name);
+    auto keyColumnName = FromProto<TString>(fieldDesc->options().GetExtension(key_column_name));
     if (!keyColumnName.empty()) {
         return keyColumnName;
     }
-    return fieldDesc->name();
+    return FromProto<TString>(fieldDesc->name());
 }
 
 void ReadMessageFromNode(const TNode& node, Message* row)
@@ -48,10 +53,10 @@ void ReadMessageFromNode(const TNode& node, Message* row)
             continue; // null field
         }
 
-        auto checkType = [&columnName] (TNode::EType expected, TNode::EType actual) {
+        auto checkType = [fieldDesc] (TNode::EType expected, TNode::EType actual) {
             if (expected != actual) {
                 ythrow TNode::TTypeError() << "expected node type " << expected
-                    << ", actual " << actual << " for node " << columnName.data();
+                    << ", actual " << actual << " for node " << GetFieldColumnName(fieldDesc);
             }
         };
 

--- a/yt/cpp/mapreduce/io/proto_table_writer.cpp
+++ b/yt/cpp/mapreduce/io/proto_table_writer.cpp
@@ -179,9 +179,12 @@ void TLenvalProtoTableWriter::AddRow(const Message& row, size_t tableIndex)
     i32 size = row.ByteSizeLong();
     stream->Write(&size, sizeof(size));
 
-    TProtobufOutputStreamAdaptor streamAdaptor(stream);
-    auto result = row.SerializeToZeroCopyStream(&streamAdaptor);
-    Y_ENSURE(result && !streamAdaptor.HasError(), "Failed to serialize protobuf message");
+    // NB: Scope is essential here since output stream adaptor flushes in destructor.
+    {
+        TProtobufOutputStreamAdaptor streamAdaptor(stream);
+        auto result = row.SerializeToZeroCopyStream(&streamAdaptor);
+        Y_ENSURE(result && !streamAdaptor.HasError(), "Failed to serialize protobuf message");
+    }
 
     Output_->OnRowFinished(tableIndex);
 }
@@ -216,9 +219,12 @@ void TLenvalProtoSingleTableWriter::AddRow(const Message& row, size_t tableIndex
     i32 size = row.ByteSizeLong();
     stream->Write(&size, sizeof(size));
 
-    TProtobufOutputStreamAdaptor streamAdaptor(stream);
-    auto result = row.SerializeToZeroCopyStream(&streamAdaptor);
-    Y_ENSURE(result && !streamAdaptor.HasError(), "Failed to serialize protobuf message");
+    // NB: Scope is essential here since output stream adaptor flushes in destructor.
+    {
+        TProtobufOutputStreamAdaptor streamAdaptor(stream);
+        auto result = row.SerializeToZeroCopyStream(&streamAdaptor);
+        Y_ENSURE(result && !streamAdaptor.HasError(), "Failed to serialize protobuf message");
+    }
 
     Output_->OnRowFinished(tableIndex);
 }

--- a/yt/cpp/mapreduce/io/proto_table_writer.cpp
+++ b/yt/cpp/mapreduce/io/proto_table_writer.cpp
@@ -3,6 +3,8 @@
 #include "node_table_writer.h"
 #include "proto_helpers.h"
 
+#include <yt/yt/core/misc/protobuf_helpers.h>
+
 #include <yt/cpp/mapreduce/common/node_builder.h>
 
 #include <yt/cpp/mapreduce/interface/io.h>
@@ -39,7 +41,7 @@ TNode MakeNodeFromMessage(const Message& row)
             continue;
         }
 
-        TString columnName = fieldDesc->options().GetExtension(column_name);
+        auto columnName = fieldDesc->options().GetExtension(column_name);
         if (columnName.empty()) {
             const auto& keyColumnName = fieldDesc->options().GetExtension(key_column_name);
             columnName = keyColumnName.empty() ? fieldDesc->name() : keyColumnName;
@@ -174,10 +176,13 @@ void TLenvalProtoTableWriter::AddRow(const Message& row, size_t tableIndex)
         "Message: %s", row.DebugString().data());
 
     auto* stream = Output_->GetStream(tableIndex);
-    i32 size = row.ByteSize();
+    i32 size = row.ByteSizeLong();
     stream->Write(&size, sizeof(size));
-    bool serializedOk = row.SerializeToArcadiaStream(stream);
-    Y_ENSURE(serializedOk, "Failed to serialize protobuf message");
+
+    TProtobufOutputStreamAdaptor streamAdaptor(stream);
+    auto result = row.SerializeToZeroCopyStream(&streamAdaptor);
+    Y_ENSURE(result && !streamAdaptor.HasError(), "Failed to serialize protobuf message");
+
     Output_->OnRowFinished(tableIndex);
 }
 
@@ -208,10 +213,13 @@ void TLenvalProtoSingleTableWriter::AddRow(const Message& row, size_t tableIndex
         "Message: %s", row.DebugString().data());
 
     auto* stream = Output_->GetStream(tableIndex);
-    i32 size = row.ByteSize();
+    i32 size = row.ByteSizeLong();
     stream->Write(&size, sizeof(size));
-    bool serializedOk = row.SerializeToArcadiaStream(stream);
-    Y_ENSURE(serializedOk, "Failed to serialize protobuf message");
+
+    TProtobufOutputStreamAdaptor streamAdaptor(stream);
+    auto result = row.SerializeToZeroCopyStream(&streamAdaptor);
+    Y_ENSURE(result && !streamAdaptor.HasError(), "Failed to serialize protobuf message");
+
     Output_->OnRowFinished(tableIndex);
 }
 

--- a/yt/cpp/mapreduce/io/ya.make
+++ b/yt/cpp/mapreduce/io/ya.make
@@ -28,6 +28,7 @@ PEERDIR(
     yt/yt_proto/yt/formats
     library/cpp/yson/node
     yt/cpp/mapreduce/skiff
+    yt/yt/core
 )
 
 END()

--- a/yt/cpp/mapreduce/library/lambda/field_copier.cpp
+++ b/yt/cpp/mapreduce/library/lambda/field_copier.cpp
@@ -2,7 +2,7 @@
 
 #include <yt/yt_proto/yt/formats/extension.pb.h>
 
-using namespace NProtoBuf;
+using namespace google::protobuf;
 
 // ===========================================================================
 namespace NYT::NDetail {
@@ -64,7 +64,7 @@ const FieldDescriptor* DescriptorByColumn(
     for (int i = 0; i < count; ++i) {
         auto* fieldDesc = descriptor->field(i);
 
-        TString curColumnName = fieldDesc->options().GetExtension(column_name);
+        auto curColumnName = fieldDesc->options().GetExtension(column_name);
         if (curColumnName.empty()) {
             const auto& keyColumnName = fieldDesc->options().GetExtension(key_column_name);
             curColumnName = keyColumnName.empty() ? fieldDesc->name() : keyColumnName;

--- a/yt/cpp/mapreduce/library/lambda/field_copier.h
+++ b/yt/cpp/mapreduce/library/lambda/field_copier.h
@@ -9,20 +9,20 @@
 // ===========================================================================
 namespace NYT {
 // ===========================================================================
-const NProtoBuf::FieldDescriptor* DescriptorByColumn(const NProtoBuf::Descriptor*, TStringBuf columnName);
+const google::protobuf::FieldDescriptor* DescriptorByColumn(const google::protobuf::Descriptor*, TStringBuf columnName);
 
 template <class TProtoType>
-const NProtoBuf::FieldDescriptor* DescriptorByColumn(TStringBuf columnName) {
+const google::protobuf::FieldDescriptor* DescriptorByColumn(TStringBuf columnName) {
     return DescriptorByColumn(TProtoType::descriptor(), columnName);
 }
 
 namespace NDetail {
-void CheckFieldCopierTypes(TStringBuf columnName, const NProtoBuf::FieldDescriptor* from, const NProtoBuf::FieldDescriptor* to = nullptr);
+void CheckFieldCopierTypes(TStringBuf columnName, const google::protobuf::FieldDescriptor* from, const google::protobuf::FieldDescriptor* to = nullptr);
 } // namespace NDetail
 
 template <class MsgFrom, class MsgTo,
-        bool FromProto = std::is_base_of<NProtoBuf::Message, MsgFrom>::value,
-        bool ToProto = std::is_base_of<NProtoBuf::Message, MsgTo>::value>
+        bool FromProto = std::is_base_of<google::protobuf::Message, MsgFrom>::value,
+        bool ToProto = std::is_base_of<google::protobuf::Message, MsgTo>::value>
 class TFieldCopier {
 public:
     TFieldCopier(const TSortColumns& columns) {
@@ -36,7 +36,7 @@ public:
     }
 
     void operator()(const MsgFrom& from, MsgTo& to) const {
-        using namespace NProtoBuf;
+        using namespace google::protobuf;
         auto reflFrom = from.GetReflection();
         auto reflTo = to.GetReflection();
         // NOTE: code below could be moved to cpp file if that would not hurt performance
@@ -80,7 +80,7 @@ public:
     }
 
 private:
-    TVector<std::pair<const NProtoBuf::FieldDescriptor*, const NProtoBuf::FieldDescriptor*>> CopyDesc_;
+    TVector<std::pair<const google::protobuf::FieldDescriptor*, const google::protobuf::FieldDescriptor*>> CopyDesc_;
 };
 
 /**
@@ -119,7 +119,7 @@ public:
 
     // NOTE: see also io/proto_table_reader.cpp
     void operator()(const MsgFrom& from, MsgTo& to) const {
-        using namespace NProtoBuf;
+        using namespace google::protobuf;
         auto reflTo = to.GetReflection();
         // NOTE: code below could be moved to cpp file if that would not hurt performance
         for (auto& desc : CopyDesc_) {
@@ -168,7 +168,7 @@ public:
     }
 
 private:
-    TVector<std::pair<TString, const NProtoBuf::FieldDescriptor*>> CopyDesc_;
+    TVector<std::pair<TString, const google::protobuf::FieldDescriptor*>> CopyDesc_;
 };
 
 /**
@@ -187,7 +187,7 @@ public:
     }
 
     void operator()(const MsgFrom& from, MsgTo& to) const {
-        using namespace NProtoBuf;
+        using namespace google::protobuf;
         auto reflFrom = from.GetReflection();
         // NOTE: code below could be moved to cpp file if that would not hurt performance
         //       and we restrict that MsgTo to TNode
@@ -231,7 +231,7 @@ public:
     }
 
 private:
-    TVector<std::pair<const NProtoBuf::FieldDescriptor*, TString>> CopyDesc_;
+    TVector<std::pair<const google::protobuf::FieldDescriptor*, TString>> CopyDesc_;
 };
 
 /* NOTE: we can restrict MsgTo in above class to TNode and uncomment this:

--- a/yt/yt/core/bus/tcp/connection.cpp
+++ b/yt/yt/core/bus/tcp/connection.cpp
@@ -328,7 +328,7 @@ void TTcpConnection::TryEnqueueHandshake()
 
 TSharedRefArray TTcpConnection::MakeHandshakeMessage(const NProto::THandshake& handshake)
 {
-    auto protoSize = handshake.ByteSize();
+    auto protoSize = handshake.ByteSizeLong();
     auto totalSize = sizeof(HandshakeMessageSignature) + protoSize;
 
     TSharedRefArrayBuilder builder(1, totalSize);

--- a/yt/yt/core/misc/error.cpp
+++ b/yt/yt/core/misc/error.cpp
@@ -1104,7 +1104,7 @@ void FromProto(TError* error, const NYT::NProto::TError& protoError)
     }
 
     error->SetCode(TErrorCode(protoError.code()));
-    error->SetMessage(protoError.message());
+    error->SetMessage(FromProto<TString>(protoError.message()));
     if (protoError.has_attributes()) {
         error->Impl_->SetAttributes(FromProto(protoError.attributes()));
     } else {

--- a/yt/yt/core/misc/protobuf_helpers.cpp
+++ b/yt/yt/core/misc/protobuf_helpers.cpp
@@ -402,7 +402,7 @@ void FromProto(TExtensionSet* extensionSet, const NYT::NProto::TExtensionSet& pr
         if (IProtobufExtensionRegistry::Get()->FindDescriptorByTag(protoExtension.tag())) {
             TExtension extension{
                 .Tag = protoExtension.tag(),
-                .Data = protoExtension.data()
+                .Data = FromProto<TString>(protoExtension.data()),
             };
             extensionSet->Extensions.push_back(std::move(extension));
         }
@@ -450,11 +450,15 @@ void Deserialize(TExtensionSet& extensionSet, NYTree::INodePtr node)
         auto& extension = extensionSet.Extensions.emplace_back();
         extension.Tag = extensionDescriptor->Tag;
 
-        StringOutputStream stream(&extension.Data);
+        TProtobufString serializedExtension;
+        StringOutputStream stream(&serializedExtension);
+
         auto writer = CreateProtobufWriter(
             &stream,
             ReflectProtobufMessageType(extensionDescriptor->MessageDescriptor));
-        VisitTree(value, writer.get(), /*stable=*/false);
+        VisitTree(value, writer.get(), /*stable*/ false);
+
+        extension.Data = FromProto<TString>(std::move(serializedExtension));
     }
 }
 
@@ -475,9 +479,9 @@ TString DumpProto(::google::protobuf::Message& message)
 {
     ::google::protobuf::TextFormat::Printer printer;
     printer.SetSingleLineMode(true);
-    TString result;
+    TProtobufString result;
     YT_VERIFY(printer.PrintToString(message, &result));
-    return result;
+    return FromProto<TString>(std::move(result));
 }
 
 } // namespace
@@ -555,6 +559,61 @@ google::protobuf::Timestamp GetProtoNow()
     // Unfortunately TimeUtil::GetCurrentTime provides only one second accuracy, so we use TInstant::Now.
     return google::protobuf::util::TimeUtil::MicrosecondsToTimestamp(TInstant::Now().MicroSeconds());
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+TProtobufInputStream::TProtobufInputStream(IInputStream* stream)
+    : Stream_(stream)
+{ }
+
+int TProtobufInputStream::Read(void* buffer, int size)
+{
+    try {
+        return Stream_->Read(buffer, size);
+    } catch (...) {
+        HasError_ = true;
+    }
+
+    return -1;
+}
+
+bool TProtobufInputStream::HasError() const
+{
+    return HasError_;
+}
+
+TProtobufInputStreamAdaptor::TProtobufInputStreamAdaptor(IInputStream* stream)
+    : TProtobufInputStream(stream)
+    , CopyingInputStreamAdaptor(this)
+{ }
+
+////////////////////////////////////////////////////////////////////////////////
+
+TProtobufOutputStream::TProtobufOutputStream(IOutputStream* stream)
+    : Stream_(stream)
+{ }
+
+bool TProtobufOutputStream::Write(const void* buffer, int size)
+{
+    try {
+        Stream_->Write(buffer, size);
+        return true;
+    } catch (...) {
+        HasError_ = true;
+    }
+
+    return false;
+}
+
+bool TProtobufOutputStream::HasError() const
+{
+    return HasError_;
+}
+
+TProtobufOutputStreamAdaptor::TProtobufOutputStreamAdaptor(IOutputStream* stream)
+    : TProtobufOutputStream(stream)
+    , CopyingOutputStreamAdaptor(this)
+{ }
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/core/misc/protobuf_helpers.h
+++ b/yt/yt/core/misc/protobuf_helpers.h
@@ -20,6 +20,7 @@
 #include <google/protobuf/repeated_field.h>
 
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/misc/protobuf_helpers.h
+++ b/yt/yt/core/misc/protobuf_helpers.h
@@ -6,6 +6,7 @@
 #include "range.h"
 #include "serialize.h"
 
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <yt/yt/core/compression/public.h>
 
 #include <yt/yt_proto/yt/core/misc/proto/guid.pb.h>
@@ -377,6 +378,78 @@ google::protobuf::Timestamp GetProtoNow();
 
 //! This macro may be used to extract std::optional<T> from protobuf message field of type T.
 #define YT_PROTO_OPTIONAL(message, field) (((message).has_##field()) ? std::make_optional((message).field()) : std::nullopt)
+
+////////////////////////////////////////////////////////////////////////////////
+
+// TODO(gritukan): This is a hack that allows to use proper string type in the protobuf-related code.
+// In Arcadia, protobuf is patched and TString is used as a string in it.
+// In vanilla protobuf, std::string is used.
+// TProtobufString is a type that you should use in code that works both with
+// Arcadia and vanilla protobuf.
+// It is an alias for TString in Arcadia and for std::string in vanilla protobuf.
+using TProtobufString = decltype(std::declval<::google::protobuf::MessageLite>().GetTypeName());
+
+constexpr bool IsVanillaProtobuf = std::is_same_v<TProtobufString, std::string>;
+constexpr bool IsArcadiaProtobuf = std::is_same_v<TProtobufString, TString>;
+
+// If this assert fails, something went very wrong. Refer to a comment above.
+static_assert(IsVanillaProtobuf || IsArcadiaProtobuf, "Unknown protobuf string type");
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TProtobufInputStream
+    : public ::google::protobuf::io::CopyingInputStream
+{
+public:
+    explicit TProtobufInputStream(IInputStream* stream);
+
+    int Read(void* buffer, int size) override;
+
+    // Arcadia-style streams throw errors instead of returning -1,
+    // so we intercept these errors and store them in a flag.
+    bool HasError() const;
+
+private:
+    IInputStream* const Stream_;
+
+    bool HasError_ = false;
+};
+
+class TProtobufInputStreamAdaptor
+    : public TProtobufInputStream
+    , public ::google::protobuf::io::CopyingInputStreamAdaptor
+{
+public:
+    explicit TProtobufInputStreamAdaptor(IInputStream* stream);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TProtobufOutputStream
+    : public ::google::protobuf::io::CopyingOutputStream
+{
+public:
+    explicit TProtobufOutputStream(IOutputStream* stream);
+
+    bool Write(const void* buffer, int size) override;
+
+    // Arcadia-style streams throw errors instead of returning -1,
+    // so we intercept these errors and store them in a flag.
+    bool HasError() const;
+
+private:
+    IOutputStream* const Stream_;
+
+    bool HasError_ = false;
+};
+
+class TProtobufOutputStreamAdaptor
+    : public TProtobufOutputStream
+    , public ::google::protobuf::io::CopyingOutputStreamAdaptor
+{
+public:
+    explicit TProtobufOutputStreamAdaptor(IOutputStream* stream);
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/core/misc/protobuf_helpers.h
+++ b/yt/yt/core/misc/protobuf_helpers.h
@@ -6,7 +6,6 @@
 #include "range.h"
 #include "serialize.h"
 
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <yt/yt/core/compression/public.h>
 
 #include <yt/yt_proto/yt/core/misc/proto/guid.pb.h>
@@ -20,6 +19,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>
 
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/rpc/authenticator.cpp
+++ b/yt/yt/core/rpc/authenticator.cpp
@@ -1,5 +1,7 @@
 #include "authenticator.h"
 
+#include <yt/yt/core/misc/protobuf_helpers.h>
+
 #include <yt/yt_proto/yt/core/rpc/proto/rpc.pb.h>
 
 namespace NYT::NRpc {
@@ -43,6 +45,8 @@ private:
     const std::vector<IAuthenticatorPtr> Authenticators_;
 };
 
+////////////////////////////////////////////////////////////////////////////////
+
 IAuthenticatorPtr CreateCompositeAuthenticator(
     std::vector<IAuthenticatorPtr> authenticators)
 {
@@ -66,13 +70,15 @@ public:
         static const auto Realm = TString("noop");
         static const auto UserTicket = TString();
         TAuthenticationResult result{
-            context.Header->has_user() ? context.Header->user() : RootUserName,
+            context.Header->has_user() ? FromProto<TString>(context.Header->user()) : RootUserName,
             Realm,
             UserTicket
         };
         return MakeFuture<TAuthenticationResult>(result);
     }
 };
+
+////////////////////////////////////////////////////////////////////////////////
 
 IAuthenticatorPtr CreateNoopAuthenticator()
 {

--- a/yt/yt/core/rpc/message_format.cpp
+++ b/yt/yt/core/rpc/message_format.cpp
@@ -17,6 +17,8 @@ using namespace NYson;
 using namespace NJson;
 using namespace NRpc::NProto;
 
+using NYT::FromProto;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct IMessageFormat
@@ -71,14 +73,14 @@ public:
 
     TSharedRef ConvertFrom(const TSharedRef& message, const NYson::TProtobufMessageType* messageType, const TYsonString& /*formatOptionsYson*/) override
     {
-        TString protoBuffer;
+        TProtobufString protoBuffer;
         {
             google::protobuf::io::StringOutputStream output(&protoBuffer);
             auto converter = CreateProtobufWriter(&output, messageType);
             // NB: formatOptionsYson is ignored, since YSON parser has no user-defined options.
             ParseYsonStringBuffer(TStringBuf(message.Begin(), message.End()), EYsonType::Node, converter.get());
         }
-        return TSharedRef::FromString(protoBuffer);
+        return TSharedRef::FromString(FromProto<TString>(protoBuffer));
     }
 
     TSharedRef ConvertTo(const TSharedRef& message, const NYson::TProtobufMessageType* messageType, const TYsonString& /*formatOptionsYson*/) override
@@ -106,7 +108,7 @@ public:
 
     TSharedRef ConvertFrom(const TSharedRef& message, const NYson::TProtobufMessageType* messageType, const TYsonString& formatOptionsYson) override
     {
-        TString protoBuffer;
+        TProtobufString protoBuffer;
         {
             google::protobuf::io::StringOutputStream output(&protoBuffer);
             auto converter = CreateProtobufWriter(&output, messageType);
@@ -117,7 +119,7 @@ public:
             }
             ParseJson(&input, converter.get(), formatConfig);
         }
-        return TSharedRef::FromString(protoBuffer);
+        return TSharedRef::FromString(FromProto<TString>(std::move(protoBuffer)));
     }
 
     TSharedRef ConvertTo(const TSharedRef& message, const NYson::TProtobufMessageType* messageType, const TYsonString& formatOptionsYson) override

--- a/yt/yt/core/rpc/per_user_request_queue_provider.cpp
+++ b/yt/yt/core/rpc/per_user_request_queue_provider.cpp
@@ -25,7 +25,7 @@ TPerUserRequestQueueProvider::TPerUserRequestQueueProvider(
 
 TRequestQueue* TPerUserRequestQueueProvider::GetQueue(const NProto::TRequestHeader& header)
 {
-    const auto& userName = header.has_user() ? header.user() : RootUserName;
+    auto userName = header.has_user() ? ::NYT::FromProto<TString>(header.user()) : RootUserName;
     return DoGetQueue(userName);
 }
 

--- a/yt/yt/core/rpc/service_detail.cpp
+++ b/yt/yt/core/rpc/service_detail.cpp
@@ -1674,7 +1674,8 @@ void TServiceBase::HandleRequest(
 {
     SetActive();
 
-    const auto& method = header->method();
+    // XXX:
+    auto method = FromProto<TString>(header->method());
     auto requestId = FromProto<TRequestId>(header->request_id());
 
     auto replyError = [&] (TError error) {

--- a/yt/yt/core/rpc/service_detail.cpp
+++ b/yt/yt/core/rpc/service_detail.cpp
@@ -1674,7 +1674,6 @@ void TServiceBase::HandleRequest(
 {
     SetActive();
 
-    // XXX:
     auto method = FromProto<TString>(header->method());
     auto requestId = FromProto<TRequestId>(header->request_id());
 
@@ -1789,7 +1788,6 @@ void TServiceBase::HandleRequest(
             NYT::NRpc::EErrorCode::AuthenticationError,
             "Request is missing credentials"));
     }
-
 }
 
 void TServiceBase::ReplyError(

--- a/yt/yt/core/tracing/trace_context.cpp
+++ b/yt/yt/core/tracing/trace_context.cpp
@@ -691,7 +691,7 @@ TTraceContextPtr TTraceContext::NewChildFromRpc(
         traceContext->SetBaggage(TYsonString(ext.baggage()));
     }
     if (ext.has_target_endpoint()) {
-        traceContext->SetTargetEndpoint(ext.target_endpoint());
+        traceContext->SetTargetEndpoint(FromProto<TString>(ext.target_endpoint()));
     }
     return traceContext;
 }

--- a/yt/yt/core/yson/protobuf_interop.cpp
+++ b/yt/yt/core/yson/protobuf_interop.cpp
@@ -196,7 +196,7 @@ public:
 
         return GetYsonNameFromDescriptor(
             descriptor,
-            descriptor->options().GetExtension(NYT::NYson::NProto::field_name));
+            FromProto<TString>(descriptor->options().GetExtension(NYT::NYson::NProto::field_name)));
     }
 
     //! This method is called while reflecting types.
@@ -205,9 +205,9 @@ public:
         VERIFY_SPINLOCK_AFFINITY(Lock_);
 
         std::vector<TStringBuf> aliases;
-        auto extensions = descriptor->options().GetRepeatedExtension(NYT::NYson::NProto::field_name_alias);
+        const auto& extensions = descriptor->options().GetRepeatedExtension(NYT::NYson::NProto::field_name_alias);
         for (const auto& alias : extensions) {
-            aliases.push_back(InternString(alias));
+            aliases.push_back(InternString(FromProto<TString>(alias)));
         }
         return aliases;
     }
@@ -219,7 +219,7 @@ public:
 
         return GetYsonNameFromDescriptor(
             descriptor,
-            descriptor->options().GetExtension(NYT::NYson::NProto::enum_value_name));
+            FromProto<TString>(descriptor->options().GetExtension(NYT::NYson::NProto::enum_value_name)));
     }
 
     const TProtobufMessageType* ReflectMessageType(const Descriptor* descriptor)
@@ -333,7 +333,9 @@ private:
     template <class TDescriptor>
     TStringBuf GetYsonNameFromDescriptor(const TDescriptor* descriptor, const TString& annotatedName)
     {
-        auto ysonName = annotatedName ? annotatedName : DeriveYsonName(descriptor->name(), descriptor->file());
+        auto ysonName = annotatedName
+            ? annotatedName
+            : DeriveYsonName(FromProto<TString>(descriptor->name()), descriptor->file());
         return InternString(ysonName);
     }
 
@@ -376,6 +378,7 @@ public:
     TProtobufField(TProtobufTypeRegistry* registry, const FieldDescriptor* descriptor)
         : Underlying_(descriptor)
         , YsonName_(registry->GetYsonName(descriptor))
+        , FullName_(FromProto<TString>(Underlying_->full_name()))
         , YsonNameAliases_(registry->GetYsonNameAliases(descriptor))
         , MessageType_(descriptor->type() == FieldDescriptor::TYPE_MESSAGE ? registry->ReflectMessageTypeInternal(
             descriptor->message_type()) : nullptr)
@@ -415,7 +418,7 @@ public:
 
     const TString& GetFullName() const
     {
-        return Underlying_->full_name();
+        return FullName_;
     }
 
     TStringBuf GetYsonName() const
@@ -587,6 +590,7 @@ public:
 private:
     const FieldDescriptor* const Underlying_;
     const TStringBuf YsonName_;
+    const TString FullName_;
     const std::vector<TStringBuf> YsonNameAliases_;
     const TProtobufMessageType* MessageType_;
     const TProtobufEnumType* EnumType_;
@@ -606,6 +610,7 @@ public:
         : Registry_(registry)
         , Underlying_(descriptor)
         , AttributeDictionary_(descriptor->options().GetExtension(NYT::NYson::NProto::attribute_dictionary))
+        , FullName_(FromProto<TString>(Underlying_->full_name()))
         , Converter_(registry->FindMessageTypeConverter(descriptor))
     { }
 
@@ -624,7 +629,7 @@ public:
         }
 
         for (int index = 0; index < Underlying_->reserved_name_count(); ++index) {
-            ReservedFieldNames_.insert(Underlying_->reserved_name(index));
+            ReservedFieldNames_.insert(FromProto<TString>(Underlying_->reserved_name(index)));
         }
     }
 
@@ -640,7 +645,7 @@ public:
 
     const TString& GetFullName() const
     {
-        return Underlying_->full_name();
+        return FullName_;
     }
 
     const std::vector<int>& GetRequiredFieldNumbers() const
@@ -728,6 +733,8 @@ private:
     const Descriptor* const Underlying_;
     const bool AttributeDictionary_;
 
+    const TString FullName_;
+
     std::vector<std::unique_ptr<TProtobufField>> Fields_;
     std::vector<int> RequiredFieldNumbers_;
     THashMap<TStringBuf, const TProtobufField*> NameToField_;
@@ -799,6 +806,7 @@ public:
     TProtobufEnumType(TProtobufTypeRegistry* registry, const EnumDescriptor* descriptor)
         : Registry_(registry)
         , Underlying_(descriptor)
+        , FullName_(FromProto<TString>(Underlying_->full_name()))
     { }
 
     void Build()
@@ -821,7 +829,7 @@ public:
 
     const TString& GetFullName() const
     {
-        return Underlying_->full_name();
+        return FullName_;
     }
 
     std::optional<int> FindValueByLiteral(TStringBuf literal) const
@@ -851,6 +859,8 @@ public:
 private:
     TProtobufTypeRegistry* const Registry_;
     const EnumDescriptor* const Underlying_;
+
+    const TString FullName_;
 
     THashMap<TStringBuf, int> LiteralToValue_;
     THashMap<int, TStringBuf> ValueToLiteral_;
@@ -1067,7 +1077,7 @@ private:
     const TProtobufMessageType* const RootType_;
     const TProtobufWriterOptions Options_;
 
-    TString BodyString_;
+    TProtobufString BodyString_;
     google::protobuf::io::StringOutputStream BodyOutputStream_;
     google::protobuf::io::CodedOutputStream BodyCodedStream_;
 
@@ -1121,7 +1131,7 @@ private:
     TStringOutput YsonStringStream_;
     TBufferedBinaryYsonWriter YsonStringWriter_;
 
-    TString SerializedMessage_;
+    TProtobufString SerializedMessage_;
     TString BytesString_;
 
     TString UnknownYsonFieldKey_;
@@ -1909,10 +1919,10 @@ private:
                 std::unique_ptr<Message> message(MessageFactory::generated_factory()->GetPrototype(messageType->GetUnderlying())->New());
                 converter.Deserializer(message.get(), node);
                 SerializedMessage_.clear();
-                Y_PROTOBUF_SUPPRESS_NODISCARD message->SerializeToString(&SerializedMessage_);
+                Y_UNUSED(message->SerializeToString(&SerializedMessage_));
                 WriteTag();
                 BodyCodedStream_.WriteVarint64(SerializedMessage_.length());
-                BodyCodedStream_.WriteRaw(SerializedMessage_.begin(), static_cast<int>(SerializedMessage_.length()));
+                BodyCodedStream_.WriteRaw(SerializedMessage_.data(), static_cast<int>(SerializedMessage_.length()));
                 FieldStack_.pop_back();
                 YPathStack_.Pop();
             });
@@ -2681,7 +2691,7 @@ private:
                             std::unique_ptr<Message> message(MessageFactory::generated_factory()->GetPrototype(messageType->GetUnderlying())->New());
                             PooledString_.resize(length);
                             CodedStream_.ReadRaw(PooledString_.data(), PooledString_.size());
-                            Y_PROTOBUF_SUPPRESS_NODISCARD message->ParseFromArray(PooledString_.data(), PooledString_.size());
+                            Y_UNUSED(message->ParseFromArray(PooledString_.data(), PooledString_.size()));
                             converter.Serializer(Consumer_, message.get());
                             YPathStack_.Pop();
                         } else {
@@ -3145,11 +3155,11 @@ TString YsonStringToProto(
     const TProtobufMessageType* payloadType,
     TProtobufWriterOptions options)
 {
-    TString serializedProto;
+    TProtobufString serializedProto;
     google::protobuf::io::StringOutputStream protobufStream(&serializedProto);
     auto protobufWriter = CreateProtobufWriter(&protobufStream, payloadType, std::move(options));
     ParseYsonStringBuffer(ysonString.AsStringBuf(), EYsonType::Node, protobufWriter.get());
-    return serializedProto;
+    return FromProto<TString>(serializedProto);
 }
 
 void WriteSchema(const TProtobufEnumType* type, IYsonConsumer* consumer)

--- a/yt/yt/core/ytree/helpers.cpp
+++ b/yt/yt/core/ytree/helpers.cpp
@@ -1,4 +1,5 @@
 #include "helpers.h"
+
 #include "attributes.h"
 #include "ypath_client.h"
 
@@ -9,6 +10,8 @@
 namespace NYT::NYTree {
 
 using namespace NYson;
+
+using NYT::FromProto;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -232,8 +235,8 @@ IAttributeDictionaryPtr FromProto(const NProto::TAttributeDictionary& protoAttri
 {
     auto attributes = CreateEphemeralAttributes();
     for (const auto& protoAttribute : protoAttributes.attributes()) {
-        const auto& key = protoAttribute.key();
-        const auto& value = protoAttribute.value();
+        auto key = FromProto<TString>(protoAttribute.key());
+        auto value = FromProto<TString>(protoAttribute.value());
         attributes->SetYson(key, TYsonString(value));
     }
     return attributes;

--- a/yt/yt/core/ytree/serialize-inl.h
+++ b/yt/yt/core/ytree/serialize-inl.h
@@ -373,14 +373,14 @@ void Serialize(const TCompactVector<T, N>& items, NYson::IYsonConsumer* consumer
 
 // RepeatedPtrField
 template <class T>
-void Serialize(const NProtoBuf::RepeatedPtrField<T>& items, NYson::IYsonConsumer* consumer)
+void Serialize(const google::protobuf::RepeatedPtrField<T>& items, NYson::IYsonConsumer* consumer)
 {
     NDetail::SerializeVector(items, consumer);
 }
 
 // RepeatedField
 template <class T>
-void Serialize(const NProtoBuf::RepeatedField<T>& items, NYson::IYsonConsumer* consumer)
+void Serialize(const google::protobuf::RepeatedField<T>& items, NYson::IYsonConsumer* consumer)
 {
     NDetail::SerializeVector(items, consumer);
 }

--- a/yt/yt/core/ytree/serialize.cpp
+++ b/yt/yt/core/ytree/serialize.cpp
@@ -1,8 +1,9 @@
 #include "serialize.h"
 
-#include <yt/yt/core/ytree/tree_visitor.h>
+#include "tree_visitor.h"
 
 #include <yt/yt/core/misc/blob.h>
+#include <yt/yt/core/misc/protobuf_helpers.h>
 
 #include <library/cpp/yt/misc/cast.h>
 
@@ -342,7 +343,7 @@ void DeserializeProtobufMessage(
     const INodePtr& node,
     const NYson::TProtobufWriterOptions& options)
 {
-    TString wireBytes;
+    TProtobufString wireBytes;
     StringOutputStream outputStream(&wireBytes);
     auto protobufWriter = CreateProtobufWriter(&outputStream, type, options);
     VisitTree(node, protobufWriter.get(), true);

--- a/yt/yt/core/ytree/ypath_client.cpp
+++ b/yt/yt/core/ytree/ypath_client.cpp
@@ -246,29 +246,19 @@ bool TYPathResponse::TryDeserializeBody(TRef /*data*/, std::optional<NCompressio
 TYPathMaybeRef GetRequestTargetYPath(const NRpc::NProto::TRequestHeader& header)
 {
     const auto& ypathExt = header.GetExtension(NProto::TYPathHeaderExt::ypath_header_ext);
-    if constexpr (IsArcadiaProtobuf) {
-        // This cast is actually always no-op and performared just to get rid of errors
-        // in case if vanilla protobuf is used.
-        return TYPathMaybeRef(ypathExt.target_path());
-    } else {
-        return FromProto<TYPath>(ypathExt.target_path());
-    }
+    // NB: If Arcadia protobuf is used, the cast is no-op `const TYPath&` -> `const TYPath&`.
+    // If vanilla protobuf is used, the cast is `std::string` -> `TString`.
+    // So in both cases the cast is correct and the most effective possible.
+    return TYPathMaybeRef(ypathExt.target_path());
 }
 
 TYPathMaybeRef GetOriginalRequestTargetYPath(const NRpc::NProto::TRequestHeader& header)
 {
     const auto& ypathExt = header.GetExtension(NProto::TYPathHeaderExt::ypath_header_ext);
-    if constexpr (IsArcadiaProtobuf) {
-        // These casts are actually always no-op and performared just to get rid of errors
-        // in case if vanilla protobuf is used.
-        return ypathExt.has_original_target_path()
-            ? TYPathMaybeRef(ypathExt.original_target_path())
-            : TYPathMaybeRef(ypathExt.target_path());
-    } else {
-        return ypathExt.has_original_target_path()
-            ? FromProto<TYPath>(ypathExt.original_target_path())
-            : FromProto<TYPath>(ypathExt.target_path());
-    }
+    // NB: TYPathMaybeRef cast is described above in `GetRequestTargetYPath`.
+    return ypathExt.has_original_target_path()
+        ? TYPathMaybeRef(ypathExt.original_target_path())
+        : TYPathMaybeRef(ypathExt.target_path());
 }
 
 void SetRequestTargetYPath(NRpc::NProto::TRequestHeader* header, TYPath path)

--- a/yt/yt/core/ytree/ypath_client.h
+++ b/yt/yt/core/ytree/ypath_client.h
@@ -199,17 +199,10 @@ protected:
 // it would be TYPathBuf, but for now it breaks the advantages for CoW of the
 // TString. Rethink it if and when YT will try to use std::string or non-CoW
 // TString everywhere.
-#ifdef YT_USE_VANILLA_PROTOBUF
+using TYPathMaybeRef = std::conditional<IsArcadiaProtobuf, const TYPath&, TYPath>::type;
 
-TYPath GetRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
-TYPath GetOriginalRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
-
-#else
-
-const TYPath& GetRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
-const TYPath& GetOriginalRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
-
-#endif
+TYPathMaybeRef GetRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
+TYPathMaybeRef GetOriginalRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
 
 void SetRequestTargetYPath(NRpc::NProto::TRequestHeader* header, TYPath path);
 

--- a/yt/yt/core/ytree/ypath_client.h
+++ b/yt/yt/core/ytree/ypath_client.h
@@ -199,7 +199,7 @@ protected:
 // it would be TYPathBuf, but for now it breaks the advantages for CoW of the
 // TString. Rethink it if and when YT will try to use std::string or non-CoW
 // TString everywhere.
-using TYPathMaybeRef = std::conditional<IsArcadiaProtobuf, const TYPath&, TYPath>::type;
+using TYPathMaybeRef = std::conditional_t<IsArcadiaProtobuf, const TYPath&, TYPath>;
 
 TYPathMaybeRef GetRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);
 TYPathMaybeRef GetOriginalRequestTargetYPath(const NRpc::NProto::TRequestHeader& header);

--- a/yt/yt/core/ytree/ypath_service.cpp
+++ b/yt/yt/core/ytree/ypath_service.cpp
@@ -28,6 +28,8 @@
 
 namespace NYT::NYTree {
 
+using NYT::FromProto;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TCacheKey
@@ -832,7 +834,7 @@ bool TCachedYPathService::DoInvoke(const IYPathServiceContextPtr& context)
 
                 TCacheKey key(
                     GetRequestTargetYPath(context->GetRequestHeader()),
-                    context->GetRequestHeader().method(),
+                    FromProto<TString>(context->GetRequestHeader().method()),
                     context->GetRequestMessage()[1]);
 
                 if (auto cachedResponse = cacheSnapshot->LookupResponse(key)) {

--- a/yt/yt/core/ytree/ypath_service.cpp
+++ b/yt/yt/core/ytree/ypath_service.cpp
@@ -28,20 +28,18 @@
 
 namespace NYT::NYTree {
 
-using NYT::FromProto;
-
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TCacheKey
 {
     TYPath Path;
-    TString Method;
+    TProtobufString Method;
     TSharedRef RequestBody;
     TChecksum RequestBodyHash;
 
     TCacheKey(
         const TYPath& path,
-        const TString& method,
+        const TProtobufString& method,
         const TSharedRef& requestBody)
         : Path(path)
         , Method(method)
@@ -834,7 +832,7 @@ bool TCachedYPathService::DoInvoke(const IYPathServiceContextPtr& context)
 
                 TCacheKey key(
                     GetRequestTargetYPath(context->GetRequestHeader()),
-                    FromProto<TString>(context->GetRequestHeader().method()),
+                    context->GetRequestHeader().method(),
                     context->GetRequestMessage()[1]);
 
                 if (auto cachedResponse = cacheSnapshot->LookupResponse(key)) {


### PR DESCRIPTION
After this PR yt/cpp and yt/yt/core are possible to be built both with Arcadia protobuf (that uses TString as a string) and vanilla protobuf (that uses std::string as a string). To achieve so, a couple of interoperability primitives are introduced.

* `TProtobufString` is an alias to protobuf string type, i.e. it can be `TString` or `std::string` depending on the protobuf implementation.
* `IsVanillaProtobuf` and `IsArcadiaProtobuf` are the constexpr boolean values that allow to check protobuf implementation both in the compile time and runtime.

The most challenging interoperability issue solved here is a string copy between protobuf message and C++ code that has a form of `TString str = msg.str()`. This code works perfect with Arcadia protobuf but does not work with vanilla protobuf. To solve it, a previously introduced primitive `FromProto<TString>` is used. This expression makes the most efficient cast possible between protobuf string and C++ string. Internally, it is just a copy in both cases. Since TString is CoW by default, this expression is almost zero-cost (actually it's just one atomic operation), so no degradation is expected for YTsaurus server builds. The most hot code is handled differently to avoid even atomic operations (see `GetRequestTargetYPath`). In case of vanilla protobuf string is copied, however there are no places in C++ SDK where it might be a problem. If such issues would appear, performance-critial code can be rewritten in `GetRequestTargetYPath`-style.