### PR TITLE
[23.2] Fix docker pull cancellation

### DIFF
--- a/yt/yt/core/actions/unittests/future_ut.cpp
+++ b/yt/yt/core/actions/unittests/future_ut.cpp
@@ -1687,6 +1687,34 @@ TEST_F(TFutureTest, AbandonDuringGet)
     thread.join();
 }
 
+TEST_F(TFutureTest, CancelAppliedToUncancellable)
+{
+    auto promise = NewPromise<void>();
+    auto future = promise.ToFuture();
+
+    auto uncancelable = future.ToUncancelable();
+    auto future1 = uncancelable.Apply(BIND([&] () -> void {}));
+    future1.Cancel(TError("Cancel"));
+    EXPECT_FALSE(promise.IsSet());
+    EXPECT_FALSE(promise.IsCanceled());
+    EXPECT_FALSE(uncancelable.IsSet());
+    EXPECT_FALSE(future1.IsSet());
+
+    auto immediatelyCancelable = uncancelable.ToImmediatelyCancelable();
+    auto future2 = immediatelyCancelable.Apply(BIND([&] () -> void {}));
+    future2.Cancel(TError("Cancel"));
+    EXPECT_FALSE(promise.IsSet());
+    EXPECT_FALSE(promise.IsCanceled());
+    EXPECT_TRUE(immediatelyCancelable.IsSet());
+    EXPECT_TRUE(future2.IsSet());
+    EXPECT_EQ(NYT::EErrorCode::Canceled, future2.Get().GetCode());
+
+    promise.Set();
+    EXPECT_TRUE(uncancelable.IsSet());
+    EXPECT_TRUE(future1.IsSet());
+    EXPECT_TRUE(future1.Get().IsOK());
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 } // namespace

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -579,10 +579,10 @@ public:
             auto guard = Guard(SpinLock_);
             if (auto* pullFuture = InflightImagePulls_.FindPtr(image.Image)) {
                 YT_LOG_DEBUG("Waiting for in-flight docker image pull (Image: %v)", image);
-                return pullFuture->Apply(BIND([=, this, this_ = MakeStrong(this)] {
-                    // Ignore errors and retry pull after end of previous concurrent attempt.
-                    return PullImage(image, /*always*/ false, authConfig, podSpec);
-                }));
+                return pullFuture->ToImmediatelyCancelable().Apply(BIND([=, this, this_ = MakeStrong(this)] {
+                        // Ignore errors and retry pull after end of previous concurrent attempt.
+                        return PullImage(image, /*always*/ false, authConfig, podSpec);
+                    }));
             }
 
             // Future for in-flight pull should not be canceled by waiters,


### PR DESCRIPTION
- Add future test CancelAppliedToUncancellable

- Fix cancellation for chained docker pull requests

---
2c1c103123f7cf1252cf2ace59bed75771f47472

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/403

(cherry picked from commit 5d83a51d8ef7b26403b0a544b87f8b771f574c04)
