### PR TITLE
[23.2] Add option for setting memory limit for user job containers

### DIFF
--- a/yt/yt/server/controller_agent/config.cpp
+++ b/yt/yt/server/controller_agent/config.cpp
@@ -367,6 +367,13 @@ void TOperationOptions::Register(TRegistrar registrar)
     registrar.Parameter("set_container_cpu_limit", &TThis::SetContainerCpuLimit)
         .Default(false);
 
+    registrar.Parameter("set_slot_container_memory_limit", &TThis::SetSlotContainerMemoryLimit)
+        .Default(false);
+
+    registrar.Parameter("slot_container_memory_overhead", &TThis::SlotContainerMemoryOverhead)
+        .Default(0)
+        .GreaterThanOrEqual(0);
+
     // NB: defaults for these values are actually in preprocessor of TControllerAgentConfig::OperationOptions.
     registrar.Parameter("controller_building_job_spec_count_limit", &TThis::ControllerBuildingJobSpecCountLimit)
         .Default();

--- a/yt/yt/server/controller_agent/config.h
+++ b/yt/yt/server/controller_agent/config.h
@@ -344,6 +344,11 @@ public:
     double CpuLimitOvercommitMultiplier;
     double InitialCpuLimitOvercommit;
 
+    //! Enforce slot container memory limit.
+    bool SetSlotContainerMemoryLimit;
+
+    i64 SlotContainerMemoryOverhead;
+
     //! Number of simultaneously building job specs after which controller starts throttling.
     std::optional<int> ControllerBuildingJobSpecCountLimit;
     //! Total slice count of currently building job specs after which controller starts throttling.

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -9995,6 +9995,14 @@ void TOperationControllerBase::InitUserJobSpec(
         joblet->EstimatedResourceUsage.GetFootprintMemory() +
         joblet->EstimatedResourceUsage.GetJobProxyMemory() * joblet->JobProxyMemoryReserveFactor.value());
 
+    if (Options->SetSlotContainerMemoryLimit) {
+        jobSpec->set_slot_container_memory_limit(
+            jobSpec->memory_limit() +
+            joblet->EstimatedResourceUsage.GetJobProxyMemory() +
+            joblet->EstimatedResourceUsage.GetFootprintMemory() +
+            Options->SlotContainerMemoryOverhead);
+    }
+
     jobSpec->add_environment(Format("YT_JOB_INDEX=%v", joblet->JobIndex));
     jobSpec->add_environment(Format("YT_TASK_JOB_INDEX=%v", joblet->TaskJobIndex));
     jobSpec->add_environment(Format("YT_JOB_ID=%v", joblet->JobId));

--- a/yt/yt/server/lib/job_proxy/config.cpp
+++ b/yt/yt/server/lib/job_proxy/config.cpp
@@ -245,6 +245,9 @@ void TJobProxyConfig::Register(TRegistrar registrar)
     registrar.Parameter("container_cpu_limit", &TThis::ContainerCpuLimit)
         .Default();
 
+    registrar.Parameter("slot_container_memory_limit", &TThis::SlotContainerMemoryLimit)
+        .Default();
+
     registrar.Parameter("testing_config", &TThis::TestingConfig)
         .DefaultNew();
 

--- a/yt/yt/server/lib/job_proxy/config.h
+++ b/yt/yt/server/lib/job_proxy/config.h
@@ -264,6 +264,8 @@ public:
 
     std::optional<double> ContainerCpuLimit;
 
+    std::optional<i64> SlotContainerMemoryLimit;
+
     NYT::NRpcProxy::TApiServiceConfigPtr ApiService;
 
     std::optional<int> StatisticsOutputTableCountLimit;

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -2410,6 +2410,10 @@ TJobProxyConfigPtr TJob::CreateConfig()
         }
     }
 
+    if (UserJobSpec_ && UserJobSpec_->slot_container_memory_limit()) {
+        proxyConfig->SlotContainerMemoryLimit = UserJobSpec_->slot_container_memory_limit();
+    }
+
     proxyConfig->MemoryTracker->MemoryStatisticsCachePeriod = proxyConfig->MemoryTracker->UseSMapsMemoryTracker
         ? Config_->SMapsMemoryTrackerCachePeriod
         : Config_->MemoryTrackerCachePeriod;

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1184,6 +1184,7 @@ private:
         }
 
         spec->Resources.CpuLimit = config->ContainerCpuLimit;
+        spec->Resources.MemoryLimit = config->SlotContainerMemoryLimit;
 
         const auto& cpusetCpu = SlotCpusetCpus_[slotIndex];
         if (cpusetCpu != EmptyCpuSet) {

--- a/yt/yt/ytlib/controller_agent/proto/job.proto
+++ b/yt/yt/ytlib/controller_agent/proto/job.proto
@@ -258,6 +258,8 @@ message TUserJobSpec
 
     optional double container_cpu_limit = 53 [default = 0];
 
+    optional int64 slot_container_memory_limit = 73;
+
     optional bool make_rootfs_writable = 54 [default = false];
 
     optional int32 restart_exit_code = 55;


### PR DESCRIPTION
This adds controller agent operation options:
"set_container_memory_limit" and "container_memory_overhead".

---
e6ab32794f88327f5dfd30970cafc79c82a9f8af

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/359

(cherry picked from commit 54bdde3388037e9744a8efe66c276b6bd721b070)
