### PR TITLE
Skip tests which requires porto if it is not available

### DIFF
--- a/yt/yt/tests/library/yt_env_setup.py
+++ b/yt/yt/tests/library/yt_env_setup.py
@@ -14,6 +14,7 @@ from yt.environment.helpers import (
     emergency_exit_within_tests,
     find_cri_endpoint,
 )
+from yt.environment.porto_helpers import porto_available
 from yt.environment.default_config import (
     get_dynamic_master_config,
 )
@@ -488,6 +489,9 @@ class YTEnvSetup(object):
             mock_tvm_id=(1000 + index if use_native_auth else None),
             enable_tls=cls.ENABLE_TLS,
         )
+
+        if yt_config.jobs_environment_type == "porto" and not porto_available():
+            pytest.skip("Porto is not available")
 
         if yt_config.jobs_environment_type == "cri" and yt_config.cri_endpoint is None:
             yt_config.cri_endpoint = find_cri_endpoint()


### PR DESCRIPTION
No description

---
8622f74793ae9f00075cf1bcf7c4de3fd6ab09d4

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/461

(cherry picked from commit 4a821202e5aa57e6a5d61bcf787a002dd08470d4)
