### PR TITLE
Fix building CRI pod cgroup name in systemd slice notation

### DIFF
--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -1845,6 +1845,12 @@ def _get_node_resource_limits_config(yt_config):
     return {"memory": memory}
 
 
+def _get_node_base_cgroup(cluster_name, index):
+    if os.path.isdir("/run/systemd/system"):
+        return "/yt.slice/yt-{}_node_{}.slice".format(cluster_name.replace('-', '_'), index)
+    return "/yt/{}_node_{}".format(cluster_name, index)
+
+
 def _get_node_job_environment_config(yt_config, index, logs_dir):
     return {
         "cri": {
@@ -1852,7 +1858,7 @@ def _get_node_job_environment_config(yt_config, index, logs_dir):
             "cri_executor": {
                 "runtime_endpoint": yt_config.cri_endpoint,
                 "image_endpoint": yt_config.cri_endpoint,
-                "base_cgroup": "yt.slice/{}-node-{}.slice".format(yt_config.cluster_name, index),
+                "base_cgroup": _get_node_base_cgroup(yt_config.cluster_name, index),
                 "namespace": "yt--{}-node-{}".format(yt_config.cluster_name, index),
                 "verbose_logging": True,
             },

--- a/yt/yt/library/containers/cri/config.h
+++ b/yt/yt/library/containers/cri/config.h
@@ -25,6 +25,7 @@ public:
     TString RuntimeHandler;
 
     //! Common parent cgroup for all pods.
+    //! Should be absolute and follow slice notation for systemd setup.
     TString BaseCgroup;
 
     //! Cpu quota period for cpu limits.

--- a/yt/yt/library/containers/cri/cri_api.h
+++ b/yt/yt/library/containers/cri/cri_api.h
@@ -19,7 +19,8 @@ constexpr TStringBuf RuntimeReady = "RuntimeReady";
 //! NetworkReady means the runtime network is up and ready to accept containers which require network.
 constexpr TStringBuf NetworkReady = "NetworkReady";
 
-//! CRI uses cgroupfs notation for systemd slices, but each name must ends with ".slice".
+//! CRI uses cgroupfs notation for systemd slices, each name must end with ".slice" and
+//! include names of all parent slices: "a.slice/a-b.slice/a-b-c.slice".
 constexpr TStringBuf SystemdSliceSuffix = ".slice";
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
In systemd notation each nested slice must include parent names:
"a.slice/a-b.slice/a-b-c.slice"

Containerd setup runc cgroup name "<slice>.slice:cri-containerd:<container-id>" if
passed parent cgroup ends with ".slice", otherwise"<parent-cgroup>/<container-id>".

OCI runc/crun in systemd mode expects cgroup-name in form "<slice>.slice:<prefix>:<name>"
which is mapped into "/<slice-path>/<prefix>-<name>.scope".

Link: https://www.freedesktop.org/software/systemd/man/latest/systemd.slice.html
Link: https://github.com/kubernetes/cri-api/blob/release-1.29/pkg/apis/runtime/v1/api.proto#L391
Link: https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#cgroups-path
