### PR TITLE
[23.2] Introduce per-object profiling in queue agent

### DIFF
--- a/yt/yt/server/lib/alert_manager/alert_manager.cpp
+++ b/yt/yt/server/lib/alert_manager/alert_manager.cpp
@@ -11,12 +11,24 @@
 namespace NYT::NAlertManager {
 
 using namespace NConcurrency;
+using namespace NLogging;
+using namespace NProfiling;
+using namespace NThreading;
 using namespace NYson;
 using namespace NYTree;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-static const auto& Logger = AlertManagerLogger;
+TError TAlert::GetTaggedError() const
+{
+    std::vector<TErrorAttribute> errorAttributes;
+    errorAttributes.reserve(Tags.size());
+    for (const auto& tag : Tags) {
+        errorAttributes.emplace_back(tag.first, tag.second);
+    }
+
+    return Error << errorAttributes;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -24,34 +36,37 @@ class TAlertManager
     : public IAlertManager
 {
 public:
-    explicit TAlertManager(IInvokerPtr controlInvoker)
-        : ControlInvoker_(std::move(controlInvoker))
+    TAlertManager(NLogging::TLogger logger, NProfiling::TProfiler alertProfiler, IInvokerPtr invoker)
+        : Logger(std::move(logger))
+        , AlertProfiler_(std::move(alertProfiler))
+        , Invoker_(std::move(invoker))
         , OrchidService_(IYPathService::FromProducer(
-            BIND(&TAlertManager::BuildOrchid, MakeWeak(this)))->Via(ControlInvoker_))
+            BIND(&TAlertManager::BuildOrchid, MakeWeak(this)))->Via(Invoker_))
         , DynamicConfig_(New<TAlertManagerDynamicConfig>())
         , AlertCollectionExecutor_(New<TPeriodicExecutor>(
-            ControlInvoker_,
+            Invoker_,
             BIND(&TAlertManager::CollectAlerts, MakeWeak(this)),
             DynamicConfig_->AlertCollectionPeriod))
     { }
 
-    NYTree::IYPathServicePtr GetOrchidService() const
+    IYPathServicePtr GetOrchidService() const override
     {
         return OrchidService_;
     }
 
-    void Start()
+    void Start() override
     {
         AlertCollectionExecutor_->Start();
     }
 
     void Reconfigure(
         const TAlertManagerDynamicConfigPtr& oldConfig,
-        const TAlertManagerDynamicConfigPtr& newConfig)
+        const TAlertManagerDynamicConfigPtr& newConfig) override
     {
-        VERIFY_SERIALIZED_INVOKER_AFFINITY(ControlInvoker_);
-
-        DynamicConfig_ = newConfig;
+        {
+            auto guard = WriterGuard(SpinLock_);
+            DynamicConfig_ = newConfig;
+        }
 
         AlertCollectionExecutor_->SetPeriod(newConfig->AlertCollectionPeriod);
 
@@ -61,56 +76,184 @@ public:
             ConvertToYsonString(newConfig, EYsonFormat::Text));
     }
 
-private:
-    const IInvokerPtr ControlInvoker_;
-    const NYTree::IYPathServicePtr OrchidService_;
-
-    TAlertManagerDynamicConfigPtr DynamicConfig_;
-    NConcurrency::TPeriodicExecutorPtr AlertCollectionExecutor_;
-
-    std::vector<TAlert> Alerts_;
-
     void CollectAlerts()
     {
-        VERIFY_SERIALIZED_INVOKER_AFFINITY(ControlInvoker_);
+        std::vector<TAlert> rawAlerts;
+        PopulateAlerts_.Fire(&rawAlerts);
 
-        std::vector<TAlert> alerts;
-        PopulateAlerts_.Fire(&alerts);
-        Alerts_.swap(alerts);
+        struct TAggregatedAlert
+        {
+            std::optional<TErrorCode> ErrorCode;
+            std::optional<TString> Description;
+            std::vector<TError> Errors;
+        };
+        THashMap<TString, TAggregatedAlert> categoryToAggregatedAlerts;
 
-        THashSet<TString> encounteredCategories;
+        THashMap<TString, THashSet<TTagList>> uniqueAlerts;
 
-        for (const auto& alert : Alerts_) {
-            InsertOrCrash(encounteredCategories, alert.Category);
+        for (const auto& rawAlert: rawAlerts) {
+            // Each category + tags combination should be unique.
+            InsertOrCrash(uniqueAlerts[rawAlert.Category], rawAlert.Tags);
 
-            YT_LOG_WARNING(alert.Error);
+            auto& aggregatedAlert = categoryToAggregatedAlerts[rawAlert.Category];
+
+            // Error codes and descriptions should be equal for alerts in the same category.
+            if (!aggregatedAlert.ErrorCode) {
+                aggregatedAlert.ErrorCode = rawAlert.ErrorCode;
+            } else {
+                YT_VERIFY(*aggregatedAlert.ErrorCode == rawAlert.ErrorCode);
+            }
+            // TODO(achulkov2): Avoid duplicating description strings? Doesn't seem to be worth the hassle for now.
+            if (!aggregatedAlert.Description) {
+                aggregatedAlert.Description = rawAlert.Description;
+            } else {
+                YT_VERIFY(*aggregatedAlert.Description == rawAlert.Description);
+            }
+            aggregatedAlert.Errors.push_back(rawAlert.GetTaggedError());
         }
+
+        THashMap<TString, TError> alerts;
+        for (const auto& [category, aggregatedAlert] : categoryToAggregatedAlerts) {
+            alerts.emplace(category, TError(*aggregatedAlert.ErrorCode, *aggregatedAlert.Description) << aggregatedAlert.Errors);
+        }
+
+        auto guard = WriterGuard(SpinLock_);
+        Alerts_ = alerts;
 
         YT_LOG_DEBUG("Collected alerts (Count: %v)", Alerts_.size());
     }
 
+    THashMap<TString, TError> GetAlerts() const override
+    {
+        auto guard = ReaderGuard(SpinLock_);
+
+        return Alerts_;
+    }
+
+    TLogger GetLogger() const override
+    {
+        return Logger;
+    }
+
+    TProfiler GetAlertProfiler() const override
+    {
+        return AlertProfiler_;
+    }
+
     void BuildOrchid(NYson::IYsonConsumer* consumer) const
     {
-        VERIFY_SERIALIZED_INVOKER_AFFINITY(ControlInvoker_);
-
         BuildYsonFluently(consumer)
             .BeginAttributes()
                 .Item("opaque").Value(true)
             .EndAttributes()
-            .DoMapFor(Alerts_, [] (TFluentMap fluent, const auto& alert) {
-                fluent
-                    .Item(alert.Category).Value(alert.Error);
-            });
+            .Value(GetAlerts());
     }
+
+    DEFINE_SIGNAL_OVERRIDE(void(std::vector<TAlert>*), PopulateAlerts);
+
+private:
+    const NLogging::TLogger Logger;
+    const TProfiler AlertProfiler_;
+    const IInvokerPtr Invoker_;
+    const IYPathServicePtr OrchidService_;
+    TAlertManagerDynamicConfigPtr DynamicConfig_;
+    const TPeriodicExecutorPtr AlertCollectionExecutor_;
+
+    YT_DECLARE_SPIN_LOCK(TReaderWriterSpinLock, SpinLock_);
+    THashMap<TString, TError> Alerts_;
 };
 
 DEFINE_REFCOUNTED_TYPE(TAlertManager)
 
+IAlertManagerPtr CreateAlertManager(NLogging::TLogger logger, NProfiling::TProfiler alertProfiler, IInvokerPtr invoker)
+{
+    return New<TAlertManager>(std::move(logger), std::move(alertProfiler), std::move(invoker));
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
-IAlertManagerPtr CreateAlertManager(IInvokerPtr controlInvoker)
+class TAlertCollector
+    : public IAlertCollector
 {
-    return New<TAlertManager>(std::move(controlInvoker));
+public:
+    TAlertCollector(const IAlertManagerPtr& alertManager)
+        : AlertManager_(alertManager)
+        , AlertProfiler_(alertManager->GetAlertProfiler())
+        , Logger(alertManager->GetLogger())
+    {
+        alertManager->SubscribePopulateAlerts(PopulateAlertsCallback_);
+    }
+
+    ~TAlertCollector()
+    {
+        if (auto alertManager = AlertManager_.Lock()) {
+            alertManager->UnsubscribePopulateAlerts(PopulateAlertsCallback_);
+        }
+    }
+
+    void StageAlert(TAlert alert) override
+    {
+        auto guard = WriterGuard(SpinLock_);
+
+        EmplaceOrCrash(StagedAlerts_[alert.Category], alert.Tags, alert);
+        CategoryToGauges_[alert.Category].try_emplace(
+            alert.Tags,
+            AlertProfiler_.WithTag("category", alert.Category).WithTags(TTagSet{alert.Tags}).Gauge("/alerts"));
+
+        YT_LOG_DEBUG(alert.Error, "Staged alert (Category: %v, Description: %v, Tags: %v)", alert.Category, alert.Description, alert.Tags);
+    }
+
+    void PublishAlerts() override
+    {
+        auto guard = WriterGuard(SpinLock_);
+
+        for (const auto& [category, tagsToGauges] : CategoryToGauges_) {
+            auto tagsToAlertsIt = StagedAlerts_.find(category);
+            for (const auto& [tags, gauge] : tagsToGauges) {
+                if (tagsToAlertsIt != StagedAlerts_.end() && tagsToAlertsIt->second.contains(tags)) {
+                    gauge.Update(1);
+                } else {
+                    gauge.Update(0);
+                }
+            }
+        }
+
+        Alerts_.clear();
+        for (const auto& [category, tagsToAlerts] : StagedAlerts_) {
+            auto alerts = GetValues(tagsToAlerts);
+            Alerts_.insert(Alerts_.end(), std::make_move_iterator(alerts.begin()), std::make_move_iterator(alerts.end()));
+        }
+
+        YT_LOG_DEBUG("Publishing staged alerts (Count: %v)", StagedAlerts_.size());
+
+        StagedAlerts_.clear();
+    }
+
+private:
+    const TCallback<void(std::vector<TAlert>*)> PopulateAlertsCallback_ =
+        BIND(&TAlertCollector::DoPopulateAlerts, MakeWeak(this));
+    const TWeakPtr<IAlertManager> AlertManager_;
+    const NProfiling::TProfiler AlertProfiler_;
+    const NLogging::TLogger Logger;
+
+    YT_DECLARE_SPIN_LOCK(NThreading::TReaderWriterSpinLock, SpinLock_);
+    std::vector<TAlert> Alerts_;
+    THashMap<TString, THashMap<NProfiling::TTagList, TAlert>> StagedAlerts_;
+    THashMap<TString, THashMap<NProfiling::TTagList, NProfiling::TGauge>> CategoryToGauges_;
+
+    void DoPopulateAlerts(std::vector<TAlert>* alerts)
+    {
+        auto guard = ReaderGuard(SpinLock_);
+
+        alerts->insert(alerts->end(), Alerts_.begin(), Alerts_.end());
+    }
+};
+
+DEFINE_REFCOUNTED_TYPE(TAlertCollector)
+
+IAlertCollectorPtr CreateAlertCollector(IAlertManagerPtr alertManager)
+{
+    return New<TAlertCollector>(std::move(alertManager));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/alert_manager/alert_manager.h
+++ b/yt/yt/server/lib/alert_manager/alert_manager.h
@@ -10,31 +10,106 @@ namespace NYT::NAlertManager {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! NB: Please read the comments below to get a picture of when error attribtutes should be specified in tags vs. the error itself.
 struct TAlert
 {
+    //! Numeric error code corresponding to a YT error enum declaration.
+    TErrorCode ErrorCode;
+    //! Human-readable representation of the error code above.
+    //! NB: Alerts with the same category name *must* have the same error code value.
     TString Category;
+    //! Human-readable description of alert instance.
+    //! It is possible to have different description variants for the same error code,
+    //! but only one description can be used for a group of alerts at any moment in the alert manager's lifetime.
+    TString Description;
+    //! A set of tags to be added to the error as attributes *and* used in profiling.
+    //! The intent of these tags is to distinguish between alerts within the same category.
+    //! E.g. when the same operation is performed for different clusters, each alert within the category should be
+    //! tagged with the cluster name. They will be grouped together under the same category. In profiling, the metrics
+    //! would be parametrized by the category as well as the specified cluster name.
+    //! NB: Therefore, alerts must be uniquely defined by their error code and tag set.
+    NProfiling::TTagList Tags;
+    //! Reported error.
+    //! This error could have additional attributes that are diagnostically relevant but not needed as a profiling tag.
     TError Error;
+
+    //! Returns the specified error with the specified tags attached as error attributes.
+    TError GetTaggedError() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Periodically collects alerts from subscribed components and groups them by specified alert categories.
+//! To produce an alert for a category, all raw errors in this category are aggregated into inner errors of a single error
+//! with the specified top-level error code and description.
+//! Stored alerts can be exported via the provided orchid service.
+//! It is recommended to utilize the collector interface below, but subscribers can also implement alert collection callback themselves.
+//! NB: Subscribers must guarantee that alerts have a unique error code + tag set combination.
+//! NB: It is recommended to submit alerts with error codes from a single YT error enum within one alert manager.
+//!
+//! Thread affinity: any.
 struct IAlertManager
     : public TRefCounted
 {
-    virtual NYTree::IYPathServicePtr GetOrchidService() const = 0;
-
     virtual void Start() = 0;
 
     virtual void Reconfigure(
         const TAlertManagerDynamicConfigPtr& oldConfig,
         const TAlertManagerDynamicConfigPtr& newConfig) = 0;
 
-    DEFINE_SIGNAL(void(std::vector<TAlert>*), PopulateAlerts);
+    //! Returns an orchid service representing a snapshot of the stored alerts.
+    virtual NYTree::IYPathServicePtr GetOrchidService() const = 0;
+    //! Returns a snapshot of managed alerts.
+    virtual THashMap<TString, TError> GetAlerts() const = 0;
+
+    virtual NLogging::TLogger GetLogger() const = 0;
+    virtual NProfiling::TProfiler GetAlertProfiler() const = 0;
+
+    DECLARE_INTERFACE_SIGNAL(void(std::vector<TAlert>*), PopulateAlerts);
 };
 
 DEFINE_REFCOUNTED_TYPE(IAlertManager)
 
-IAlertManagerPtr CreateAlertManager(IInvokerPtr controlInvoker);
+//! If a non-default (non-dummy) profiler is specified and alert collectors are used, metrics
+//! corresponding to the alert categories and tags will be reported by emitting 0/1 values to a gauge.
+IAlertManagerPtr CreateAlertManager(
+    NLogging::TLogger logger,
+    NProfiling::TProfiler alertProfiler = {},
+    IInvokerPtr invoker = GetCurrentInvoker());
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! A helper-class for storing and publishing per-component alerts, as well as reporting alert-based metrics.
+//! The purpose of this class is to isolate alert lifetimes across components and logical processes of a service.
+//! While the alert manager serves as a central export point of all of the alerts of a service, each collector is
+//! responsible for grouping alerts with the same stage-publish cycle, as well as managing the corresponding gauges.
+//! Different logical components and regular processes with differing periods should use different collectors.
+//! Alerts from different collectors can share the same category, in which case they will be grouped together by the alert manager into a single aggregated alert.
+//! This allows grouping alerts from multiple similar user-configurable periodic processes (e.g. exports from queues into static tables).
+//!
+//! Thread affinity: any.
+struct IAlertCollector
+    : public TRefCounted
+{
+public:
+    //! Stages and stores alert.
+    //! NB: The descriptions of staged alerts should be equal within the same category. This means that you
+    //! can use the same category for alerts with different descriptions, but not within the same stage-publish cycle.
+    //! Otherwise, it would be unclear what description the alert manager should use when grouping these alerts together.
+    virtual void StageAlert(TAlert alert) = 0;
+    //! Publishes alerts so they are visible to the alert manager. Reports metrics on all known category + tags combinations.
+    //! NB: Stored gauges are persistent. If an alert with some (category, tags) combinations was staged during the lifetime of this class,
+    //! 0/1 values will be reported for it up until the collector is destroyed. This is necessary for reporting that an alert is no longer applicable.
+    //! NB: Due to the comment above, it is important to keep the number of (category, tags) combinations very reasonably finite, since each of them causes a sensor to be produced.
+    virtual void PublishAlerts() = 0;
+
+    // TODO(achulkov2): Implement some mechanism for clearing out unneeded gauges.
+};
+
+DEFINE_REFCOUNTED_TYPE(IAlertCollector)
+
+//! The alert collector will subscribe itself to the manager upon construction and unsubscribe upon destruction.
+IAlertCollectorPtr CreateAlertCollector(IAlertManagerPtr alertManager);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/lib/alert_manager/helpers-inl.h
+++ b/yt/yt/server/lib/alert_manager/helpers-inl.h
@@ -9,14 +9,10 @@ namespace NYT::NAlertManager {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class EErrorCode>
-TAlert CreateAlert(const TError& error)
+    requires std::is_enum_v<EErrorCode>
+TAlert CreateAlert(EErrorCode errorCode, TString description, NProfiling::TTagList tags, TError error)
 {
-    auto category = static_cast<EErrorCode>(static_cast<int>(error.GetCode()));
-
-    static const auto possibleAlertErrorCodes = TEnumTraits<EErrorCode>::GetDomainValues();
-    YT_VERIFY(std::find(possibleAlertErrorCodes.begin(), possibleAlertErrorCodes.end(), category) != possibleAlertErrorCodes.end());
-
-    return TAlert{FormatEnum(category), error};
+    return {errorCode, FormatEnum(errorCode), std::move(description), std::move(tags), std::move(error)};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/alert_manager/helpers.h
+++ b/yt/yt/server/lib/alert_manager/helpers.h
@@ -7,7 +7,8 @@ namespace NYT::NAlertManager {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class EErrorCode>
-TAlert CreateAlert(const TError& error);
+    requires std::is_enum_v<EErrorCode>
+TAlert CreateAlert(EErrorCode errorCode, TString description, NProfiling::TTagList tags, TError error);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/lib/alert_manager/public.h
+++ b/yt/yt/server/lib/alert_manager/public.h
@@ -8,6 +8,7 @@ namespace NYT::NAlertManager {
 
 DECLARE_REFCOUNTED_STRUCT(IAlertManager)
 DECLARE_REFCOUNTED_CLASS(TAlertManagerDynamicConfig)
+DECLARE_REFCOUNTED_STRUCT(IAlertCollector)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/query_tracker/bootstrap.cpp
+++ b/yt/yt/server/query_tracker/bootstrap.cpp
@@ -149,7 +149,7 @@ void TBootstrap::DoRun()
 
     HttpServer_ = NHttp::CreateServer(Config_->CreateMonitoringHttpServerConfig());
 
-    AlertManager_ = CreateAlertManager(ControlInvoker_);
+    AlertManager_ = CreateAlertManager(QueryTrackerLogger, TProfiler{}, ControlInvoker_);
 
     if (Config_->CoreDumper) {
         CoreDumper_ = NCoreDump::CreateCoreDumper(Config_->CoreDumper);
@@ -202,11 +202,11 @@ void TBootstrap::DoRun()
         DynamicConfigManager_->GetConfig()->QueryTracker,
         SelfAddress_,
         ControlInvoker_,
+        CreateAlertCollector(AlertManager_),
         NativeClient_,
         Config_->Root,
         Config_->MinRequiredStateVersion);
 
-    AlertManager_->SubscribePopulateAlerts(BIND(&IQueryTracker::PopulateAlerts, QueryTracker_));
     AlertManager_->Start();
 
     QueryTracker_->Start();

--- a/yt/yt/server/query_tracker/query_tracker.h
+++ b/yt/yt/server/query_tracker/query_tracker.h
@@ -22,8 +22,6 @@ struct IQueryTracker
     virtual void Start() = 0;
 
     virtual void Reconfigure(const TQueryTrackerDynamicConfigPtr& config) = 0;
-
-    virtual void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IQueryTracker)
@@ -34,6 +32,7 @@ IQueryTrackerPtr CreateQueryTracker(
     TQueryTrackerDynamicConfigPtr config,
     TString selfAddress,
     IInvokerPtr controlInvoker,
+    NAlertManager::IAlertCollectorPtr alertCollector,
     NApi::NNative::IClientPtr stateClient,
     NYPath::TYPath stateRoot,
     int minRequiredStateVersion);

--- a/yt/yt/server/queue_agent/config.cpp
+++ b/yt/yt/server/queue_agent/config.cpp
@@ -64,6 +64,8 @@ void TQueueControllerDynamicConfig::Register(TRegistrar registrar)
         .Default();
     registrar.Parameter("enable_queue_static_export", &TThis::EnableQueueStaticExport)
         .Default(false);
+    registrar.Parameter("alert_manager", &TThis::AlertManager)
+        .DefaultNew();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/queue_agent/config.h
+++ b/yt/yt/server/queue_agent/config.h
@@ -114,6 +114,8 @@ public:
 
     bool EnableQueueStaticExport;
 
+    NAlertManager::TAlertManagerDynamicConfigPtr AlertManager;
+
     REGISTER_YSON_STRUCT(TQueueControllerDynamicConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/server/queue_agent/cypress_synchronizer.h
+++ b/yt/yt/server/queue_agent/cypress_synchronizer.h
@@ -24,8 +24,6 @@ struct ICypressSynchronizer
     virtual void OnDynamicConfigChanged(
         const TCypressSynchronizerDynamicConfigPtr& oldConfig,
         const TCypressSynchronizerDynamicConfigPtr& newConfig) = 0;
-
-    virtual void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(ICypressSynchronizer)
@@ -34,7 +32,8 @@ ICypressSynchronizerPtr CreateCypressSynchronizer(
     TCypressSynchronizerConfigPtr config,
     IInvokerPtr controlInvoker,
     NQueueClient::TDynamicStatePtr dynamicState,
-    NHiveClient::TClientDirectoryPtr clientDirectory);
+    NHiveClient::TClientDirectoryPtr clientDirectory,
+    NAlertManager::IAlertCollectorPtr alertCollector);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/queue_agent/private.h
+++ b/yt/yt/server/queue_agent/private.h
@@ -33,6 +33,9 @@ YT_DEFINE_ERROR_ENUM(
 
     ((QueueAgentPassFailed)                                       (3025))
 
+    ((QueueAgentQueueControllerStaticExportFailed)                (3035))
+    ((QueueAgentQueueControllerTrimFailed)                        (3036))
+
     ((QueueAgentShardingManagerPassFailed)                        (3050))
 );
 

--- a/yt/yt/server/queue_agent/profile_manager.cpp
+++ b/yt/yt/server/queue_agent/profile_manager.cpp
@@ -122,6 +122,11 @@ public:
         , Logger(logger)
     { }
 
+    TProfiler GetQueueProfiler() const override
+    {
+        return QueueProfiler_;
+    }
+
     void Profile(
         const TQueueSnapshotPtr& previousQueueSnapshot,
         const TQueueSnapshotPtr& currentQueueSnapshot) override

--- a/yt/yt/server/queue_agent/profile_manager.h
+++ b/yt/yt/server/queue_agent/profile_manager.h
@@ -14,6 +14,8 @@ struct IQueueProfileManager
     virtual void Profile(
         const TQueueSnapshotPtr& previousQueueSnapshot,
         const TQueueSnapshotPtr& currentQueueSnapshot) = 0;
+
+    virtual NProfiling::TProfiler GetQueueProfiler() const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IQueueProfileManager)

--- a/yt/yt/server/queue_agent/queue_agent.h
+++ b/yt/yt/server/queue_agent/queue_agent.h
@@ -49,6 +49,7 @@ public:
         IInvokerPtr controlInvoker,
         NQueueClient::TDynamicStatePtr dynamicState,
         NCypressElection::ICypressElectionManagerPtr electionManager,
+        NAlertManager::IAlertCollectorPtr alertCollector,
         TString agentId);
 
     void Start();
@@ -58,8 +59,6 @@ public:
     void OnDynamicConfigChanged(
         const TQueueAgentDynamicConfigPtr& oldConfig,
         const TQueueAgentDynamicConfigPtr& newConfig);
-
-    void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const;
 
     // IObjectStore implementation.
 
@@ -77,6 +76,7 @@ private:
     const IInvokerPtr ControlInvoker_;
     const NQueueClient::TDynamicStatePtr DynamicState_;
     const NCypressElection::ICypressElectionManagerPtr ElectionManager_;
+    const NAlertManager::IAlertCollectorPtr AlertCollector_;
     const NConcurrency::IThreadPoolPtr ControllerThreadPool_;
     const NConcurrency::TPeriodicExecutorPtr PassExecutor_;
 
@@ -115,8 +115,6 @@ private:
 
     TEnumIndexedArray<EObjectKind, NYTree::INodePtr> ObjectServiceNodes_;
 
-    std::vector<NAlertManager::TAlert> Alerts_;
-
     NYTree::IYPathServicePtr RedirectYPathRequest(const TString& host, TStringBuf queryRoot, TStringBuf key) const;
 
     void BuildObjectYson(
@@ -130,8 +128,6 @@ private:
 
     //! Stops periodic passes and destroys all controllers.
     void DoStop();
-
-    void DoPopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const;
 
     TTaggedProfilingCounters& GetOrCreateTaggedProfilingCounters(const NQueueClient::TProfilingTags& profilingTags);
 

--- a/yt/yt/server/queue_agent/queue_agent_sharding_manager.h
+++ b/yt/yt/server/queue_agent/queue_agent_sharding_manager.h
@@ -24,14 +24,13 @@ struct IQueueAgentShardingManager
     virtual void OnDynamicConfigChanged(
         const TQueueAgentShardingManagerDynamicConfigPtr& oldConfig,
         const TQueueAgentShardingManagerDynamicConfigPtr& newConfig) = 0;
-
-    virtual void PopulateAlerts(std::vector<NAlertManager::TAlert>* alerts) const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IQueueAgentShardingManager)
 
 IQueueAgentShardingManagerPtr CreateQueueAgentShardingManager(
     IInvokerPtr controlInvoker,
+    NAlertManager::IAlertCollectorPtr alertCollector,
     NQueueClient::TDynamicStatePtr dynamicState,
     NDiscoveryClient::IMemberClientPtr memberClient,
     NDiscoveryClient::IDiscoveryClientPtr discoveryClient,

--- a/yt/yt/server/queue_agent/snapshot_representation.h
+++ b/yt/yt/server/queue_agent/snapshot_representation.h
@@ -8,7 +8,7 @@ namespace NYT::NQueueAgent {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void BuildQueueStatusYson(const TQueueSnapshotPtr& snapshot, NYTree::TFluentAny fluent);
+void BuildQueueStatusYson(const TQueueSnapshotPtr& snapshot, const NAlertManager::IAlertManagerPtr& alertManager, NYTree::TFluentAny fluent);
 void BuildQueuePartitionListYson(const TQueueSnapshotPtr& snapshot, NYTree::TFluentAny fluent);
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR revamps lib/alert_manager to facilitate alert aggregation across several logical components and adds multiple features related to queue agent introspection, including:
- New metrics for reporting the number of rows/chunks/tables exported into static tables.
- Per-object alerts are now collected for queues, exposing trim/static export errors to Cypress.
- Per-object alerts are reported via gauges in profiling.

---
f243d093ce2c059fe58a0b114ad11af63538c3af

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/345

