### PR TITLE
Add option controlling exposure of various configs through Orchid nodes

### DIFF
--- a/yt/chyt/server/bootstrap.cpp
+++ b/yt/chyt/server/bootstrap.cpp
@@ -120,10 +120,12 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        ConfigNode_);
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            ConfigNode_);
+    }
     SetBuildAttributes(
         orchidRoot,
         "clickhouse_server");

--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -23,6 +23,7 @@ class LocalYtConfig(object):
     local_cypress_dir = attr.ib(None)
     meta_files_suffix = attr.ib(".meta")
     cluster_name = attr.ib(None)
+    wait_for_dynamic_config = attr.ib(True)
 
     """High level master configuration"""
     primary_cell_tag = attr.ib(1)

--- a/yt/python/yt/environment/yt_env.py
+++ b/yt/python/yt/environment/yt_env.py
@@ -1671,12 +1671,16 @@ class YTInstance(object):
                     return False, "No active scheduler found"
 
                 try:
-                    master_cell_id = client.get("//sys/@cell_id")
-                    scheduler_cell_id = client.get(
-                        active_scheduler_orchid_path + "/config/cluster_connection/primary_master/cell_id")
-                    if master_cell_id != scheduler_cell_id:
-                        return False, "Incorrect scheduler connected, its cell_id {0} does not match master cell {1}"\
-                                      .format(scheduler_cell_id, master_cell_id)
+                    # Don't run the check below if the config is not exposed in the scheduler's Orchid
+                    # (e.g. due to expose_config_in_orchid = %false in scheduler's config).
+                    orchid_keys = client.list(active_scheduler_orchid_path)
+                    if "config" in orchid_keys:
+                        master_cell_id = client.get("//sys/@cell_id")
+                        scheduler_cell_id = client.get(
+                            active_scheduler_orchid_path + "/config/cluster_connection/primary_master/cell_id")
+                        if master_cell_id != scheduler_cell_id:
+                            return False, "Incorrect scheduler connected, its cell_id {0} does not match master cell {1}"\
+                                          .format(scheduler_cell_id, master_cell_id)
                 except YtResponseError as error:
                     if error.is_resolve_error():
                         return False, "Failed to request primary master cell id from master and scheduler" + str(error)
@@ -2143,6 +2147,9 @@ class YTInstance(object):
         self._wait_for_dynamic_config_update({}, client, config_node_name="bundle_dynamic_config_manager")
 
     def _wait_for_dynamic_config_update(self, expected_config, client, instance_type="cluster_nodes", config_node_name="dynamic_config_manager"):
+        if not self.yt_config.wait_for_dynamic_config:
+            return
+
         nodes = client.list("//sys/{0}".format(instance_type))
 
         if not nodes:

--- a/yt/yql/agent/bootstrap.cpp
+++ b/yt/yql/agent/bootstrap.cpp
@@ -162,14 +162,16 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,

--- a/yt/yt/server/cell_balancer/bootstrap.cpp
+++ b/yt/yt/server/cell_balancer/bootstrap.cpp
@@ -198,10 +198,12 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/cell_balancer",

--- a/yt/yt/server/clock_server/cluster_clock/bootstrap.cpp
+++ b/yt/yt/server/clock_server/cluster_clock/bootstrap.cpp
@@ -277,10 +277,12 @@ void TBootstrap::DoRun()
         "/election",
         HydraFacade_->GetElectionManager()->GetMonitoringProducer());
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+    }
     SetBuildAttributes(
         orchidRoot,
         "clock");

--- a/yt/yt/server/controller_agent/bootstrap.cpp
+++ b/yt/yt/server/controller_agent/bootstrap.cpp
@@ -161,10 +161,12 @@ void TBootstrap::DoRun()
 
     ControllerAgent_->Initialize();
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/controller_agent",

--- a/yt/yt/server/cypress_proxy/bootstrap.cpp
+++ b/yt/yt/server/cypress_proxy/bootstrap.cpp
@@ -231,14 +231,16 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         SetBuildAttributes(
             OrchidRoot_,
             "cypress_proxy");

--- a/yt/yt/server/discovery_server/bootstrap.cpp
+++ b/yt/yt/server/discovery_server/bootstrap.cpp
@@ -157,10 +157,12 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            ConvertTo<INodePtr>(Config_));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                ConvertTo<INodePtr>(Config_));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/discovery_server",

--- a/yt/yt/server/http_proxy/bootstrap.cpp
+++ b/yt/yt/server/http_proxy/bootstrap.cpp
@@ -119,10 +119,6 @@ TBootstrap::TBootstrap(TProxyConfigPtr config, INodePtr configNode)
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
     SetBuildAttributes(
         orchidRoot,
         "http_proxy");
@@ -163,14 +159,20 @@ TBootstrap::TBootstrap(TProxyConfigPtr config, INodePtr configNode)
     DynamicConfigManager_ = CreateDynamicConfigManager(this);
     DynamicConfigManager_->SubscribeConfigChanged(BIND(&TBootstrap::OnDynamicConfigChanged, MakeWeak(this)));
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/cluster_connection",
-        CreateVirtualNode(Connection_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        SetNodeByYPath(
+            orchidRoot,
+            "/cluster_connection",
+            CreateVirtualNode(Connection_->GetOrchidService()));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/disk_monitoring",

--- a/yt/yt/server/lib/misc/config.cpp
+++ b/yt/yt/server/lib/misc/config.cpp
@@ -48,6 +48,8 @@ void TServerConfig::Register(TRegistrar registrar)
         .Default(0)
         .GreaterThanOrEqual(0)
         .LessThan(65536);
+    registrar.Parameter("expose_config_in_orchid", &TThis::ExposeConfigInOrchid)
+        .Default(true);
 
     registrar.Postprocessor([] (TThis* config) {
         if (config->RpcPort > 0) {

--- a/yt/yt/server/lib/misc/config.h
+++ b/yt/yt/server/lib/misc/config.h
@@ -41,6 +41,9 @@ public:
     int RpcPort;
     int TvmOnlyRpcPort;
     int MonitoringPort;
+    //! This option may be used to prevent config-containing nodes to be exposed in Orchid as a mean of security
+    //! (disclosing less information about YT servers to a potential attacker).
+    bool ExposeConfigInOrchid;
 
     NHttp::TServerConfigPtr CreateMonitoringHttpServerConfig();
 

--- a/yt/yt/server/master/cell_master/bootstrap.cpp
+++ b/yt/yt/server/master/cell_master/bootstrap.cpp
@@ -1133,10 +1133,12 @@ void TBootstrap::DoRun()
         "/election",
         HydraFacade_->GetElectionManager()->GetMonitoringProducer());
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/incumbent_manager",

--- a/yt/yt/server/master_cache/bootstrap.cpp
+++ b/yt/yt/server/master_cache/bootstrap.cpp
@@ -237,14 +237,16 @@ private:
             GetControlInvoker(),
             Logger);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/disk_monitoring",

--- a/yt/yt/server/node/cluster_node/bootstrap.cpp
+++ b/yt/yt/server/node/cluster_node/bootstrap.cpp
@@ -1129,26 +1129,32 @@ private:
 
         Connection_->GetMasterCellDirectorySynchronizer()->Start();
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConfigNode_));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConfigNode_));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/cluster_connection",
+                CreateVirtualNode(Connection_->GetOrchidService()));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/bundle_dynamic_config_manager",
+                CreateVirtualNode(BundleDynamicConfigManager_->GetOrchidService()));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/connected_secondary_masters",
+                CreateVirtualNode(GetSecondaryMasterConnectionConfigsOrchidService()));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/restart_manager",
             CreateVirtualNode(RestartManager_->GetOrchidService()));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/cluster_connection",
-            CreateVirtualNode(Connection_->GetOrchidService()));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/bundle_dynamic_config_manager",
-            CreateVirtualNode(BundleDynamicConfigManager_->GetOrchidService()));
         SetNodeByYPath(
             OrchidRoot_,
             "/object_service_cache",
@@ -1157,10 +1163,6 @@ private:
             OrchidRoot_,
             "/node_resource_manager",
             CreateVirtualNode(NodeResourceManager_->GetOrchidService()));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/connected_secondary_masters",
-            CreateVirtualNode(GetSecondaryMasterConnectionConfigsOrchidService()));
         SetBuildAttributes(
             OrchidRoot_,
             "node");

--- a/yt/yt/server/query_tracker/bootstrap.cpp
+++ b/yt/yt/server/query_tracker/bootstrap.cpp
@@ -171,14 +171,16 @@ void TBootstrap::DoRun()
         orchidRoot,
         "/alerts",
         CreateVirtualNode(AlertManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,

--- a/yt/yt/server/queue_agent/bootstrap.cpp
+++ b/yt/yt/server/queue_agent/bootstrap.cpp
@@ -212,14 +212,16 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,

--- a/yt/yt/server/replicated_table_tracker/bootstrap.cpp
+++ b/yt/yt/server/replicated_table_tracker/bootstrap.cpp
@@ -178,14 +178,16 @@ private:
             &MonitoringManager_,
             &orchidRoot);
 
-        SetNodeByYPath(
-            orchidRoot,
-            "/config",
-            CreateVirtualNode(ConfigNode_));
-        SetNodeByYPath(
-            orchidRoot,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                orchidRoot,
+                "/config",
+                CreateVirtualNode(ConfigNode_));
+            SetNodeByYPath(
+                orchidRoot,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         if (CoreDumper_) {
             SetNodeByYPath(
                 orchidRoot,

--- a/yt/yt/server/rpc_proxy/bootstrap.cpp
+++ b/yt/yt/server/rpc_proxy/bootstrap.cpp
@@ -242,22 +242,24 @@ void TBootstrap::DoRun()
         &orchidRoot);
     NProfiling::TSolomonRegistry::Get()->SetDynamicTags({NProfiling::TTag{"proxy_role", DefaultRpcProxyRole}});
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/bundle_dynamic_config_manager",
-        CreateVirtualNode(BundleDynamicConfigManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/cluster_connection",
-        CreateVirtualNode(Connection_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        SetNodeByYPath(
+            orchidRoot,
+            "/bundle_dynamic_config_manager",
+            CreateVirtualNode(BundleDynamicConfigManager_->GetOrchidService()));
+        SetNodeByYPath(
+            orchidRoot,
+            "/cluster_connection",
+            CreateVirtualNode(Connection_->GetOrchidService()));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/disk_monitoring",

--- a/yt/yt/server/scheduler/bootstrap.cpp
+++ b/yt/yt/server/scheduler/bootstrap.cpp
@@ -156,10 +156,12 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/scheduler",

--- a/yt/yt/server/tablet_balancer/bootstrap.cpp
+++ b/yt/yt/server/tablet_balancer/bootstrap.cpp
@@ -184,11 +184,6 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,
@@ -201,10 +196,16 @@ void TBootstrap::DoRun()
         "/tablet_balancer",
         CreateVirtualNode(TabletBalancer_->GetOrchidService()));
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
 
     RpcServer_->RegisterService(NAdmin::CreateAdminService(
         ControlInvoker_,

--- a/yt/yt/server/tcp_proxy/bootstrap.cpp
+++ b/yt/yt/server/tcp_proxy/bootstrap.cpp
@@ -201,18 +201,20 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/role",
             CreateVirtualNode(ConvertTo<INodePtr>(Config_->Role)));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
         SetBuildAttributes(
             OrchidRoot_,
             "cypress_proxy");

--- a/yt/yt/server/timestamp_provider/bootstrap.cpp
+++ b/yt/yt/server/timestamp_provider/bootstrap.cpp
@@ -124,10 +124,12 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        }
         SetBuildAttributes(
             OrchidRoot_,
             "timestamp_provider");

--- a/yt/yt/tests/library/yt_env_setup.py
+++ b/yt/yt/tests/library/yt_env_setup.py
@@ -315,6 +315,8 @@ class YTEnvSetup(object):
     # COMPAT(kvk1920)
     TEST_MAINTENANCE_FLAGS = False
 
+    WAIT_FOR_DYNAMIC_CONFIG = True
+
     @classmethod
     def is_multicell(cls):
         return cls.NUM_SECONDARY_MASTER_CELLS > 0
@@ -497,6 +499,7 @@ class YTEnvSetup(object):
             enable_tvm_only_proxies=cls.get_param("ENABLE_TVM_ONLY_PROXIES", index),
             mock_tvm_id=(1000 + index if use_native_auth else None),
             enable_tls=cls.ENABLE_TLS,
+            wait_for_dynamic_config=cls.WAIT_FOR_DYNAMIC_CONFIG,
         )
 
         if yt_config.jobs_environment_type == "porto" and not porto_available():
@@ -1556,6 +1559,9 @@ class YTEnvSetup(object):
             self._wait_for_scheduler_state_restored(driver=driver)
 
     def _wait_for_dynamic_config(self, root_path, config, instances, driver=None):
+        if not self.WAIT_FOR_DYNAMIC_CONFIG:
+            return
+
         def check():
             responses = yt_commands.execute_batch(
                 [


### PR DESCRIPTION
This PR adds an `ExposeConfigInOrchid` server config option. This option may be used to prevent 
config-containing nodes to be exposed in Orchid as a mean of security (disclosing less information 
about YT servers to a potential attacker).

