### PR TITLE
#405: Fix compat test for composite value truncation

### DIFF
--- a/yt/yt/tests/integration/controller/test_map_operation.py
+++ b/yt/yt/tests/integration/controller/test_map_operation.py
@@ -822,7 +822,7 @@ print row + table_index
     @authors("achulkov2")
     def test_truncate_composite_partitioning_sample(self):
         # TODO(achulkov2): Lower/remove after cherry-picks.
-        if self.Env.get_component_version("ytserver-controller-agent").abi <= (24, 1):
+        if self.Env.get_component_version("ytserver-job-proxy").abi <= (24, 1):
             pytest.skip()
 
         max_sample_size = 64 * 1024  # 64KiB


### PR DESCRIPTION
Semantics changed in job proxies, not in controller agents.