### PR TITLE
Add option controlling exposure of various configs through Orchid nodes

### DIFF
--- a/yt/chyt/server/bootstrap.cpp
+++ b/yt/chyt/server/bootstrap.cpp
@@ -120,10 +120,12 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        ConfigNode_);
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            ConfigNode_);
+    }
     SetBuildAttributes(
         orchidRoot,
         "clickhouse_server");

--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -23,6 +23,7 @@ class LocalYtConfig(object):
     local_cypress_dir = attr.ib(None)
     meta_files_suffix = attr.ib(".meta")
     cluster_name = attr.ib(None)
+    wait_for_dynamic_config = attr.ib(True)
 
     """High level master configuration"""
     primary_cell_tag = attr.ib(1)

--- a/yt/yql/agent/bootstrap.cpp
+++ b/yt/yql/agent/bootstrap.cpp
@@ -161,14 +161,16 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,

--- a/yt/yt/server/cell_balancer/bootstrap.cpp
+++ b/yt/yt/server/cell_balancer/bootstrap.cpp
@@ -186,10 +186,12 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/cell_balancer",

--- a/yt/yt/server/clock_server/cluster_clock/bootstrap.cpp
+++ b/yt/yt/server/clock_server/cluster_clock/bootstrap.cpp
@@ -284,10 +284,12 @@ void TBootstrap::DoRun()
         "/election",
         HydraFacade_->GetElectionManager()->GetMonitoringProducer());
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+    }
     SetBuildAttributes(
         orchidRoot,
         "clock");

--- a/yt/yt/server/controller_agent/bootstrap.cpp
+++ b/yt/yt/server/controller_agent/bootstrap.cpp
@@ -162,10 +162,12 @@ void TBootstrap::DoRun()
 
     ControllerAgent_->Initialize();
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/controller_agent",

--- a/yt/yt/server/cypress_proxy/bootstrap.cpp
+++ b/yt/yt/server/cypress_proxy/bootstrap.cpp
@@ -231,14 +231,16 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         SetBuildAttributes(
             OrchidRoot_,
             "cypress_proxy");

--- a/yt/yt/server/discovery_server/bootstrap.cpp
+++ b/yt/yt/server/discovery_server/bootstrap.cpp
@@ -157,10 +157,12 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            ConvertTo<INodePtr>(Config_));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                ConvertTo<INodePtr>(Config_));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/discovery_server",

--- a/yt/yt/server/http_proxy/bootstrap.cpp
+++ b/yt/yt/server/http_proxy/bootstrap.cpp
@@ -119,10 +119,6 @@ TBootstrap::TBootstrap(TProxyConfigPtr config, INodePtr configNode)
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
     SetBuildAttributes(
         orchidRoot,
         "http_proxy");
@@ -164,14 +160,20 @@ TBootstrap::TBootstrap(TProxyConfigPtr config, INodePtr configNode)
     DynamicConfigManager_ = CreateDynamicConfigManager(this);
     DynamicConfigManager_->SubscribeConfigChanged(BIND(&TBootstrap::OnDynamicConfigChanged, MakeWeak(this)));
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/cluster_connection",
-        CreateVirtualNode(Connection_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        SetNodeByYPath(
+            orchidRoot,
+            "/cluster_connection",
+            CreateVirtualNode(Connection_->GetOrchidService()));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/disk_monitoring",

--- a/yt/yt/server/lib/misc/config.cpp
+++ b/yt/yt/server/lib/misc/config.cpp
@@ -48,6 +48,8 @@ void TServerConfig::Register(TRegistrar registrar)
         .Default(0)
         .GreaterThanOrEqual(0)
         .LessThan(65536);
+    registrar.Parameter("expose_config_in_orchid", &TThis::ExposeConfigInOrchid)
+        .Default(true);
 
     registrar.Postprocessor([] (TThis* config) {
         if (config->RpcPort > 0) {

--- a/yt/yt/server/lib/misc/config.h
+++ b/yt/yt/server/lib/misc/config.h
@@ -41,6 +41,9 @@ public:
     int RpcPort;
     int TvmOnlyRpcPort;
     int MonitoringPort;
+    //! This option may be used to prevent config-containing nodes to be exposed in Orchid as a mean of security
+    //! (disclosing less information about YT servers to a potential attacker).
+    bool ExposeConfigInOrchid;
 
     NHttp::TServerConfigPtr CreateMonitoringHttpServerConfig();
 

--- a/yt/yt/server/master/cell_master/bootstrap.cpp
+++ b/yt/yt/server/master/cell_master/bootstrap.cpp
@@ -1103,10 +1103,12 @@ void TBootstrap::DoRun()
         "/election",
         HydraFacade_->GetElectionManager()->GetMonitoringProducer());
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/incumbent_manager",

--- a/yt/yt/server/master_cache/bootstrap.cpp
+++ b/yt/yt/server/master_cache/bootstrap.cpp
@@ -237,14 +237,16 @@ private:
             GetControlInvoker(),
             Logger);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/disk_monitoring",

--- a/yt/yt/server/node/cluster_node/bootstrap.cpp
+++ b/yt/yt/server/node/cluster_node/bootstrap.cpp
@@ -1122,26 +1122,29 @@ private:
 
         Connection_->GetClusterDirectorySynchronizer()->Start();
 
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConfigNode_));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/cluster_connection",
+                CreateVirtualNode(Connection_->GetOrchidService()));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
+
         SetNodeByYPath(
             OrchidRoot_,
             "/tcp_dispatcher",
             CreateVirtualNode(NYT::NBus::TTcpDispatcher::Get()->GetOrchidService()));
         SetNodeByYPath(
             OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConfigNode_));
-        SetNodeByYPath(
-            OrchidRoot_,
             "/restart_manager",
             CreateVirtualNode(RestartManager_->GetOrchidService()));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/cluster_connection",
-            CreateVirtualNode(Connection_->GetOrchidService()));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
         SetNodeByYPath(
             OrchidRoot_,
             "/object_service_cache",

--- a/yt/yt/server/query_tracker/bootstrap.cpp
+++ b/yt/yt/server/query_tracker/bootstrap.cpp
@@ -171,14 +171,16 @@ void TBootstrap::DoRun()
         orchidRoot,
         "/alerts",
         CreateVirtualNode(AlertManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,

--- a/yt/yt/server/queue_agent/bootstrap.cpp
+++ b/yt/yt/server/queue_agent/bootstrap.cpp
@@ -209,14 +209,16 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,

--- a/yt/yt/server/replicated_table_tracker/bootstrap.cpp
+++ b/yt/yt/server/replicated_table_tracker/bootstrap.cpp
@@ -178,14 +178,16 @@ private:
             &MonitoringManager_,
             &orchidRoot);
 
-        SetNodeByYPath(
-            orchidRoot,
-            "/config",
-            CreateVirtualNode(ConfigNode_));
-        SetNodeByYPath(
-            orchidRoot,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                orchidRoot,
+                "/config",
+                CreateVirtualNode(ConfigNode_));
+            SetNodeByYPath(
+                orchidRoot,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         if (CoreDumper_) {
             SetNodeByYPath(
                 orchidRoot,

--- a/yt/yt/server/rpc_proxy/bootstrap.cpp
+++ b/yt/yt/server/rpc_proxy/bootstrap.cpp
@@ -215,18 +215,20 @@ void TBootstrap::DoRun()
         &orchidRoot);
     NProfiling::TSolomonRegistry::Get()->SetDynamicTags({NProfiling::TTag{"proxy_role", DefaultRpcProxyRole}});
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
-    SetNodeByYPath(
-        orchidRoot,
-        "/cluster_connection",
-        CreateVirtualNode(Connection_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        SetNodeByYPath(
+            orchidRoot,
+            "/cluster_connection",
+            CreateVirtualNode(Connection_->GetOrchidService()));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/disk_monitoring",

--- a/yt/yt/server/scheduler/bootstrap.cpp
+++ b/yt/yt/server/scheduler/bootstrap.cpp
@@ -157,10 +157,12 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+    }
     SetNodeByYPath(
         orchidRoot,
         "/scheduler",

--- a/yt/yt/server/tablet_balancer/bootstrap.cpp
+++ b/yt/yt/server/tablet_balancer/bootstrap.cpp
@@ -184,11 +184,6 @@ void TBootstrap::DoRun()
         &MonitoringManager_,
         &orchidRoot);
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/config",
-        CreateVirtualNode(ConfigNode_));
-
     if (CoreDumper_) {
         SetNodeByYPath(
             orchidRoot,
@@ -201,10 +196,16 @@ void TBootstrap::DoRun()
         "/tablet_balancer",
         CreateVirtualNode(TabletBalancer_->GetOrchidService()));
 
-    SetNodeByYPath(
-        orchidRoot,
-        "/dynamic_config_manager",
-        CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    if (Config_->ExposeConfigInOrchid) {
+        SetNodeByYPath(
+            orchidRoot,
+            "/config",
+            CreateVirtualNode(ConfigNode_));
+        SetNodeByYPath(
+            orchidRoot,
+            "/dynamic_config_manager",
+            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+    }
 
     RpcServer_->RegisterService(NAdmin::CreateAdminService(
         ControlInvoker_,

--- a/yt/yt/server/tcp_proxy/bootstrap.cpp
+++ b/yt/yt/server/tcp_proxy/bootstrap.cpp
@@ -201,18 +201,20 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/dynamic_config_manager",
+                CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
+        }
         SetNodeByYPath(
             OrchidRoot_,
             "/role",
             CreateVirtualNode(ConvertTo<INodePtr>(Config_->Role)));
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/dynamic_config_manager",
-            CreateVirtualNode(DynamicConfigManager_->GetOrchidService()));
         SetBuildAttributes(
             OrchidRoot_,
             "cypress_proxy");

--- a/yt/yt/server/timestamp_provider/bootstrap.cpp
+++ b/yt/yt/server/timestamp_provider/bootstrap.cpp
@@ -122,10 +122,12 @@ private:
             &MonitoringManager_,
             &OrchidRoot_);
 
-        SetNodeByYPath(
-            OrchidRoot_,
-            "/config",
-            CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        if (Config_->ExposeConfigInOrchid) {
+            SetNodeByYPath(
+                OrchidRoot_,
+                "/config",
+                CreateVirtualNode(ConvertTo<INodePtr>(Config_)));
+        }
         SetBuildAttributes(
             OrchidRoot_,
             "timestamp_provider");

--- a/yt/yt/tests/library/yt_env_setup.py
+++ b/yt/yt/tests/library/yt_env_setup.py
@@ -310,6 +310,8 @@ class YTEnvSetup(object):
     # COMPAT(kvk1920)
     TEST_MAINTENANCE_FLAGS = False
 
+    WAIT_FOR_DYNAMIC_CONFIG = True
+
     @classmethod
     def is_multicell(cls):
         return cls.NUM_SECONDARY_MASTER_CELLS > 0
@@ -488,6 +490,7 @@ class YTEnvSetup(object):
             enable_tvm_only_proxies=cls.get_param("ENABLE_TVM_ONLY_PROXIES", index),
             mock_tvm_id=(1000 + index if use_native_auth else None),
             enable_tls=cls.ENABLE_TLS,
+            wait_for_dynamic_config=cls.WAIT_FOR_DYNAMIC_CONFIG,
         )
 
         if yt_config.jobs_environment_type == "porto" and not porto_available():
@@ -1594,6 +1597,9 @@ class YTEnvSetup(object):
             self._wait_for_scheduler_state_restored(driver=driver)
 
     def _wait_for_dynamic_config(self, root_path, config, instances, driver=None):
+        if not self.WAIT_FOR_DYNAMIC_CONFIG:
+            return
+
         def check():
             responses = yt_commands.execute_batch(
                 [


### PR DESCRIPTION
(Cherry-pick into 23.2)

This PR adds an `ExposeConfigInOrchid` server config option. This option may be used to prevent
config-containing nodes to be exposed in Orchid as a mean of security (disclosing less information
about YT servers to a potential attacker).

