### PR TITLE
Add use_chunk_slice_statistics to implement #287

### DIFF
--- a/yt/yt/server/controller_agent/controllers/input_manager.cpp
+++ b/yt/yt/server/controller_agent/controllers/input_manager.cpp
@@ -285,7 +285,7 @@ TFetchInputTablesStatistics TInputManager::FetchInputTables()
         InputClient,
         Logger);
 
-    if (auto error = Host_->GetUseChunkSliceStatisticsError(); !error.IsOK()) {
+    if (auto error = Host_->GetUseChunkSliceStatisticsError(); Spec_->UseChunkSliceStatistics && !error.IsOK()) {
         SetOperationAlert(EOperationAlertType::UseChunkSliceStatisticsDisabled, error);
         chunkSliceSizeFetcher = nullptr;
     }

--- a/yt/yt/server/controller_agent/controllers/input_manager.cpp
+++ b/yt/yt/server/controller_agent/controllers/input_manager.cpp
@@ -17,6 +17,7 @@
 #include <yt/yt/ytlib/object_client/helpers.h>
 
 #include <yt/yt/ytlib/table_client/chunk_meta_extensions.h>
+#include <yt/yt/ytlib/table_client/chunk_slice_size_fetcher.h>
 #include <yt/yt/ytlib/table_client/columnar_statistics_fetcher.h>
 #include <yt/yt/ytlib/table_client/table_ypath_proxy.h>
 
@@ -276,6 +277,19 @@ TFetchInputTablesStatistics TInputManager::FetchInputTables()
 
     TFetchInputTablesStatistics fetchStatistics;
 
+    auto chunkSliceSizeFetcher = New<TChunkSliceSizeFetcher>(
+        Config->Fetcher,
+        InputNodeDirectory_,
+        CancelableInvokerPool->GetInvoker(EOperationControllerQueue::Default),
+        /*chunkScraper*/ CreateFetcherChunkScraper(),
+        InputClient,
+        Logger);
+
+    if (auto error = Host_->GetUseChunkSliceStatisticsError(); !error.IsOK()) {
+        SetOperationAlert(EOperationAlertType::UseChunkSliceStatisticsDisabled, error);
+        chunkSliceSizeFetcher = nullptr;
+    }
+
     auto chunkSpecFetcher = MakeChunkSpecFetcher();
 
     auto columnarStatisticsFetcher = New<TColumnarStatisticsFetcher>(
@@ -329,10 +343,36 @@ TFetchInputTablesStatistics TInputManager::FetchInputTables()
             }
             RegisterInputChunk(table->Chunks.back());
 
+            bool shouldSkipChunkInFetchers = IsUnavailable(inputChunk, GetChunkAvailabilityPolicy()) && Spec_->UnavailableChunkStrategy == EUnavailableChunkAction::Skip;
+
+            // We only fetch chunk slice sizes for unversioned table chunks with non-trivial limits.
+            // We do not fetch slice sizes in cases when ChunkSliceFetcher will later be used, since it performs similar computations and will misuse the scaling factors.
+            // To be more exact, we do not fetch slice sizes in operations that use any of the two sorted controllers.
+            bool willFetchChunkSliceStatistics =
+                !shouldSkipChunkInFetchers &&
+                chunkSliceSizeFetcher &&
+                !table->IsVersioned() &&
+                !inputChunk->IsCompleteChunk() &&
+                Spec_->UseChunkSliceStatistics;
+            if (willFetchChunkSliceStatistics) {
+                YT_VERIFY(!inputChunk->IsFile());
+
+                if (auto columns = table->Path.GetColumns()) {
+                    chunkSliceSizeFetcher->AddChunk(inputChunk, MapNamesToStableNames(*table->Schema, *columns, NonexistentColumnName));
+                } else {
+                    chunkSliceSizeFetcher->AddChunk(inputChunk);
+                }
+            }
+
             // We fetch columnar statistics only for the tables that have column selectors specified.
+            // NB: We do not fetch columnar statistics for chunks for which chunk slice statistics are fetched
+            // because chunk slice statistics already take columns into consideration.
             auto hasColumnSelectors = table->Path.GetColumns().operator bool();
-            bool shouldSkip = IsUnavailable(inputChunk, Host_->GetChunkAvailabilityPolicy()) && Host_->GetSpec()->UnavailableChunkStrategy == EUnavailableChunkAction::Skip;
-            if (hasColumnSelectors && Host_->GetSpec()->InputTableColumnarStatistics->Enabled.value_or(Host_->GetConfig()->UseColumnarStatisticsDefault) && !shouldSkip) {
+            if (!shouldSkipChunkInFetchers &&
+                !willFetchChunkSliceStatistics &&
+                hasColumnSelectors &&
+                Spec_->InputTableColumnarStatistics->Enabled.value_or(Config->UseColumnarStatisticsDefault))
+            {
                 auto stableColumnNames = MapNamesToStableNames(
                     *table->Schema,
                     *table->Path.GetColumns(),
@@ -357,6 +397,17 @@ TFetchInputTablesStatistics TInputManager::FetchInputTables()
             .ThrowOnError();
         YT_LOG_INFO("Columnar statistics fetched");
         columnarStatisticsFetcher->ApplyColumnSelectivityFactors();
+    }
+
+    if (chunkSliceSizeFetcher && chunkSliceSizeFetcher->GetChunkCount() > 0) {
+        YT_LOG_INFO("Fetching input chunk slice statistics for input tables (ChunkCount: %v)",
+            chunkSliceSizeFetcher->GetChunkCount());
+        // TODO(achulkov2): Do we need a cancellation stage similar to columnar statistics fetch? It is a testing option.
+        chunkSliceSizeFetcher->SetCancelableContext(GetCancelableContext());
+        WaitFor(chunkSliceSizeFetcher->Fetch())
+            .ThrowOnError();
+        YT_LOG_INFO("Input chunk slice statistics fetched");
+        chunkSliceSizeFetcher->ApplyBlockSelectivityFactors();
     }
 
     // TODO(galtsev): remove after YT-20281 is fixed

--- a/yt/yt/server/controller_agent/controllers/input_manager.cpp
+++ b/yt/yt/server/controller_agent/controllers/input_manager.cpp
@@ -346,7 +346,7 @@ TFetchInputTablesStatistics TInputManager::FetchInputTables()
             bool shouldSkipChunkInFetchers = IsUnavailable(inputChunk, GetChunkAvailabilityPolicy()) && Spec_->UnavailableChunkStrategy == EUnavailableChunkAction::Skip;
 
             // We only fetch chunk slice sizes for unversioned table chunks with non-trivial limits.
-            // We do not fetch slice sizes in cases when ChunkSliceFetcher will later be used, since it performs similar computations and will misuse the scaling factors.
+            // We do not fetch slice sizes in cases when ChunkSliceFetcher should later be used, since it performs similar computations and will misuse the scaling factors.
             // To be more exact, we do not fetch slice sizes in operations that use any of the two sorted controllers.
             bool willFetchChunkSliceStatistics =
                 !shouldSkipChunkInFetchers &&
@@ -402,7 +402,6 @@ TFetchInputTablesStatistics TInputManager::FetchInputTables()
     if (chunkSliceSizeFetcher && chunkSliceSizeFetcher->GetChunkCount() > 0) {
         YT_LOG_INFO("Fetching input chunk slice statistics for input tables (ChunkCount: %v)",
             chunkSliceSizeFetcher->GetChunkCount());
-        // TODO(achulkov2): Do we need a cancellation stage similar to columnar statistics fetch? It is a testing option.
         chunkSliceSizeFetcher->SetCancelableContext(GetCancelableContext());
         WaitFor(chunkSliceSizeFetcher->Fetch())
             .ThrowOnError();

--- a/yt/yt/server/controller_agent/controllers/input_manager.h
+++ b/yt/yt/server/controller_agent/controllers/input_manager.h
@@ -32,6 +32,9 @@ public:
     virtual void ValidateInputTablesTypes() const = 0;
 
     virtual void InvokeSafely(std::function<void()> callback) = 0;
+
+    //! If fetching chunk slice statistics is not possible for the operation, returns an error with a reason.
+    virtual TError GetUseChunkSliceStatisticsError() const = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IInputManagerHost)

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -70,6 +70,7 @@
 
 #include <yt/yt/ytlib/table_client/chunk_meta_extensions.h>
 #include <yt/yt/ytlib/table_client/chunk_slice_fetcher.h>
+#include <yt/yt/ytlib/table_client/chunk_slice_size_fetcher.h>
 #include <yt/yt/ytlib/table_client/columnar_statistics_fetcher.h>
 #include <yt/yt/ytlib/table_client/helpers.h>
 #include <yt/yt/ytlib/table_client/schema.h>
@@ -7343,6 +7344,11 @@ void TOperationControllerBase::InferInputRanges()
 TError TOperationControllerBase::GetAutoMergeError() const
 {
     return TError("Automatic output merge is not supported for %lv operations", OperationType);
+}
+
+TError TOperationControllerBase::GetUseChunkSliceStatisticsError() const
+{
+    return TError("Fetching chunk slice statistics is not supported for %lv operations", OperationType);
 }
 
 void TOperationControllerBase::FillPrepareResult(TOperationControllerPrepareResult* result)

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.h
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.h
@@ -733,7 +733,7 @@ protected:
     bool TryInitAutoMerge(int outputChunkCountEstimate);
 
     //! If fetching chunk slice statistics is not possible for the operation, returns an error with a reason.
-    virtual TError GetUseChunkSliceStatisticsError() const;
+    TError GetUseChunkSliceStatisticsError() const override;
 
     //! Return stream descriptors adjusted according to existing auto-merge tasks.
     std::vector<TOutputStreamDescriptorPtr> GetAutoMergeStreamDescriptors();

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.h
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.h
@@ -732,6 +732,9 @@ protected:
     //! If auto-merge is needed, init auto-merge tasks and auto-merge director and return true, otherwise return false.
     bool TryInitAutoMerge(int outputChunkCountEstimate);
 
+    //! If fetching chunk slice statistics is not possible for the operation, returns an error with a reason.
+    virtual TError GetUseChunkSliceStatisticsError() const;
+
     //! Return stream descriptors adjusted according to existing auto-merge tasks.
     std::vector<TOutputStreamDescriptorPtr> GetAutoMergeStreamDescriptors();
 

--- a/yt/yt/server/controller_agent/controllers/ordered_controller.cpp
+++ b/yt/yt/server/controller_agent/controllers/ordered_controller.cpp
@@ -497,6 +497,11 @@ protected:
     {
         return OrderedTask_->GetVertexDescriptor();
     }
+
+    TError GetUseChunkSliceStatisticsError() const override
+    {
+        return TError();
+    }
 };
 
 DEFINE_DYNAMIC_PHOENIX_TYPE(TOrderedControllerBase::TOrderedTask);

--- a/yt/yt/server/controller_agent/controllers/sort_controller.cpp
+++ b/yt/yt/server/controller_agent/controllers/sort_controller.cpp
@@ -2437,6 +2437,11 @@ protected:
         TOperationControllerBase::OnOperationCompleted(interrupted);
     }
 
+    TError GetUseChunkSliceStatisticsError() const override
+    {
+        return TError();
+    }
+
     void OnFinalPartitionCompleted(TPartitionPtr partition)
     {
         YT_VERIFY(partition->IsFinal());

--- a/yt/yt/server/controller_agent/controllers/table.cpp
+++ b/yt/yt/server/controller_agent/controllers/table.cpp
@@ -54,6 +54,11 @@ bool TInputTable::IsPrimary() const
     return !IsForeign();
 }
 
+bool TInputTable::IsVersioned() const
+{
+    return Dynamic && Schema->IsSorted();
+}
+
 bool TInputTable::UseReadViaExecNode() const
 {
     return Path.GetReadViaExecNode();

--- a/yt/yt/server/controller_agent/controllers/table.h
+++ b/yt/yt/server/controller_agent/controllers/table.h
@@ -77,6 +77,7 @@ struct TInputTable
 
     bool IsForeign() const;
     bool IsPrimary() const;
+    bool IsVersioned() const;
     bool UseReadViaExecNode() const;
 
     //! Returns true unless teleportation is forbidden by some table options,

--- a/yt/yt/server/controller_agent/controllers/unordered_controller.cpp
+++ b/yt/yt/server/controller_agent/controllers/unordered_controller.cpp
@@ -533,6 +533,11 @@ protected:
     {
         return UnorderedTask_->GetVertexDescriptor();
     }
+
+    TError GetUseChunkSliceStatisticsError() const override
+    {
+        return TError();
+    }
 };
 
 DEFINE_DYNAMIC_PHOENIX_TYPE(TUnorderedControllerBase::TUnorderedTask);

--- a/yt/yt/server/lib/controller_agent/serialize.h
+++ b/yt/yt/server/lib/controller_agent/serialize.h
@@ -44,6 +44,7 @@ DEFINE_ENUM(ESnapshotVersion,
     ((ForceAllowJobInterruption)            (301504))
     ((BatchRowCount_24_1)                   (301505))
     ((InputManagerIntroduction)             (301506))
+    ((ChunkSliceStatistics)                 (301507))
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/scheduler/public.h
+++ b/yt/yt/server/lib/scheduler/public.h
@@ -103,6 +103,7 @@ DEFINE_ENUM(EOperationAlertType,
     ((BaseLayerProbeFailed)                        (33))
     ((MtnExperimentFailed)                         (34))
     ((NewPartitionsCountIsSignificantlyLarger)     (36))
+    ((UseChunkSliceStatisticsDisabled)             (37))
 );
 
 DEFINE_ENUM(EAgentToSchedulerOperationEventType,

--- a/yt/yt/server/node/data_node/data_node_service.cpp
+++ b/yt/yt/server/node/data_node/data_node_service.cpp
@@ -1547,16 +1547,35 @@ private:
                     return;
                 }
 
+                TNameTablePtr nameTable;
+                if (request->has_name_table()) {
+                    nameTable = FromProto<TNameTablePtr>(request->name_table());
+                }
+
                 const auto& results = resultsError.Value();
                 YT_VERIFY(std::ssize(results) == requestCount);
 
-                auto keySetWriter = New<TKeySetWriter>();
-
                 for (int requestIndex = 0; requestIndex < requestCount; ++requestIndex) {
+                    const auto& chunkRequest = request->chunk_requests(requestIndex);
+
+                    std::optional<std::vector<TColumnStableName>> columnStableNames;
+
+                    if (chunkRequest.has_column_filter()) {
+                        YT_VERIFY(nameTable);
+
+                        columnStableNames.emplace();
+                        columnStableNames->reserve(chunkRequest.column_filter().indexes_size());
+
+                        for (auto columnIndex : chunkRequest.column_filter().indexes()) {
+                            columnStableNames->push_back(TColumnStableName(TString{nameTable->GetName(columnIndex)}));
+                        }
+                    }
+
                     ProcessSliceSize(
-                        request->chunk_requests(requestIndex),
+                        chunkRequest,
                         response->add_chunk_responses(),
-                        results[requestIndex]);
+                        results[requestIndex],
+                        columnStableNames);
                 }
 
                 context->Reply();
@@ -1566,7 +1585,8 @@ private:
     void ProcessSliceSize(
         const TReqGetChunkSliceDataWeights::TChunkSlice& weightedChunkRequest,
         TRspGetChunkSliceDataWeights::TWeightedChunk* weightedChunkResponse,
-        const TErrorOr<TRefCountedChunkMetaPtr>& metaOrError)
+        const TErrorOr<TRefCountedChunkMetaPtr>& metaOrError,
+        const std::optional<std::vector<TColumnStableName>>& columnStableNames)
     {
         auto chunkId = FromProto<TChunkId>(weightedChunkRequest.chunk_id());
         try {
@@ -1589,7 +1609,8 @@ private:
 
             auto dataWeight = GetChunkSliceDataWeight(
                 weightedChunkRequest,
-                *chunkMeta);
+                *chunkMeta,
+                columnStableNames);
 
             weightedChunkResponse->set_data_weight(dataWeight);
         } catch (const std::exception& ex) {

--- a/yt/yt/tests/integration/controller/test_merge_operation.py
+++ b/yt/yt/tests/integration/controller/test_merge_operation.py
@@ -2376,12 +2376,17 @@ class TestSchedulerMergeCommands(YTEnvSetup):
                 "data_size_per_job": 5000,
                 "force_transform": True,
                 "use_chunk_slice_statistics": True,
-                # NB: In sorted mode this behaviour is facilitated by TChunkSliceFetcher and not by the option above.
+                # NB: In sorted mode this behavior is facilitated by TChunkSliceFetcher and not by the option above.
                 "mode": merge_mode,
             }
         )
 
         op.track()
+
+        if merge_mode == "sorted":
+            assert "use_chunk_slice_statistics_disabled" in op.get_alerts()
+        else:
+            assert "use_chunk_slice_statistics_disabled" not in op.get_alerts()
 
         assert get("//tmp/d/@chunk_count") < 5
 
@@ -2415,7 +2420,7 @@ class TestSchedulerMergeCommands(YTEnvSetup):
                 "data_size_per_job": 400,
                 "force_transform": True,
                 "use_chunk_slice_statistics": True,
-                # NB: In sorted mode this behaviour is facilitated by TChunkSliceFetcher and not by the option above.
+                # NB: In sorted mode this behavior is facilitated by TChunkSliceFetcher and not by the option above.
                 "mode": merge_mode,
             }
         )
@@ -2459,6 +2464,15 @@ class TestSchedulerMergeCommands(YTEnvSetup):
         op.track()
 
         assert get("//tmp/d/@chunk_count") == 1
+
+    @authors("achulkov2")
+    def test_plain_run_produces_no_alerts(self):
+        self._prepare_tables()
+
+        op = merge(mode="unordered", in_=[self.t1, self.t2], out="//tmp/t_out")
+        op.track()
+
+        assert not op.get_alerts()
 
 ##################################################################
 

--- a/yt/yt/tests/integration/controller/test_merge_operation.py
+++ b/yt/yt/tests/integration/controller/test_merge_operation.py
@@ -11,7 +11,7 @@ from yt_commands import (
 from yt_type_helpers import (
     make_schema, normalize_schema, normalize_schema_v3, optional_type, list_type)
 
-from yt_helpers import skip_if_no_descending, skip_if_renaming_disabled
+from yt_helpers import skip_if_no_descending, skip_if_old, skip_if_renaming_disabled
 
 from yt.environment.helpers import assert_items_equal
 from yt.common import YtError
@@ -2353,6 +2353,8 @@ class TestSchedulerMergeCommands(YTEnvSetup):
     @authors("achulkov2")
     @pytest.mark.parametrize("merge_mode", ["unordered", "ordered", "sorted"])
     def test_chunk_slice_statistics(self, merge_mode):
+        skip_if_old(self.Env, (24, 2), "use_chunk_slice_statistics is not supported in older versions")
+
         create("table", "//tmp/t", attributes={
             "optimize_for": "lookup",
             "schema": [
@@ -2393,6 +2395,8 @@ class TestSchedulerMergeCommands(YTEnvSetup):
     @authors("achulkov2")
     @pytest.mark.parametrize("merge_mode", ["unordered", "ordered", "sorted"])
     def test_chunk_slice_statistics_underestimation(self, merge_mode):
+        skip_if_old(self.Env, (24, 2), "use_chunk_slice_statistics is not supported in older versions")
+
         create("table", "//tmp/t", attributes={
             "optimize_for": "lookup",
             "schema": [
@@ -2434,6 +2438,8 @@ class TestSchedulerMergeCommands(YTEnvSetup):
     # TODO(achulkov2): Add sorted mode to check once columns are supported by TChunkSliceFetcher.
     @pytest.mark.parametrize("merge_mode", ["unordered", "ordered"])
     def test_chunk_slice_statistics_work_as_columnar_statistics(self, merge_mode):
+        skip_if_old(self.Env, (24, 2), "use_chunk_slice_statistics is not supported in older versions")
+
         create("table", "//tmp/t", attributes={
             "optimize_for": "scan",
             "schema": [

--- a/yt/yt/tests/integration/controller/test_merge_operation.py
+++ b/yt/yt/tests/integration/controller/test_merge_operation.py
@@ -2386,6 +2386,46 @@ class TestSchedulerMergeCommands(YTEnvSetup):
         assert get("//tmp/d/@chunk_count") < 5
 
     @authors("achulkov2")
+    @pytest.mark.parametrize("merge_mode", ["unordered", "ordered", "sorted"])
+    def test_chunk_slice_statistics_underestimation(self, merge_mode):
+        create("table", "//tmp/t", attributes={
+            "optimize_for": "lookup",
+            "schema": [
+                {"name": "a", "type": "string", "sort_order": "ascending"},
+                {"name": "b", "type": "string"},
+                {"name": "c", "type": "string"},
+            ],
+        })
+
+        row_count = 50
+        slice_row_count = 5
+
+        write_table(
+            "//tmp/t",
+            [{"a": f"x{i:02d}", "b": "y" * 100, "c": "z"} for i in range(row_count)],
+            table_writer={"block_size": 100}
+        )
+
+        create("table", "//tmp/d")
+
+        op = merge(
+            in_=[f"//tmp/t{{a, b}}[x{i:02d}:x{i + slice_row_count:02d}]" for i in range(0, row_count, slice_row_count)],
+            out="//tmp/d",
+            spec={
+                "data_size_per_job": 400,
+                "force_transform": True,
+                "use_chunk_slice_statistics": True,
+                # NB: In sorted mode this behaviour is facilitated by TChunkSliceFetcher and not by the option above.
+                "mode": merge_mode,
+            }
+        )
+
+        op.track()
+
+        # We check for >= because TChunkSliceFetcher can make smaller slices.
+        assert get("//tmp/d/@chunk_count") >= row_count // slice_row_count
+
+    @authors("achulkov2")
     # TODO(achulkov2): Add sorted mode to check once columns are supported by TChunkSliceFetcher.
     @pytest.mark.parametrize("merge_mode", ["unordered", "ordered"])
     def test_chunk_slice_statistics_work_as_columnar_statistics(self, merge_mode):

--- a/yt/yt/ytlib/chunk_client/input_chunk.cpp
+++ b/yt/yt/ytlib/chunk_client/input_chunk.cpp
@@ -213,6 +213,11 @@ void TInputChunk::Persist(const TStreamPersistenceContext& context)
     if (context.GetVersion() >= 300303) {
         Persist<TUniquePtrSerializer<>>(context, HeavyColumnarStatisticsExt_);
     }
+
+    // COMPAT(achulkov2): This is ESnpashotVersion::ChunkSliceStatistics.
+    if (context.GetVersion() >= 301505) {
+        Persist(context, BlockSelectivityFactor_);
+    }
 }
 
 size_t TInputChunk::SpaceUsed() const
@@ -280,6 +285,11 @@ i64 TInputChunk::GetRowCount() const
     return rowCount;
 }
 
+double TInputChunk::GetSelectivityFactor() const
+{
+    return GetBlockSelectivityFactor().value_or(1.0) * GetColumnSelectivityFactor();
+}
+
 i64 TInputChunk::GetDataWeight() const
 {
     if (IsFile()) {
@@ -287,35 +297,41 @@ i64 TInputChunk::GetDataWeight() const
         //             so let's define file's data weight as its uncompressed size.
         return TotalUncompressedDataSize_;
     }
-    auto rowCount = GetRowCount();
-    auto rowSelectivityFactor = static_cast<double>(rowCount) / TotalRowCount_;
-    return std::max<i64>(std::ceil(TotalDataWeight_ * ColumnSelectivityFactor_ * rowSelectivityFactor), rowCount);
+
+    return ApplySelectivityFactors(TotalDataWeight_, /*applyColumnarSelectivityToNonColumnarFormats*/ true);
 }
 
 i64 TInputChunk::GetUncompressedDataSize() const
 {
-    return ApplySelectivityFactors(TotalUncompressedDataSize_);
+    return ApplySelectivityFactors(TotalUncompressedDataSize_, /*applyColumnarSelectivityToNonColumnarFormats*/ false);
 }
 
 i64 TInputChunk::GetCompressedDataSize() const
 {
-    return ApplySelectivityFactors(CompressedDataSize_);
+    return ApplySelectivityFactors(CompressedDataSize_, /*applyColumnarSelectivityToNonColumnarFormats*/ false);
 }
 
-i64 TInputChunk::ApplySelectivityFactors(i64 dataSize) const
+i64 TInputChunk::ApplySelectivityFactors(i64 dataSize, bool applyColumnarSelectivityToNonColumnarFormats) const
 {
     auto rowCount = GetRowCount();
-    auto rowSelectivityFactor = static_cast<double>(rowCount) / TotalRowCount_;
-    i64 result;
-    if (ChunkFormat_ == EChunkFormat::TableUnversionedColumnar ||
+
+    auto result = dataSize;
+
+    if (BlockSelectivityFactor_) {
+        result = std::ceil(*BlockSelectivityFactor_ * result);
+    } else {
+        auto rowSelectivityFactor = static_cast<double>(rowCount) / TotalRowCount_;
+        result = std::ceil(rowSelectivityFactor * result);
+    }
+
+    if (applyColumnarSelectivityToNonColumnarFormats ||
+        ChunkFormat_ == EChunkFormat::TableUnversionedColumnar ||
         ChunkFormat_ == EChunkFormat::TableVersionedColumnar)
     {
-        result = std::ceil(dataSize * ColumnSelectivityFactor_ * rowSelectivityFactor);
-    } else {
-        result = std::ceil(dataSize * rowSelectivityFactor);
+        result = std::ceil(ColumnSelectivityFactor_ * result);
     }
-    result = std::max<i64>(result, rowCount);
-    return std::max<i64>(result, 1);
+
+    return std::max<i64>({result, rowCount, 1});
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/chunk_client/input_chunk.cpp
+++ b/yt/yt/ytlib/chunk_client/input_chunk.cpp
@@ -287,7 +287,7 @@ i64 TInputChunk::GetRowCount() const
 
 double TInputChunk::GetSelectivityFactor() const
 {
-    return GetBlockSelectivityFactor().value_or(1.0) * GetColumnSelectivityFactor();
+    return GetBlockSelectivityFactor().value_or(GetColumnSelectivityFactor());
 }
 
 i64 TInputChunk::GetDataWeight() const
@@ -322,13 +322,13 @@ i64 TInputChunk::ApplySelectivityFactors(i64 dataSize, bool applyColumnarSelecti
     } else {
         auto rowSelectivityFactor = static_cast<double>(rowCount) / TotalRowCount_;
         result = std::ceil(rowSelectivityFactor * result);
-    }
 
-    if (applyColumnarSelectivityToNonColumnarFormats ||
-        ChunkFormat_ == EChunkFormat::TableUnversionedColumnar ||
-        ChunkFormat_ == EChunkFormat::TableVersionedColumnar)
-    {
-        result = std::ceil(ColumnSelectivityFactor_ * result);
+        if (applyColumnarSelectivityToNonColumnarFormats ||
+            ChunkFormat_ == EChunkFormat::TableUnversionedColumnar ||
+            ChunkFormat_ == EChunkFormat::TableVersionedColumnar)
+        {
+            result = std::ceil(ColumnSelectivityFactor_ * result);
+        }
     }
 
     return std::max<i64>({result, rowCount, 1});

--- a/yt/yt/ytlib/chunk_client/input_chunk.h
+++ b/yt/yt/ytlib/chunk_client/input_chunk.h
@@ -154,10 +154,10 @@ public:
     //!      and use it alongisde `ColumnSelectivityFactor`.
     i64 GetDataWeight() const;
     //! Same as above, but for uncompressed data size.
-    //! Columnar factors are only considered for columnar formats, i.e. we approximate the uncompressed data size that needs to be read from disk.
+    //! Columnar factors are only considered for columnar formats, i.e. we approximate the uncompressed size of data that is needed to be read from disk.
     i64 GetUncompressedDataSize() const;
     //! Same as above, but for uncompressed data size.
-    //! Columnar factors are only considered for columnar formats, i.e. we approximate the compressed data size that needs to be read from disk.
+    //! Columnar factors are only considered for columnar formats, i.e. we approximate the compressed data size that is needed to be read from disk.
     i64 GetCompressedDataSize() const;
 
     //! Returns the combined selectivity factor, which is used to propogate reductions based on external knowledge about the chunk slice referencing this input chunk.

--- a/yt/yt/ytlib/chunk_client/input_chunk.h
+++ b/yt/yt/ytlib/chunk_client/input_chunk.h
@@ -67,7 +67,6 @@ public:
     DEFINE_BYVAL_RW_PROPERTY(double, ColumnSelectivityFactor, 1.0);
 
     DEFINE_BYVAL_RO_PROPERTY(bool, StripedErasure, false);
-
 public:
     TInputChunkBase() = default;
     TInputChunkBase(TInputChunkBase&& other) = default;
@@ -112,6 +111,11 @@ public:
     using TInputChunkHeavyColumnarStatisticsExt = std::unique_ptr<NTableClient::NProto::THeavyColumnStatisticsExt>;
     DEFINE_BYREF_RO_PROPERTY(TInputChunkHeavyColumnarStatisticsExt, HeavyColumnarStatisticsExt);
 
+    //! Factor providing a ratio of data weight inferred from limits to the total data weight.
+    //! It is used to propagate the reduction of a chunk total weight to chunk and data slices that are formed from it.
+    //! NB: Setting this factor overrides generic logic which computes a row selectivity factor based on a limit-inferred row count.
+    DEFINE_BYVAL_RW_PROPERTY(std::optional<double>, BlockSelectivityFactor);
+
 public:
     TInputChunk() = default;
     TInputChunk(TInputChunk&& other) = default;
@@ -140,10 +144,12 @@ public:
     i64 GetUncompressedDataSize() const;
     i64 GetCompressedDataSize() const;
 
+    double GetSelectivityFactor() const;
+
     friend void ToProto(NProto::TChunkSpec* chunkSpec, const TInputChunkPtr& inputChunk);
 
 private:
-    i64 ApplySelectivityFactors(i64 dataSize) const;
+    i64 ApplySelectivityFactors(i64 dataSize, bool applyColumnarSelectivityToNonColumnarFormats) const;
 };
 
 DEFINE_REFCOUNTED_TYPE(TInputChunk)

--- a/yt/yt/ytlib/chunk_client/input_chunk_slice.cpp
+++ b/yt/yt/ytlib/chunk_client/input_chunk_slice.cpp
@@ -424,7 +424,7 @@ TInputChunkSlice::TInputChunkSlice(
     }
 
     if (LegacyUpperLimit_.RowIndex) {
-        OverrideSize(*LegacyUpperLimit_.RowIndex - *LegacyLowerLimit_.RowIndex, std::max<i64>(1, dataWeight * inputChunk->GetColumnSelectivityFactor()));
+        OverrideSize(*LegacyUpperLimit_.RowIndex - *LegacyLowerLimit_.RowIndex, std::max<i64>(1, dataWeight * inputChunk->GetSelectivityFactor()));
     }
 }
 
@@ -441,7 +441,7 @@ TInputChunkSlice::TInputChunkSlice(
 
     if (protoChunkSlice.has_row_count_override() || protoChunkSlice.has_data_weight_override()) {
         YT_VERIFY((protoChunkSlice.has_row_count_override() && protoChunkSlice.has_data_weight_override()));
-        OverrideSize(protoChunkSlice.row_count_override(), std::max<i64>(1, protoChunkSlice.data_weight_override() * inputChunk->GetColumnSelectivityFactor()));
+        OverrideSize(protoChunkSlice.row_count_override(), std::max<i64>(1, protoChunkSlice.data_weight_override() * inputChunk->GetSelectivityFactor()));
     }
 }
 
@@ -464,7 +464,7 @@ TInputChunkSlice::TInputChunkSlice(
 
     if (protoChunkSlice.has_row_count_override() || protoChunkSlice.has_data_weight_override()) {
         YT_VERIFY(protoChunkSlice.has_row_count_override() && protoChunkSlice.has_data_weight_override());
-        OverrideSize(protoChunkSlice.row_count_override(), std::max<i64>(1, protoChunkSlice.data_weight_override() * chunkSlice.GetInputChunk()->GetColumnSelectivityFactor()));
+        OverrideSize(protoChunkSlice.row_count_override(), std::max<i64>(1, protoChunkSlice.data_weight_override() * chunkSlice.GetInputChunk()->GetSelectivityFactor()));
     }
 }
 
@@ -489,7 +489,7 @@ TInputChunkSlice::TInputChunkSlice(
 
     if (protoChunkSlice.has_row_count_override() || protoChunkSlice.has_data_weight_override()) {
         YT_VERIFY(protoChunkSlice.has_row_count_override() && protoChunkSlice.has_data_weight_override());
-        OverrideSize(protoChunkSlice.row_count_override(), std::max<i64>(1, protoChunkSlice.data_weight_override() * chunkSlice.GetInputChunk()->GetColumnSelectivityFactor()));
+        OverrideSize(protoChunkSlice.row_count_override(), std::max<i64>(1, protoChunkSlice.data_weight_override() * chunkSlice.GetInputChunk()->GetSelectivityFactor()));
     }
 }
 
@@ -506,7 +506,7 @@ TInputChunkSlice::TInputChunkSlice(
 
     if (protoChunkSpec.has_row_count_override() || protoChunkSpec.has_data_weight_override()) {
         YT_VERIFY((protoChunkSpec.has_row_count_override() && protoChunkSpec.has_data_weight_override()));
-        OverrideSize(protoChunkSpec.row_count_override(), std::max<i64>(1, protoChunkSpec.data_weight_override() * inputChunk->GetColumnSelectivityFactor()));
+        OverrideSize(protoChunkSpec.row_count_override(), std::max<i64>(1, protoChunkSpec.data_weight_override() * inputChunk->GetSelectivityFactor()));
     }
 }
 

--- a/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
+++ b/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
@@ -423,10 +423,14 @@ message TReqGetChunkSliceDataWeights
         required NYT.NProto.TGuid chunk_id = 1;
         optional TReadLimit lower_limit = 2;
         optional TReadLimit upper_limit = 3;
+        optional NTableClient.NProto.TColumnFilter column_filter = 4;
     }
 
     repeated TChunkSlice chunk_requests = 1;
     required NYT.NProto.TWorkloadDescriptor workload_descriptor = 4;
+    // Name table for mapping column ids to column names across the whole request.
+    // Required if any column filters are set.
+    optional NYT.NTableClient.NProto.TNameTableExt name_table = 5;
 }
 
 message TRspGetChunkSliceDataWeights

--- a/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
+++ b/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
@@ -429,7 +429,7 @@ message TReqGetChunkSliceDataWeights
     repeated TChunkSlice chunk_requests = 1;
     required NYT.NProto.TWorkloadDescriptor workload_descriptor = 4;
     // Name table for mapping column ids to column names across the whole request.
-    // Required if any column filters are set.
+    // Required if any column filter is set.
     optional NYT.NTableClient.NProto.TNameTableExt name_table = 5;
 }
 

--- a/yt/yt/ytlib/scheduler/config.cpp
+++ b/yt/yt/ytlib/scheduler/config.cpp
@@ -720,6 +720,8 @@ void TOperationSpecBase::Register(TRegistrar registrar)
 
     registrar.Parameter("use_columnar_statistics", &TThis::UseColumnarStatistics)
         .Default(false);
+    registrar.Parameter("use_chunk_slice_statistics", &TThis::UseChunkSliceStatistics)
+        .Default(false);
 
     registrar.Parameter("ban_nodes_with_failed_jobs", &TThis::BanNodesWithFailedJobs)
         .Default(false);

--- a/yt/yt/ytlib/scheduler/config.h
+++ b/yt/yt/ytlib/scheduler/config.h
@@ -1019,6 +1019,11 @@ public:
     //! Note that turning this on may significantly affect workload partitioning for existing operations.
     bool UseColumnarStatistics;
 
+    //! If true, enables more accurate job size estimation for operations on tables with key-bounds.
+    //! This is achieved by computing more precise data weights for slices with non-trivial limits based on data node block key bounds.
+    //! Note that turning this on might significantly affect workload partitioning for existing operations.
+    bool UseChunkSliceStatistics;
+
     //! If true, node is banned each time a job is failed there.
     bool BanNodesWithFailedJobs;
 

--- a/yt/yt/ytlib/scheduler/config.h
+++ b/yt/yt/ytlib/scheduler/config.h
@@ -1019,7 +1019,7 @@ public:
     //! Note that turning this on may significantly affect workload partitioning for existing operations.
     bool UseColumnarStatistics;
 
-    //! If true, enables more accurate job size estimation for operations on tables with key-bounds.
+    //! If true, enables more accurate job size estimation for operations on tables with key bounds.
     //! This is achieved by computing more precise data weights for slices with non-trivial limits based on data node block key bounds.
     //! Note that turning this on might significantly affect workload partitioning for existing operations.
     bool UseChunkSliceStatistics;

--- a/yt/yt/ytlib/table_client/chunk_slice.cpp
+++ b/yt/yt/ytlib/table_client/chunk_slice.cpp
@@ -3,12 +3,12 @@
 #include "private.h"
 #include "chunk_meta_extensions.h"
 #include "key_set.h"
-
 #include <yt/yt/ytlib/chunk_client/chunk_meta_extensions.h>
 
 #include <yt/yt/client/table_client/comparator.h>
 #include <yt/yt/client/table_client/key_bound.h>
 #include <yt/yt/client/table_client/schema.h>
+#include <yt/yt/client/table_client/name_table.h>
 
 #include <yt/yt/library/erasure/impl/codec.h>
 
@@ -406,15 +406,59 @@ void ToProto(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+std::optional<THashSet<int>> GetBlockFilter(
+    const NChunkClient::NProto::TChunkMeta& chunkMeta,
+    const std::optional<std::vector<TColumnStableName>>& columnStableNames)
+{
+    if (columnStableNames) {
+        TNameTablePtr nameTable;
+        if (auto nameTableExt = FindProtoExtension<TNameTableExt>(chunkMeta.extensions())) {
+            nameTable = FromProto<TNameTablePtr>(*nameTableExt);
+        } else if (auto schemaExt = FindProtoExtension<TTableSchemaExt>(chunkMeta.extensions())) {
+            nameTable = TNameTable::FromSchemaStable(FromProto<TTableSchema>(*schemaExt));
+        } else {
+            return {};
+        }
+
+        THashSet<int> blockFilter;
+
+        auto columnMetaExt = FindProtoExtension<TColumnMetaExt>(chunkMeta.extensions());
+
+        for (const auto& columName : *columnStableNames) {
+            if (auto columnId = nameTable->FindId(columName.Underlying())) {
+                YT_VERIFY(*columnId < columnMetaExt->columns_size());
+                auto columnMeta = columnMetaExt->columns(*columnId);
+                for (const auto& segment : columnMeta.segments()) {
+                    blockFilter.insert(segment.block_index());
+                }
+            }
+        }
+
+        return blockFilter;
+    }
+
+    return {};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace
+
 i64 GetChunkSliceDataWeight(
     const NChunkClient::NProto::TReqGetChunkSliceDataWeights::TChunkSlice& weightedChunkRequest,
-    const NChunkClient::NProto::TChunkMeta& chunkMeta)
+    const NChunkClient::NProto::TChunkMeta& chunkMeta,
+    const std::optional<std::vector<TColumnStableName>>& columnStableNames)
 {
     auto miscExt = GetProtoExtension<NChunkClient::NProto::TMiscExt>(chunkMeta.extensions());
     auto chunkId = FromProto<TChunkId>(weightedChunkRequest.chunk_id());
 
     i64 chunkDataWeight = miscExt.data_weight();
     i64 chunkUncompressedSize = miscExt.uncompressed_data_size();
+    i64 chunkRowCount = miscExt.row_count();
 
     auto chunkFormat = CheckedEnumCast<EChunkFormat>(chunkMeta.format());
     switch (chunkFormat) {
@@ -440,6 +484,8 @@ i64 GetChunkSliceDataWeight(
         chunkComparator = TComparator(std::vector<ESortOrder>(keyColumnCount, ESortOrder::Ascending));
     }
 
+    auto blockFilter = GetBlockFilter(chunkMeta, columnStableNames);
+
     TOwningKeyBound chunkLowerBound;
     TOwningKeyBound chunkUpperBound;
     YT_VERIFY(FindBoundaryKeyBounds(chunkMeta, &chunkLowerBound, &chunkUpperBound));
@@ -463,6 +509,9 @@ i64 GetChunkSliceDataWeight(
     sliceLowerBound = ShortenKeyBound(sliceLowerBound, chunkComparator.GetLength());
     sliceUpperBound = ShortenKeyBound(sliceUpperBound, chunkComparator.GetLength());
 
+    auto sliceStartRowIndex = sliceLowerLimit.GetRowIndex().value_or(0);
+    auto sliceEndRowIndex = sliceUpperLimit.GetRowIndex().value_or(chunkRowCount);
+
     i64 sliceUncompressedSize = 0;
 
     auto blockMetaExt = GetProtoExtension<TDataBlockMetaExt>(chunkMeta.extensions());
@@ -471,16 +520,33 @@ i64 GetChunkSliceDataWeight(
         const auto& block = blockMetaExt.data_blocks(blockIndex);
         YT_VERIFY(block.block_index() == blockIndex);
 
+        // We can skip blocks which do not contain any of the requested columns.
+        if (blockFilter && !blockFilter->contains(blockIndex)) {
+            continue;
+        }
+
         auto blockLastKeyRow = FromProto<TUnversionedOwningRow>(block.last_key());
         auto blockLastKey = TKey::FromRowUnchecked(blockLastKeyRow);
 
-        // Block is completely to the left of the slice.
+        // Block is completely to the left of the slice by key bound.
         if (!chunkComparator.TestKey(blockLastKey, sliceLowerBound)) {
             continue;
         }
 
-        // Block is partially to the right of the slice.
+        // Block is completely to the left of the slice by row index.
+        if (block.chunk_row_count() <= sliceStartRowIndex) {
+            continue;
+        }
+
+        // Block is partially to the right of the slice by key bound.
+        // We can break here, since in all current layouts blocks in sorted tables are sorted by last_key.
         if (!chunkComparator.TestKey(blockLastKey, sliceUpperBound)) {
+            break;
+        }
+
+        // Block is partially to the right of the slice by row index.
+        // We can break here, since in all current layouts chunk_row_counts are monotonous.
+        if (block.chunk_row_count() > sliceEndRowIndex) {
             break;
         }
 

--- a/yt/yt/ytlib/table_client/chunk_slice.cpp
+++ b/yt/yt/ytlib/table_client/chunk_slice.cpp
@@ -428,6 +428,10 @@ std::optional<THashSet<int>> GetBlockFilter(
 
         auto columnMetaExt = FindProtoExtension<TColumnMetaExt>(chunkMeta.extensions());
 
+        if (!columnMetaExt) {
+            return {};
+        }
+
         for (const auto& columName : *columnStableNames) {
             if (auto columnId = nameTable->FindId(columName.Underlying())) {
                 YT_VERIFY(*columnId < columnMetaExt->columns_size());

--- a/yt/yt/ytlib/table_client/chunk_slice.cpp
+++ b/yt/yt/ytlib/table_client/chunk_slice.cpp
@@ -3,6 +3,7 @@
 #include "private.h"
 #include "chunk_meta_extensions.h"
 #include "key_set.h"
+
 #include <yt/yt/ytlib/chunk_client/chunk_meta_extensions.h>
 
 #include <yt/yt/client/table_client/comparator.h>

--- a/yt/yt/ytlib/table_client/chunk_slice.h
+++ b/yt/yt/ytlib/table_client/chunk_slice.h
@@ -43,7 +43,8 @@ void ToProto(
 
 i64 GetChunkSliceDataWeight(
     const NChunkClient::NProto::TReqGetChunkSliceDataWeights::TChunkSlice& weightedChunkRequest,
-    const NChunkClient::NProto::TChunkMeta& meta);
+    const NChunkClient::NProto::TChunkMeta& meta,
+    const std::optional<std::vector<TColumnStableName>>& columnStableNames);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/ytlib/table_client/chunk_slice_size_fetcher.cpp
+++ b/yt/yt/ytlib/table_client/chunk_slice_size_fetcher.cpp
@@ -72,7 +72,7 @@ TFuture<void> TChunkSliceSizeFetcher::DoFetchFromNode(
     req->SetMultiplexingBand(EMultiplexingBand::Heavy);
 
     // We use this name table to replace all column names with their ids across the whole rpc request message.
-    TNameTablePtr nameTable = New<TNameTable>();
+    auto nameTable = New<TNameTable>();
 
     for (int index : chunkIndexes) {
         const auto& chunk = Chunks_[index];

--- a/yt/yt/ytlib/table_client/chunk_slice_size_fetcher.cpp
+++ b/yt/yt/ytlib/table_client/chunk_slice_size_fetcher.cpp
@@ -5,6 +5,8 @@
 
 #include <yt/yt/client/node_tracker_client/node_directory.h>
 
+#include <yt/yt/client/table_client/name_table.h>
+
 #include <yt/yt/client/rpc/helpers.h>
 
 #include <yt/yt/core/rpc/channel.h>
@@ -41,6 +43,12 @@ TChunkSliceSizeFetcher::TChunkSliceSizeFetcher(
         logger)
 { }
 
+void TChunkSliceSizeFetcher::AddChunk(TInputChunkPtr chunk, std::vector<TColumnStableName> columnStableNames)
+{
+    ChunkColumnFilterIds_[Chunks_.size()] = ColumnFilterDictionary_.GetIdOrRegisterAdmittedColumns(std::move(columnStableNames));
+    TFetcherBase::AddChunk(std::move(chunk));
+}
+
 TFuture<void> TChunkSliceSizeFetcher::FetchFromNode(
     NNodeTrackerClient::TNodeId nodeId,
     std::vector<int> chunkIndexes)
@@ -63,6 +71,9 @@ TFuture<void> TChunkSliceSizeFetcher::DoFetchFromNode(
     req->SetResponseHeavy(true);
     req->SetMultiplexingBand(EMultiplexingBand::Heavy);
 
+    // We use this name table to replace all column names with their ids across the whole rpc request message.
+    TNameTablePtr nameTable = New<TNameTable>();
+
     for (int index : chunkIndexes) {
         const auto& chunk = Chunks_[index];
         auto chunkId = EncodeChunkId(chunk, nodeId);
@@ -75,7 +86,16 @@ TFuture<void> TChunkSliceSizeFetcher::DoFetchFromNode(
         if (chunk->UpperLimit()) {
             ToProto(weightedChunkRequest->mutable_upper_limit(), *chunk->UpperLimit());
         }
+
+        if (auto columnStableNames = GetColumnStableNames(index)) {
+            for (const auto& columnName : *columnStableNames) {
+                auto columnId = nameTable->GetIdOrRegisterName(columnName.Underlying());
+                weightedChunkRequest->mutable_column_filter()->add_indexes(columnId);
+            }
+        }
     }
+
+    ToProto(req->mutable_name_table(), nameTable);
 
     if (req->chunk_requests_size() == 0) {
         return VoidFuture;
@@ -131,6 +151,24 @@ void TChunkSliceSizeFetcher::OnResponse(
 void TChunkSliceSizeFetcher::OnFetchingStarted()
 {
     WeightedChunks_.resize(Chunks_.size());
+}
+
+const std::optional<std::vector<TColumnStableName>> TChunkSliceSizeFetcher::GetColumnStableNames(int chunkIndex) const
+{
+    if (auto columnFilterIdIt = ChunkColumnFilterIds_.find(chunkIndex); columnFilterIdIt != ChunkColumnFilterIds_.end()) {
+        return ColumnFilterDictionary_.GetAdmittedColumns(columnFilterIdIt->second);
+    }
+
+    return {};
+}
+
+void TChunkSliceSizeFetcher::ApplyBlockSelectivityFactors() const
+{
+    for (const auto& weightedChunk : WeightedChunks_) {
+        auto totalDataWeight = weightedChunk->GetInputChunk()->GetTotalDataWeight();
+        auto blockSelectivityFactor = std::min(static_cast<double>(weightedChunk->GetDataWeight()) / totalDataWeight, 1.0);
+        weightedChunk->GetInputChunk()->SetBlockSelectivityFactor(blockSelectivityFactor);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/table_client/chunk_slice_size_fetcher.h
+++ b/yt/yt/ytlib/table_client/chunk_slice_size_fetcher.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "public.h"
+#include "column_filter_dictionary.h"
 
 #include <yt/yt/ytlib/chunk_client/fetcher.h>
 #include <yt/yt/ytlib/chunk_client/data_node_service_proxy.h>
@@ -24,7 +25,24 @@ public:
         NApi::NNative::IClientPtr client,
         const NLogging::TLogger& logger);
 
+    // TODO(achulkov2): Generalize column-related logic into the main interface and TFetcherBase.
+    // It is similar in TColumnarStatisticsFetcher and the same will eventually be needed in ChunkSliceFetcher.
+
+    //! A list of columns can be specified to be used as a filter.
+    //! Only blocks containing at least one of the specified columns will be considered.
+    void AddChunk(NChunkClient::TInputChunkPtr chunk, std::vector<TColumnStableName> columnStableNames);
+    //! NB: When not provided, no column filter is assumed.
+    using TFetcherBase::AddChunk;
+
+    //! Set block selectivity factor for all processed chunks according to the fetched data weights.
+    void ApplyBlockSelectivityFactors() const;
+
 private:
+    THashMap<int, int> ChunkColumnFilterIds_;
+    TColumnStableNameFilterDictionary ColumnFilterDictionary_;
+
+    const std::optional<std::vector<TColumnStableName>> GetColumnStableNames(int chunkIndex) const;
+
     void ProcessDynamicStore(int chunkIndex) override;
 
     TFuture<void> FetchFromNode(


### PR DESCRIPTION
Uses and improves the existing `TChunkSliceSizeFetcher` implemented for dynamic table resharding. 
The fetcher can now be supplied with a column filter for chunk slices, which will be used to only consider blocks that contain the relevant columns.

If `use_chunk_slice_statistics` is set to true for an operation, we compute approximate data weights for all slices with non-trivial limits based on block key/row bounds.

Caveats:
- Turning this feature on disables fetching columnar statistics to avoid squaring the columnar coefficient. Currently this is not very good for non-columnar tables, since currently we are accounting whole blocks and not columns. **Using this feature (for now) effectively disables columnar approximations for non-columnar tables**.
- This feature does not work well with `TChunkSliceFetcher`, since it does its own similar data weight approximation. For this reason this feature cannot be enabled for operations which use the sorted controller and is ignored for dynamic tables.
- Small slices that do not cross the boundary of any block will have an approximated data weight of **zero**. This could lead to some surprising effects and might be changed in the future by adding an additional flag to `TChunkSliceSizeFetcher` to force it to round up to the data weight of at least one block.
- `TChunkSliceSizeFetcher` approximates data weights based on block uncompressed size, which might be inaccurate for heavily-encoded columns of columnar tables. This can be improved later by storing data weights in block meta.

