### PR TITLE
[stable/23.2] HTTP proxy TLS certificate update - follow-up

### DIFF
--- a/yt/yt/core/https/server.cpp
+++ b/yt/yt/core/https/server.cpp
@@ -30,7 +30,7 @@ class TServer
     : public IServer
 {
 public:
-    explicit TServer(IServerPtr underlying, TPeriodicExecutorPtr certificateUpdater)
+    TServer(IServerPtr underlying, TPeriodicExecutorPtr certificateUpdater)
         : Underlying_(std::move(underlying))
         , CertificateUpdater_(certificateUpdater)
     { }
@@ -101,7 +101,8 @@ static void ApplySslConfig(const TSslContextPtr&  sslContext, const TServerCrede
 IServerPtr CreateServer(
     const TServerConfigPtr& config,
     const IPollerPtr& poller,
-    const IPollerPtr& acceptor)
+    const IPollerPtr& acceptor,
+    const IInvokerPtr& controlInvoker)
 {
     auto sslContext =  New<TSslContext>();
     ApplySslConfig(sslContext, config->Credentials);
@@ -113,9 +114,10 @@ IServerPtr CreateServer(
         sslConfig->CertChain->FileName &&
         sslConfig->PrivateKey->FileName)
     {
+        YT_VERIFY(controlInvoker);
         certificateUpdater = New<TPeriodicExecutor>(
-            poller->GetInvoker(),
-            BIND([=, serverName = config->ServerName] {
+            controlInvoker,
+            BIND([=] {
                 try {
                     auto modificationTime = Max(
                         NFS::GetPathStatistics(*sslConfig->CertChain->FileName).ModificationTime,
@@ -125,14 +127,19 @@ IServerPtr CreateServer(
                     if (modificationTime > sslContext->GetCommitTime() &&
                         modificationTime + sslConfig->UpdatePeriod <= TInstant::Now())
                     {
-                        YT_LOG_INFO("Updating TLS certificates (ServerName: %v, ModificationTime: %v)", serverName, modificationTime);
+                        YT_LOG_INFO("Updating TLS certificates (ServerName: %v, ModificationTime: %v)",
+                            config->ServerName,
+                            modificationTime);
                         sslContext->Reset();
                         ApplySslConfig(sslContext, sslConfig);
                         sslContext->Commit(modificationTime);
-                        YT_LOG_INFO("TLS certificates updated (ServerName: %v)", serverName);
+                        YT_LOG_INFO("TLS certificates updated (ServerName: %v)",
+                            config->ServerName);
                     }
                 } catch (const std::exception& ex) {
-                    YT_LOG_WARNING(ex, "Unexpected exception while updating TLS certificates (ServerName: %v)", serverName);
+                    YT_LOG_WARNING(ex,
+                        "Unexpected exception while updating TLS certificates (ServerName: %v)",
+                        config->ServerName);
                 }
             }),
             sslConfig->UpdatePeriod);
@@ -150,7 +157,7 @@ IServerPtr CreateServer(
 
 IServerPtr CreateServer(const TServerConfigPtr& config, const IPollerPtr& poller)
 {
-    return CreateServer(config, poller, poller);
+    return CreateServer(config, poller, poller, /*controlInvoker*/ nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/https/server.h
+++ b/yt/yt/core/https/server.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include "yt/yt/core/actions/public.h"
+
 #include <yt/yt/core/concurrency/public.h>
 
 #include <yt/yt/core/http/public.h>
@@ -17,7 +19,8 @@ NHttp::IServerPtr CreateServer(
 NHttp::IServerPtr CreateServer(
     const TServerConfigPtr& config,
     const NConcurrency::IPollerPtr& poller,
-    const NConcurrency::IPollerPtr& acceptor);
+    const NConcurrency::IPollerPtr& acceptor,
+    const IInvokerPtr& controlInvoker);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/http_proxy/bootstrap.cpp
+++ b/yt/yt/server/http_proxy/bootstrap.cpp
@@ -270,7 +270,7 @@ TBootstrap::TBootstrap(TProxyConfigPtr config, INodePtr configNode)
 
     if (Config_->HttpsServer) {
         Config_->HttpsServer->ServerName = "HttpsApi";
-        ApiHttpsServer_ = NHttps::CreateServer(Config_->HttpsServer, Poller_, Acceptor_);
+        ApiHttpsServer_ = NHttps::CreateServer(Config_->HttpsServer, Poller_, Acceptor_, GetControlInvoker());
         RegisterRoutes(ApiHttpsServer_);
     }
 
@@ -282,7 +282,7 @@ TBootstrap::TBootstrap(TProxyConfigPtr config, INodePtr configNode)
 
     if (Config_->TvmOnlyHttpsServer) {
         Config_->TvmOnlyHttpsServer->ServerName = "TvmOnlyHttpsApi";
-        TvmOnlyApiHttpsServer_ = NHttps::CreateServer(Config_->TvmOnlyHttpsServer, Poller_, Acceptor_);
+        TvmOnlyApiHttpsServer_ = NHttps::CreateServer(Config_->TvmOnlyHttpsServer, Poller_, Acceptor_, GetControlInvoker());
         RegisterRoutes(TvmOnlyApiHttpsServer_);
     }
 


### PR DESCRIPTION
- Move TLS context commit time into impl

- Update TLS certificates in http proxy control invoker

---
94ebe9cd2c4ddb7b1fd520bf8c6bd6c56baa50fa

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/418

(cherry picked from commit 17f82b7f2ea7ce2bfb8fc043955a3630cd810b93)
