### PR TITLE
Cleanup disk quota options

### DIFF
--- a/yt/yt/server/lib/exec_node/config.cpp
+++ b/yt/yt/server/lib/exec_node/config.cpp
@@ -111,12 +111,16 @@ void TSlotLocationConfig::Register(TRegistrar registrar)
     registrar.Parameter("disk_quota", &TThis::DiskQuota)
         .Default()
         .GreaterThan(0);
+
     registrar.Parameter("disk_usage_watermark", &TThis::DiskUsageWatermark)
         .Default(10_GB)
         .GreaterThanOrEqual(0);
 
     registrar.Parameter("medium_name", &TThis::MediumName)
         .Default(NChunkClient::DefaultSlotsMediumName);
+
+    registrar.Parameter("enable_disk_quota", &TThis::EnableDiskQuota)
+        .Default(true);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/exec_node/config.h
+++ b/yt/yt/server/lib/exec_node/config.h
@@ -172,10 +172,16 @@ class TSlotLocationConfig
     : public TDiskLocationConfig
 {
 public:
+    //! Maximum reported total disk capacity.
     std::optional<i64> DiskQuota;
+
+    //! Reserve subtracted from disk capacity.
     i64 DiskUsageWatermark;
 
     TString MediumName;
+
+    //! Enforce disk space limits using disk quota.
+    bool EnableDiskQuota;
 
     REGISTER_YSON_STRUCT(TSlotLocationConfig);
 
@@ -274,7 +280,7 @@ class TSlotManagerDynamicConfig
 public:
     bool DisableJobsOnGpuCheckFailure;
 
-    //! Enables disk usage checks in periodic disk resources update.
+    //! Enforce disk space limits in periodic disk resources update.
     bool CheckDiskSpaceLimit;
 
     //! How to distribute cpu resources between 'common' and 'idle' slots.
@@ -637,6 +643,7 @@ public:
 
     TDuration CpuOverdraftTimeout;
 
+    //! Default disk space request.
     i64 MinRequiredDiskSpace;
 
     TDuration MemoryOverdraftTimeout;

--- a/yt/yt/server/node/data_node/config.h
+++ b/yt/yt/server/node/data_node/config.h
@@ -369,6 +369,7 @@ public:
     double CacheCapacityFraction;
     int LayerImportConcurrency;
 
+    //! Enforce disk space limits for porto volumes.
     bool EnableDiskQuota;
 
     TTmpfsLayerCacheConfigPtr RegularTmpfsLayerCache;

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -2764,8 +2764,8 @@ TUserSandboxOptions TJob::BuildUserSandboxOptions()
     // NB: this eventually results in job graceful abort.
     options.DiskOverdraftCallback = BIND(&TJob::Fail, MakeWeak(this))
         .Via(Invoker_);
-    options.HasRootFSQuota = false;
-    options.EnableDiskQuota = Bootstrap_->GetConfig()->DataNode->VolumeManager->EnableDiskQuota;
+    // TODO(khlebnikov): Move into volume manager.
+    options.EnableRootVolumeDiskQuota = false;
     options.UserId = GetUserSlot()->GetUserId();
 
     if (UserJobSpec_) {

--- a/yt/yt/server/node/exec_node/job_directory_manager.cpp
+++ b/yt/yt/server/node/exec_node/job_directory_manager.cpp
@@ -114,11 +114,6 @@ public:
         return AllSucceeded(asyncUnlinkResults);
     }
 
-    bool UseVolumeQuota() override
-    {
-        return true;
-    }
-
 private:
     const TString Path_;
     const IPortoExecutorPtr Executor_;
@@ -275,11 +270,6 @@ public:
         })
         .AsyncVia(Invoker_)
         .Run();
-    }
-
-    bool UseVolumeQuota() override
-    {
-        return false;
     }
 
 private:

--- a/yt/yt/server/node/exec_node/job_directory_manager.h
+++ b/yt/yt/server/node/exec_node/job_directory_manager.h
@@ -29,8 +29,6 @@ struct IJobDirectoryManager
         const TString& path,
         const TJobDirectoryProperties& properties) = 0;
 
-    virtual bool UseVolumeQuota() = 0;
-
     //! Releases all managed directories with given path prefix.
     virtual TFuture<void> CleanDirectories(const TString& pathPrefix) = 0;
 };

--- a/yt/yt/server/node/exec_node/public.h
+++ b/yt/yt/server/node/exec_node/public.h
@@ -40,8 +40,7 @@ struct TUserSandboxOptions
     std::vector<TTmpfsVolume> TmpfsVolumes;
     std::optional<i64> InodeLimit;
     std::optional<i64> DiskSpaceLimit;
-    bool HasRootFSQuota = false;
-    bool EnableDiskQuota = false;
+    bool EnableRootVolumeDiskQuota = false;
     int UserId = 0;
 
     TCallback<void(const TError&)> DiskOverdraftCallback;

--- a/yt/yt/server/node/exec_node/volume_manager.cpp
+++ b/yt/yt/server/node/exec_node/volume_manager.cpp
@@ -1308,7 +1308,8 @@ private:
             {"place", PlacePath_}
         };
 
-        if (options.EnableDiskQuota && options.HasRootFSQuota) {
+        // NB: Root volume quota is independent from sandbox quota but enforces the same limits.
+        if (options.EnableRootVolumeDiskQuota) {
             volumeProperties["user"] = ToString(options.UserId);
             volumeProperties["permissions"] = "0777";
 

--- a/yt/yt/ytlib/scheduler/config.h
+++ b/yt/yt/ytlib/scheduler/config.h
@@ -730,8 +730,12 @@ class TDiskRequestConfig
     : public NYTree::TYsonStruct
 {
 public:
+    //! Required disk space in bytes, may be enforced as a limit.
     i64 DiskSpace;
+
+    //! Limit for disk inodes.
     std::optional<i64> InodeCount;
+
     std::optional<TString> MediumName;
     std::optional<int> MediumIndex;
     std::optional<TString> Account;


### PR DESCRIPTION
Add slot location option for enabling disk quota for sandbox directories.
It is implemented as user disk quota or as porto (project) quota volume.
    
Root volume quota works independently but enforces the same limits.
It is implemented only for porto volume.