### PR TITLE
Fix historically_non_vital for erasure chunks and explicit vitality changes

### DIFF
--- a/yt/yt/server/master/cell_master/serialize.h
+++ b/yt/yt/server/master/cell_master/serialize.h
@@ -243,6 +243,7 @@ DEFINE_ENUM(EMasterReign,
     ((RemoveParameterizedBalancingMetricSetting)                    (2611))  // alexelexa
     ((RipAevum)                                                     (2612))  // babenko
     ((SecondaryIndexSchemaValidation)                               (2613))  // sabdenovch
+    ((ErasureChunksCanBeNonVital)                                   (2614))  // achulkov2
 );
 
 static_assert(TEnumTraits<EMasterReign>::IsMonotonic, "Master reign enum is not monotonic");

--- a/yt/yt/server/master/chunk_server/chunk.cpp
+++ b/yt/yt/server/master/chunk_server/chunk.cpp
@@ -510,8 +510,6 @@ bool TChunk::GetHistoricallyNonVital() const
 
 void TChunk::SetHistoricallyNonVital(bool value)
 {
-    YT_ASSERT(!value || !IsErasure());
-
     Flags_.HistoricallyNonVital = value;
 }
 

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -4218,7 +4218,7 @@ private:
 
         THashMap<TChunkRequisitionIndex, bool> durabilityRequiredCache;
         std::pair<TChunkRequisitionIndex, bool> lastDurabilityRequiredCacheEntry{EmptyChunkRequisitionIndex, false};
-        auto isDurabilityRequired = [&] (TChunkRequisitionIndex requisitionIndex) {
+        auto isDurabilityRequired = [&] (TChunkRequisitionIndex requisitionIndex, TChunk* chunk) {
             // Very fast path.
             if (requisitionIndex == lastDurabilityRequiredCacheEntry.first) {
                 return lastDurabilityRequiredCacheEntry.second;
@@ -4231,7 +4231,7 @@ private:
                 durabilityRequired = it->second;
             } else {
                 auto replication = requisitionRegistry->GetReplication(requisitionIndex);
-                durabilityRequired = replication.IsDurabilityRequired(this);
+                durabilityRequired = replication.IsDurable(this, /*isErasureChunk*/ chunk->IsErasure());
                 EmplaceOrCrash(durabilityRequiredCache, requisitionIndex, durabilityRequired);
             }
 
@@ -4251,7 +4251,7 @@ private:
             }
 
             auto aggregatedRequisitionIndex = chunk->GetAggregatedRequisitionIndex();
-            if (!chunk->IsErasure() && !isDurabilityRequired(aggregatedRequisitionIndex)) {
+            if (!isDurabilityRequired(aggregatedRequisitionIndex, chunk)) {
                 chunk->SetHistoricallyNonVital(true);
             }
         };

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -4231,7 +4231,7 @@ private:
                 durabilityRequired = it->second;
             } else {
                 auto replication = requisitionRegistry->GetReplication(requisitionIndex);
-                durabilityRequired = replication.IsDurable(this, /*isErasureChunk*/ chunk->IsErasure());
+                durabilityRequired = replication.IsDurable(this, chunk->IsErasure());
                 EmplaceOrCrash(durabilityRequiredCache, requisitionIndex, durabilityRequired);
             }
 

--- a/yt/yt/server/master/chunk_server/chunk_replicator.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.cpp
@@ -2827,13 +2827,9 @@ bool TChunkReplicator::IsDurabilityRequired(
         return false;
     }
 
-    if (chunk->IsErasure()) {
-        return true;
-    }
-
     const auto& chunkManager = Bootstrap_->GetChunkManager();
     auto replication = GetChunkAggregatedReplication(chunk, replicas);
-    return replication.IsDurabilityRequired(chunkManager);
+    return replication.IsDurabilityRequired(chunkManager, /*isErasureChunk*/ chunk->IsErasure());
 }
 
 void TChunkReplicator::OnCheckEnabled()

--- a/yt/yt/server/master/chunk_server/chunk_replicator.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.cpp
@@ -2829,7 +2829,7 @@ bool TChunkReplicator::IsDurabilityRequired(
 
     const auto& chunkManager = Bootstrap_->GetChunkManager();
     auto replication = GetChunkAggregatedReplication(chunk, replicas);
-    return replication.IsDurabilityRequired(chunkManager, /*isErasureChunk*/ chunk->IsErasure());
+    return replication.IsDurabilityRequired(chunkManager, chunk->IsErasure());
 }
 
 void TChunkReplicator::OnCheckEnabled()

--- a/yt/yt/server/master/chunk_server/chunk_requisition.h
+++ b/yt/yt/server/master/chunk_server/chunk_requisition.h
@@ -210,7 +210,10 @@ public:
     bool GetVital() const;
     void SetVital(bool vital);
 
-    bool IsDurabilityRequired(const IChunkManagerPtr& chunkManager) const;
+    //! The difference between the two methods below is in whether or not the `Vital` flag itself is considered.
+    bool IsDurable(const IChunkManagerPtr& chunkManager, bool isErasureChunk) const;
+    //! This method always returns `false` for non-vital chunks.
+    bool IsDurabilityRequired(const IChunkManagerPtr& chunkManager, bool isErasureChunk) const;
 
     //! Returns |true| iff this replication settings would not result in a data
     //! loss (i.e. on at least on medium, replication factor is non-zero and

--- a/yt/yt/tests/integration/master/test_chunk_server.py
+++ b/yt/yt/tests/integration/master/test_chunk_server.py
@@ -4,7 +4,7 @@ from yt_commands import (
     authors, create_user, wait, create, ls, get, set, remove, exists,
     start_transaction, insert_rows, build_snapshot, gc_collect, concatenate, create_account, create_rack,
     read_table, write_table, write_journal, merge, sync_create_cells, sync_mount_table, sync_unmount_table, sync_control_chunk_replicator, get_singular_chunk_id,
-    multicell_sleep, update_nodes_dynamic_config, switch_leader, set_node_banned, add_maintenance, remove_maintenance,
+    multicell_sleep, update_nodes_dynamic_config, switch_leader, set_node_banned, set_all_nodes_banned, add_maintenance, remove_maintenance,
     set_node_decommissioned, execute_command, is_active_primary_master_leader, is_active_primary_master_follower,
     get_active_primary_master_leader_address, get_active_primary_master_follower_address, create_tablet_cell_bundle)
 
@@ -354,9 +354,7 @@ class TestChunkServer(YTEnvSetup):
         assert get(f"#{chunk_id}/@vital")
         assert not get(f"#{chunk_id}/@historically_non_vital")
 
-        nodes = list(get("//sys/cluster_nodes"))
-        for node in nodes:
-            set_node_banned(node, True)
+        set_all_nodes_banned(True)
 
         wait(lambda: chunk_id in get("//sys/lost_vital_chunks"))
 
@@ -364,8 +362,7 @@ class TestChunkServer(YTEnvSetup):
         wait(lambda: chunk_id not in get("//sys/lost_vital_chunks"))
         assert chunk_id in get("//sys/lost_chunks")
 
-        for node in nodes:
-            set_node_banned(node, False)
+        set_all_nodes_banned(False)
 
         wait(lambda: chunk_id not in get("//sys/lost_chunks"))
 
@@ -387,14 +384,11 @@ class TestChunkServer(YTEnvSetup):
         wait(lambda: get(f"#{chunk_id}/@vital"))
         assert not get(f"#{chunk_id}/@historically_non_vital")
 
-        nodes = list(get("//sys/cluster_nodes"))
-        for node in nodes:
-            set_node_banned(node, True)
+        set_all_nodes_banned(True)
 
         wait(lambda: chunk_id in get("//sys/lost_vital_chunks"))
 
-        for node in nodes:
-            set_node_banned(node, False)
+        set_all_nodes_banned(False)
 
         wait(lambda: chunk_id not in get("//sys/lost_vital_chunks"))
 

--- a/yt/yt/tests/integration/master/test_chunk_server.py
+++ b/yt/yt/tests/integration/master/test_chunk_server.py
@@ -345,6 +345,59 @@ class TestChunkServer(YTEnvSetup):
         wait(lambda: chunk_id in get("//sys/lost_chunks"))
         assert chunk_id not in get("//sys/lost_vital_chunks")
 
+    @authors("achulkov2")
+    def test_historically_non_vital_with_erasure(self):
+        create("table", "//tmp/t", attributes={"erasure_codec": "isa_reed_solomon_3_3"})
+        write_table("//tmp/t", {"a": "b"})
+        chunk_id = get_singular_chunk_id("//tmp/t")
+
+        assert get(f"#{chunk_id}/@vital")
+        assert not get(f"#{chunk_id}/@historically_non_vital")
+
+        nodes = list(get("//sys/cluster_nodes"))
+        for node in nodes:
+            set_node_banned(node, True)
+
+        wait(lambda: chunk_id in get("//sys/lost_vital_chunks"))
+
+        set("//tmp/t/@vital", False)
+        wait(lambda: chunk_id not in get("//sys/lost_vital_chunks"))
+        assert chunk_id in get("//sys/lost_chunks")
+
+        for node in nodes:
+            set_node_banned(node, False)
+
+        wait(lambda: chunk_id not in get("//sys/lost_chunks"))
+
+    @authors("achulkov2")
+    def test_historically_non_vital_explicit_vitality_change(self):
+        create("table", "//tmp/t")
+        write_table("//tmp/t", {"a": "b"})
+        chunk_id = get_singular_chunk_id("//tmp/t")
+
+        assert get(f"#{chunk_id}/@vital")
+        assert not get(f"#{chunk_id}/@historically_non_vital")
+
+        set("//tmp/t/@vital", False)
+
+        wait(lambda: not get(f"#{chunk_id}/@vital"))
+        assert not get(f"#{chunk_id}/@historically_non_vital")
+
+        set("//tmp/t/@vital", True)
+        wait(lambda: get(f"#{chunk_id}/@vital"))
+        assert not get(f"#{chunk_id}/@historically_non_vital")
+
+        nodes = list(get("//sys/cluster_nodes"))
+        for node in nodes:
+            set_node_banned(node, True)
+
+        wait(lambda: chunk_id in get("//sys/lost_vital_chunks"))
+
+        for node in nodes:
+            set_node_banned(node, False)
+
+        wait(lambda: chunk_id not in get("//sys/lost_vital_chunks"))
+
     @authors("danilalexeev")
     def test_unexpected_overreplicated_chunks(self):
         create("table", "//tmp/t", attributes={"replication_factor": 8})


### PR DESCRIPTION
This PR fixes two bugs introduced with `historically_non_vital`:
* Erasure chunks were always considered vital, even when explicitly setting `@vital = %false` on their owning nodes.
* Setting `@vital` to `%false` and then back to `%true` triggered `historically_non_vital = %true`. This wasn't intended, as it makes `@vital = %false` unusable for "muting" LVC.