### PR TITLE
Always retry chained docker image pull

### DIFF
--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -592,8 +592,10 @@ public:
             auto guard = Guard(SpinLock_);
             if (auto* pullFuture = InflightImagePulls_.FindPtr(image.Image)) {
                 YT_LOG_DEBUG("Waiting for in-flight docker image pull (Image: %v)", image);
-                return pullFuture->ToImmediatelyCancelable().Apply(BIND([=, this, this_ = MakeStrong(this)] {
+                return pullFuture->ToImmediatelyCancelable()
+                    .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TError& error) {
                         // Ignore errors and retry pull after end of previous concurrent attempt.
+                        Y_UNUSED(error);
                         return PullImage(image, /*always*/ false, authConfig, podSpec);
                     }));
             }


### PR DESCRIPTION
Without unused "error" argument retry does not happens.

Fixes: c437f3bb48e ("Cosmetics")
