### PR TITLE
[23.2] Change tokens format to `ytct-{}-{}`, add token description and prefix

### DIFF
--- a/yt/yt/client/api/security_client.h
+++ b/yt/yt/client/api/security_client.h
@@ -74,7 +74,9 @@ struct TSetUserPasswordOptions
 
 struct TIssueTokenOptions
     : public TTimeoutOptions
-{ };
+{
+    TString Description;
+};
 
 struct TIssueTokenResult
 {
@@ -87,12 +89,15 @@ struct TRevokeTokenOptions
 
 struct TListUserTokensOptions
     : public TTimeoutOptions
-{ };
+{
+    bool WithMetadata;
+};
 
 struct TListUserTokensResult
 {
     // Tokens are SHA256-encoded.
     std::vector<TString> Tokens;
+    THashMap<TString, NYson::TYsonString> Metadata;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/driver/authentication_commands.cpp
+++ b/yt/yt/client/driver/authentication_commands.cpp
@@ -37,6 +37,8 @@ TIssueTokenCommand::TIssueTokenCommand()
     RegisterParameter("user", User_);
     RegisterParameter("password_sha256", PasswordSha256_)
         .Default();
+    RegisterParameter("description", Options.Description)
+        .Default();
 }
 
 void TIssueTokenCommand::DoExecute(ICommandContextPtr context)
@@ -79,6 +81,8 @@ TListUserTokensCommand::TListUserTokensCommand()
     RegisterParameter("user", User_);
     RegisterParameter("password_sha256", PasswordSha256_)
         .Default();
+    RegisterParameter("with_metadata", Options.WithMetadata)
+        .Default(false);
 }
 
 void TListUserTokensCommand::DoExecute(ICommandContextPtr context)
@@ -89,7 +93,11 @@ void TListUserTokensCommand::DoExecute(ICommandContextPtr context)
         Options))
         .ValueOrThrow();
 
-    context->ProduceOutputValue(ConvertToYsonString(result.Tokens));
+    if (Options.WithMetadata) {
+        context->ProduceOutputValue(ConvertToYsonString(result.Metadata));
+    } else {
+        context->ProduceOutputValue(ConvertToYsonString(result.Tokens));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/tests/integration/master/test_users.py
+++ b/yt/yt/tests/integration/master/test_users.py
@@ -16,6 +16,7 @@ from yt_helpers import profiler_factory
 
 from yt.environment.helpers import assert_items_equal
 from yt.common import YtError
+from yt.yson import YsonEntity
 
 import pytest
 import builtins
@@ -632,7 +633,7 @@ class TestUsers(YTEnvSetup):
         rev4 = get("//sys/users/u/@password_revision")
         assert rev4 > rev3
 
-    @authors("gritukan")
+    @authors("gritukan", "aleksandr.gaev")
     def test_tokens(self):
         if self.DRIVER_BACKEND == "rpc":
             return
@@ -642,12 +643,14 @@ class TestUsers(YTEnvSetup):
         set_user_password("u", "u")
         set_user_password("v", "v")
 
-        _, t1_hash = issue_token("u")
+        t1_token, t1_hash = issue_token("u")
+        assert t1_token[:5] == "ytct-" and t1_token[9] == "-"
         assert get(f"//sys/cypress_tokens/{t1_hash}/@user") == "u"
         assert_items_equal(list_user_tokens("u"), [t1_hash])
         assert list_user_tokens("v") == []
 
-        _, t2_hash = issue_token("u", "u", authenticated_user="u")
+        t2_token, t2_hash = issue_token("u", "u", authenticated_user="u")
+        assert t2_token[:5] == "ytct-" and t2_token[9] == "-"
         assert_items_equal(list_user_tokens("u"), [t1_hash, t2_hash])
 
         with raises_yt_error("User provided invalid password"):
@@ -670,6 +673,50 @@ class TestUsers(YTEnvSetup):
 
         revoke_token("u", t2_hash, "u", authenticated_user="u")
         assert list_user_tokens("u") == []
+
+    @authors("aleksandr.gaev")
+    def test_tokens_with_metadata(self):
+        if self.DRIVER_BACKEND == "rpc":
+            return
+
+        create_user("u")
+        create_user("v")
+        set_user_password("u", "u")
+        set_user_password("v", "v")
+
+        assert list_user_tokens("v", with_metadata=True) == {}
+
+        token, token_hash = issue_token("u")
+        result = list_user_tokens("u", with_metadata=True)
+        ct = get(f"//sys/cypress_tokens/{token_hash}/@creation_time")
+        assert token_hash in result
+        assert result[token_hash]["description"] == ""
+        assert len(result[token_hash]["token_prefix"]) == len("ytct-abcd-") and result[token_hash]["token_prefix"][:5] == "ytct-" and result[token_hash]["token_prefix"][9] == "-"
+        assert token[:10] == result[token_hash]["token_prefix"]
+        assert result[token_hash]["creation_time"] == ct
+        assert result[token_hash]["effective_expiration"] == {"time": YsonEntity(), "timeout": YsonEntity()}
+        revoke_token("u", token_hash)
+
+        token, token_hash = issue_token("u", description="")
+        result = list_user_tokens("u", with_metadata=True)
+        ct = get(f"//sys/cypress_tokens/{token_hash}/@creation_time")
+        assert token_hash in result
+        assert result[token_hash]["description"] == ""
+        assert len(result[token_hash]["token_prefix"]) == len("ytct-abcd-") and result[token_hash]["token_prefix"][:5] == "ytct-" and result[token_hash]["token_prefix"][9] == "-"
+        assert token[:10] == result[token_hash]["token_prefix"]
+        assert result[token_hash]["creation_time"] == ct
+        assert result[token_hash]["effective_expiration"] == {"time": YsonEntity(), "timeout": YsonEntity()}
+        revoke_token("u", token_hash)
+
+        token, token_hash = issue_token("u", description="desc")
+        result = list_user_tokens("u", with_metadata=True)
+        ct = get(f"//sys/cypress_tokens/{token_hash}/@creation_time")
+        assert token_hash in result
+        assert result[token_hash]["description"] == "desc"
+        assert len(result[token_hash]["token_prefix"]) == len("ytct-abcd-") and result[token_hash]["token_prefix"][:5] == "ytct-" and result[token_hash]["token_prefix"][9] == "-"
+        assert token[:10] == result[token_hash]["token_prefix"]
+        assert result[token_hash]["creation_time"] == ct
+        assert result[token_hash]["effective_expiration"] == {"time": YsonEntity(), "timeout": YsonEntity()}
 
     @authors("shakurov")
     def test_user_request_profiling(self):

--- a/yt/yt/tests/integration/misc/test_get_supported_features.py
+++ b/yt/yt/tests/integration/misc/test_get_supported_features.py
@@ -2,6 +2,8 @@ from yt_env_setup import YTEnvSetup
 
 from yt_commands import authors, get_driver, get_supported_features
 
+import yt.yson as yson
+
 import builtins
 
 import pytest
@@ -113,3 +115,11 @@ class TestGetFeatures(YTEnvSetup):
             description = features["operation_statistics_descriptions"][desc_name]
             assert "description" in description
             assert "unit" in description
+
+    @authors("aleksandr.gaev")
+    def test_user_tokens_with_metadata_feature(self):
+        driver = get_driver(api_version=4)
+        features = get_supported_features(driver=driver)
+
+        assert "user_tokens_metadata" in features
+        assert features["user_tokens_metadata"] == yson.YsonBoolean(True)

--- a/yt/yt/tests/library/yt_commands.py
+++ b/yt/yt/tests/library/yt_commands.py
@@ -1819,11 +1819,13 @@ def set_user_password(user, new_password, current_password=None, **kwargs):
     return execute_command("set_user_password", kwargs)
 
 
-def issue_token(user, password=None, **kwargs):
+def issue_token(user, password=None, description=None, **kwargs):
     kwargs["user"] = user
     if password:
         password = hashlib.sha256(password.encode("utf-8")).hexdigest()
         kwargs["password_sha256"] = password
+    if description:
+        kwargs["description"] = description
     token = execute_command("issue_token", kwargs, parse_yson=True)
     token_sha256 = hashlib.sha256(token.encode("utf-8")).hexdigest()
     return token, token_sha256
@@ -1838,12 +1840,13 @@ def revoke_token(user, token_sha256, password=None, **kwargs):
     return execute_command("revoke_token", kwargs)
 
 
-def list_user_tokens(user, password=None, **kwargs):
+def list_user_tokens(user, password=None, with_metadata=False, **kwargs):
     kwargs["user"] = user
+    kwargs["with_metadata"] = with_metadata
     if password:
         password = hashlib.sha256(password.encode("utf-8")).hexdigest()
         kwargs["password_sha256"] = password
-    return execute_command("list_user_tokens", kwargs, parse_yson=True)
+    return execute_command("list_user_tokens", kwargs, parse_yson=True, unwrap_v4_result=False)
 
 
 def migrate_replication_cards(chaos_cell_id, replication_card_ids=None, **kwargs):

--- a/yt/yt/ytlib/api/native/client_authentication_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_authentication_impl.cpp
@@ -1,5 +1,6 @@
 #include "client_impl.h"
 
+#include <yt/yt/library/re2/re2.h>
 #include <yt/yt/core/crypto/crypto.h>
 
 #include <util/string/hex.h>
@@ -67,9 +68,13 @@ TIssueTokenResult TClient::DoIssueToken(
         passwordSha256,
         options);
 
-    constexpr int TokenLength = 16;
-    auto tokenBytes = GenerateCryptoStrongRandomString(TokenLength);
-    auto token = to_lower(HexEncode(tokenBytes.data(), tokenBytes.size()));
+    constexpr int TokenBodyBytesLength = 16;
+    constexpr int TokenPrefixBytesLength = 2;
+    auto tokenBodyBytes = GenerateCryptoStrongRandomString(TokenBodyBytesLength);
+    auto tokenBody = to_lower(HexEncode(tokenBodyBytes.data(), tokenBodyBytes.size()));
+    auto tokenPrefixBytes = GenerateCryptoStrongRandomString(TokenPrefixBytesLength);
+    auto tokenPrefix = Format("ytct-%v-", to_lower(HexEncode(tokenPrefixBytes.data(), tokenPrefixBytes.size())));
+    auto token = tokenPrefix + tokenBody;
     auto tokenHash = GetSha256HexDigestLowerCase(token);
 
     TCreateNodeOptions createOptions;
@@ -77,10 +82,13 @@ TIssueTokenResult TClient::DoIssueToken(
 
     createOptions.Attributes = BuildAttributeDictionaryFluently()
         .Item("user").Value(user)
+        .Item("token_prefix").Value(tokenPrefix)
+        .Item("description").Value(options.Description)
         .Finish();
 
-    YT_LOG_DEBUG("Issuing new token for user (User: %v, TokenHash: %v)",
+    YT_LOG_DEBUG("Issuing new token for user (User: %v, TokenPrefix: %v, TokenHash: %v)",
         user,
+        tokenPrefix,
         tokenHash);
 
     auto rootClient = CreateRootClient();
@@ -92,15 +100,17 @@ TIssueTokenResult TClient::DoIssueToken(
 
     if (!rspOrError.IsOK()) {
         YT_LOG_DEBUG(rspOrError, "Failed to issue new token for user "
-            "(User: %v, TokenHash: %v)",
+            "(User: %v, TokenPrefix: %v, TokenHash: %v)",
             user,
+            tokenPrefix,
             tokenHash);
         auto error = TError("Failed to issue new token for user") << rspOrError;
         THROW_ERROR error;
     }
 
-    YT_LOG_DEBUG("Issued new token for user (User: %v, TokenHash: %v)",
+    YT_LOG_DEBUG("Issued new token for user (User: %v, TokenPrefix: %v, TokenHash: %v)",
         user,
+        tokenPrefix,
         tokenHash);
 
     return TIssueTokenResult{
@@ -171,10 +181,20 @@ TListUserTokensResult TClient::DoListUserTokens(
         passwordSha256,
         options);
 
+    YT_LOG_DEBUG("Listing tokens for user (User: %v, WithMetadata: %v)",
+        user,
+        options.WithMetadata);
+
     TListNodeOptions listOptions;
     static_cast<TTimeoutOptions&>(listOptions) = options;
 
     listOptions.Attributes = TAttributeFilter({"user"});
+    if (options.WithMetadata) {
+        listOptions.Attributes.Keys.emplace_back("description");
+        listOptions.Attributes.Keys.emplace_back("token_prefix");
+        listOptions.Attributes.Keys.emplace_back("creation_time");
+        listOptions.Attributes.Keys.emplace_back("effective_expiration");
+    }
 
     auto rootClient = CreateRootClient();
     auto rspOrError = WaitFor(rootClient->ListNode("//sys/cypress_tokens", listOptions));
@@ -185,6 +205,7 @@ TListUserTokensResult TClient::DoListUserTokens(
     }
 
     std::vector<TString> userTokens;
+    THashMap<TString, NYson::TYsonString> tokenMetadata;
 
     auto tokens = ConvertTo<IListNodePtr>(rspOrError.Value());
     for (const auto& tokenNode : tokens->GetChildren()) {
@@ -192,11 +213,22 @@ TListUserTokensResult TClient::DoListUserTokens(
         auto userAttribute = attributes.Find<TString>("user");
         if (userAttribute == user) {
             userTokens.push_back(ConvertTo<TString>(tokenNode));
+            if (options.WithMetadata) {
+                auto metadata = BuildYsonStringFluently()
+                    .BeginMap()
+                        .Item("description").Value(attributes.Find<TString>("description"))
+                        .Item("token_prefix").Value(attributes.Find<TString>("token_prefix"))
+                        .Item("creation_time").Value(attributes.Find<TString>("creation_time"))
+                        .Item("effective_expiration").Value(attributes.GetYson("effective_expiration"))
+                    .EndMap();
+                tokenMetadata[ConvertTo<TString>(tokenNode)] = ConvertToYsonString(metadata);
+            }
         }
     }
 
     return TListUserTokensResult{
         .Tokens = std::move(userTokens),
+        .Metadata = std::move(tokenMetadata),
     };
 }
 


### PR DESCRIPTION
This is a cherry-pick of [d736ed4a7c04028e2a2d62d277f72843b2ef5290](https://github.com/ytsaurus/ytsaurus/commit/d736ed4a7c04028e2a2d62d277f72843b2ef5290) to 23.2 with manual conflict resolution

Issue: https://github.com/ytsaurus/ytsaurus/issues/413

Adding description parameter to issue_token. Adding with_metadata mode to list_user_tokens

Using `ytct-{}-{}` format for randomly generated tokens, save token prefix to attributes and return it in list_user_tokens

This is required for UI (Issue: https://github.com/ytsaurus/ytsaurus-ui/issues/241)

Since issue_token currently returns a list, it is not possible to make a backwards-compatible change with added fields. A new parameter "WithMetadata" was added, which leads to a different structure of the output

---
b3dd71dc509c19c23d7c6ca69ef4a04a09d34aff

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/444

