### PR TITLE
Add configuration for retryable errors for CRI executor

### DIFF
--- a/yt/yt/library/containers/cri/config.cpp
+++ b/yt/yt/library/containers/cri/config.cpp
@@ -24,6 +24,14 @@ void TCriExecutorConfig::Register(TRegistrar registrar)
 
     registrar.Parameter("cpu_period", &TThis::CpuPeriod)
         .Default(TDuration::MilliSeconds(100));
+
+    registrar.Parameter("retry_error_prefixes", &TThis::RetryErrorPrefixes)
+        .Default({
+            // https://github.com/containerd/containerd/pull/9565
+            "server is not initialized yet",
+            // https://github.com/containerd/containerd/issues/9160
+            "failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to create new parent process: namespace path: lstat /proc/0/ns/ipc: no such file or directory: unknown",
+        });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/library/containers/cri/config.h
+++ b/yt/yt/library/containers/cri/config.h
@@ -31,6 +31,9 @@ public:
     //! Cpu quota period for cpu limits.
     TDuration CpuPeriod;
 
+    //! Retry requests on generic error with these message prefixes.
+    std::vector<TString> RetryErrorPrefixes;
+
     REGISTER_YSON_STRUCT(TCriExecutorConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -741,14 +741,21 @@ private:
         }
     }
 
-    static TRetryChecker GetRetryChecker()
+    TRetryChecker GetRetryChecker()
     {
-        static const auto Result = BIND_NO_PROPAGATE([] (const TError& error) {
-            return IsRetriableError(error) ||
-                   (error.GetCode() == NYT::EErrorCode::Generic &&
-                    error.GetMessage() == "server is not initialized yet");
+        return BIND_NO_PROPAGATE([config = Config_] (const TError& error) {
+            if (IsRetriableError(error)) {
+                return true;
+            }
+            if (error.GetCode() == NYT::EErrorCode::Generic) {
+                for (const auto& prefix: config->RetryErrorPrefixes) {
+                    if (error.GetMessage().StartsWith(prefix)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         });
-        return Result;
     }
 };
 


### PR DESCRIPTION
Retry after error "create containerd task" which should be transient and
more likely caused by well-known race in containerd.

Link: https://github.com/containerd/containerd/issues/9160
