### PR TITLE
Add YYYY-MM-DD commit date into "nightly" docker image tag

### DIFF
--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -40,7 +40,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ytsaurus
-          fetch-depth: 0
 
       - name: Checkout ydb
         uses: actions/checkout@v3
@@ -89,8 +88,8 @@ jobs:
             IMAGE_TAG=dev-test
           fi
 
-          cd ytsaurus
-          NIGHTLY_IMAGE_TAG=${IMAGE_TAG}-$(git rev-list --count HEAD)-${GITHUB_SHA}
+          NIGHTLY_IMAGE_TAG=${IMAGE_TAG}-$(git -C ytsaurus show -s --pretty=%cs)-${GITHUB_SHA}
+
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "NIGHTLY_IMAGE_TAG=$NIGHTLY_IMAGE_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ya_make.yaml
+++ b/.github/workflows/ya_make.yaml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ytsaurus
-          fetch-depth: 0
       - name: Checkout ydb
         uses: actions/checkout@v3
         with:
@@ -85,8 +84,8 @@ jobs:
             IMAGE_TAG=dev-test
           fi
 
-          cd ytsaurus
-          NIGHTLY_IMAGE_TAG=${IMAGE_TAG}-$(git rev-list --count HEAD)-${GITHUB_SHA}
+          NIGHTLY_IMAGE_TAG=${IMAGE_TAG}-$(git -C ytsaurus show -s --pretty=%cs)-${GITHUB_SHA}
+
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
           echo "NIGHTLY_IMAGE_TAG=$NIGHTLY_IMAGE_TAG" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Date of last commit is much more useful than obscure count of commits.
And it does not require full depth checkout.
