### PR TITLE
Increase chardet version limit for python-requests in contrib

### DIFF
--- a/yt/python/contrib/python-requests/requests/__init__.py
+++ b/yt/python/contrib/python-requests/requests/__init__.py
@@ -87,8 +87,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     if chardet_version:
         major, minor, patch = chardet_version.split('.')[:3]
         major, minor, patch = int(major), int(minor), int(patch)
-        # chardet_version >= 3.0.2, <= 5.2.0
-        assert (3, 0, 2) <= (major, minor, patch) <= (5, 2, 0)
+        # chardet_version >= 3.0.2, < 6.0.0
+        assert (3, 0, 2) <= (major, minor, patch) < (6, 0, 0)
     elif charset_normalizer_version:
         major, minor, patch = charset_normalizer_version.split('.')[:3]
         major, minor, patch = int(major), int(minor), int(patch)

--- a/yt/python/contrib/python-requests/requests/__init__.py
+++ b/yt/python/contrib/python-requests/requests/__init__.py
@@ -87,8 +87,8 @@ def check_compatibility(urllib3_version, chardet_version, charset_normalizer_ver
     if chardet_version:
         major, minor, patch = chardet_version.split('.')[:3]
         major, minor, patch = int(major), int(minor), int(patch)
-        # chardet_version >= 3.0.2, < 5.0.0
-        assert (3, 0, 2) <= (major, minor, patch) < (5, 0, 0)
+        # chardet_version >= 3.0.2, <= 5.2.0
+        assert (3, 0, 2) <= (major, minor, patch) <= (5, 2, 0)
     elif charset_normalizer_version:
         major, minor, patch = charset_normalizer_version.split('.')[:3]
         major, minor, patch = int(major), int(minor), int(patch)


### PR DESCRIPTION
Fix warning from https://github.com/ytsaurus/ytsaurus/issues/222

1. [zlobober](https://github.com/zlobober) is using charset_normalizer == `5.1.0` for a couple of months and confirms that everything works fine.
2. As far as I can see, difference between `5.1.0` and `5.2.0` is only in one commit - https://github.com/chardet/chardet/commit/0e9b7bc20366163efcc221281201baff4100fe19

Thus I propose to increase charset_normalizer version limit to 5.2.0.