### PR TITLE
Improve Query Tracker odin checks with soft_timeout and error messages

### DIFF
--- a/yt/odin/bin/yt_odin_generate_config/__main__.py
+++ b/yt/odin/bin/yt_odin_generate_config/__main__.py
@@ -281,6 +281,24 @@ def create_odin_checks_config():
                     "total_threshold": 1000000
                 }
             },
+            "query_tracker_yql_liveness": {
+                "check_timeout": 240,
+                "options": {
+                    "soft_query_timeout": 165,
+                },
+            },
+            "query_tracker_chyt_liveness": {
+                "check_timeout": 60,
+                "options": {
+                    "soft_query_timeout": 30,
+                },
+            },
+            "query_tracker_ql_liveness": {
+                "check_timeout": 60,
+                "options": {
+                    "soft_query_timeout": 30,
+                },
+            },
         },
     }
 

--- a/yt/odin/checks/bin/query_tracker_chyt_liveness/__main__.py
+++ b/yt/odin/checks/bin/query_tracker_chyt_liveness/__main__.py
@@ -11,8 +11,10 @@ RESULT_DATA = [{"result": i + 1} for i in range(VALUES_COUNT)]
 
 
 def run_check(secrets, yt_client, logger, options, states):
-    chyt_stage_client = YtClient(proxy=options["chyt_cluster_name"], token=secrets["yt_token"])
+    chyt_cluster_address = options.get("chyt_cluster_address", options["chyt_cluster_name"])
+    chyt_stage_client = YtClient(proxy=chyt_cluster_address, token=secrets["yt_token"])
     stage = options["cluster_name_to_query_tracker_stage"].get(options["cluster_name"], "production")
+    soft_timeout = options["soft_query_timeout"]
 
     return run_check_impl(
         yt_client,
@@ -20,6 +22,7 @@ def run_check(secrets, yt_client, logger, options, states):
         logger,
         stage,
         states,
+        soft_timeout,
         "chyt",
         "select x + 1 as result from `{table}`",
         Data(SCHEMA, SOURCE_DATA, RESULT_DATA),

--- a/yt/odin/checks/bin/query_tracker_ql_liveness/__main__.py
+++ b/yt/odin/checks/bin/query_tracker_ql_liveness/__main__.py
@@ -11,6 +11,7 @@ RESULT_DATA = [{"result": i + 1} for i in range(VALUES_COUNT)]
 
 def run_check(yt_client, logger, options, states):
     stage = options["cluster_name_to_query_tracker_stage"].get(options["cluster_name"], "production")
+    soft_timeout = options["soft_query_timeout"]
 
     return run_check_impl(
         yt_client,
@@ -18,6 +19,7 @@ def run_check(yt_client, logger, options, states):
         logger,
         stage,
         states,
+        soft_timeout,
         "ql",
         "select x + 1 as result from [{table}]",
         Data(SCHEMA, SOURCE_DATA, RESULT_DATA, dynamic=True),

--- a/yt/odin/checks/bin/query_tracker_yql_liveness/__main__.py
+++ b/yt/odin/checks/bin/query_tracker_yql_liveness/__main__.py
@@ -11,6 +11,7 @@ RESULT_DATA = [{"result": i + 1} for i in range(VALUES_COUNT)]
 
 def run_check(yt_client, logger, options, states):
     stage = options["cluster_name_to_query_tracker_stage"].get(options["cluster_name"], "production")
+    soft_timeout = options["soft_query_timeout"]
 
     return run_check_impl(
         yt_client,
@@ -18,6 +19,7 @@ def run_check(yt_client, logger, options, states):
         logger,
         stage,
         states,
+        soft_timeout,
         "yql",
         "select x + 1 as result from `{table}`",
         Data(SCHEMA, SOURCE_DATA, RESULT_DATA),

--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -1,4 +1,3 @@
-from yt.common import YtError
 import yt.yson as yson
 
 
@@ -14,28 +13,46 @@ class Data():
 
 
 POLL_FREQUENCY = 0.1
+LOG_FREQUENCY = 1.0
 TEMP_PATH = "//sys/admin/odin/query_tracker_liveness"
-QUERY_TIMEOUT_SECONDS = 30
-TABLE_EXPIRATION_TIMEOUT_MILLISECONDS = 60 * 1000
+TABLE_EXPIRATION_TIMEOUT_MILLISECONDS = 360 * 1000
+
+
+def get_query_state(yt_client, query_id, stage):
+    query = yt_client.get_query(query_id, attributes=["state", "error"], stage=stage)
+    return query["state"]
+
+
+def check_failed_state(state):
+    return state in ("failed", "aborted")
+
+
+def check_finished_state(state):
+    return state in ("completed")
+
+
+def check_terminal_state(state):
+    return check_failed_state(state) or check_finished_state(state)
+
+
+def log_query(logger, query_id, state):
+    logger.info(f"Query {query_id}: {state}")
 
 
 def track_query(yt_client, logger, query_id, stage):
-    counter = 0
+    last_log_time = time.time()
+    while True:
+        state = get_query_state(yt_client, query_id, stage)
 
-    max_iterations = QUERY_TIMEOUT_SECONDS / POLL_FREQUENCY
-    while counter < max_iterations:
-        query = yt_client.get_query(query_id, attributes=["state", "error"], stage=stage)
-        state = query["state"]
-        if counter % 10 == 0 or state in ("failed", "aborted", "completed"):
-            logger.info(f"Query {query_id}: {state}")
+        current_time = time.time()
+        if current_time - last_log_time >= LOG_FREQUENCY:
+            log_query(logger, query_id, state)
+            last_log_time = current_time
 
-        if state in ("failed", "aborted"):
-            raise YtError.from_dict(query["error"])
-        elif state == "completed":
-            return
+        if check_terminal_state(state):
+            return state
 
         time.sleep(POLL_FREQUENCY)
-        counter += 1
 
 
 def run_check_impl(
@@ -44,6 +61,7 @@ def run_check_impl(
     logger,
     stage,
     states,
+    soft_timeout,
     engine,
     query,
     data,
@@ -59,7 +77,7 @@ def run_check_impl(
             engine_client.mkdir(temp_path, recursive=True)
 
         source_table_path = engine_client.create_temp_table(path=temp_path, attributes={"expiration_timeout": TABLE_EXPIRATION_TIMEOUT_MILLISECONDS, "dynamic": data.dynamic, "schema": data.schema})
-        if data.dynamic :
+        if data.dynamic:
             engine_client.mount_table(source_table_path, sync=True)
             engine_client.insert_rows(source_table_path, data.source_data)
         else :
@@ -67,23 +85,29 @@ def run_check_impl(
         logger.info("Created %s table.", source_table_path)
 
         query_id = query_tracker_client.start_query(engine, query.format(table=source_table_path), settings=settings, stage=stage)
+        query_start_time = time.time()
+        final_query_state = track_query(query_tracker_client, logger, query_id, stage)
+        query_execution_time = int(time.time() - query_start_time)
 
-        try:
-            track_query(query_tracker_client, logger, query_id, stage)
-        except YtError as error:
-            logger.error("Query '%s' failed", query_id)
-            logger.exception(error)
-            return states.UNAVAILABLE_STATE
+        log_query(logger, query_id, final_query_state)
 
-        result_bytes = query_tracker_client.read_query_result(query_id, 0, stage=stage).read()
-        result = list(yson.loads(result_bytes, yson_type="list_fragment"))
-
-        if result == data.result_data:
-            check_result = states.FULLY_AVAILABLE_STATE
-            logger.info("Query finished correctly")
-        else:
+        if check_failed_state(final_query_state):
             check_result = states.UNAVAILABLE_STATE
-            logger.error("Query returned an incorrect result; expected:\n%s\nreceived:\n%s", data.result_data, result)
+            logger.info("Query %s failed", query_id)
+        else:
+            logger.info("Query %s finished in %d seconds", query_id, query_execution_time)
+            result_bytes = query_tracker_client.read_query_result(query_id, 0, stage=stage).read()
+            result = list(yson.loads(result_bytes, yson_type="list_fragment"))
+
+            if result != data.result_data:
+                check_result = states.UNAVAILABLE_STATE
+                logger.error("Query %s returned an incorrect result; expected:\n%s\nreceived:\n%s", query_id, data.result_data, result)
+            elif query_execution_time > soft_timeout:
+                check_result = states.PARTIALLY_AVAILABLE_STATE
+                logger.error("Query %s finished correctly, but took more than %d seconds to complete", query_id, soft_timeout)
+            else:
+                check_result = states.FULLY_AVAILABLE_STATE
+                logger.info("Query %s finished correctly", query_id)
 
     except Exception as error:
         logger.info('Can\'t check query tracker with error: {}'.format(str(error)))


### PR DESCRIPTION
Issue: #563 

Improve Query Tracker odin checks with soft_timeout and error messages

YQL query consists of 2 sequential operations: map and unordered merge. Map operation requires downloading 250mb file.

165 soft_query_timeout was formed by addition of 105s (`map_result` soft timeout) and 60s for unordered merge one
240 check_timeout was formed the same way (180s + 60s)