### PR TITLE
Move state managing logic from proxies to qt

### DIFF
--- a/yt/yt/client/api/rpc_proxy/helpers.cpp
+++ b/yt/yt/client/api/rpc_proxy/helpers.cpp
@@ -1437,7 +1437,7 @@ void FromProto(
     } else {
         query->State.reset();
     }
-    if (protoQuery.result_count()) {
+    if (protoQuery.has_result_count()) {
         query->ResultCount = protoQuery.result_count();
     } else {
         query->ResultCount.reset();

--- a/yt/yt/server/lib/discovery_server/unittests/mock/connection.h
+++ b/yt/yt/server/lib/discovery_server/unittests/mock/connection.h
@@ -198,6 +198,11 @@ public:
         YT_UNIMPLEMENTED();
     }
 
+    NRpc::IChannelPtr GetQueryTrackerChannelOrThrow(const TString& /*stage*/) override
+    {
+        YT_UNIMPLEMENTED();
+    }
+
     const NTabletClient::ITableMountCachePtr& GetTableMountCache() override
     {
         YT_UNIMPLEMENTED();

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -6022,16 +6022,33 @@ private:
     // QUERY TRACKER
     ////////////////////////////////////////////////////////////////////////////////
 
-    DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, StartQuery)
+    template <class TRequest>
+    TQueryTrackerServiceProxy GetQueryTrackerProxy(
+        const IServiceContextPtr& context,
+        const TRequest* request)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
+        return TQueryTrackerServiceProxy(
             client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+    }
+
+    template <class TProxyRequest, class TQTRequestPtr>
+    void FillQueryTrackerRequest(
+        const IServiceContextPtr& context,
+        const TProxyRequest* proxyRequest,
+        const TQTRequestPtr qtRequest)
+    {
+        qtRequest->SetTimeout(context->GetTimeout());
+        qtRequest->SetUser(context->GetAuthenticationIdentity().User);
+        qtRequest->mutable_rpc_proxy_request()->MergeFrom(*proxyRequest);
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, StartQuery)
+    {
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.StartQuery();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo("QueryTrackerStage: %v, Engine: %v",
             request->query_tracker_stage(),
@@ -6052,14 +6069,10 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, AbortQuery)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
-            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.AbortQuery();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v",
             request->query_tracker_stage(),
@@ -6077,14 +6090,10 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, GetQueryResult)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
-            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.GetQueryResult();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, ResultIndex: %v",
             request->query_tracker_stage(),
@@ -6106,14 +6115,10 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, ReadQueryResult)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
-            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.ReadQueryResult();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, ResultIndex: %v",
             request->query_tracker_stage(),
@@ -6132,17 +6137,12 @@ private:
             });
     }
 
-
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, GetQuery)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
-            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.GetQuery();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, StartTimestamp: %v",
             request->query_tracker_stage(),
@@ -6164,14 +6164,10 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, ListQueries)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
-            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.ListQueries();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo(
             "QueryTrackerStage: %v, Limit: %v",
@@ -6194,17 +6190,12 @@ private:
             });
     }
 
-
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, AlterQuery)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
-        TQueryTrackerServiceProxy proxy(
-            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
+        auto proxy = GetQueryTrackerProxy(context, request);
 
         auto req = proxy.AlterQuery();
-        req->SetTimeout(context->GetTimeout());
-        req->SetUser(context->GetAuthenticationIdentity().User);
-        req->mutable_rpc_proxy_request()->MergeFrom(*request);
+        FillQueryTrackerRequest(context, request, req);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v",
             request->query_tracker_stage(),
@@ -6222,34 +6213,23 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, GetQueryTrackerInfo)
     {
-        auto client = GetAuthenticatedClientOrThrow(context, request);
+        auto proxy = GetQueryTrackerProxy(context, request);
 
-        TGetQueryTrackerInfoOptions options;
-        SetTimeoutOptions(&options, context.Get());
+        auto req = proxy.GetQueryTrackerInfo();
+        FillQueryTrackerRequest(context, request, req);
 
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        if (request->has_attributes()) {
-            options.Attributes = FromProto<NYTree::TAttributeFilter>(request->attributes());
-        }
-
-        context->SetRequestInfo("QueryTrackerStage: %v", options.QueryTrackerStage);
+        context->SetRequestInfo("QueryTrackerStage: %v", request->query_tracker_stage());
 
         ExecuteCall(
             context,
             [=] {
-                return client->GetQueryTrackerInfo(options);
+                return req->Invoke();
             },
             [] (const auto& context, const auto& result) {
                 auto* response = &context->Response();
+                response->MergeFrom(result->rpc_proxy_response());
 
-                response->set_cluster_name(result.ClusterName);
-                response->set_supported_features(result.SupportedFeatures.ToString());
-                for (const auto& accessControlObject : result.AccessControlObjects) {
-                    *response->add_access_control_objects() = accessControlObject;
-                }
-
-                context->SetResponseInfo("ClusterName: %v", result.ClusterName);
+                context->SetResponseInfo("ClusterName: %v", response->cluster_name());
             });
     }
 

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -19,6 +19,8 @@
 
 #include <yt/yt/ytlib/misc/memory_usage_tracker.h>
 
+#include <yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h>
+
 #include <yt/yt/client/api/config.h>
 #include <yt/yt/client/api/client.h>
 #include <yt/yt/client/api/file_reader.h>
@@ -103,6 +105,7 @@ using namespace NTransactionClient;
 using namespace NYPath;
 using namespace NYTree;
 using namespace NYson;
+using namespace NQueryTrackerClient;
 
 using NYT::FromProto;
 using NYT::ToProto;
@@ -6022,167 +6025,110 @@ private:
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, StartQuery)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TStartQueryOptions options;
-        SetTimeoutOptions(&options, context.Get());
+        auto req = proxy.StartQuery();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        if (request->has_settings()) {
-            options.Settings = ConvertToNode(TYsonStringBuf(request->settings()));
-        }
-
-        options.Draft = request->draft();
-
-        if (request->has_annotations()) {
-            options.Annotations = ConvertToNode(TYsonStringBuf(request->annotations()))->AsMap();
-        }
-
-        for (const auto& requestFile : request->files()) {
-            auto file = New<TQueryFile>();
-            file->Name = requestFile.name();
-            file->Content = requestFile.content();
-            file->Type = FromProto<EContentType>(requestFile.type());
-            options.Files.emplace_back(file);
-        }
-
-        if (request->has_access_control_object()) {
-            options.AccessControlObject = request->access_control_object();
-        }
-
-        auto engine = FromProto<NQueryTrackerClient::EQueryEngine>(request->engine());
-
-        context->SetRequestInfo("QueryTrackerStage: %v, Engine: %v, Draft: %v, AccessControlObject: %v",
-            options.QueryTrackerStage,
-            engine,
-            options.Draft,
-            options.AccessControlObject);
+        context->SetRequestInfo("QueryTrackerStage: %v, Engine: %v",
+            request->query_tracker_stage(),
+            FromProto<EQueryEngine>(request->engine()));
 
         ExecuteCall(
             context,
             [=] {
-                return client->StartQuery(engine, request->query(), options);
+                return req->Invoke();
             },
             [] (const auto& context, const auto& result) {
                 auto* response = &context->Response();
-                ToProto(response->mutable_query_id(), result);
+                response->MergeFrom(result->rpc_proxy_response());
 
-                context->SetResponseInfo("QueryId: %v", result);
+                context->SetResponseInfo("QueryId: %v", response->query_id());
             });
     }
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, AbortQuery)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TAbortQueryOptions options;
-        SetTimeoutOptions(&options, context.Get());
+        auto req = proxy.AbortQuery();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        if (request->has_abort_message()) {
-            options.AbortMessage = request->abort_message();
-        }
-
-        auto queryId = FromProto<NQueryTrackerClient::TQueryId>(request->query_id());
-
-        context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, AbortMessage: %v",
-            options.QueryTrackerStage,
-            queryId,
-            options.AbortMessage);
+        context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v",
+            request->query_tracker_stage(),
+            FromProto<NQueryTrackerClient::TQueryId>(request->query_id()));
 
         ExecuteCall(
             context,
             [=] {
-                return client->AbortQuery(queryId, options);
+                return req->Invoke();
+            },
+            [] (const auto& /*context*/, const auto& /*result*/) {
+                // do nothing.
             });
     }
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, GetQueryResult)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TGetQueryResultOptions options;
-        SetTimeoutOptions(&options, context.Get());
-
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        auto queryId = FromProto<NQueryTrackerClient::TQueryId>(request->query_id());
+        auto req = proxy.GetQueryResult();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, ResultIndex: %v",
-            options.QueryTrackerStage,
-            queryId,
+            request->query_tracker_stage(),
+            FromProto<NQueryTrackerClient::TQueryId>(request->query_id()),
             request->result_index());
 
         ExecuteCall(
             context,
             [=] {
-                return client->GetQueryResult(queryId, request->result_index(), options);
+                return req->Invoke();
             },
             [] (const auto& context, const auto& result) {
                 auto* response = &context->Response();
+                response->MergeFrom(result->rpc_proxy_response());
 
-                ToProto(response->mutable_query_id(), result.Id);
-                response->set_result_index(result.ResultIndex);
-                ToProto(response->mutable_error(), result.Error);
-
-                if (result.Schema) {
-                    ToProto(response->mutable_schema(), result.Schema);
-                }
-
-                ToProto(response->mutable_data_statistics(), result.DataStatistics);
-                response->set_is_truncated(result.IsTruncated);
-
-                context->SetResponseInfo("QueryId: %v, ResultIndex: %v, Error: %v, IsTruncated: %v",
-                    result.Id,
-                    result.ResultIndex,
-                    result.Error,
-                    result.IsTruncated);
+                context->SetResponseInfo("QueryId: %v", response->query_id());
             });
     }
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, ReadQueryResult)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TReadQueryResultOptions options;
-        SetTimeoutOptions(&options, context.Get());
-
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        auto queryId = FromProto<NQueryTrackerClient::TQueryId>(request->query_id());
-
-        if (request->has_columns()) {
-            options.Columns = FromProto<std::vector<TString>>(request->columns().items());
-        }
-
-        if (request->has_lower_row_index()) {
-            options.LowerRowIndex = request->lower_row_index();
-        }
-
-        if (request->has_upper_row_index()) {
-            options.UpperRowIndex = request->upper_row_index();
-        }
+        auto req = proxy.ReadQueryResult();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, ResultIndex: %v",
-            options.QueryTrackerStage,
-            queryId,
+            request->query_tracker_stage(),
+            FromProto<NQueryTrackerClient::TQueryId>(request->query_id()),
             request->result_index());
 
         ExecuteCall(
             context,
             [=] {
-                return client->ReadQueryResult(queryId, request->result_index(), options);
+                return req->Invoke();
             },
-            [] (const auto& context, const auto& rowset) {
+            [] (const auto& context, const auto& result) {
                 auto* response = &context->Response();
-
-                response->Attachments() = NApi::NRpcProxy::SerializeRowset(
-                    *rowset->GetSchema(),
-                    rowset->GetRows(),
-                    response->mutable_rowset_descriptor());
-
-                context->SetResponseInfo("RowCount: %v", rowset->GetRows().Size());
+                response->MergeFrom(result->rpc_proxy_response());
+                response->Attachments() = result->Attachments();
             });
     }
 
@@ -6190,116 +6136,61 @@ private:
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, GetQuery)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TGetQueryOptions options;
-        SetTimeoutOptions(&options, context.Get());
-
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        if (request->has_attributes()) {
-            options.Attributes = FromProto<NYTree::TAttributeFilter>(request->attributes());
-        }
-
-        auto queryId = FromProto<NQueryTrackerClient::TQueryId>(request->query_id());
-
-        if (request->has_timestamp()) {
-            options.Timestamp = request->timestamp();
-        }
+        auto req = proxy.GetQuery();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
         context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, StartTimestamp: %v",
-            options.QueryTrackerStage,
-            queryId,
-            options.Timestamp);
+            request->query_tracker_stage(),
+            FromProto<NQueryTrackerClient::TQueryId>(request->query_id()),
+            request->timestamp());
 
         ExecuteCall(
             context,
             [=] {
-                return client->GetQuery(queryId, options);
+                return req->Invoke();
             },
-            [] (const auto& context, const auto& query) {
+            [] (const auto& context, const auto& result) {
                 auto* response = &context->Response();
+                response->MergeFrom(result->rpc_proxy_response());
 
-                ToProto(response->mutable_query(), query);
-
-                context->SetResponseInfo("QueryId: %v, Engine: %v, State: %v",
-                    query.Id,
-                    query.Engine,
-                    query.State);
+                context->SetResponseInfo("QueryId: %v", response->query().id());
             });
     }
 
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, ListQueries)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TListQueriesOptions options;
-        SetTimeoutOptions(&options, context.Get());
-
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        if (request->has_from_time()) {
-            options.FromTime = TInstant::FromValue(request->from_time());
-        }
-        if (request->has_to_time()) {
-            options.ToTime = TInstant::FromValue(request->to_time());
-        }
-        if (request->has_cursor_time()) {
-            options.CursorTime = TInstant::FromValue(request->cursor_time());
-        }
-        options.CursorDirection = FromProto<EOperationSortDirection>(request->cursor_direction());
-
-        if (request->has_user_filter()) {
-            options.UserFilter = request->user_filter();
-        }
-        if (request->has_state_filter()) {
-            options.StateFilter = FromProto<NQueryTrackerClient::EQueryState>(request->state_filter());
-        }
-        if (request->has_engine_filter()) {
-            options.EngineFilter = FromProto<NQueryTrackerClient::EQueryEngine>(request->engine_filter());
-        }
-        if (request->has_substr_filter()) {
-            options.SubstrFilter = request->substr_filter();
-        }
-
-        options.Limit = request->limit();
-
-        if (request->has_attributes()) {
-            options.Attributes = FromProto<NYTree::TAttributeFilter>(request->attributes());
-        }
+        auto req = proxy.ListQueries();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
         context->SetRequestInfo(
-            "QueryTrackerStage: %v, FromTime: %v, ToTime: %v, CursorTime: %v, CursorDirection: %v, "
-            "UserFilter: %v, StateFilter: %v, EngineFilter: %v, SubstrFilter: %v, Limit: %v",
-            options.QueryTrackerStage,
-            options.FromTime,
-            options.ToTime,
-            options.CursorTime,
-            options.CursorDirection,
-            options.UserFilter,
-            options.StateFilter,
-            options.EngineFilter,
-            options.SubstrFilter,
-            options.Limit);
+            "QueryTrackerStage: %v, Limit: %v",
+            request->query_tracker_stage(),
+            request->limit());
 
         ExecuteCall(
             context,
             [=] {
-                return client->ListQueries(options);
+                return req->Invoke();
             },
             [] (const auto& context, const auto& result) {
                 auto* response = &context->Response();
-
-                for (const auto& query : result.Queries) {
-                    ToProto(response->add_queries(), query);
-                }
-
-                response->set_incomplete(result.Incomplete);
-                response->set_timestamp(result.Timestamp);
+                response->MergeFrom(result->rpc_proxy_response());
 
                 context->SetResponseInfo("QueryCount: %v, Incomplete: %v, Timestamp: %v",
-                    result.Queries.size(),
-                    result.Incomplete,
-                    result.Timestamp);
+                    response->queries_size(),
+                    response->incomplete(),
+                    response->timestamp());
             });
     }
 
@@ -6307,31 +6198,25 @@ private:
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, AlterQuery)
     {
         auto client = GetAuthenticatedClientOrThrow(context, request);
+        TQueryTrackerServiceProxy proxy(
+            client->GetNativeConnection()->GetQueryTrackerChannelOrThrow(request->query_tracker_stage()));
 
-        TAlterQueryOptions options;
-        SetTimeoutOptions(&options, context.Get());
+        auto req = proxy.AlterQuery();
+        req->SetTimeout(context->GetTimeout());
+        req->SetUser(context->GetAuthenticationIdentity().User);
+        req->mutable_rpc_proxy_request()->MergeFrom(*request);
 
-        options.QueryTrackerStage = request->query_tracker_stage();
-
-        if (request->has_annotations()) {
-            options.Annotations = ConvertToNode(TYsonStringBuf(request->annotations()))->AsMap();
-        }
-
-        if (request->has_access_control_object()) {
-            options.AccessControlObject = request->access_control_object();
-        }
-
-        auto queryId = FromProto<NQueryTrackerClient::TQueryId>(request->query_id());
-
-        context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v, AccessControlObject: %v",
-            options.QueryTrackerStage,
-            queryId,
-            options.AccessControlObject);
+        context->SetRequestInfo("QueryTrackerStage: %v, QueryId: %v",
+            request->query_tracker_stage(),
+            FromProto<NQueryTrackerClient::TQueryId>(request->query_id()));
 
         ExecuteCall(
             context,
             [=] {
-                return client->AlterQuery(queryId, options);
+                return req->Invoke();
+            },
+            [] (const auto& /*context*/, const auto& /*result*/) {
+                // do nothing.
             });
     }
 

--- a/yt/yt/server/query_tracker/bootstrap.cpp
+++ b/yt/yt/server/query_tracker/bootstrap.cpp
@@ -1,8 +1,10 @@
 #include "bootstrap.h"
 
 #include "query_tracker.h"
+#include "query_tracker_proxy.h"
 #include "config.h"
 #include "private.h"
+#include "proxy_service.h"
 #include "dynamic_config_manager.h"
 
 #include <yt/yt/server/lib/admin/admin_service.h>
@@ -105,6 +107,9 @@ void TBootstrap::Run()
     ControlQueue_ = New<TActionQueue>("Control");
     ControlInvoker_ = ControlQueue_->GetInvoker();
 
+    ProxyPool_ = CreateThreadPool(Config_->ProxyThreadPoolSize, "Proxy");
+    ProxyInvoker_ = ProxyPool_->GetInvoker();
+
     BIND(&TBootstrap::DoRun, this)
         .AsyncVia(ControlInvoker_)
         .Run()
@@ -194,6 +199,11 @@ void TBootstrap::DoRun()
         orchidRoot,
         "query_tracker");
 
+    QueryTrackerProxy_ = CreateQueryTrackerProxy(
+        NativeClient_,
+        Config_->Root
+    );
+
     RpcServer_->RegisterService(CreateAdminService(
         ControlInvoker_,
         CoreDumper_,
@@ -202,6 +212,9 @@ void TBootstrap::DoRun()
         orchidRoot,
         ControlInvoker_,
         NativeAuthenticator_));
+    RpcServer_->RegisterService(CreateProxyService(
+        ProxyInvoker_,
+        QueryTrackerProxy_));
 
     QueryTracker_ = CreateQueryTracker(
         DynamicConfigManager_->GetConfig()->QueryTracker,

--- a/yt/yt/server/query_tracker/bootstrap.cpp
+++ b/yt/yt/server/query_tracker/bootstrap.cpp
@@ -201,8 +201,8 @@ void TBootstrap::DoRun()
 
     QueryTrackerProxy_ = CreateQueryTrackerProxy(
         NativeClient_,
-        Config_->Root
-    );
+        Config_->Root,
+        DynamicConfigManager_->GetConfig()->QueryTracker->ProxyConfig);
 
     RpcServer_->RegisterService(CreateAdminService(
         ControlInvoker_,
@@ -280,6 +280,9 @@ void TBootstrap::OnDynamicConfigChanged(
     }
     if (QueryTracker_) {
         QueryTracker_->Reconfigure(newConfig->QueryTracker);
+    }
+    if (QueryTrackerProxy_) {
+        QueryTrackerProxy_->Reconfigure(newConfig->QueryTracker->ProxyConfig);
     }
 
     YT_LOG_DEBUG(

--- a/yt/yt/server/query_tracker/bootstrap.h
+++ b/yt/yt/server/query_tracker/bootstrap.h
@@ -46,7 +46,9 @@ private:
 
     NMonitoring::TMonitoringManagerPtr MonitoringManager_;
     NConcurrency::TActionQueuePtr ControlQueue_;
+    NConcurrency::IThreadPoolPtr ProxyPool_;
     IInvokerPtr ControlInvoker_;
+    IInvokerPtr ProxyInvoker_;
     NBus::IBusServerPtr BusServer_;
     NRpc::IServerPtr RpcServer_;
     NHttp::IServerPtr HttpServer_;
@@ -62,6 +64,8 @@ private:
     NAlertManager::IAlertManagerPtr AlertManager_;
 
     IQueryTrackerPtr QueryTracker_;
+
+    TQueryTrackerProxyPtr QueryTrackerProxy_;
 
     void DoRun();
 

--- a/yt/yt/server/query_tracker/config.cpp
+++ b/yt/yt/server/query_tracker/config.cpp
@@ -72,6 +72,18 @@ void TSpytEngineConfig::Register(TRegistrar registrar)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TQueryTrackerProxyConfig::Register(TRegistrar registrar)
+{
+    registrar.Parameter("max_query_file_count", &TThis::MaxQueryFileCount)
+        .Default(8192);
+    registrar.Parameter("max_query_file_name_size_bytes", &TThis::MaxQueryFileNameSizeBytes)
+        .Default(1_KB);
+    registrar.Parameter("max_query_file_content_size_bytes", &TThis::MaxQueryFileContentSizeBytes)
+        .Default(2_KB);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TQueryTrackerDynamicConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("active_query_acquisition_period", &TThis::ActiveQueryAcquisitionPeriod)
@@ -91,6 +103,8 @@ void TQueryTrackerDynamicConfig::Register(TRegistrar registrar)
     registrar.Parameter("spyt_engine", &TThis::SpytEngine)
         .DefaultNew();
     registrar.Parameter("mock_engine", &TThis::MockEngine)
+        .DefaultNew();
+    registrar.Parameter("proxy_config", &TThis::ProxyConfig)
         .DefaultNew();
 }
 

--- a/yt/yt/server/query_tracker/config.cpp
+++ b/yt/yt/server/query_tracker/config.cpp
@@ -102,6 +102,8 @@ void TQueryTrackerServerConfig::Register(TRegistrar registrar)
         .Default(7);
     registrar.Parameter("abort_on_unrecognized_options", &TThis::AbortOnUnrecognizedOptions)
         .Default(false);
+    registrar.Parameter("proxy_thread_pool_size", &TThis::ProxyThreadPoolSize)
+        .Default(4);
     registrar.Parameter("user", &TThis::User);
     registrar.Parameter("cypress_annotations", &TThis::CypressAnnotations)
         .Default(NYTree::BuildYsonNodeFluently()

--- a/yt/yt/server/query_tracker/config.h
+++ b/yt/yt/server/query_tracker/config.h
@@ -106,6 +106,23 @@ DEFINE_REFCOUNTED_TYPE(TSpytEngineConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TQueryTrackerProxyConfig
+    : public NYTree::TYsonStruct
+{
+public:
+    i64 MaxQueryFileCount;
+    i64 MaxQueryFileNameSizeBytes;
+    i64 MaxQueryFileContentSizeBytes;
+
+    REGISTER_YSON_STRUCT(TQueryTrackerProxyConfig);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TQueryTrackerProxyConfig)
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TQueryTrackerDynamicConfig
     : public NYTree::TYsonStruct
 {
@@ -120,6 +137,8 @@ public:
     TYqlEngineConfigPtr YqlEngine;
     TChytEngineConfigPtr ChytEngine;
     TSpytEngineConfigPtr SpytEngine;
+
+    TQueryTrackerProxyConfigPtr ProxyConfig;
 
     REGISTER_YSON_STRUCT(TQueryTrackerDynamicConfig);
 

--- a/yt/yt/server/query_tracker/config.h
+++ b/yt/yt/server/query_tracker/config.h
@@ -137,6 +137,8 @@ public:
     int MinRequiredStateVersion;
     bool AbortOnUnrecognizedOptions;
 
+    int ProxyThreadPoolSize;
+
     TString User;
 
     NYTree::IMapNodePtr CypressAnnotations;

--- a/yt/yt/server/query_tracker/private.h
+++ b/yt/yt/server/query_tracker/private.h
@@ -39,6 +39,7 @@ YT_DEFINE_ERROR_ENUM(
 ////////////////////////////////////////////////////////////////////////////////
 
 DECLARE_REFCOUNTED_CLASS(TQueryTracker)
+DECLARE_REFCOUNTED_CLASS(TQueryTrackerProxy)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerDynamicConfig)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerServerConfig)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerServerDynamicConfig)

--- a/yt/yt/server/query_tracker/private.h
+++ b/yt/yt/server/query_tracker/private.h
@@ -43,6 +43,7 @@ DECLARE_REFCOUNTED_CLASS(TQueryTrackerProxy)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerDynamicConfig)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerServerConfig)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerServerDynamicConfig)
+DECLARE_REFCOUNTED_CLASS(TQueryTrackerProxyConfig)
 
 DECLARE_REFCOUNTED_CLASS(TDynamicConfigManager)
 

--- a/yt/yt/server/query_tracker/proxy_service.cpp
+++ b/yt/yt/server/query_tracker/proxy_service.cpp
@@ -1,0 +1,268 @@
+#include "private.h"
+#include "proxy_service.h"
+#include "query_tracker_proxy.h"
+
+#include <yt/yt/client/api/rpc_proxy/helpers.h>
+
+#include <yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.pb.h>
+
+#include <yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h>
+#include <yt/yt/ytlib/query_tracker_client/helpers.h>
+
+#include <yt/yt/core/rpc/service_detail.h>
+
+namespace NYT::NQueryTracker {
+
+using namespace NApi;
+using namespace NConcurrency;
+using namespace NQueryTrackerClient;
+using namespace NRpc;
+using namespace NYTree;
+
+static const TYsonString EmptyMap = TYsonString(TString("{}"));
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TProxyService
+    : public TServiceBase
+{
+public:
+    TProxyService(IInvokerPtr proxyInvoker, TQueryTrackerProxyPtr queryTracker)
+        : TServiceBase(
+            std::move(proxyInvoker),
+            TQueryTrackerServiceProxy::GetDescriptor(),
+            QueryTrackerLogger)
+        , QueryTracker_(std::move(queryTracker))
+    {
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(StartQuery));
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(AbortQuery));
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(GetQueryResult));
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(ReadQueryResult));
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(GetQuery));
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(ListQueries));
+        RegisterMethod(RPC_SERVICE_METHOD_DESC(AlterQuery));
+    }
+
+private:
+    const TQueryTrackerProxyPtr QueryTracker_;
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, StartQuery)
+    {
+        auto queryId = TQueryId::Create();
+        ToProto(response->mutable_query_id(), queryId);
+
+        TStartQueryOptions options;
+        if (request->has_settings()) {
+            options.Settings = ConvertToNode(TYsonStringBuf(request->settings()));
+        }
+        if (request->has_annotations()) {
+            options.Annotations = ConvertToNode(TYsonStringBuf(request->annotations()))->AsMap();
+        }
+        if (request->has_access_control_object()) {
+            options.AccessControlObject = request->access_control_object();
+        }
+        options.Draft = request->draft();
+        options.Files = ConvertTo<std::vector<TQueryFilePtr>>(TYsonStringBuf(request->files()));
+
+        auto engine = static_cast<EQueryEngine>(request->engine());
+        auto query = request->query();
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("QueryId: %v, User: %v", queryId, user);
+        context->SetResponseInfo("QueryId: %v", queryId);
+
+        QueryTracker_->StartQuery(queryId, engine, query, options, user);
+
+        context->Reply();
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, AbortQuery)
+    {
+        TQueryId queryId;
+        FromProto(&queryId, request->query_id());
+
+        TAbortQueryOptions options;
+        options.AbortMessage = request->has_abort_message()
+            ? std::make_optional(request->abort_message())
+            : std::nullopt;
+
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("QueryId: %v, User: %v", queryId, user);
+        context->SetResponseInfo("QueryId: %v", queryId);
+
+        QueryTracker_->AbortQuery(queryId, options, user);
+
+        context->Reply();
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, GetQueryResult)
+    {
+        TQueryId queryId;
+        FromProto(&queryId, request->query_id());
+
+        auto resultIndex = request->result_index();
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("QueryId: %v, ResultIndex: %v, User: %v", queryId, resultIndex, user);
+        context->SetResponseInfo("QueryId: %v", queryId);
+
+        auto queryResult = QueryTracker_->GetQueryResult(queryId, resultIndex, user);
+
+        ToProto(response->mutable_query_id(), queryResult.Id);
+        response->set_result_index(queryResult.ResultIndex);
+        if (queryResult.Schema) {
+            ToProto(response->mutable_schema(), queryResult.Schema);
+        }
+        ToProto(response->mutable_error(), queryResult.Error);
+        response->set_is_truncated(queryResult.IsTruncated);
+        ToProto(response->mutable_data_statistics(), queryResult.DataStatistics);
+
+        context->Reply();
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, ReadQueryResult)
+    {
+        TQueryId queryId;
+        FromProto(&queryId, request->query_id());
+
+        TReadQueryResultOptions options;
+        options.LowerRowIndex = request->has_lower_row_index()
+            ? std::make_optional(request->lower_row_index())
+            : std::nullopt;
+        options.UpperRowIndex = request->has_upper_row_index()
+            ? std::make_optional(request->upper_row_index())
+            : std::nullopt;
+        options.Columns = request->has_columns()
+            ? std::make_optional(FromProto<std::vector<TString>>(request->columns().items()))
+            : std::nullopt;
+
+        auto resultIndex = request->result_index();
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("QueryId: %v, ResultIndex: %v, User: %v", queryId, resultIndex, user);
+        context->SetResponseInfo("QueryId: %v", queryId);
+
+        auto rowset = QueryTracker_->ReadQueryResult(queryId, resultIndex, options, user);
+
+        response->Attachments() = NRpcProxy::SerializeRowset(
+            *rowset->GetSchema(),
+            rowset->GetRows(),
+            response->mutable_rowset_descriptor());
+
+        context->Reply();
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, GetQuery)
+    {
+        TQueryId queryId;
+        FromProto(&queryId, request->query_id());
+
+        TGetQueryOptions options;
+        options.Attributes = request->has_attributes()
+            ? FromProto<TAttributeFilter>(request->attributes())
+            : TAttributeFilter();
+        options.Timestamp = request->has_timestamp()
+            ? request->timestamp()
+            : NTransactionClient::NullTimestamp;
+
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("QueryId: %v, User: %v", queryId, user);
+        context->SetResponseInfo("QueryId: %v", queryId);
+
+        auto query = QueryTracker_->GetQuery(queryId, options, user);
+        ToProto(response->mutable_query(), query);
+
+        context->Reply();
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, ListQueries)
+    {
+        TListQueriesOptions options;
+        options.FromTime = request->has_from_time()
+            ? std::make_optional(TInstant::FromValue(request->from_time()))
+            : std::nullopt;
+
+        options.ToTime = request->has_to_time()
+            ? std::make_optional(TInstant::FromValue(request->to_time()))
+            : std::nullopt;
+
+        options.CursorTime = request->has_cursor_time()
+            ? std::make_optional(TInstant::FromValue(request->cursor_time()))
+            : std::nullopt;
+
+        options.CursorDirection = FromProto<EOperationSortDirection>(request->cursor_direction());
+
+        options.UserFilter = request->has_user_filter()
+            ? std::make_optional(request->user_filter())
+            : std::nullopt;
+
+        options.StateFilter = request->has_state_filter()
+            ? std::make_optional(FromProto<EQueryState>(request->state_filter()))
+            : std::nullopt;
+
+        options.EngineFilter = request->has_engine_filter()
+            ? std::make_optional(FromProto<EQueryEngine>(request->engine_filter()))
+            : std::nullopt;
+
+        options.SubstrFilter = request->has_substr_filter()
+            ? std::make_optional(request->substr_filter())
+            : std::nullopt;
+
+        options.Limit = request->limit();
+
+        options.Attributes = request->has_attributes()
+            ? FromProto<TAttributeFilter>(request->attributes())
+            : TAttributeFilter();
+
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("User: %v", context->GetAuthenticationIdentity().User);
+
+        auto result = QueryTracker_->ListQueries(options, user);
+
+        for (const auto& query : result.Queries) {
+            ToProto(response->add_queries(), query);
+        }
+        response->set_incomplete(result.Incomplete);
+        response->set_timestamp(result.Timestamp);
+
+        context->Reply();
+    }
+
+    DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, AlterQuery)
+    {
+        TQueryId queryId;
+        FromProto(&queryId, request->query_id());
+
+        TAlterQueryOptions options;
+        options.Annotations = request->has_annotations()
+            ? ConvertToNode(TYsonStringBuf(request->annotations()))->AsMap()
+            : nullptr;
+
+        options.AccessControlObject = request->has_access_control_object()
+            ? std::make_optional(request->access_control_object())
+            : std::nullopt;
+
+        auto user = context->GetAuthenticationIdentity().User;
+
+        context->SetRequestInfo("QueryId: %v, User: %v", queryId, user);
+        context->SetResponseInfo("QueryId: %v", queryId);
+
+        QueryTracker_->AlterQuery(queryId, options, user);
+
+        context->Reply();
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+IServicePtr CreateProxyService(IInvokerPtr proxyInvoker, TQueryTrackerProxyPtr queryTracker)
+{
+    return New<TProxyService>(std::move(proxyInvoker), std::move(queryTracker));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NQueryTracker

--- a/yt/yt/server/query_tracker/proxy_service.cpp
+++ b/yt/yt/server/query_tracker/proxy_service.cpp
@@ -7,7 +7,6 @@
 #include <yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.pb.h>
 
 #include <yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h>
-#include <yt/yt/ytlib/query_tracker_client/helpers.h>
 
 #include <yt/yt/core/rpc/service_detail.h>
 
@@ -17,7 +16,10 @@ using namespace NApi;
 using namespace NConcurrency;
 using namespace NQueryTrackerClient;
 using namespace NRpc;
+using namespace NRpcProxy;
+using namespace NTransactionClient;
 using namespace NYTree;
+using namespace NYson;
 
 static const TYsonString EmptyMap = TYsonString(TString("{}"));
 
@@ -31,7 +33,7 @@ public:
         : TServiceBase(
             std::move(proxyInvoker),
             TQueryTrackerServiceProxy::GetDescriptor(),
-            QueryTrackerLogger)
+            QueryTrackerLogger())
         , QueryTracker_(std::move(queryTracker))
     {
         RegisterMethod(RPC_SERVICE_METHOD_DESC(StartQuery));
@@ -48,24 +50,37 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, StartQuery)
     {
+        YT_VERIFY(NRpcProxy::NProto::TReqStartQuery::GetDescriptor()->field_count() == 8);
+        YT_VERIFY(NRpcProxy::NProto::TRspStartQuery::GetDescriptor()->field_count() == 1);
+
+        auto rpcRequest = request->rpc_proxy_request();
+        auto* rpcResponse = response->mutable_rpc_proxy_response();
+
         auto queryId = TQueryId::Create();
-        ToProto(response->mutable_query_id(), queryId);
+        ToProto(rpcResponse->mutable_query_id(), queryId);
 
         TStartQueryOptions options;
-        if (request->has_settings()) {
-            options.Settings = ConvertToNode(TYsonStringBuf(request->settings()));
+        if (rpcRequest.has_settings()) {
+            options.Settings = ConvertToNode(TYsonStringBuf(rpcRequest.settings()));
         }
-        if (request->has_annotations()) {
-            options.Annotations = ConvertToNode(TYsonStringBuf(request->annotations()))->AsMap();
+        if (rpcRequest.has_annotations()) {
+            options.Annotations = ConvertToNode(TYsonStringBuf(rpcRequest.annotations()))->AsMap();
         }
-        if (request->has_access_control_object()) {
-            options.AccessControlObject = request->access_control_object();
+        if (rpcRequest.has_access_control_object()) {
+            options.AccessControlObject = rpcRequest.access_control_object();
         }
-        options.Draft = request->draft();
-        options.Files = ConvertTo<std::vector<TQueryFilePtr>>(TYsonStringBuf(request->files()));
+        options.Draft = rpcRequest.draft();
 
-        auto engine = static_cast<EQueryEngine>(request->engine());
-        auto query = request->query();
+        for (const auto& requestFile : rpcRequest.files()) {
+            auto file = New<TQueryFile>();
+            file->Name = requestFile.name();
+            file->Content = requestFile.content();
+            file->Type = FromProto<EContentType>(requestFile.type());
+            options.Files.emplace_back(file);
+        }
+
+        auto engine = ConvertQueryEngineFromProto(rpcRequest.engine());
+        auto query = rpcRequest.query();
         auto user = context->GetAuthenticationIdentity().User;
 
         context->SetRequestInfo("QueryId: %v, User: %v", queryId, user);
@@ -78,12 +93,17 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, AbortQuery)
     {
+        YT_VERIFY(NRpcProxy::NProto::TReqAbortQuery::GetDescriptor()->field_count() == 3);
+        YT_VERIFY(NRpcProxy::NProto::TRspAbortQuery::GetDescriptor()->field_count() == 0);
+
+        auto rpcRequest = request->rpc_proxy_request();
+
         TQueryId queryId;
-        FromProto(&queryId, request->query_id());
+        FromProto(&queryId, rpcRequest.query_id());
 
         TAbortQueryOptions options;
-        options.AbortMessage = request->has_abort_message()
-            ? std::make_optional(request->abort_message())
+        options.AbortMessage = rpcRequest.has_abort_message()
+            ? std::make_optional(rpcRequest.abort_message())
             : std::nullopt;
 
         auto user = context->GetAuthenticationIdentity().User;
@@ -98,10 +118,16 @@ private:
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, GetQueryResult)
     {
-        TQueryId queryId;
-        FromProto(&queryId, request->query_id());
+        YT_VERIFY(NRpcProxy::NProto::TReqGetQueryResult::GetDescriptor()->field_count() == 3);
+        YT_VERIFY(NRpcProxy::NProto::TRspGetQueryResult::GetDescriptor()->field_count() == 6);
 
-        auto resultIndex = request->result_index();
+        auto rpcRequest = request->rpc_proxy_request();
+        auto* rpcResponse = response->mutable_rpc_proxy_response();
+
+        TQueryId queryId;
+        FromProto(&queryId, rpcRequest.query_id());
+
+        auto resultIndex = rpcRequest.result_index();
         auto user = context->GetAuthenticationIdentity().User;
 
         context->SetRequestInfo("QueryId: %v, ResultIndex: %v, User: %v", queryId, resultIndex, user);
@@ -109,35 +135,41 @@ private:
 
         auto queryResult = QueryTracker_->GetQueryResult(queryId, resultIndex, user);
 
-        ToProto(response->mutable_query_id(), queryResult.Id);
-        response->set_result_index(queryResult.ResultIndex);
+        ToProto(rpcResponse->mutable_query_id(), queryResult.Id);
+        rpcResponse->set_result_index(queryResult.ResultIndex);
         if (queryResult.Schema) {
-            ToProto(response->mutable_schema(), queryResult.Schema);
+            ToProto(rpcResponse->mutable_schema(), queryResult.Schema);
         }
-        ToProto(response->mutable_error(), queryResult.Error);
-        response->set_is_truncated(queryResult.IsTruncated);
-        ToProto(response->mutable_data_statistics(), queryResult.DataStatistics);
+        ToProto(rpcResponse->mutable_error(), queryResult.Error);
+        rpcResponse->set_is_truncated(queryResult.IsTruncated);
+        ToProto(rpcResponse->mutable_data_statistics(), queryResult.DataStatistics);
 
         context->Reply();
     }
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, ReadQueryResult)
     {
+        YT_VERIFY(NRpcProxy::NProto::TReqReadQueryResult::GetDescriptor()->field_count() == 6);
+        YT_VERIFY(NRpcProxy::NProto::TRspReadQueryResult::GetDescriptor()->field_count() == 1);
+
+        auto rpcRequest = request->rpc_proxy_request();
+        auto* rpcResponse = response->mutable_rpc_proxy_response();
+
         TQueryId queryId;
-        FromProto(&queryId, request->query_id());
+        FromProto(&queryId, rpcRequest.query_id());
 
         TReadQueryResultOptions options;
-        options.LowerRowIndex = request->has_lower_row_index()
-            ? std::make_optional(request->lower_row_index())
+        options.LowerRowIndex = rpcRequest.has_lower_row_index()
+            ? std::make_optional(rpcRequest.lower_row_index())
             : std::nullopt;
-        options.UpperRowIndex = request->has_upper_row_index()
-            ? std::make_optional(request->upper_row_index())
+        options.UpperRowIndex = rpcRequest.has_upper_row_index()
+            ? std::make_optional(rpcRequest.upper_row_index())
             : std::nullopt;
-        options.Columns = request->has_columns()
-            ? std::make_optional(FromProto<std::vector<TString>>(request->columns().items()))
+        options.Columns = rpcRequest.has_columns()
+            ? std::make_optional(FromProto<std::vector<TString>>(rpcRequest.columns().items()))
             : std::nullopt;
 
-        auto resultIndex = request->result_index();
+        auto resultIndex = rpcRequest.result_index();
         auto user = context->GetAuthenticationIdentity().User;
 
         context->SetRequestInfo("QueryId: %v, ResultIndex: %v, User: %v", queryId, resultIndex, user);
@@ -145,26 +177,32 @@ private:
 
         auto rowset = QueryTracker_->ReadQueryResult(queryId, resultIndex, options, user);
 
-        response->Attachments() = NRpcProxy::SerializeRowset(
+        response->Attachments() = SerializeRowset(
             *rowset->GetSchema(),
             rowset->GetRows(),
-            response->mutable_rowset_descriptor());
+            rpcResponse->mutable_rowset_descriptor());
 
         context->Reply();
     }
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, GetQuery)
     {
+        YT_VERIFY(NRpcProxy::NProto::TReqGetQuery::GetDescriptor()->field_count() == 4);
+        YT_VERIFY(NRpcProxy::NProto::TRspGetQuery::GetDescriptor()->field_count() == 1);
+
+        auto rpcRequest = request->rpc_proxy_request();
+        auto* rpcResponse = response->mutable_rpc_proxy_response();
+
         TQueryId queryId;
-        FromProto(&queryId, request->query_id());
+        FromProto(&queryId, rpcRequest.query_id());
 
         TGetQueryOptions options;
-        options.Attributes = request->has_attributes()
-            ? FromProto<TAttributeFilter>(request->attributes())
+        options.Attributes = rpcRequest.has_attributes()
+            ? FromProto<TAttributeFilter>(rpcRequest.attributes())
             : TAttributeFilter();
-        options.Timestamp = request->has_timestamp()
-            ? request->timestamp()
-            : NTransactionClient::NullTimestamp;
+        options.Timestamp = rpcRequest.has_timestamp()
+            ? rpcRequest.timestamp()
+            : NullTimestamp;
 
         auto user = context->GetAuthenticationIdentity().User;
 
@@ -172,48 +210,54 @@ private:
         context->SetResponseInfo("QueryId: %v", queryId);
 
         auto query = QueryTracker_->GetQuery(queryId, options, user);
-        ToProto(response->mutable_query(), query);
+        ToProto(rpcResponse->mutable_query(), query);
 
         context->Reply();
     }
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, ListQueries)
     {
+        YT_VERIFY(NRpcProxy::NProto::TReqListQueries::GetDescriptor()->field_count() == 11);
+        YT_VERIFY(NRpcProxy::NProto::TRspListQueries::GetDescriptor()->field_count() == 3);
+
+        auto rpcRequest = request->rpc_proxy_request();
+        auto* rpcResponse = response->mutable_rpc_proxy_response();
+
         TListQueriesOptions options;
-        options.FromTime = request->has_from_time()
-            ? std::make_optional(TInstant::FromValue(request->from_time()))
+        options.FromTime = rpcRequest.has_from_time()
+            ? std::make_optional(TInstant::FromValue(rpcRequest.from_time()))
             : std::nullopt;
 
-        options.ToTime = request->has_to_time()
-            ? std::make_optional(TInstant::FromValue(request->to_time()))
+        options.ToTime = rpcRequest.has_to_time()
+            ? std::make_optional(TInstant::FromValue(rpcRequest.to_time()))
             : std::nullopt;
 
-        options.CursorTime = request->has_cursor_time()
-            ? std::make_optional(TInstant::FromValue(request->cursor_time()))
+        options.CursorTime = rpcRequest.has_cursor_time()
+            ? std::make_optional(TInstant::FromValue(rpcRequest.cursor_time()))
             : std::nullopt;
 
-        options.CursorDirection = FromProto<EOperationSortDirection>(request->cursor_direction());
+        options.CursorDirection = FromProto<EOperationSortDirection>(rpcRequest.cursor_direction());
 
-        options.UserFilter = request->has_user_filter()
-            ? std::make_optional(request->user_filter())
+        options.UserFilter = rpcRequest.has_user_filter()
+            ? std::make_optional(rpcRequest.user_filter())
             : std::nullopt;
 
-        options.StateFilter = request->has_state_filter()
-            ? std::make_optional(FromProto<EQueryState>(request->state_filter()))
+        options.StateFilter = rpcRequest.has_state_filter()
+            ? std::make_optional(FromProto<EQueryState>(rpcRequest.state_filter()))
             : std::nullopt;
 
-        options.EngineFilter = request->has_engine_filter()
-            ? std::make_optional(FromProto<EQueryEngine>(request->engine_filter()))
+        options.EngineFilter = rpcRequest.has_engine_filter()
+            ? std::make_optional(ConvertQueryEngineFromProto(rpcRequest.engine_filter()))
             : std::nullopt;
 
-        options.SubstrFilter = request->has_substr_filter()
-            ? std::make_optional(request->substr_filter())
+        options.SubstrFilter = rpcRequest.has_substr_filter()
+            ? std::make_optional(rpcRequest.substr_filter())
             : std::nullopt;
 
-        options.Limit = request->limit();
+        options.Limit = rpcRequest.limit();
 
-        options.Attributes = request->has_attributes()
-            ? FromProto<TAttributeFilter>(request->attributes())
+        options.Attributes = rpcRequest.has_attributes()
+            ? FromProto<TAttributeFilter>(rpcRequest.attributes())
             : TAttributeFilter();
 
         auto user = context->GetAuthenticationIdentity().User;
@@ -223,26 +267,31 @@ private:
         auto result = QueryTracker_->ListQueries(options, user);
 
         for (const auto& query : result.Queries) {
-            ToProto(response->add_queries(), query);
+            ToProto(rpcResponse->add_queries(), query);
         }
-        response->set_incomplete(result.Incomplete);
-        response->set_timestamp(result.Timestamp);
+        rpcResponse->set_incomplete(result.Incomplete);
+        rpcResponse->set_timestamp(result.Timestamp);
 
         context->Reply();
     }
 
     DECLARE_RPC_SERVICE_METHOD(NQueryTrackerClient::NProto, AlterQuery)
     {
+        YT_VERIFY(NRpcProxy::NProto::TReqAlterQuery::GetDescriptor()->field_count() == 4);
+        YT_VERIFY(NRpcProxy::NProto::TRspAlterQuery::GetDescriptor()->field_count() == 0);
+
+        auto rpcRequest = request->rpc_proxy_request();
+
         TQueryId queryId;
-        FromProto(&queryId, request->query_id());
+        FromProto(&queryId, rpcRequest.query_id());
 
         TAlterQueryOptions options;
-        options.Annotations = request->has_annotations()
-            ? ConvertToNode(TYsonStringBuf(request->annotations()))->AsMap()
+        options.Annotations = rpcRequest.has_annotations()
+            ? ConvertToNode(TYsonStringBuf(rpcRequest.annotations()))->AsMap()
             : nullptr;
 
-        options.AccessControlObject = request->has_access_control_object()
-            ? std::make_optional(request->access_control_object())
+        options.AccessControlObject = rpcRequest.has_access_control_object()
+            ? std::make_optional(rpcRequest.access_control_object())
             : std::nullopt;
 
         auto user = context->GetAuthenticationIdentity().User;

--- a/yt/yt/server/query_tracker/proxy_service.h
+++ b/yt/yt/server/query_tracker/proxy_service.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "private.h"
+
+#include <yt/yt/core/rpc/public.h>
+
+namespace NYT::NQueryTracker {
+
+////////////////////////////////////////////////////////////////////////////////
+
+NRpc::IServicePtr CreateProxyService(IInvokerPtr proxyInvoker, TQueryTrackerProxyPtr proxy);
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NQueryTracker

--- a/yt/yt/server/query_tracker/query_tracker_proxy.cpp
+++ b/yt/yt/server/query_tracker/query_tracker_proxy.cpp
@@ -1123,6 +1123,7 @@ TGetQueryTrackerInfoResult TQueryTrackerProxy::GetQueryTrackerInfo(
     static const TYsonString EmptyMap = TYsonString(TString("{}"));
     TYsonString supportedFeatures = EmptyMap;
     if (attributes.AdmitsKeySlow("supported_features")) {
+        // These features are guaranteed to be deployed before or with this code.
         supportedFeatures = BuildYsonStringFluently()
             .BeginMap()
                 .Item("access_control").Value(true)

--- a/yt/yt/server/query_tracker/query_tracker_proxy.cpp
+++ b/yt/yt/server/query_tracker/query_tracker_proxy.cpp
@@ -1,0 +1,1088 @@
+#include "query_tracker_proxy.h"
+
+#include <yt/yt/client/api/transaction.h>
+
+#include <yt/yt/client/chunk_client/data_statistics.h>
+
+#include <yt/yt/client/query_client/query_builder.h>
+
+#include <yt/yt/client/table_client/record_helpers.h>
+#include <yt/yt/client/table_client/wire_protocol.h>
+
+#include <yt/yt/client/transaction_client/timestamp_provider.h>
+
+#include <yt/yt/ytlib/api/native/client.h>
+
+#include <yt/yt/ytlib/query_tracker_client/records/query.record.h>
+#include <yt/yt/ytlib/query_tracker_client/helpers.h>
+
+#include <yt/yt/core/logging/log.h>
+
+#include <yt/yt/core/ytree/convert.h>
+
+#include <library/cpp/iterator/functools.h>
+
+#include <contrib/libs/pfr/include/pfr/tuple_size.hpp>
+
+namespace NYT::NQueryTracker {
+
+using namespace NApi;
+using namespace NChunkClient::NProto;
+using namespace NConcurrency;
+using namespace NLogging;
+using namespace NQueryTrackerClient;
+using namespace NQueryTrackerClient::NRecords;
+using namespace NTableClient;
+using namespace NTransactionClient;
+using namespace NYPath;
+using namespace NYTree;
+using namespace NYson;
+
+///////////////////////////////////////////////////////////////////////////////
+
+static TLogger Logger("QueryTrackerProxy");
+
+namespace NDetail {
+
+// Applies when a query doesn't have an access control object.
+constexpr TStringBuf DefaultAccessControlObject = "nobody";
+
+// Path to access control object namespace for QT.
+constexpr TStringBuf QueriesAcoNamespacePath = "//sys/access_control_object_namespaces/queries";
+
+TQuery PartialRecordToQuery(const auto& partialRecord)
+{
+    static_assert(pfr::tuple_size<TQuery>::value == 15);
+    static_assert(TActiveQueryDescriptor::FieldCount == 19);
+    static_assert(TFinishedQueryDescriptor::FieldCount == 14);
+
+    TQuery query;
+    // Note that some of the fields are twice optional.
+    // First time due to the fact that they are optional in the record,
+    // and second time due to the extra optionality of any field in the partial record.
+    // TODO(max42): coalesce the optionality of the fields in the partial record.
+    query.Id = partialRecord.Key.QueryId;
+    query.Engine = partialRecord.Engine;
+    query.Query = partialRecord.Query;
+    query.Files = partialRecord.Files.value_or(std::nullopt);
+    query.StartTime = partialRecord.StartTime;
+    query.FinishTime = partialRecord.FinishTime.value_or(std::nullopt);
+    query.Settings = partialRecord.Settings.value_or(TYsonString());
+    query.User = partialRecord.User;
+    query.AccessControlObject = partialRecord.AccessControlObject.value_or(std::nullopt);
+    query.State = partialRecord.State;
+    query.ResultCount = partialRecord.ResultCount.value_or(std::nullopt);
+    query.Progress = partialRecord.Progress.value_or(TYsonString());
+    query.Error = partialRecord.Error.value_or(std::nullopt);
+    query.Annotations = partialRecord.Annotations.value_or(TYsonString());
+
+    IAttributeDictionaryPtr otherAttributes;
+    auto fillIfPresent = [&] (const TString& key, const auto& value) {
+        if (value) {
+            if (!otherAttributes) {
+                otherAttributes = CreateEphemeralAttributes();
+            }
+            otherAttributes->Set(key, *value);
+        }
+    };
+
+    if constexpr (std::is_same_v<std::decay_t<decltype(partialRecord)>, TActiveQueryPartial>) {
+        fillIfPresent("abort_request", partialRecord.AbortRequest.value_or(std::nullopt));
+        fillIfPresent("incarnation", partialRecord.Incarnation);
+        fillIfPresent("lease_transaction_id", partialRecord.LeaseTransactionId);
+        fillIfPresent("assigned_tracker", partialRecord.AssignedTracker);
+    }
+
+    query.OtherAttributes = std::move(otherAttributes);
+
+    return query;
+}
+
+//! Lookup one of query tracker state tables by query id.
+template <class TRecordDescriptor>
+TFuture<typename TRecordDescriptor::TRecordPartial> LookupQueryTrackerRecord(
+    TQueryId queryId,
+    const IClientPtr& client,
+    const TString& tablePath,
+    const TString& tableKind,
+    const std::optional<std::vector<TString>>& lookupKeys,
+    NTransactionClient::TTimestamp timestamp)
+{
+    auto rowBuffer = New<TRowBuffer>();
+    const auto& nameTable = TRecordDescriptor::Get()->GetNameTable();
+
+    TLookupRowsOptions lookupOptions;
+    if (lookupKeys) {
+        std::vector<int> columnIds;
+        for (const auto& key : *lookupKeys) {
+            if (auto columnId = nameTable->FindId(key)) {
+                columnIds.push_back(*columnId);
+            }
+        }
+        lookupOptions.ColumnFilter = TColumnFilter(columnIds);
+    }
+    lookupOptions.Timestamp = timestamp;
+    lookupOptions.KeepMissingRows = true;
+    std::vector keys{
+        TActiveQueryKey{.QueryId = queryId}.ToKey(rowBuffer),
+    };
+    auto asyncLookupResult = client->LookupRows(
+        tablePath,
+        TRecordDescriptor::Get()->GetNameTable(),
+        MakeSharedRange(std::move(keys), rowBuffer),
+        lookupOptions);
+    auto asyncRecord = asyncLookupResult.Apply(BIND([=] (const TUnversionedLookupRowsResult& result) {
+        auto optionalRecords = ToOptionalRecords<typename TRecordDescriptor::TRecordPartial>(result.Rowset);
+        YT_VERIFY(optionalRecords.size() == 1);
+        if (!optionalRecords[0]) {
+            THROW_ERROR_EXCEPTION("Query %v is not found in %Qv query table", queryId, tableKind);
+        }
+        return *optionalRecords[0];
+    }));
+    return asyncRecord;
+};
+
+THashSet<TString> GetUserSubjects(const TString& user, const IClientPtr& client)
+{
+    // Get all subjects for the user.
+    TGetNodeOptions options;
+    options.ReadFrom = EMasterChannelKind::Cache;
+    auto userSubjectsOrError = WaitFor(client->GetNode("//sys/users/" + user + "/@member_of_closure", options));
+    if (!userSubjectsOrError.IsOK()) {
+        THROW_ERROR_EXCEPTION("Error while fetching user membership for the user %Qv", user)
+            << userSubjectsOrError;
+    }
+    auto userSubjects = ConvertTo<THashSet<TString>>(userSubjectsOrError.Value());
+    return userSubjects;
+}
+
+NSecurityClient::ESecurityAction CheckAccessControl(
+    const TString& user,
+    const std::optional<TString>& accessControlObject,
+    const TString& queryAuthor,
+    const IClientPtr& client,
+    EPermission permission,
+    const NLogging::TLogger& logger)
+{
+    auto& Logger = logger;
+    if (user == queryAuthor) {
+        return NSecurityClient::ESecurityAction::Allow;
+    }
+    auto actualAccessControlObject = accessControlObject.value_or(TString(DefaultAccessControlObject));
+    auto aclOrError = WaitFor(client->GetNode(Format(
+        "%v/%v/@principal_acl",
+        QueriesAcoNamespacePath,
+        NYPath::ToYPathLiteral(actualAccessControlObject))));
+    if (!aclOrError.IsOK()) {
+        YT_LOG_WARNING(aclOrError,
+            "Error while fetching access control object queries/%v",
+            actualAccessControlObject);
+        auto userSubjects = GetUserSubjects(user, client);
+        if (userSubjects.contains(NSecurityClient::SuperusersGroupName)) {
+            return NSecurityClient::ESecurityAction::Allow;
+        }
+        THROW_ERROR_EXCEPTION(
+            "Error while fetching access control object queries/%v. "
+            "Please make sure it exists",
+            actualAccessControlObject)
+            << aclOrError;
+    }
+    return WaitFor(client->CheckPermissionByAcl(user, permission, ConvertToNode(aclOrError.Value())))
+        .ValueOrThrow()
+        .Action;
+}
+
+void ThrowAccessDeniedException(
+    TQueryId queryId,
+    EPermission permission,
+    const TString& user,
+    const std::optional<TString>& accessControlObject,
+    const TString& queryAuthor)
+{
+    THROW_ERROR_EXCEPTION(NSecurityClient::EErrorCode::AuthorizationError,
+        "Access denied to query %v due to missing %Qv permission",
+        queryId,
+        permission)
+        << TErrorAttribute("user", user)
+        << TErrorAttribute("access_control_object", accessControlObject)
+        << TErrorAttribute("query_author", queryAuthor);
+}
+
+//! Lookup a query in active_queries and finished_queries tables by query id.
+TQuery LookupQuery(
+    TQueryId queryId,
+    const IClientPtr& client,
+    const TString& root,
+    const std::optional<std::vector<TString>>& lookupKeys,
+    NTransactionClient::TTimestamp timestamp,
+    const NLogging::TLogger& logger)
+{
+    auto asyncActiveRecord = LookupQueryTrackerRecord<TActiveQueryDescriptor>(
+        queryId,
+        client,
+        root + "/active_queries",
+        "active",
+        lookupKeys,
+        timestamp);
+    auto asyncFinishedRecord = LookupQueryTrackerRecord<TFinishedQueryDescriptor>(
+        queryId,
+        client,
+        root + "/finished_queries",
+        "finished",
+        lookupKeys,
+        timestamp);
+
+    auto error = WaitFor(AnySucceeded(std::vector{asyncActiveRecord.AsVoid(), asyncFinishedRecord.AsVoid()}));
+    if (!error.IsOK()) {
+        THROW_ERROR_EXCEPTION(NQueryTrackerClient::EErrorCode::QueryNotFound,
+            "Query %v is not found neither in active nor in finished query tables",
+            queryId)
+            << error;
+    }
+    bool isActive = asyncActiveRecord.IsSet() && asyncActiveRecord.Get().IsOK();
+    bool isFinished = asyncFinishedRecord.IsSet() && asyncFinishedRecord.Get().IsOK();
+    YT_VERIFY(isActive || isFinished);
+    if (isActive && isFinished) {
+        const auto& Logger = logger;
+        YT_LOG_ALERT(
+            "Query is found in both active and finished query tables "
+            "(QueryId: %v, Timestamp: %v)",
+            queryId,
+            timestamp);
+    }
+    if (isActive) {
+        return PartialRecordToQuery(asyncActiveRecord.Get().Value());
+    } else {
+        return PartialRecordToQuery(asyncFinishedRecord.Get().Value());
+    }
+}
+
+void ValidateQueryPermissions(
+    TQueryId queryId,
+    const TString& root,
+    NTransactionClient::TTimestamp timestamp,
+    const TString& user,
+    const IClientPtr& client,
+    EPermission permission,
+    const NLogging::TLogger& logger)
+{
+    std::vector<TString> lookupKeys = {"user", "access_control_object"};
+    auto query = LookupQuery(queryId, client, root, lookupKeys, timestamp, logger);
+    if (CheckAccessControl(user, query.AccessControlObject, *query.User, client, permission, logger) == NSecurityClient::ESecurityAction::Deny) {
+        ThrowAccessDeniedException(queryId, permission, user, query.AccessControlObject, *query.User);
+    }
+}
+
+std::vector<TString> GetAcosForSubjects(const THashSet<TString>& subjects, const IClientPtr& client)
+{
+    // Get all access control objects.
+    TGetNodeOptions options;
+    options.Attributes = {
+        "principal_acl",
+    };
+    options.ReadFrom = EMasterChannelKind::Cache;
+
+    auto allAcosOrError = WaitFor(client->GetNode(TString(QueriesAcoNamespacePath), options));
+
+    if (!allAcosOrError.IsOK()) {
+        THROW_ERROR_EXCEPTION(
+            "Error while fetching all access control objects in the namespace \"queries\". "
+            "Please make sure that the namespace exists")
+            << allAcosOrError;
+    }
+
+    auto allAcos = ConvertToNode(allAcosOrError.Value())->AsMap()->GetChildren();
+
+    std::vector<TString> acosForUser;
+    // We expect average user to have access to a small number of access control objects.
+    acosForUser.reserve(10);
+
+    for (const auto& aco : allAcos) {
+        auto acoName = aco.first;
+        auto aclRules = ConvertToNode(aco.second->Attributes().GetYson("principal_acl"))->AsList()->GetChildren();
+        bool allowUseRuleFound = false;
+        bool denyUseRuleFound = false;
+        // Check if there are allow or deny "Use" rules matching the subjects.
+        for (const auto& aclRule : aclRules) {
+            auto aclSubjects = aclRule->AsMap()->GetChildOrThrow("subjects")->AsList()->GetChildren();
+            auto aclPermissions = aclRule->AsMap()->GetChildOrThrow("permissions")->AsList()->GetChildren();
+            bool usePermissionFound = false;
+            for (const auto& aclPermission : aclPermissions) {
+                auto aclPermissionName = aclPermission->GetValue<TString>();
+                aclPermissionName.to_lower();
+                if (aclPermissionName == "use") {
+                    usePermissionFound = true;
+                    break;
+                }
+            }
+            if (!usePermissionFound) {
+                continue;
+            }
+            for (const auto& aclSubject : aclSubjects) {
+                auto aclSubjectName = aclSubject->GetValue<TString>();
+                if (subjects.find(aclSubjectName) != subjects.end()) {
+                    auto aclAction = aclRule->AsMap()->GetChildOrThrow("action")->GetValue<TString>();
+                    aclAction.to_lower();
+                    if (aclAction == "allow") {
+                        allowUseRuleFound = true;
+                    } else if (aclAction == "deny") {
+                        denyUseRuleFound = true;
+                    }
+                }
+            }
+        }
+        if (allowUseRuleFound && !denyUseRuleFound) {
+            acosForUser.emplace_back(acoName);
+        }
+    }
+    return acosForUser;
+}
+
+void VerifyAccessControlObjectExists(const TString& accessControlObject, const IClientPtr& client)
+{
+    auto error = WaitFor(client->NodeExists(Format(
+        "%v/%v",
+        QueriesAcoNamespacePath,
+        NYPath::ToYPathLiteral(accessControlObject))));
+
+    if (!error.IsOK()) {
+        THROW_ERROR_EXCEPTION("Failed to check whether access control object %Qv exists", accessControlObject)
+            << error;
+    }
+    if (!error.Value()) {
+        THROW_ERROR_EXCEPTION(NYTree::EErrorCode::ResolveError,
+            "Access control object %Qv does not exist",
+            accessControlObject);
+    }
+}
+
+IUnversionedRowsetPtr FilterRowsetColumns(IUnversionedRowsetPtr rowset, std::vector<TString> columns)
+{
+    const auto& schema = rowset->GetSchema();
+    const auto& rows = rowset->GetRows();
+    auto rowBuffer = New<TRowBuffer>();
+    auto nameTable = TNameTable::FromSchema(*schema);
+    std::vector<int> columnIndexes;
+    THashSet<int> columnIndexSet;
+    for (const auto& column : columns) {
+        if (auto id = nameTable->FindId(column); id && columnIndexSet.insert(*id).second) {
+            columnIndexes.push_back(*id);
+        }
+    }
+    TColumnFilter columnFilter(columnIndexes);
+
+    std::vector<TUnversionedRow> newRows;
+    newRows.reserve(rows.size());
+    for (const auto& row : rows) {
+        auto newRow = rowBuffer->AllocateUnversioned(columnIndexes.size());
+        for (auto [newIndex, index] : Enumerate(columnIndexes)) {
+            auto value = row[index];
+            value.Id = newIndex;
+            newRow[newIndex] = rowBuffer->CaptureValue(value);
+        }
+        newRows.emplace_back(newRow);
+    }
+
+    auto newSchema = schema->Filter(columnFilter);
+
+    return CreateRowset(newSchema, MakeSharedRange(std::move(newRows), std::move(rowBuffer)));
+}
+
+std::vector<TQuery> PartialRecordsToQueries(const auto& partialRecords)
+{
+    std::vector<TQuery> queries;
+    queries.reserve(partialRecords.size());
+    for (const auto& partialRecord : partialRecords) {
+        queries.push_back(PartialRecordToQuery(partialRecord));
+    }
+    return queries;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NDetail
+
+using namespace NDetail;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TQueryTrackerProxy::TQueryTrackerProxy(
+    NApi::NNative::IClientPtr stateClient,
+    TYPath stateRoot
+)
+    : StateClient_(std::move(stateClient))
+    , StateRoot_(std::move(stateRoot))
+{ }
+
+void TQueryTrackerProxy::StartQuery(
+        const TQueryId queryId,
+        const EQueryEngine engine,
+        const TString& query,
+        const TStartQueryOptions& options,
+        const TString& user)
+{
+    static const TYsonString EmptyMap = TYsonString(TString("{}"));
+
+    YT_LOG_DEBUG("Starting query (QueryId: %v, Draft: %v)", queryId, options.Draft);
+
+    auto rowBuffer = New<TRowBuffer>();
+    auto transaction = WaitFor(StateClient_->StartTransaction(ETransactionType::Tablet, {}))
+        .ValueOrThrow();
+
+    if (options.AccessControlObject) {
+        VerifyAccessControlObjectExists(*options.AccessControlObject, StateClient_);
+    }
+
+    // Draft queries go directly to finished query tables (regular and ordered by start time),
+    // non-draft queries go to the active query table.
+
+    if (options.Draft) {
+        TString filterFactors;
+        auto startTime = TInstant::Now();
+        {
+            static_assert(TFinishedQueryDescriptor::FieldCount == 14);
+            TFinishedQuery newRecord{
+                .Key = {.QueryId = queryId},
+                .Engine = engine,
+                .Query = query,
+                .Files = ConvertToYsonString(options.Files),
+                .Settings = options.Settings ? ConvertToYsonString(options.Settings) : EmptyMap,
+                .User = user,
+                .AccessControlObject = options.AccessControlObject,
+                .StartTime = startTime,
+                .State = EQueryState::Draft,
+                .Progress = EmptyMap,
+                .Annotations = options.Annotations ? ConvertToYsonString(options.Annotations) : EmptyMap,
+            };
+            filterFactors = GetFilterFactors(newRecord);
+            std::vector rows{
+                newRecord.ToUnversionedRow(rowBuffer, TFinishedQueryDescriptor::Get()->GetIdMapping()),
+            };
+            transaction->WriteRows(
+                StateRoot_ + "/finished_queries",
+                TFinishedQueryDescriptor::Get()->GetNameTable(),
+                MakeSharedRange(std::move(rows), rowBuffer));
+        }
+        {
+            TFinishedQueryByStartTime newRecord{
+                .Key = {.StartTime = startTime, .QueryId = queryId},
+                .Engine = engine,
+                .User = user,
+                .AccessControlObject = options.AccessControlObject,
+                .State = EQueryState::Draft,
+                .FilterFactors = filterFactors,
+            };
+            std::vector rows{
+                newRecord.ToUnversionedRow(rowBuffer, TFinishedQueryByStartTimeDescriptor::Get()->GetIdMapping()),
+            };
+            transaction->WriteRows(
+                StateRoot_ + "/finished_queries_by_start_time",
+                TFinishedQueryByStartTimeDescriptor::Get()->GetNameTable(),
+                MakeSharedRange(std::move(rows), rowBuffer));
+        }
+    } else {
+        static_assert(TActiveQueryDescriptor::FieldCount == 19);
+        TActiveQueryPartial newRecord{
+            .Key = {.QueryId = queryId},
+            .Engine = engine,
+            .Query = query,
+            .Files = ConvertToYsonString(options.Files),
+            .Settings = options.Settings ? ConvertToYsonString(options.Settings) : EmptyMap,
+            .User = user,
+            .AccessControlObject = options.AccessControlObject,
+            .StartTime = TInstant::Now(),
+            .State = EQueryState::Pending,
+            .Incarnation = -1,
+            .Progress = EmptyMap,
+            .Annotations = options.Annotations ? ConvertToYsonString(options.Annotations) : EmptyMap,
+        };
+        newRecord.FilterFactors = GetFilterFactors(newRecord);
+        std::vector rows{
+            newRecord.ToUnversionedRow(rowBuffer, TActiveQueryDescriptor::Get()->GetIdMapping()),
+        };
+        transaction->WriteRows(
+            StateRoot_ + "/active_queries",
+            TActiveQueryDescriptor::Get()->GetNameTable(),
+            MakeSharedRange(std::move(rows), rowBuffer));
+    }
+    WaitFor(transaction->Commit())
+        .ThrowOnError();
+}
+
+void TQueryTrackerProxy::AbortQuery(
+    const TQueryId queryId,
+    const TAbortQueryOptions& options,
+    const TString& user)
+{
+    auto abortError = TError(
+        "Query was aborted by user %Qv%v",
+        user,
+        options.AbortMessage ? Format(" with message %Qv", *options.AbortMessage) : TString());
+
+    TActiveQueryPartial newRecord{
+        .Key = {.QueryId = queryId},
+        .State = EQueryState::Aborting,
+        .FinishTime = TInstant::Now(),
+        .AbortRequest = ConvertToYsonString(abortError),
+    };
+    auto rowBuffer = New<TRowBuffer>();
+    std::vector rows{
+        newRecord.ToUnversionedRow(rowBuffer, TActiveQueryDescriptor::Get()->GetIdMapping()),
+    };
+    auto transaction = WaitFor(StateClient_->StartTransaction(ETransactionType::Tablet, {}))
+        .ValueOrThrow();
+
+    ValidateQueryPermissions(queryId, StateRoot_, transaction->GetStartTimestamp(), user, StateClient_, EPermission::Administer, Logger);
+
+    YT_LOG_DEBUG("Aborting query (QueryId: %v, AbortMessage: %v)", queryId, options.AbortMessage);
+
+    {
+        const auto& idMapping = TActiveQueryDescriptor::Get()->GetIdMapping();
+        TLookupRowsOptions options;
+        options.Timestamp = transaction->GetStartTimestamp();
+        options.ColumnFilter = {*idMapping.State};
+        options.KeepMissingRows = true;
+        TActiveQueryKey key{.QueryId = queryId};
+        std::vector keys{
+            key.ToKey(rowBuffer),
+        };
+        auto asyncLookupResult = StateClient_->LookupRows(
+            StateRoot_ + "/active_queries",
+            TActiveQueryDescriptor::Get()->GetNameTable(),
+            MakeSharedRange(std::move(keys), rowBuffer),
+            options);
+        auto rowset = WaitFor(asyncLookupResult)
+            .ValueOrThrow()
+            .Rowset;
+        auto optionalRecords = ToOptionalRecords<TActiveQuery>(rowset);
+        YT_VERIFY(optionalRecords.size() == 1);
+        if (!optionalRecords[0]) {
+            THROW_ERROR_EXCEPTION(
+                NQueryTrackerClient::EErrorCode::QueryNotFound,
+                "Query %v not found or is not running",
+                queryId);
+        }
+        const auto& record = *optionalRecords[0];
+        if (record.State != EQueryState::Pending && record.State != EQueryState::Running) {
+            THROW_ERROR_EXCEPTION("Cannot abort query %v which is in state %Qlv",
+                queryId,
+                record.State);
+        }
+    }
+
+    transaction->WriteRows(
+        StateRoot_ + "/active_queries",
+        TActiveQueryDescriptor::Get()->GetNameTable(),
+        MakeSharedRange(std::move(rows), std::move(rowBuffer)));
+
+    auto error = WaitFor(transaction->Commit());
+    if (!error.IsOK()) {
+        if (error.FindMatching(NTabletClient::EErrorCode::TransactionLockConflict)) {
+            // TODO(max42): retry such errors automatically?
+            THROW_ERROR_EXCEPTION("Cannot abort query because its state is being changed at the moment; please try again")
+                << error;
+        }
+        THROW_ERROR error;
+    }
+}
+
+TQueryResult TQueryTrackerProxy::GetQueryResult(
+    const TQueryId queryId,
+    const i64 resultIndex,
+    const TString& user)
+{
+    auto timestamp = WaitFor(StateClient_->GetTimestampProvider()->GenerateTimestamps())
+        .ValueOrThrow();
+
+    YT_LOG_DEBUG("Getting query result (QueryId: %v, ResultIndex: %v)", queryId, resultIndex);
+
+    TQueryResult queryResult;
+    {
+        auto rowBuffer = New<TRowBuffer>();
+        TLookupRowsOptions options;
+        options.KeepMissingRows = true;
+
+        ValidateQueryPermissions(queryId, StateRoot_, timestamp, user, StateClient_, EPermission::Read, Logger);
+
+        TFinishedQueryResultKey key{.QueryId = queryId, .Index = resultIndex};
+        std::vector keys{
+            key.ToKey(rowBuffer),
+        };
+        auto asyncLookupResult = StateClient_->LookupRows(
+            StateRoot_ + "/finished_query_results",
+            TFinishedQueryResultDescriptor::Get()->GetNameTable(),
+            MakeSharedRange(std::move(keys), rowBuffer),
+            options);
+        auto rowset = WaitFor(asyncLookupResult)
+            .ValueOrThrow()
+            .Rowset;
+        auto optionalRecords = ToOptionalRecords<TFinishedQueryResult>(rowset);
+        YT_VERIFY(optionalRecords.size() == 1);
+        if (!optionalRecords[0]) {
+            THROW_ERROR_EXCEPTION(
+                NQueryTrackerClient::EErrorCode::QueryResultNotFound,
+                "Query %v result %v not found or is expired",
+                queryId,
+                resultIndex);
+        }
+        const auto& record = *optionalRecords[0];
+
+        queryResult.Id = queryId;
+        queryResult.ResultIndex = resultIndex;
+        auto schemaNode = record.Schema ? ConvertToNode(*record.Schema) : nullptr;
+        queryResult.Schema = schemaNode && schemaNode->GetType() == ENodeType::List ? ConvertTo<TTableSchemaPtr>(schemaNode) : nullptr;
+        queryResult.Error = record.Error;
+        queryResult.IsTruncated = record.IsTruncated;
+        queryResult.DataStatistics = ConvertTo<TDataStatistics>(record.DataStatistics);
+    }
+
+    return queryResult;
+}
+
+IUnversionedRowsetPtr TQueryTrackerProxy::ReadQueryResult(
+    const TQueryId queryId,
+    const i64 resultIndex,
+    const TReadQueryResultOptions& options,
+    const TString& user)
+{
+    YT_LOG_DEBUG(
+        "Reading query result (QueryId: %v, ResultIndex: %v, LowerRowIndex: %v, UpperRowIndex: %v)",
+        queryId,
+        resultIndex,
+        options.LowerRowIndex,
+        options.UpperRowIndex);
+
+    auto timestamp = WaitFor(StateClient_->GetTimestampProvider()->GenerateTimestamps())
+        .ValueOrThrow();
+
+    TString wireRowset;
+    TTableSchemaPtr schema;
+    {
+        auto rowBuffer = New<TRowBuffer>();
+        TLookupRowsOptions options;
+        options.KeepMissingRows = true;
+
+        ValidateQueryPermissions(queryId, StateRoot_, timestamp, user, StateClient_, EPermission::Read, Logger);
+
+        TFinishedQueryResultKey key{.QueryId = queryId, .Index = resultIndex};
+        std::vector keys{
+            key.ToKey(rowBuffer),
+        };
+        auto asyncLookupResult = StateClient_->LookupRows(
+            StateRoot_ + "/finished_query_results",
+            TFinishedQueryResultDescriptor::Get()->GetNameTable(),
+            MakeSharedRange(std::move(keys), rowBuffer),
+            options);
+        auto rowset = WaitFor(asyncLookupResult)
+            .ValueOrThrow()
+            .Rowset;
+        auto optionalRecords = ToOptionalRecords<TFinishedQueryResult>(rowset);
+        YT_VERIFY(optionalRecords.size() == 1);
+        if (!optionalRecords[0]) {
+            THROW_ERROR_EXCEPTION(
+                NQueryTrackerClient::EErrorCode::QueryResultNotFound,
+                "Query %v result %v not found or is expired",
+                queryId,
+                resultIndex);
+        }
+        const auto& record = *optionalRecords[0];
+        if (!record.Error.IsOK()) {
+            THROW_ERROR record.Error;
+        }
+        if (!record.Rowset) {
+            // This should not normally happen, but better this than abort.
+            THROW_ERROR_EXCEPTION(
+                NQueryTrackerClient::EErrorCode::QueryResultNotFound,
+                "Query %v result %v rowset is missing",
+                queryId,
+                resultIndex);
+        }
+        wireRowset = *record.Rowset;
+        schema = ConvertTo<TTableSchemaPtr>(record.Schema);
+    }
+
+    auto wireReader = CreateWireProtocolReader(TSharedRef::FromString(std::move(wireRowset)));
+    auto schemaData = IWireProtocolReader::GetSchemaData(*schema);
+    auto rows = wireReader->ReadSchemafulRowset(schemaData, /*captureValues*/ true);
+
+    {
+        auto lowerRowIndex = options.LowerRowIndex.value_or(0);
+        lowerRowIndex = std::clamp<i64>(lowerRowIndex, 0, rows.size());
+        auto upperRowIndex = options.UpperRowIndex.value_or(rows.size());
+        upperRowIndex = std::clamp<i64>(upperRowIndex, lowerRowIndex, rows.size());
+        rows = rows.Slice(lowerRowIndex, upperRowIndex);
+    }
+
+    auto rowset = CreateRowset(std::move(schema), std::move(rows));
+    if (options.Columns) {
+        rowset = FilterRowsetColumns(rowset, *options.Columns);
+    }
+    return rowset;
+}
+
+TQuery TQueryTrackerProxy::GetQuery(
+    const TQueryId queryId,
+    const TGetQueryOptions& options,
+    const TString& user)
+{
+    auto timestamp = options.Timestamp != NTransactionClient::NullTimestamp
+        ? options.Timestamp
+        : WaitFor(StateClient_->GetTimestampProvider()->GenerateTimestamps())
+            .ValueOrThrow();
+
+    YT_LOG_DEBUG("Getting query (QueryId: %v, Timestamp: %v, Attributes: %v)", queryId, timestamp, options.Attributes);
+
+    options.Attributes.ValidateKeysOnly();
+
+    ValidateQueryPermissions(queryId, StateRoot_, timestamp, user, StateClient_, EPermission::Use, Logger);
+
+    auto lookupKeys = options.Attributes ? std::make_optional(options.Attributes.Keys) : std::nullopt;
+
+    auto query = LookupQuery(queryId, StateClient_, StateRoot_, lookupKeys, timestamp, Logger);
+    return query;
+}
+
+TListQueriesResult TQueryTrackerProxy::ListQueries(
+    const TListQueriesOptions& options,
+    const TString& user)
+{
+    auto timestamp = WaitFor(StateClient_->GetTimestampProvider()->GenerateTimestamps())
+        .ValueOrThrow();
+
+    YT_LOG_DEBUG(
+        "Listing queries (Timestamp: %v, State: %v, CursorDirection: %v, FromTime: %v, ToTime: %v, CursorTime: %v,"
+        "Substr: %v, User: %v, Engine: %v, Limit: %v, Attributes: %v)",
+        timestamp,
+        options.StateFilter,
+        options.CursorDirection,
+        options.FromTime,
+        options.ToTime,
+        options.CursorTime,
+        options.SubstrFilter,
+        options.UserFilter,
+        options.EngineFilter,
+        options.Limit,
+        options.Attributes);
+
+    auto attributes = options.Attributes;
+
+    attributes.ValidateKeysOnly();
+
+    if (!attributes.AdmitsKeySlow("start_time")) {
+        YT_VERIFY(attributes);
+        attributes.Keys.push_back("start_time");
+    }
+
+    auto userSubjects = GetUserSubjects(user, StateClient_);
+    userSubjects.insert(user);
+
+    std::vector<TString> userSubjectsVector(userSubjects.begin(), userSubjects.end());
+    YT_LOG_DEBUG("Fetched user %Qv subjects: %v", user, userSubjectsVector);
+
+    bool isSuperuser = userSubjects.contains(NSecurityClient::SuperusersGroupName);
+    std::vector<TString> acosForUser;
+
+    if (!isSuperuser) {
+        acosForUser = GetAcosForSubjects(userSubjects, StateClient_);
+        YT_LOG_DEBUG("Fetched suitable access control objects for user %Qv: %v", user, acosForUser);
+    }
+
+    auto addSelectExpressionsFromAttributes = [&] (NQueryClient::TQueryBuilder& builder, const TNameTablePtr& nameTable) {
+        if (attributes) {
+            for (const auto& key : attributes.Keys) {
+                if (nameTable->FindId(key)) {
+                    builder.AddSelectExpression("[" + key + "]");
+                }
+            }
+        } else {
+            builder.AddSelectExpression("*");
+        }
+    };
+
+    auto addSelectExpressionsForMerging = [&] (NQueryClient::TQueryBuilder& builder) {
+        if (!attributes.AdmitsKeySlow("query_id")) {
+            builder.AddSelectExpression("[query_id]");
+        }
+    };
+
+    auto addFilterConditions = [&] (NQueryClient::TQueryBuilder& builder, TYsonString& placeholderValues) {
+        auto placeholdersFluentMap = BuildYsonNodeFluently().BeginMap();
+        if (options.UserFilter) {
+            builder.AddWhereConjunct("[user] = {UserFilter}");
+            placeholdersFluentMap.Item("UserFilter").Value(*options.UserFilter);
+        }
+        if (options.EngineFilter) {
+            builder.AddWhereConjunct("[engine] = {EngineFilter}");
+            placeholdersFluentMap.Item("EngineFilter").Value(*options.EngineFilter);
+        }
+        if (options.StateFilter) {
+            builder.AddWhereConjunct("[state] = {StateFilter}");
+            placeholdersFluentMap.Item("StateFilter").Value(*options.StateFilter);
+        }
+        if (options.FromTime) {
+            builder.AddWhereConjunct("[start_time] >= " + ToString(options.FromTime->MicroSeconds()));
+        }
+        if (options.ToTime) {
+            builder.AddWhereConjunct("[start_time] <= " + ToString(options.ToTime->MicroSeconds()));
+        }
+        if (options.SubstrFilter) {
+            builder.AddWhereConjunct("is_substr({SubstrFilter}, filter_factors)");
+            placeholdersFluentMap.Item("SubstrFilter").Value(*options.SubstrFilter);
+        }
+        if (!isSuperuser) {
+            placeholdersFluentMap.Item("User").Value(user);
+
+            if (acosForUser.empty()) {
+                builder.AddWhereConjunct("user = {User}");
+            } else {
+                builder.AddWhereConjunct("user = {User} OR access_control_object IN {acosForUser}");
+                placeholdersFluentMap.Item("acosForUser").DoListFor(acosForUser, [] (TFluentList fluent, const TString& aco) {
+                    fluent.Item().Value(aco);
+                });
+            }
+        }
+
+        placeholderValues = ConvertToYsonString(placeholdersFluentMap.EndMap());
+    };
+
+    auto selectActiveQueries = [=, this, this_ = MakeStrong(this)] {
+        try {
+            NQueryClient::TQueryBuilder builder;
+            TYsonString placeholderValues;
+            builder.SetSource(StateRoot_ + "/active_queries");
+            addFilterConditions(builder, placeholderValues);
+            addSelectExpressionsFromAttributes(builder, TActiveQueryDescriptor::Get()->GetNameTable());
+            addSelectExpressionsForMerging(builder);
+            TSelectRowsOptions options;
+            options.Timestamp = timestamp;
+            options.PlaceholderValues = placeholderValues;
+            auto query = builder.Build();
+            YT_LOG_DEBUG("Selecting active queries (Query: %v)", query);
+            auto selectResult = WaitFor(StateClient_->SelectRows(query, options))
+                .ValueOrThrow();
+            auto records = ToRecords<TActiveQueryPartial>(selectResult.Rowset);
+            return PartialRecordsToQueries(records);
+        } catch (const std::exception& ex) {
+            THROW_ERROR_EXCEPTION("Error while selecting active queries")
+                << ex;
+        }
+    };
+
+    auto selectFinishedQueries = [=, this, this_ = MakeStrong(this)] () -> std::vector<TQuery> {
+        try {
+            TStringBuilder admittedQueryIds;
+            {
+                NQueryClient::TQueryBuilder builder;
+                TYsonString placeholderValues;
+                builder.SetSource(StateRoot_ + "/finished_queries_by_start_time");
+                addFilterConditions(builder, placeholderValues);
+                builder.AddSelectExpression("[query_id]");
+                TSelectRowsOptions options;
+                options.Timestamp = timestamp;
+                options.PlaceholderValues = placeholderValues;
+                auto query = builder.Build();
+                YT_LOG_DEBUG("Selecting finished queries by start time (Query: %v)", query);
+                auto selectResult = WaitFor(StateClient_->SelectRows(query, options))
+                    .ValueOrThrow();
+                bool isFirst = true;
+                for (const auto& record : ToRecords<TFinishedQueryByStartTime>(selectResult.Rowset)) {
+                    if (!isFirst) {
+                        admittedQueryIds.AppendString(", ");
+                    }
+                    admittedQueryIds.AppendFormat("\"%v\"", record.Key.QueryId);
+                    isFirst = false;
+                }
+                if (isFirst) {
+                    return {};
+                }
+            }
+            {
+                NQueryClient::TQueryBuilder builder;
+                builder.SetSource(StateRoot_ + "/finished_queries");
+                addSelectExpressionsFromAttributes(builder, TFinishedQueryDescriptor::Get()->GetNameTable());
+                builder.AddWhereConjunct("[query_id] in (" + admittedQueryIds.Flush() + ")");
+                addSelectExpressionsForMerging(builder);
+                TSelectRowsOptions options;
+                options.Timestamp = timestamp;
+                auto query = builder.Build();
+                YT_LOG_DEBUG("Selecting admitted finished queries (Query: %v)", query);
+                auto selectResult = WaitFor(StateClient_->SelectRows(query, options))
+                    .ValueOrThrow();
+                auto records = ToRecords<TFinishedQueryPartial>(selectResult.Rowset);
+                return PartialRecordsToQueries(records);
+            }
+        } catch (const std::exception& ex) {
+            THROW_ERROR_EXCEPTION("Error while selecting finished queries")
+                << ex;
+        }
+    };
+
+    std::vector<TQuery> queries;
+    {
+        std::vector<TFuture<std::vector<TQuery>>> futures;
+        std::optional<bool> stateFilterDefinesFinishedQuery = options.StateFilter
+            ? std::make_optional(IsFinishedState(*options.StateFilter))
+            : std::nullopt;
+        if (!options.StateFilter || *stateFilterDefinesFinishedQuery) {
+            futures.push_back(BIND(selectFinishedQueries).AsyncVia(GetCurrentInvoker()).Run());
+        }
+        if (!options.StateFilter || !*stateFilterDefinesFinishedQuery) {
+            futures.push_back(BIND(selectActiveQueries).AsyncVia(GetCurrentInvoker()).Run());
+        }
+        auto queryVectors = WaitFor(AllSucceeded(futures))
+            .ValueOrThrow();
+        for (const auto& queryVector : queryVectors) {
+            queries.insert(queries.end(), queryVector.begin(), queryVector.end());
+        }
+    }
+
+    std::vector<TQuery> result;
+    bool incomplete = false;
+    if (options.CursorDirection != EOperationSortDirection::None) {
+        auto compare = [&] (const TQuery& lhs, const TQuery& rhs) {
+            return options.CursorDirection == EOperationSortDirection::Past
+                ? std::tie(lhs.StartTime, lhs.Query) > std::tie(rhs.StartTime, rhs.Query)
+                : std::tie(lhs.StartTime, lhs.Query) < std::tie(rhs.StartTime, rhs.Query);
+        };
+        std::sort(queries.begin(), queries.end(), compare);
+        for (auto& query : queries) {
+            if (!options.CursorTime ||
+                (options.CursorDirection == EOperationSortDirection::Past && query.StartTime < options.CursorTime) ||
+                (options.CursorDirection == EOperationSortDirection::Future && query.StartTime > options.CursorTime))
+            {
+                if (result.size() == options.Limit) {
+                    // We are finishing collecting queries prematurely, set incomplete flag and break.
+                    incomplete = true;
+                    break;
+                }
+                result.push_back(std::move(query));
+            }
+        }
+    } else {
+        incomplete = options.Limit < queries.size();
+        result = std::vector(queries.begin(), queries.end() + std::min(options.Limit, queries.size()));
+    }
+
+    return TListQueriesResult{
+        .Queries = std::move(result),
+        .Incomplete = incomplete,
+        .Timestamp = timestamp,
+    };
+}
+
+void TQueryTrackerProxy::AlterQuery(
+    const TQueryId queryId,
+    const TAlterQueryOptions& options,
+    const TString& user)
+{
+    auto transaction = WaitFor(StateClient_->StartTransaction(ETransactionType::Tablet, {}))
+        .ValueOrThrow();
+
+    auto timestamp = transaction->GetStartTimestamp();
+
+    ValidateQueryPermissions(queryId, StateRoot_, timestamp, user, StateClient_, EPermission::Administer, Logger);
+
+    std::vector<TString> lookupKeys = {"state", "start_time"};
+
+    auto query = LookupQuery(queryId, StateClient_, StateRoot_, lookupKeys, timestamp, Logger);
+
+    YT_LOG_DEBUG(
+        "Altering query (QueryId: %v, State: %v, HasAnnotations: %v, HasAccessControlObject: %v)",
+        queryId,
+        *query.State,
+        static_cast<bool>(options.Annotations),
+        static_cast<bool>(options.AccessControlObject));
+
+    if (!options.Annotations && !options.AccessControlObject) {
+        WaitFor(transaction->Commit())
+            .ThrowOnError();
+        return;
+    }
+
+    if (options.AccessControlObject) {
+        VerifyAccessControlObjectExists(*options.AccessControlObject, StateClient_);
+    }
+
+    if (IsFinishedState(*query.State)) {
+        auto rowBuffer = New<TRowBuffer>();
+        TString filterFactors;
+        {
+            TFinishedQueryPartial record{
+                .Key = {.QueryId = queryId},
+            };
+            if (options.Annotations) {
+                record.Annotations = ConvertToYsonString(options.Annotations);
+                filterFactors = GetFilterFactors(record);
+            }
+            if (options.AccessControlObject) {
+                record.AccessControlObject = options.AccessControlObject;
+            }
+            std::vector rows{
+                record.ToUnversionedRow(rowBuffer, TFinishedQueryDescriptor::Get()->GetIdMapping()),
+            };
+            transaction->WriteRows(
+                StateRoot_ + "/finished_queries",
+                TFinishedQueryDescriptor::Get()->GetNameTable(),
+                MakeSharedRange(std::move(rows), rowBuffer));
+        }
+        {
+            TFinishedQueryByStartTimePartial record{
+                .Key = {.StartTime = *query.StartTime, .QueryId = queryId},
+            };
+            if (options.Annotations) {
+                record.FilterFactors = filterFactors;
+            }
+            if (options.AccessControlObject) {
+                record.AccessControlObject = options.AccessControlObject;
+            }
+            std::vector rows{
+                record.ToUnversionedRow(rowBuffer, TFinishedQueryByStartTimeDescriptor::Get()->GetIdMapping()),
+            };
+            transaction->WriteRows(
+                StateRoot_ + "/finished_queries_by_start_time",
+                TFinishedQueryByStartTimeDescriptor::Get()->GetNameTable(),
+                MakeSharedRange(std::move(rows), rowBuffer));
+        }
+    } else {
+        auto rowBuffer = New<TRowBuffer>();
+        {
+            TActiveQueryPartial record{
+                .Key = {.QueryId = queryId},
+            };
+            if (options.Annotations) {
+                record.Annotations = ConvertToYsonString(options.Annotations);
+                record.FilterFactors = GetFilterFactors(record);
+            }
+            if (options.AccessControlObject) {
+                record.AccessControlObject = options.AccessControlObject;
+            }
+            std::vector rows{
+                record.ToUnversionedRow(rowBuffer, TActiveQueryDescriptor::Get()->GetIdMapping()),
+            };
+            transaction->WriteRows(
+                StateRoot_ + "/active_queries",
+                TActiveQueryDescriptor::Get()->GetNameTable(),
+                MakeSharedRange(std::move(rows), rowBuffer));
+        }
+    }
+
+    WaitFor(transaction->Commit())
+        .ThrowOnError();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+TQueryTrackerProxyPtr CreateQueryTrackerProxy(
+    NApi::NNative::IClientPtr stateClient,
+    TYPath stateRoot
+)
+{
+    return New<TQueryTrackerProxy>(
+        std::move(stateClient),
+        std::move(stateRoot)
+    );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NQueryTracker

--- a/yt/yt/server/query_tracker/query_tracker_proxy.h
+++ b/yt/yt/server/query_tracker/query_tracker_proxy.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "private.h"
+
+#include <yt/yt/client/api/client.h>
+
+#include <yt/yt/ytlib/api/native/public.h>
+
+#include <yt/yt/core/ypath/public.h>
+
+namespace NYT::NQueryTracker {
+
+using namespace NApi;
+using namespace NYPath;
+using namespace NYson;
+
+///////////////////////////////////////////////////////////////////////////////
+
+class TQueryTrackerProxy
+    : public TRefCounted
+{
+public:
+    TQueryTrackerProxy(
+        NNative::IClientPtr stateClient,
+        TYPath stateRoot);
+
+    void StartQuery(
+        const TQueryId queryId,
+        const NQueryTrackerClient::EQueryEngine engine,
+        const TString& query,
+        const TStartQueryOptions& options,
+        const TString& user);
+
+    void AbortQuery(
+        const TQueryId queryId,
+        const TAbortQueryOptions& options,
+        const TString& user);
+
+    TQueryResult GetQueryResult(
+        const TQueryId queryId,
+        const i64 resultIndex,
+        const TString& user);
+
+    IUnversionedRowsetPtr ReadQueryResult(
+        const TQueryId queryId,
+        const i64 resultIndex,
+        const TReadQueryResultOptions& options,
+        const TString& user);
+
+    TQuery GetQuery(
+        const TQueryId queryId,
+        const TGetQueryOptions& options,
+        const TString& user);
+
+    TListQueriesResult ListQueries(
+        const TListQueriesOptions& options,
+        const TString& user);
+
+    void AlterQuery(
+        const TQueryId queryId,
+        const TAlterQueryOptions& options,
+        const TString& user);
+
+private:
+    const NNative::IClientPtr StateClient_;
+    const TYPath StateRoot_;
+};
+
+DEFINE_REFCOUNTED_TYPE(TQueryTrackerProxy)
+
+///////////////////////////////////////////////////////////////////////////////
+
+TQueryTrackerProxyPtr CreateQueryTrackerProxy(
+    NNative::IClientPtr stateClient,
+    NYPath::TYPath stateRoot
+);
+
+///////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NQueryTracker

--- a/yt/yt/server/query_tracker/query_tracker_proxy.h
+++ b/yt/yt/server/query_tracker/query_tracker_proxy.h
@@ -60,6 +60,9 @@ public:
         const NApi::TAlterQueryOptions& options,
         const TString& user);
 
+    NApi::TGetQueryTrackerInfoResult GetQueryTrackerInfo(
+        const NApi::TGetQueryTrackerInfoOptions& options);
+
 private:
     const NApi::NNative::IClientPtr StateClient_;
     const NYPath::TYPath StateRoot_;

--- a/yt/yt/server/query_tracker/query_tracker_proxy.h
+++ b/yt/yt/server/query_tracker/query_tracker_proxy.h
@@ -10,10 +10,6 @@
 
 namespace NYT::NQueryTracker {
 
-using namespace NApi;
-using namespace NYPath;
-using namespace NYson;
-
 ///////////////////////////////////////////////////////////////////////////////
 
 class TQueryTrackerProxy
@@ -21,49 +17,53 @@ class TQueryTrackerProxy
 {
 public:
     TQueryTrackerProxy(
-        NNative::IClientPtr stateClient,
-        TYPath stateRoot);
+        NApi::NNative::IClientPtr stateClient,
+        NYPath::TYPath stateRoot,
+        TQueryTrackerProxyConfigPtr config);
+
+    void Reconfigure(const TQueryTrackerProxyConfigPtr& config);
 
     void StartQuery(
         const TQueryId queryId,
-        const NQueryTrackerClient::EQueryEngine engine,
+        const EQueryEngine engine,
         const TString& query,
-        const TStartQueryOptions& options,
+        const NApi::TStartQueryOptions& options,
         const TString& user);
 
     void AbortQuery(
         const TQueryId queryId,
-        const TAbortQueryOptions& options,
+        const NApi::TAbortQueryOptions& options,
         const TString& user);
 
-    TQueryResult GetQueryResult(
+    NApi::TQueryResult GetQueryResult(
         const TQueryId queryId,
         const i64 resultIndex,
         const TString& user);
 
-    IUnversionedRowsetPtr ReadQueryResult(
+    NApi::IUnversionedRowsetPtr ReadQueryResult(
         const TQueryId queryId,
         const i64 resultIndex,
-        const TReadQueryResultOptions& options,
+        const NApi::TReadQueryResultOptions& options,
         const TString& user);
 
-    TQuery GetQuery(
+    NApi::TQuery GetQuery(
         const TQueryId queryId,
-        const TGetQueryOptions& options,
+        const NApi::TGetQueryOptions& options,
         const TString& user);
 
-    TListQueriesResult ListQueries(
-        const TListQueriesOptions& options,
+    NApi::TListQueriesResult ListQueries(
+        const NApi::TListQueriesOptions& options,
         const TString& user);
 
     void AlterQuery(
         const TQueryId queryId,
-        const TAlterQueryOptions& options,
+        const NApi::TAlterQueryOptions& options,
         const TString& user);
 
 private:
-    const NNative::IClientPtr StateClient_;
-    const TYPath StateRoot_;
+    const NApi::NNative::IClientPtr StateClient_;
+    const NYPath::TYPath StateRoot_;
+    TQueryTrackerProxyConfigPtr ProxyConfig_;
 };
 
 DEFINE_REFCOUNTED_TYPE(TQueryTrackerProxy)
@@ -71,9 +71,9 @@ DEFINE_REFCOUNTED_TYPE(TQueryTrackerProxy)
 ///////////////////////////////////////////////////////////////////////////////
 
 TQueryTrackerProxyPtr CreateQueryTrackerProxy(
-    NNative::IClientPtr stateClient,
-    NYPath::TYPath stateRoot
-);
+    NApi::NNative::IClientPtr stateClient,
+    NYPath::TYPath stateRoot,
+    TQueryTrackerProxyConfigPtr config);
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/query_tracker/ya.make
+++ b/yt/yt/server/query_tracker/ya.make
@@ -8,7 +8,9 @@ SRCS(
     config.cpp
     dynamic_config_manager.cpp
     handler_base.cpp
+    proxy_service.cpp
     query_tracker.cpp
+    query_tracker_proxy.cpp
     mock_engine.cpp
     ql_engine.cpp
     spyt_engine.cpp
@@ -39,6 +41,8 @@ PEERDIR(
 
     yt/yt/ytlib
     yt/yt/ytlib/query_tracker_client
+
+    yt/yt/client
 )
 
 END()

--- a/yt/yt/tests/integration/queries/test_mock.py
+++ b/yt/yt/tests/integration/queries/test_mock.py
@@ -1,7 +1,7 @@
 from yt_env_setup import YTEnvSetup
 
 from yt_commands import (
-    add_member, authors, create_access_control_object, create_access_control_object_namespace, remove,
+    add_member, authors, create_access_control_object, remove,
     make_ace, raises_yt_error, wait, create_user, print_debug, select_rows)
 
 from yt_error_codes import AuthorizationErrorCode, ResolveErrorCode
@@ -456,14 +456,6 @@ class TestAccessControl(YTEnvSetup):
     @authors("aleksandr.gaev")
     def test_get_query_tracker_info(self, query_tracker):
         assert get_query_tracker_info() == {'cluster_name': 'primary', 'supported_features': {'access_control': True}, 'access_control_objects': ['nobody']}
-
-        remove("//sys/access_control_object_namespaces/queries/nobody")
-        remove("//sys/access_control_object_namespaces/queries")
-
-        assert get_query_tracker_info() == {'cluster_name': 'primary', 'supported_features': {'access_control': False}, 'access_control_objects': []}
-
-        create_access_control_object_namespace("queries")
-        create_access_control_object("nobody", "queries")
 
         assert get_query_tracker_info(attributes=[]) == {'cluster_name': '', 'supported_features': {}, 'access_control_objects': []}
         assert get_query_tracker_info(attributes=["cluster_name"]) == {'cluster_name': 'primary', 'supported_features': {}, 'access_control_objects': []}

--- a/yt/yt/ytlib/api/native/client_queries_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_queries_impl.cpp
@@ -1,33 +1,15 @@
 #include "client_impl.h"
 #include "config.h"
 
-#include <yt/yt/ytlib/query_tracker_client/records/query.record.h>
+#include <yt/yt/client/api/rpc_proxy/helpers.h>
 
 #include <yt/yt/ytlib/query_tracker_client/config.h>
 #include <yt/yt/ytlib/query_tracker_client/helpers.h>
-
-#include <yt/yt/client/table_client/name_table.h>
-#include <yt/yt/client/table_client/row_buffer.h>
-#include <yt/yt/client/table_client/record_helpers.h>
-#include <yt/yt/client/table_client/wire_protocol.h>
-
-#include <yt/yt/client/transaction_client/timestamp_provider.h>
-
-#include <yt/yt/client/query_client/query_builder.h>
-
-#include <yt/yt/client/api/transaction.h>
-#include <yt/yt/client/api/connection.h>
-
-#include <yt/yt/client/chunk_client/data_statistics.h>
-
-#include <yt/yt/core/ytree/convert.h>
-
-#include <contrib/libs/pfr/include/pfr/tuple_size.hpp>
-
-#include <library/cpp/iterator/functools.h>
+#include <yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h>
 
 namespace NYT::NApi::NNative {
 
+using namespace NRpcProxy;
 using namespace NQueryTrackerClient;
 using namespace NQueryTrackerClient::NRecords;
 using namespace NConcurrency;
@@ -40,319 +22,8 @@ using namespace NChunkClient::NProto;
 
 namespace NDetail {
 
-// Applies when a query doesn't have an access control object.
-constexpr TStringBuf DefaultAccessControlObject = "nobody";
-
 // Path to access control object namespace for QT.
 constexpr TStringBuf QueriesAcoNamespacePath = "//sys/access_control_object_namespaces/queries";
-
-TQuery PartialRecordToQuery(const auto& partialRecord)
-{
-    static_assert(pfr::tuple_size<TQuery>::value == 15);
-    static_assert(TActiveQueryDescriptor::FieldCount == 19);
-    static_assert(TFinishedQueryDescriptor::FieldCount == 14);
-
-    TQuery query;
-    // Note that some of the fields are twice optional.
-    // First time due to the fact that they are optional in the record,
-    // and second time due to the extra optionality of any field in the partial record.
-    // TODO(max42): coalesce the optionality of the fields in the partial record.
-    query.Id = partialRecord.Key.QueryId;
-    query.Engine = partialRecord.Engine;
-    query.Query = partialRecord.Query;
-    query.Files = partialRecord.Files.value_or(std::nullopt);
-    query.StartTime = partialRecord.StartTime;
-    query.FinishTime = partialRecord.FinishTime.value_or(std::nullopt);
-    query.Settings = partialRecord.Settings.value_or(TYsonString());
-    query.User = partialRecord.User;
-    query.AccessControlObject = partialRecord.AccessControlObject.value_or(std::nullopt);
-    query.State = partialRecord.State;
-    query.ResultCount = partialRecord.ResultCount.value_or(std::nullopt);
-    query.Progress = partialRecord.Progress.value_or(TYsonString());
-    query.Error = partialRecord.Error.value_or(std::nullopt);
-    query.Annotations = partialRecord.Annotations.value_or(TYsonString());
-
-    IAttributeDictionaryPtr otherAttributes;
-    auto fillIfPresent = [&] (const TString& key, const auto& value) {
-        if (value) {
-            if (!otherAttributes) {
-                otherAttributes = CreateEphemeralAttributes();
-            }
-            otherAttributes->Set(key, *value);
-        }
-    };
-
-    if constexpr (std::is_same_v<std::decay_t<decltype(partialRecord)>, TActiveQueryPartial>) {
-        fillIfPresent("abort_request", partialRecord.AbortRequest.value_or(std::nullopt));
-        fillIfPresent("incarnation", partialRecord.Incarnation);
-        fillIfPresent("lease_transaction_id", partialRecord.LeaseTransactionId);
-        fillIfPresent("assigned_tracker", partialRecord.AssignedTracker);
-    }
-
-    query.OtherAttributes = std::move(otherAttributes);
-
-    return query;
-}
-
-//! Lookup one of query tracker state tables by query id.
-template <class TRecordDescriptor>
-TFuture<typename TRecordDescriptor::TRecordPartial> LookupQueryTrackerRecord(
-    TQueryId queryId,
-    const IClientPtr& client,
-    const TString& tablePath,
-    const TString& tableKind,
-    const std::optional<std::vector<TString>>& lookupKeys,
-    NTransactionClient::TTimestamp timestamp)
-{
-    auto rowBuffer = New<TRowBuffer>();
-    const auto& nameTable = TRecordDescriptor::Get()->GetNameTable();
-
-    TLookupRowsOptions lookupOptions;
-    if (lookupKeys) {
-        std::vector<int> columnIds;
-        for (const auto& key : *lookupKeys) {
-            if (auto columnId = nameTable->FindId(key)) {
-                columnIds.push_back(*columnId);
-            }
-        }
-        lookupOptions.ColumnFilter = TColumnFilter(columnIds);
-    }
-    lookupOptions.Timestamp = timestamp;
-    lookupOptions.KeepMissingRows = true;
-    std::vector keys{
-        TActiveQueryKey{.QueryId = queryId}.ToKey(rowBuffer),
-    };
-    auto asyncLookupResult = client->LookupRows(
-        tablePath,
-        TRecordDescriptor::Get()->GetNameTable(),
-        MakeSharedRange(std::move(keys), rowBuffer),
-        lookupOptions);
-    auto asyncRecord = asyncLookupResult.Apply(BIND([=] (const TUnversionedLookupRowsResult& result) {
-        auto optionalRecords = ToOptionalRecords<typename TRecordDescriptor::TRecordPartial>(result.Rowset);
-        YT_VERIFY(optionalRecords.size() == 1);
-        if (!optionalRecords[0]) {
-            THROW_ERROR_EXCEPTION("Query %v is not found in %Qv query table", queryId, tableKind);
-        }
-        return *optionalRecords[0];
-    }));
-    return asyncRecord;
-};
-
-THashSet<TString> GetUserSubjects(const TString& user, const IClientPtr& client)
-{
-    // Get all subjects for the user.
-    TGetNodeOptions options;
-    options.ReadFrom = EMasterChannelKind::Cache;
-    auto userSubjectsOrError = WaitFor(client->GetNode("//sys/users/" + user + "/@member_of_closure", options));
-    if (!userSubjectsOrError.IsOK()) {
-        THROW_ERROR_EXCEPTION("Error while fetching user membership for the user %Qv", user)
-            << userSubjectsOrError;
-    }
-    auto userSubjects = ConvertTo<THashSet<TString>>(userSubjectsOrError.Value());
-    return userSubjects;
-}
-
-NSecurityClient::ESecurityAction CheckAccessControl(
-    const TString& user,
-    const std::optional<TString>& accessControlObject,
-    const TString& queryAuthor,
-    const IClientPtr& client,
-    EPermission permission,
-    const NLogging::TLogger& logger)
-{
-    auto& Logger = logger;
-    if (user == queryAuthor) {
-        return NSecurityClient::ESecurityAction::Allow;
-    }
-    auto actualAccessControlObject = accessControlObject.value_or(TString(DefaultAccessControlObject));
-    auto aclOrError = WaitFor(client->GetNode(Format(
-        "%v/%v/@principal_acl",
-        QueriesAcoNamespacePath,
-        NYPath::ToYPathLiteral(actualAccessControlObject))));
-    if (!aclOrError.IsOK()) {
-        YT_LOG_WARNING(aclOrError,
-            "Error while fetching access control object queries/%v",
-            actualAccessControlObject);
-        auto userSubjects = GetUserSubjects(user, client);
-        if (userSubjects.contains(NSecurityClient::SuperusersGroupName)) {
-            return NSecurityClient::ESecurityAction::Allow;
-        }
-        THROW_ERROR_EXCEPTION(
-            "Error while fetching access control object queries/%v. "
-            "Please make sure it exists",
-            actualAccessControlObject)
-            << aclOrError;
-    }
-    return WaitFor(client->CheckPermissionByAcl(user, permission, ConvertToNode(aclOrError.Value())))
-        .ValueOrThrow()
-        .Action;
-}
-
-void ThrowAccessDeniedException(
-    TQueryId queryId,
-    EPermission permission,
-    const TString& user,
-    const std::optional<TString>& accessControlObject,
-    const TString& queryAuthor)
-{
-    THROW_ERROR_EXCEPTION(NSecurityClient::EErrorCode::AuthorizationError,
-        "Access denied to query %v due to missing %Qv permission",
-        queryId,
-        permission)
-        << TErrorAttribute("user", user)
-        << TErrorAttribute("access_control_object", accessControlObject)
-        << TErrorAttribute("query_author", queryAuthor);
-}
-
-//! Lookup a query in active_queries and finished_queries tables by query id.
-TQuery LookupQuery(
-    TQueryId queryId,
-    const IClientPtr& client,
-    const TString& root,
-    const std::optional<std::vector<TString>>& lookupKeys,
-    NTransactionClient::TTimestamp timestamp,
-    const NLogging::TLogger& logger)
-{
-    auto asyncActiveRecord = LookupQueryTrackerRecord<TActiveQueryDescriptor>(
-        queryId,
-        client,
-        root + "/active_queries",
-        "active",
-        lookupKeys,
-        timestamp);
-    auto asyncFinishedRecord = LookupQueryTrackerRecord<TFinishedQueryDescriptor>(
-        queryId,
-        client,
-        root + "/finished_queries",
-        "finished",
-        lookupKeys,
-        timestamp);
-
-    auto error = WaitFor(AnySucceeded(std::vector{asyncActiveRecord.AsVoid(), asyncFinishedRecord.AsVoid()}));
-    if (!error.IsOK()) {
-        THROW_ERROR_EXCEPTION(NQueryTrackerClient::EErrorCode::QueryNotFound,
-            "Query %v is not found neither in active nor in finished query tables",
-            queryId)
-            << error;
-    }
-    bool isActive = asyncActiveRecord.IsSet() && asyncActiveRecord.Get().IsOK();
-    bool isFinished = asyncFinishedRecord.IsSet() && asyncFinishedRecord.Get().IsOK();
-    YT_VERIFY(isActive || isFinished);
-    if (isActive && isFinished) {
-        const auto& Logger = logger;
-        YT_LOG_ALERT(
-            "Query is found in both active and finished query tables "
-            "(QueryId: %v, Timestamp: %v)",
-            queryId,
-            timestamp);
-    }
-    if (isActive) {
-        return PartialRecordToQuery(asyncActiveRecord.Get().Value());
-    } else {
-        return PartialRecordToQuery(asyncFinishedRecord.Get().Value());
-    }
-}
-
-void ValidateQueryPermissions(
-    TQueryId queryId,
-    const TString& root,
-    NTransactionClient::TTimestamp timestamp,
-    const TString& user,
-    const IClientPtr& client,
-    EPermission permission,
-    const NLogging::TLogger& logger)
-{
-    std::vector<TString> lookupKeys = {"user", "access_control_object"};
-    auto query = LookupQuery(queryId, client, root, lookupKeys, timestamp, logger);
-    if (CheckAccessControl(user, query.AccessControlObject, *query.User, client, permission, logger) == NSecurityClient::ESecurityAction::Deny) {
-        ThrowAccessDeniedException(queryId, permission, user, query.AccessControlObject, *query.User);
-    }
-}
-
-std::vector<TString> GetAcosForSubjects(const THashSet<TString>& subjects, const IClientPtr& client)
-{
-    // Get all access control objects.
-    TGetNodeOptions options;
-    options.Attributes = {
-        "principal_acl",
-    };
-    options.ReadFrom = EMasterChannelKind::Cache;
-
-    auto allAcosOrError = WaitFor(client->GetNode(TString(QueriesAcoNamespacePath), options));
-
-    if (!allAcosOrError.IsOK()) {
-        THROW_ERROR_EXCEPTION(
-            "Error while fetching all access control objects in the namespace \"queries\". "
-            "Please make sure that the namespace exists")
-            << allAcosOrError;
-    }
-
-    auto allAcos = ConvertToNode(allAcosOrError.Value())->AsMap()->GetChildren();
-
-    std::vector<TString> acosForUser;
-    // We expect average user to have access to a small number of access control objects.
-    acosForUser.reserve(10);
-
-    for (const auto& aco : allAcos) {
-        auto acoName = aco.first;
-        auto aclRules = ConvertToNode(aco.second->Attributes().GetYson("principal_acl"))->AsList()->GetChildren();
-        bool allowUseRuleFound = false;
-        bool denyUseRuleFound = false;
-        // Check if there are allow or deny "Use" rules matching the subjects.
-        for (const auto& aclRule : aclRules) {
-            auto aclSubjects = aclRule->AsMap()->GetChildOrThrow("subjects")->AsList()->GetChildren();
-            auto aclPermissions = aclRule->AsMap()->GetChildOrThrow("permissions")->AsList()->GetChildren();
-            bool usePermissionFound = false;
-            for (const auto& aclPermission : aclPermissions) {
-                auto aclPermissionName = aclPermission->GetValue<TString>();
-                aclPermissionName.to_lower();
-                if (aclPermissionName == "use") {
-                    usePermissionFound = true;
-                    break;
-                }
-            }
-            if (!usePermissionFound) {
-                continue;
-            }
-            for (const auto& aclSubject : aclSubjects) {
-                auto aclSubjectName = aclSubject->GetValue<TString>();
-                if (subjects.find(aclSubjectName) != subjects.end()) {
-                    auto aclAction = aclRule->AsMap()->GetChildOrThrow("action")->GetValue<TString>();
-                    aclAction.to_lower();
-                    if (aclAction == "allow") {
-                        allowUseRuleFound = true;
-                    } else if (aclAction == "deny") {
-                        denyUseRuleFound = true;
-                    }
-                }
-            }
-        }
-        if (allowUseRuleFound && !denyUseRuleFound) {
-            acosForUser.emplace_back(acoName);
-        }
-    }
-    return acosForUser;
-}
-
-void VerifyAccessControlObjectExists(const TString& accessControlObject, const IClientPtr& client)
-{
-    auto error = WaitFor(client->NodeExists(Format(
-        "%v/%v",
-        QueriesAcoNamespacePath,
-        NYPath::ToYPathLiteral(accessControlObject))));
-
-    if (!error.IsOK()) {
-        THROW_ERROR_EXCEPTION("Failed to check whether access control object %Qv exists", accessControlObject)
-            << error;
-    }
-    if (!error.Value()) {
-        THROW_ERROR_EXCEPTION(NYTree::EErrorCode::ResolveError,
-            "Access control object %Qv does not exist",
-            accessControlObject);
-    }
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NDetail
 
@@ -383,605 +54,191 @@ TQueryId TClient::DoStartQuery(EQueryEngine engine, const TString& query, const 
         }
     }
 
-    auto [client, root] = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    static const TYsonString EmptyMap = TYsonString(TString("{}"));
+    auto req = proxy.StartQuery();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    auto queryId = TQueryId::Create();
-
-    YT_LOG_DEBUG("Starting query (QueryId: %v, Draft: %v)", queryId, options.Draft);
-
-    auto rowBuffer = New<TRowBuffer>();
-    auto transaction = WaitFor(client->StartTransaction(ETransactionType::Tablet, {}))
-        .ValueOrThrow();
-
+    if (options.Settings) {
+        req->set_settings(ConvertToYsonString(options.Settings).ToString());
+    }
+    if (options.Annotations) {
+        req->set_annotations(ConvertToYsonString(options.Annotations).ToString());
+    }
     if (options.AccessControlObject) {
-        VerifyAccessControlObjectExists(*options.AccessControlObject, client);
+        req->set_access_control_object(*options.AccessControlObject);
     }
+    req->set_draft(options.Draft);
+    req->set_files(ConvertToYsonString(options.Files).ToString());
 
-    // Draft queries go directly to finished query tables (regular and ordered by start time),
-    // non-draft queries go to the active query table.
+    req->set_engine(NProto::ConvertQueryEngineToProto(engine));
+    req->set_query(query);
 
-    if (options.Draft) {
-        TString filterFactors;
-        auto startTime = TInstant::Now();
-        {
-            static_assert(TFinishedQueryDescriptor::FieldCount == 14);
-            TFinishedQuery newRecord{
-                .Key = {.QueryId = queryId},
-                .Engine = engine,
-                .Query = query,
-                .Files = ConvertToYsonString(options.Files),
-                .Settings = options.Settings ? ConvertToYsonString(options.Settings) : EmptyMap,
-                .User = *Options_.User,
-                .AccessControlObject = options.AccessControlObject,
-                .StartTime = startTime,
-                .State = EQueryState::Draft,
-                .Progress = EmptyMap,
-                .Annotations = options.Annotations ? ConvertToYsonString(options.Annotations) : EmptyMap,
-            };
-            filterFactors = GetFilterFactors(newRecord);
-            std::vector rows{
-                newRecord.ToUnversionedRow(rowBuffer, TFinishedQueryDescriptor::Get()->GetIdMapping()),
-            };
-            transaction->WriteRows(
-                root + "/finished_queries",
-                TFinishedQueryDescriptor::Get()->GetNameTable(),
-                MakeSharedRange(std::move(rows), rowBuffer));
-        }
-        {
-            TFinishedQueryByStartTime newRecord{
-                .Key = {.StartTime = startTime, .QueryId = queryId},
-                .Engine = engine,
-                .User = *Options_.User,
-                .AccessControlObject = options.AccessControlObject,
-                .State = EQueryState::Draft,
-                .FilterFactors = filterFactors,
-            };
-            std::vector rows{
-                newRecord.ToUnversionedRow(rowBuffer, TFinishedQueryByStartTimeDescriptor::Get()->GetIdMapping()),
-            };
-            transaction->WriteRows(
-                root + "/finished_queries_by_start_time",
-                TFinishedQueryByStartTimeDescriptor::Get()->GetNameTable(),
-                MakeSharedRange(std::move(rows), rowBuffer));
-        }
-    } else {
-        static_assert(TActiveQueryDescriptor::FieldCount == 19);
-        TActiveQueryPartial newRecord{
-            .Key = {.QueryId = queryId},
-            .Engine = engine,
-            .Query = query,
-            .Files = ConvertToYsonString(options.Files),
-            .Settings = options.Settings ? ConvertToYsonString(options.Settings) : EmptyMap,
-            .User = *Options_.User,
-            .AccessControlObject = options.AccessControlObject,
-            .StartTime = TInstant::Now(),
-            .State = EQueryState::Pending,
-            .Incarnation = -1,
-            .Progress = EmptyMap,
-            .Annotations = options.Annotations ? ConvertToYsonString(options.Annotations) : EmptyMap,
-        };
-        newRecord.FilterFactors = GetFilterFactors(newRecord);
-        std::vector rows{
-            newRecord.ToUnversionedRow(rowBuffer, TActiveQueryDescriptor::Get()->GetIdMapping()),
-        };
-        transaction->WriteRows(
-            root + "/active_queries",
-            TActiveQueryDescriptor::Get()->GetNameTable(),
-            MakeSharedRange(std::move(rows), rowBuffer));
-    }
-    WaitFor(transaction->Commit())
-        .ThrowOnError();
-    return queryId;
+    auto rsp = WaitFor(req->Invoke()).ValueOrThrow();
+
+    return FromProto<TQueryId>(rsp->query_id());
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 void TClient::DoAbortQuery(TQueryId queryId, const TAbortQueryOptions& options)
 {
-    auto [client, root] = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    auto abortError = TError(
-        "Query was aborted by user %Qv%v",
-        Options_.User,
-        options.AbortMessage ? Format(" with message %Qv", *options.AbortMessage) : TString());
+    auto req = proxy.AbortQuery();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    TActiveQueryPartial newRecord{
-        .Key = {.QueryId = queryId},
-        .State = EQueryState::Aborting,
-        .FinishTime = TInstant::Now(),
-        .AbortRequest = ConvertToYsonString(abortError),
-    };
-    auto rowBuffer = New<TRowBuffer>();
-    std::vector rows{
-        newRecord.ToUnversionedRow(rowBuffer, TActiveQueryDescriptor::Get()->GetIdMapping()),
-    };
-    auto transaction = WaitFor(client->StartTransaction(ETransactionType::Tablet, {}))
-        .ValueOrThrow();
-
-    ValidateQueryPermissions(queryId, root, transaction->GetStartTimestamp(), *Options_.User, client, EPermission::Administer, Logger);
-
-    {
-        const auto& idMapping = TActiveQueryDescriptor::Get()->GetIdMapping();
-        TLookupRowsOptions options;
-        options.Timestamp = transaction->GetStartTimestamp();
-        options.ColumnFilter = {*idMapping.State};
-        options.KeepMissingRows = true;
-        TActiveQueryKey key{.QueryId = queryId};
-        std::vector keys{
-            key.ToKey(rowBuffer),
-        };
-        auto asyncLookupResult = client->LookupRows(
-            root + "/active_queries",
-            TActiveQueryDescriptor::Get()->GetNameTable(),
-            MakeSharedRange(std::move(keys), rowBuffer),
-            options);
-        auto rowset = WaitFor(asyncLookupResult)
-            .ValueOrThrow()
-            .Rowset;
-        auto optionalRecords = ToOptionalRecords<TActiveQuery>(rowset);
-        YT_VERIFY(optionalRecords.size() == 1);
-        if (!optionalRecords[0]) {
-            THROW_ERROR_EXCEPTION(
-                NQueryTrackerClient::EErrorCode::QueryNotFound,
-                "Query %v not found or is not running",
-                queryId);
-        }
-        const auto& record = *optionalRecords[0];
-        if (record.State != EQueryState::Pending && record.State != EQueryState::Running) {
-            THROW_ERROR_EXCEPTION("Cannot abort query %v which is in state %Qlv",
-                queryId,
-                record.State);
-        }
+    ToProto(req->mutable_query_id(), queryId);
+    if (options.AbortMessage) {
+        req->set_abort_message(*options.AbortMessage);
     }
 
-    transaction->WriteRows(
-        root + "/active_queries",
-        TActiveQueryDescriptor::Get()->GetNameTable(),
-        MakeSharedRange(std::move(rows), std::move(rowBuffer)));
-
-    auto error = WaitFor(transaction->Commit());
-    if (!error.IsOK()) {
-        if (error.FindMatching(NTabletClient::EErrorCode::TransactionLockConflict)) {
-            // TODO(max42): retry such errors automatically?
-            THROW_ERROR_EXCEPTION("Cannot abort query because its state is being changed at the moment; please try again")
-                << error;
-        }
-        THROW_ERROR error;
-    }
+    WaitFor(req->Invoke())
+        .ThrowOnError();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TQueryResult TClient::DoGetQueryResult(TQueryId queryId, i64 resultIndex, const TGetQueryResultOptions& options)
 {
-    auto [client, root] = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    auto timestamp = WaitFor(client->GetTimestampProvider()->GenerateTimestamps())
-        .ValueOrThrow();
+    auto req = proxy.GetQueryResult();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    TQueryResult queryResult;
-    {
-        auto rowBuffer = New<TRowBuffer>();
-        TLookupRowsOptions options;
-        options.KeepMissingRows = true;
+    ToProto(req->mutable_query_id(), queryId);
+    req->set_result_index(resultIndex);
 
-        ValidateQueryPermissions(queryId, root, timestamp, *Options_.User, client, EPermission::Read, Logger);
+    auto rsp = WaitFor(req->Invoke()).ValueOrThrow();
 
-        TFinishedQueryResultKey key{.QueryId = queryId, .Index = resultIndex};
-        std::vector keys{
-            key.ToKey(rowBuffer),
-        };
-        auto asyncLookupResult = client->LookupRows(
-            root + "/finished_query_results",
-            TFinishedQueryResultDescriptor::Get()->GetNameTable(),
-            MakeSharedRange(std::move(keys), rowBuffer),
-            options);
-        auto rowset = WaitFor(asyncLookupResult)
-            .ValueOrThrow()
-            .Rowset;
-        auto optionalRecords = ToOptionalRecords<TFinishedQueryResult>(rowset);
-        YT_VERIFY(optionalRecords.size() == 1);
-        if (!optionalRecords[0]) {
-            THROW_ERROR_EXCEPTION(
-                NQueryTrackerClient::EErrorCode::QueryResultNotFound,
-                "Query %v result %v not found or is expired",
-                queryId,
-                resultIndex);
-        }
-        const auto& record = *optionalRecords[0];
-
-        queryResult.Id = queryId;
-        queryResult.ResultIndex = resultIndex;
-        auto schemaNode = record.Schema ? ConvertToNode(*record.Schema) : nullptr;
-        queryResult.Schema = schemaNode && schemaNode->GetType() == ENodeType::List ? ConvertTo<TTableSchemaPtr>(schemaNode) : nullptr;
-        queryResult.Error = record.Error;
-        queryResult.IsTruncated = record.IsTruncated;
-        queryResult.DataStatistics = ConvertTo<TDataStatistics>(record.DataStatistics);
-    }
-
-    return queryResult;
+    return TQueryResult {
+        .Id = FromProto<TQueryId>(rsp->query_id()),
+        .ResultIndex = rsp->result_index(),
+        .Error = FromProto<TError>(rsp->error()),
+        .Schema = rsp->has_schema() ? FromProto<TTableSchemaPtr>(rsp->schema()) : nullptr,
+        .DataStatistics = FromProto<TDataStatistics>(rsp->data_statistics()),
+        .IsTruncated = rsp->is_truncated(),
+    };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
-IUnversionedRowsetPtr FilterRowsetColumns(IUnversionedRowsetPtr rowset, std::vector<TString> columns)
-{
-    const auto& schema = rowset->GetSchema();
-    const auto& rows = rowset->GetRows();
-    auto rowBuffer = New<TRowBuffer>();
-    auto nameTable = TNameTable::FromSchema(*schema);
-    std::vector<int> columnIndexes;
-    THashSet<int> columnIndexSet;
-    for (const auto& column : columns) {
-        if (auto id = nameTable->FindId(column); id && columnIndexSet.insert(*id).second) {
-            columnIndexes.push_back(*id);
-        }
-    }
-    TColumnFilter columnFilter(columnIndexes);
-
-    std::vector<TUnversionedRow> newRows;
-    newRows.reserve(rows.size());
-    for (const auto& row : rows) {
-        auto newRow = rowBuffer->AllocateUnversioned(columnIndexes.size());
-        for (auto [newIndex, index] : Enumerate(columnIndexes)) {
-            auto value = row[index];
-            value.Id = newIndex;
-            newRow[newIndex] = rowBuffer->CaptureValue(value);
-        }
-        newRows.emplace_back(newRow);
-    }
-
-    auto newSchema = schema->Filter(columnFilter);
-
-    return CreateRowset(newSchema, MakeSharedRange(std::move(newRows), std::move(rowBuffer)));
-}
 
 IUnversionedRowsetPtr TClient::DoReadQueryResult(TQueryId queryId, i64 resultIndex, const TReadQueryResultOptions& options)
 {
-    auto [client, root] = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    YT_LOG_DEBUG(
-        "Reading query result (QueryId: %v, ResultIndex: %v, LowerRowIndex: %v, UpperRowIndex: %v)",
-        queryId,
-        resultIndex,
-        options.UpperRowIndex,
-        options.UpperRowIndex);
+    auto req = proxy.ReadQueryResult();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    auto timestamp = WaitFor(client->GetTimestampProvider()->GenerateTimestamps())
-        .ValueOrThrow();
-
-    TString wireRowset;
-    TTableSchemaPtr schema;
-    {
-        auto rowBuffer = New<TRowBuffer>();
-        TLookupRowsOptions options;
-        options.KeepMissingRows = true;
-
-        ValidateQueryPermissions(queryId, root, timestamp, *Options_.User, client, EPermission::Read, Logger);
-
-        TFinishedQueryResultKey key{.QueryId = queryId, .Index = resultIndex};
-        std::vector keys{
-            key.ToKey(rowBuffer),
-        };
-        auto asyncLookupResult = client->LookupRows(
-            root + "/finished_query_results",
-            TFinishedQueryResultDescriptor::Get()->GetNameTable(),
-            MakeSharedRange(std::move(keys), rowBuffer),
-            options);
-        auto rowset = WaitFor(asyncLookupResult)
-            .ValueOrThrow()
-            .Rowset;
-        auto optionalRecords = ToOptionalRecords<TFinishedQueryResult>(rowset);
-        YT_VERIFY(optionalRecords.size() == 1);
-        if (!optionalRecords[0]) {
-            THROW_ERROR_EXCEPTION(
-                NQueryTrackerClient::EErrorCode::QueryResultNotFound,
-                "Query %v result %v not found or is expired",
-                queryId,
-                resultIndex);
-        }
-        const auto& record = *optionalRecords[0];
-        if (!record.Error.IsOK()) {
-            THROW_ERROR record.Error;
-        }
-        if (!record.Rowset) {
-            // This should not normally happen, but better this than abort.
-            THROW_ERROR_EXCEPTION(
-                NQueryTrackerClient::EErrorCode::QueryResultNotFound,
-                "Query %v result %v rowset is missing",
-                queryId,
-                resultIndex);
-        }
-        wireRowset = *record.Rowset;
-        schema = ConvertTo<TTableSchemaPtr>(record.Schema);
-    }
-
-    auto wireReader = CreateWireProtocolReader(TSharedRef::FromString(std::move(wireRowset)));
-    auto schemaData = IWireProtocolReader::GetSchemaData(*schema);
-    auto rows = wireReader->ReadSchemafulRowset(schemaData, /*captureValues*/ true);
-
-    {
-        auto lowerRowIndex = options.LowerRowIndex.value_or(0);
-        lowerRowIndex = std::clamp<i64>(lowerRowIndex, 0, rows.size());
-        auto upperRowIndex = options.UpperRowIndex.value_or(rows.size());
-        upperRowIndex = std::clamp<i64>(upperRowIndex, lowerRowIndex, rows.size());
-        rows = rows.Slice(lowerRowIndex, upperRowIndex);
-    }
-
-    auto rowset = CreateRowset(std::move(schema), std::move(rows));
+    ToProto(req->mutable_query_id(), queryId);
+    req->set_result_index(resultIndex);
 
     if (options.Columns) {
-        rowset = FilterRowsetColumns(rowset, *options.Columns);
+        auto* protoColumns = req->mutable_columns();
+        for (const auto& column : *options.Columns) {
+            protoColumns->add_items(column);
+        }
+    }
+    if (options.LowerRowIndex) {
+        req->set_lower_row_index(*options.LowerRowIndex);
+    }
+    if (options.UpperRowIndex) {
+        req->set_upper_row_index(*options.UpperRowIndex);
     }
 
-    return rowset;
+    auto rsp = WaitFor(req->Invoke()).ValueOrThrow();
+    struct TQueryTrackerNativeClientTag { };
+    return NRpcProxy::DeserializeRowset<TUnversionedRow>(
+        rsp->rowset_descriptor(),
+        MergeRefsToRef<TQueryTrackerNativeClientTag>(rsp->Attachments()));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::vector<TQuery> PartialRecordsToQueries(const auto& partialRecords)
-{
-    std::vector<TQuery> queries;
-    queries.reserve(partialRecords.size());
-    for (const auto& partialRecord : partialRecords) {
-        queries.push_back(PartialRecordToQuery(partialRecord));
-    }
-    return queries;
-}
-
 TQuery TClient::DoGetQuery(TQueryId queryId, const TGetQueryOptions& options)
 {
-    IClientPtr client;
-    TString root;
-    std::tie(client, root) = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    auto timestamp = options.Timestamp != NTransactionClient::NullTimestamp
-        ? options.Timestamp
-        : WaitFor(client->GetTimestampProvider()->GenerateTimestamps())
-            .ValueOrThrow();
+    auto req = proxy.GetQuery();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    YT_LOG_DEBUG("Getting query (QueryId: %v, Timestamp: %v, Attributes: %v)", queryId, timestamp, options.Attributes);
+    ToProto(req->mutable_query_id(), queryId);
+    if (options.Attributes) {
+        ToProto(req->mutable_attributes(), options.Attributes);
+    }
+    if (options.Timestamp) {
+        req->set_timestamp(ToProto<i64>(options.Timestamp));
+    }
 
-    options.Attributes.ValidateKeysOnly();
+    auto rsp = WaitFor(req->Invoke()).ValueOrThrow();
 
-    ValidateQueryPermissions(queryId, root, timestamp, *Options_.User, client, EPermission::Use, Logger);
-
-    auto lookupKeys = options.Attributes ? std::make_optional(options.Attributes.Keys) : std::nullopt;
-
-    return LookupQuery(queryId, client, root, lookupKeys, timestamp, Logger);
+    TQuery query;
+    FromProto(&query, rsp->query());
+    return query;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 TListQueriesResult TClient::DoListQueries(const TListQueriesOptions& options)
 {
-    IClientPtr client;
-    TString root;
-    std::tie(client, root) = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    auto timestamp = WaitFor(client->GetTimestampProvider()->GenerateTimestamps())
-        .ValueOrThrow();
+    auto req = proxy.ListQueries();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    YT_LOG_DEBUG(
-        "Listing queries (Timestamp: %v, State: %v, CursorDirection: %v, FromTime: %v, ToTime: %v, CursorTime: %v,"
-        "Substr: %v, User: %v, Engine: %v, Limit: %v, Attributes: %v)",
-        timestamp,
-        options.StateFilter,
-        options.CursorDirection,
-        options.FromTime,
-        options.ToTime,
-        options.CursorTime,
-        options.SubstrFilter,
-        options.UserFilter,
-        options.EngineFilter,
-        options.Limit,
-        options.Attributes);
-
-    auto attributes = options.Attributes;
-
-    attributes.ValidateKeysOnly();
-
-    if (!attributes.AdmitsKeySlow("start_time")) {
-        YT_VERIFY(attributes);
-        attributes.Keys.push_back("start_time");
+    if (options.FromTime) {
+        req->set_from_time(NYT::ToProto<i64>(*options.FromTime));
+    }
+    if (options.ToTime) {
+        req->set_to_time(NYT::ToProto<i64>(*options.ToTime));
+    }
+    if (options.CursorTime) {
+        req->set_cursor_time(NYT::ToProto<i64>(*options.CursorTime));
     }
 
-    auto userSubjects = GetUserSubjects(*Options_.User, client);
-    userSubjects.insert(*Options_.User);
+    req->set_cursor_direction(static_cast<NProto::EOperationSortDirection>(options.CursorDirection));
 
-    std::vector<TString> userSubjectsVector(userSubjects.begin(), userSubjects.end());
-    YT_LOG_DEBUG("Fetched user %Qv subjects: %v", *Options_.User, userSubjectsVector);
-
-    bool isSuperuser = userSubjects.contains(NSecurityClient::SuperusersGroupName);
-    std::vector<TString> acosForUser;
-
-    if (!isSuperuser) {
-        acosForUser = GetAcosForSubjects(userSubjects, client);
-        YT_LOG_DEBUG("Fetched suitable access control objects for user %Qv: %v", *Options_.User, acosForUser);
+    if (options.UserFilter) {
+        req->set_user_filter(*options.UserFilter);
+    }
+    if (options.StateFilter) {
+        req->set_state_filter(NProto::ConvertQueryStateToProto(*options.StateFilter));
+    }
+    if (options.EngineFilter) {
+        req->set_engine_filter(NProto::ConvertQueryEngineToProto(*options.EngineFilter));
+    }
+    if (options.SubstrFilter) {
+        req->set_substr_filter(*options.SubstrFilter);
     }
 
-    auto addSelectExpressionsFromAttributes = [&] (TQueryBuilder& builder, const TNameTablePtr& nameTable) {
-        if (attributes) {
-            for (const auto& key : attributes.Keys) {
-                if (nameTable->FindId(key)) {
-                    builder.AddSelectExpression("[" + key + "]");
-                }
-            }
-        } else {
-            builder.AddSelectExpression("*");
-        }
-    };
+    req->set_limit(options.Limit);
 
-    auto addSelectExpressionsForMerging = [&] (TQueryBuilder& builder) {
-        if (!attributes.AdmitsKeySlow("query_id")) {
-            builder.AddSelectExpression("[query_id]");
-        }
-    };
-
-    auto addFilterConditions = [&] (TQueryBuilder& builder, TYsonString& placeholderValues) {
-        auto placeholdersFluentMap = BuildYsonNodeFluently().BeginMap();
-        if (options.UserFilter) {
-            builder.AddWhereConjunct("[user] = {UserFilter}");
-            placeholdersFluentMap.Item("UserFilter").Value(*options.UserFilter);
-        }
-        if (options.EngineFilter) {
-            builder.AddWhereConjunct("[engine] = {EngineFilter}");
-            placeholdersFluentMap.Item("EngineFilter").Value(*options.EngineFilter);
-        }
-        if (options.StateFilter) {
-            builder.AddWhereConjunct("[state] = {StateFilter}");
-            placeholdersFluentMap.Item("StateFilter").Value(*options.StateFilter);
-        }
-        if (options.FromTime) {
-            builder.AddWhereConjunct("[start_time] >= " + ToString(options.FromTime->MicroSeconds()));
-        }
-        if (options.ToTime) {
-            builder.AddWhereConjunct("[start_time] <= " + ToString(options.ToTime->MicroSeconds()));
-        }
-        if (options.SubstrFilter) {
-            builder.AddWhereConjunct("is_substr({SubstrFilter}, filter_factors)");
-            placeholdersFluentMap.Item("SubstrFilter").Value(*options.SubstrFilter);
-        }
-        if (!isSuperuser) {
-            placeholdersFluentMap.Item("User").Value(*Options_.User);
-
-            if (acosForUser.empty()) {
-                builder.AddWhereConjunct("user = {User}");
-            } else {
-                builder.AddWhereConjunct("user = {User} OR access_control_object IN {acosForUser}");
-                placeholdersFluentMap.Item("acosForUser").DoListFor(acosForUser, [] (TFluentList fluent, const TString& aco) {
-                    fluent.Item().Value(aco);
-                });
-            }
-        }
-
-        placeholderValues = ConvertToYsonString(placeholdersFluentMap.EndMap());
-    };
-
-    auto selectActiveQueries = [=, this, this_ = MakeStrong(this)] {
-        try {
-            TQueryBuilder builder;
-            TYsonString placeholderValues;
-            builder.SetSource(root + "/active_queries");
-            addFilterConditions(builder, placeholderValues);
-            addSelectExpressionsFromAttributes(builder, TActiveQueryDescriptor::Get()->GetNameTable());
-            addSelectExpressionsForMerging(builder);
-            TSelectRowsOptions options;
-            options.Timestamp = timestamp;
-            options.PlaceholderValues = placeholderValues;
-            auto query = builder.Build();
-            YT_LOG_DEBUG("Selecting active queries (Query: %v)", query);
-            auto selectResult = WaitFor(client->SelectRows(query, options))
-                .ValueOrThrow();
-            auto records = ToRecords<TActiveQueryPartial>(selectResult.Rowset);
-            return PartialRecordsToQueries(records);
-        } catch (const std::exception& ex) {
-            THROW_ERROR_EXCEPTION("Error while selecting active queries")
-                << ex;
-        }
-    };
-
-    auto selectFinishedQueries = [=, this, this_ = MakeStrong(this)] () -> std::vector<TQuery> {
-        try {
-            TStringBuilder admittedQueryIds;
-            {
-                TQueryBuilder builder;
-                TYsonString placeholderValues;
-                builder.SetSource(root + "/finished_queries_by_start_time");
-                addFilterConditions(builder, placeholderValues);
-                builder.AddSelectExpression("[query_id]");
-                TSelectRowsOptions options;
-                options.Timestamp = timestamp;
-                options.PlaceholderValues = placeholderValues;
-                auto query = builder.Build();
-                YT_LOG_DEBUG("Selecting finished queries by start time (Query: %v)", query);
-                auto selectResult = WaitFor(client->SelectRows(query, options))
-                    .ValueOrThrow();
-                bool isFirst = true;
-                for (const auto& record : ToRecords<TFinishedQueryByStartTime>(selectResult.Rowset)) {
-                    if (!isFirst) {
-                        admittedQueryIds.AppendString(", ");
-                    }
-                    admittedQueryIds.AppendFormat("\"%v\"", record.Key.QueryId);
-                    isFirst = false;
-                }
-                if (isFirst) {
-                    return {};
-                }
-            }
-            {
-                TQueryBuilder builder;
-                builder.SetSource(root + "/finished_queries");
-                addSelectExpressionsFromAttributes(builder, TFinishedQueryDescriptor::Get()->GetNameTable());
-                builder.AddWhereConjunct("[query_id] in (" + admittedQueryIds.Flush() + ")");
-                addSelectExpressionsForMerging(builder);
-                TSelectRowsOptions options;
-                options.Timestamp = timestamp;
-                auto query = builder.Build();
-                YT_LOG_DEBUG("Selecting admitted finished queries (Query: %v)", query);
-                auto selectResult = WaitFor(client->SelectRows(query, options))
-                    .ValueOrThrow();
-                auto records = ToRecords<TFinishedQueryPartial>(selectResult.Rowset);
-                return PartialRecordsToQueries(records);
-            }
-        } catch (const std::exception& ex) {
-            THROW_ERROR_EXCEPTION("Error while selecting finished queries")
-                << ex;
-        }
-    };
-
-    std::vector<TQuery> queries;
-    {
-        std::vector<TFuture<std::vector<TQuery>>> futures;
-        std::optional<bool> stateFilterDefinesFinishedQuery = options.StateFilter
-            ? std::make_optional(IsFinishedState(*options.StateFilter))
-            : std::nullopt;
-        if (!options.StateFilter || *stateFilterDefinesFinishedQuery) {
-            futures.push_back(BIND(selectFinishedQueries).AsyncVia(GetCurrentInvoker()).Run());
-        }
-        if (!options.StateFilter || !*stateFilterDefinesFinishedQuery) {
-            futures.push_back(BIND(selectActiveQueries).AsyncVia(GetCurrentInvoker()).Run());
-        }
-        auto queryVectors = WaitFor(AllSucceeded(futures))
-            .ValueOrThrow();
-        for (const auto& queryVector : queryVectors) {
-            queries.insert(queries.end(), queryVector.begin(), queryVector.end());
-        }
+    if (options.Attributes) {
+        ToProto(req->mutable_attributes(), options.Attributes);
     }
 
-    std::vector<TQuery> result;
-    bool incomplete = false;
-    if (options.CursorDirection != EOperationSortDirection::None) {
-        auto compare = [&] (const TQuery& lhs, const TQuery& rhs) {
-            return options.CursorDirection == EOperationSortDirection::Past
-                ? std::tie(lhs.StartTime, lhs.Query) > std::tie(rhs.StartTime, rhs.Query)
-                : std::tie(lhs.StartTime, lhs.Query) < std::tie(rhs.StartTime, rhs.Query);
-        };
-        std::sort(queries.begin(), queries.end(), compare);
-        for (auto& query : queries) {
-            if (!options.CursorTime ||
-                (options.CursorDirection == EOperationSortDirection::Past && query.StartTime < options.CursorTime) ||
-                (options.CursorDirection == EOperationSortDirection::Future && query.StartTime > options.CursorTime))
-            {
-                if (result.size() == options.Limit) {
-                    // We are finishing collecting queries prematurely, set incomplete flag and break.
-                    incomplete = true;
-                    break;
-                }
-                result.push_back(std::move(query));
-            }
-        }
-    } else {
-        incomplete = options.Limit < queries.size();
-        result = std::vector(queries.begin(), queries.end() + std::min(options.Limit, queries.size()));
-    }
+    auto rsp = WaitFor(req->Invoke()).ValueOrThrow();
 
+    std::vector<TQuery> queries(rsp->queries_size());
+    for (auto i = 0; i < rsp->queries_size(); i++) {
+        FromProto(&queries[i], rsp->queries()[i]);
+    }
     return TListQueriesResult{
-        .Queries = std::move(result),
-        .Incomplete = incomplete,
-        .Timestamp = timestamp,
+        .Queries = std::move(queries),
+        .Incomplete = rsp->incomplete(),
+        .Timestamp = rsp->timestamp(),
     };
 }
 
@@ -989,100 +246,22 @@ TListQueriesResult TClient::DoListQueries(const TListQueriesOptions& options)
 
 void TClient::DoAlterQuery(TQueryId queryId, const TAlterQueryOptions& options)
 {
-    auto [client, root] = GetNativeConnection()->GetQueryTrackerStage(options.QueryTrackerStage);
+    TQueryTrackerServiceProxy proxy(
+        Connection_->GetQueryTrackerChannelOrThrow(options.QueryTrackerStage));
 
-    auto transaction = WaitFor(client->StartTransaction(ETransactionType::Tablet, {}))
-        .ValueOrThrow();
+    auto req = proxy.AlterQuery();
+    req->SetTimeout(options.Timeout);
+    req->SetUser(*Options_.User);
 
-    auto timestamp = transaction->GetStartTimestamp();
-
-    ValidateQueryPermissions(queryId, root, timestamp, *Options_.User, client, EPermission::Administer, Logger);
-
-    std::vector<TString> lookupKeys = {"state", "start_time"};
-
-    auto query = LookupQuery(queryId, client, root, lookupKeys, timestamp, Logger);
-
-    YT_LOG_DEBUG(
-        "Altering query (QueryId: %v, State: %v, HasAnnotations: %v, HasAccessControlObject: %v)",
-        queryId,
-        *query.State,
-        static_cast<bool>(options.Annotations),
-        static_cast<bool>(options.AccessControlObject));
-
-    if (!options.Annotations && !options.AccessControlObject) {
-        WaitFor(transaction->Commit())
-            .ThrowOnError();
-        return;
+    ToProto(req->mutable_query_id(), queryId);
+    if (options.Annotations) {
+        req->set_annotations(ConvertToYsonString(options.Annotations).ToString());
     }
-
     if (options.AccessControlObject) {
-        VerifyAccessControlObjectExists(*options.AccessControlObject, client);
+        req->set_access_control_object(*options.AccessControlObject);
     }
 
-    if (IsFinishedState(*query.State)) {
-        auto rowBuffer = New<TRowBuffer>();
-        TString filterFactors;
-        {
-            TFinishedQueryPartial record{
-                .Key = {.QueryId = queryId},
-            };
-            if (options.Annotations) {
-                record.Annotations = ConvertToYsonString(options.Annotations);
-                filterFactors = GetFilterFactors(record);
-            }
-            if (options.AccessControlObject) {
-                record.AccessControlObject = options.AccessControlObject;
-            }
-            std::vector rows{
-                record.ToUnversionedRow(rowBuffer, TFinishedQueryDescriptor::Get()->GetIdMapping()),
-            };
-            transaction->WriteRows(
-                root + "/finished_queries",
-                TFinishedQueryDescriptor::Get()->GetNameTable(),
-                MakeSharedRange(std::move(rows), rowBuffer));
-        }
-        {
-            TFinishedQueryByStartTimePartial record{
-                .Key = {.StartTime = *query.StartTime, .QueryId = queryId},
-            };
-            if (options.Annotations) {
-                record.FilterFactors = filterFactors;
-            }
-            if (options.AccessControlObject) {
-                record.AccessControlObject = options.AccessControlObject;
-            }
-            std::vector rows{
-                record.ToUnversionedRow(rowBuffer, TFinishedQueryByStartTimeDescriptor::Get()->GetIdMapping()),
-            };
-            transaction->WriteRows(
-                root + "/finished_queries_by_start_time",
-                TFinishedQueryByStartTimeDescriptor::Get()->GetNameTable(),
-                MakeSharedRange(std::move(rows), rowBuffer));
-        }
-    } else {
-        auto rowBuffer = New<TRowBuffer>();
-        {
-            TActiveQueryPartial record{
-                .Key = {.QueryId = queryId},
-            };
-            if (options.Annotations) {
-                record.Annotations = ConvertToYsonString(options.Annotations);
-                record.FilterFactors = GetFilterFactors(record);
-            }
-            if (options.AccessControlObject) {
-                record.AccessControlObject = options.AccessControlObject;
-            }
-            std::vector rows{
-                record.ToUnversionedRow(rowBuffer, TActiveQueryDescriptor::Get()->GetIdMapping()),
-            };
-            transaction->WriteRows(
-                root + "/active_queries",
-                TActiveQueryDescriptor::Get()->GetNameTable(),
-                MakeSharedRange(std::move(rows), rowBuffer));
-        }
-    }
-
-    WaitFor(transaction->Commit())
+    WaitFor(req->Invoke())
         .ThrowOnError();
 }
 

--- a/yt/yt/ytlib/api/native/connection.cpp
+++ b/yt/yt/ytlib/api/native/connection.cpp
@@ -1124,7 +1124,8 @@ private:
             }));
     }
 
-    std::pair<IClientPtr, TQueryTrackerStageConfigPtr> FindQueryTrackerStage(const TString& stage) {
+    std::pair<IClientPtr, TQueryTrackerStageConfigPtr> FindQueryTrackerStage(const TString& stage)
+    {
         auto findStage = [&stage, this] (const TString& cluster) -> std::pair<IClientPtr, TQueryTrackerStageConfigPtr> {
             auto clusterConnection = FindRemoteConnection(MakeStrong(this), cluster);
             YT_VERIFY(clusterConnection);

--- a/yt/yt/ytlib/api/native/connection.cpp
+++ b/yt/yt/ytlib/api/native/connection.cpp
@@ -122,6 +122,7 @@ using namespace NNodeTrackerClient;
 using namespace NObjectClient;
 using namespace NProfiling;
 using namespace NQueryClient;
+using namespace NQueryTrackerClient;
 using namespace NQueueClient;
 using namespace NScheduler;
 using namespace NSecurityClient;
@@ -1070,6 +1071,27 @@ private:
             std::move(endpointAttributes));
     }
 
+    IChannelPtr CreateQueryTrackerChannel(TQueryTrackerChannelConfigPtr config) const
+    {
+        if (!config) {
+            THROW_ERROR_EXCEPTION("Missing \"channel\" parameter in query tracker connection configuration");
+        }
+
+        auto endpointDescription = "QueryTracker";
+        auto endpointAttributes = ConvertToAttributes(BuildYsonStringFluently()
+            .BeginMap()
+                .Item("query_tracker").Value(true)
+            .EndMap());
+
+        auto channel = CreateBalancingChannel(
+            config,
+            ChannelFactory_,
+            std::move(endpointDescription),
+            std::move(endpointAttributes));
+
+        return CreateDefaultTimeoutChannel(channel, config->Timeout);
+    }
+
     void SetupTvmIdSynchronization()
     {
         auto config = Config_.Acquire();
@@ -1102,10 +1124,8 @@ private:
             }));
     }
 
-    //! Returns a pair consisting of the client for the Query Tracker cluster and the path to the Query Tracker root in Cypress.
-    std::pair<IClientPtr, TString> GetQueryTrackerStage(const TString& stage) override
-    {
-        auto findStage = [&stage, this] (const TString& cluster) -> std::pair<IClientPtr, TString> {
+    std::pair<IClientPtr, TQueryTrackerStageConfigPtr> FindQueryTrackerStage(const TString& stage) {
+        auto findStage = [&stage, this] (const TString& cluster) -> std::pair<IClientPtr, TQueryTrackerStageConfigPtr> {
             auto clusterConnection = FindRemoteConnection(MakeStrong(this), cluster);
             YT_VERIFY(clusterConnection);
 
@@ -1114,13 +1134,13 @@ private:
             if (auto iter = stages.find(stage); iter != stages.end()) {
                 const auto& stage = iter->second;
                 auto client = NNative::CreateClient(clusterConnection, TClientOptions::FromUser(stage->User));
-                return {client, stage->Root};
+                return {client, stage};
             }
 
-            return {nullptr, ""};
+            return {nullptr, nullptr};
         };
 
-        std::pair<IClientPtr, TString> resultStage;
+        std::pair<IClientPtr, TQueryTrackerStageConfigPtr> resultStage;
         TString resultCluster;
         for (const auto& cluster: GetClusterDirectory()->GetClusterNames()) {
             if (auto existingStage = findStage(cluster); existingStage.first) {
@@ -1131,11 +1151,23 @@ private:
                 resultCluster = cluster;
             }
         }
-        if (resultStage.first) {
-            return resultStage;
-        } else {
+
+        if (!resultStage.first) {
             THROW_ERROR_EXCEPTION("Query tracker stage %Qv is not found in cluster directory", stage);
         }
+        return resultStage;
+    }
+
+    //! Returns a pair consisting of the client for the Query Tracker cluster and the path to the Query Tracker root in Cypress.
+    std::pair<IClientPtr, TString> GetQueryTrackerStage(const TString& stage) override
+    {
+        auto resultStage = FindQueryTrackerStage(stage);
+        return {resultStage.first, resultStage.second->Root};
+    }
+
+    IChannelPtr GetQueryTrackerChannelOrThrow(const TString& stage) override
+    {
+        return CreateQueryTrackerChannel(FindQueryTrackerStage(stage).second->Channel);
     }
 
     IChannelPtr WrapChaosChannel(IChannelPtr channel)

--- a/yt/yt/ytlib/api/native/connection.h
+++ b/yt/yt/ytlib/api/native/connection.h
@@ -83,6 +83,7 @@ struct IConnection
     virtual const NChunkClient::IChunkReplicaCachePtr& GetChunkReplicaCache() = 0;
 
     virtual std::pair<IClientPtr, NYPath::TYPath> GetQueryTrackerStage(const TString& stage) = 0;
+    virtual NRpc::IChannelPtr GetQueryTrackerChannelOrThrow(const TString& stage) = 0;
 
     virtual const NHiveClient::TCellTrackerPtr& GetDownedCellTracker() = 0;
 

--- a/yt/yt/ytlib/query_tracker_client/config.cpp
+++ b/yt/yt/ytlib/query_tracker_client/config.cpp
@@ -28,12 +28,6 @@ void TQueryTrackerConnectionConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("stages", &TThis::Stages)
         .Default();
-    registrar.Parameter("max_query_file_count", &TThis::MaxQueryFileCount)
-        .Default(8192);
-    registrar.Parameter("max_query_file_name_size_bytes", &TThis::MaxQueryFileNameSizeBytes)
-        .Default(1_KB);
-    registrar.Parameter("max_query_file_content_size_bytes", &TThis::MaxQueryFileContentSizeBytes)
-        .Default(2_KB);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/config.cpp
+++ b/yt/yt/ytlib/query_tracker_client/config.cpp
@@ -2,6 +2,14 @@
 
 namespace NYT::NQueryTrackerClient {
 
+////////////////////////////////////////////////////////////////////////////////
+
+void TQueryTrackerChannelConfig::Register(TRegistrar registrar)
+{
+    registrar.Parameter("timeout", &TThis::Timeout)
+        .Default(TDuration::Minutes(1));
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 void TQueryTrackerStageConfig::Register(TRegistrar registrar)
@@ -10,6 +18,8 @@ void TQueryTrackerStageConfig::Register(TRegistrar registrar)
         .Default("//sys/query_tracker");
     registrar.Parameter("user", &TThis::User)
         .Default("query_tracker");
+    registrar.Parameter("channel", &TThis::Channel)
+        .Default();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/config.h
+++ b/yt/yt/ytlib/query_tracker_client/config.h
@@ -48,10 +48,6 @@ class TQueryTrackerConnectionConfig
 public:
     THashMap<TString, TQueryTrackerStageConfigPtr> Stages;
 
-    i64 MaxQueryFileCount;
-    i64 MaxQueryFileNameSizeBytes;
-    i64 MaxQueryFileContentSizeBytes;
-
     REGISTER_YSON_STRUCT(TQueryTrackerConnectionConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/ytlib/query_tracker_client/config.h
+++ b/yt/yt/ytlib/query_tracker_client/config.h
@@ -2,9 +2,26 @@
 
 #include "public.h"
 
+#include <yt/yt/core/rpc/config.h>
+
 #include <yt/yt/core/ytree/yson_struct.h>
 
 namespace NYT::NQueryTrackerClient {
+
+///////////////////////////////////////////////////////////////////////////////
+
+class TQueryTrackerChannelConfig
+    : public NRpc::TBalancingChannelConfig
+{
+public:
+    TDuration Timeout;
+
+    REGISTER_YSON_STRUCT(TQueryTrackerChannelConfig);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TQueryTrackerChannelConfig)
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -12,6 +29,7 @@ class TQueryTrackerStageConfig
     : public NYTree::TYsonStruct
 {
 public:
+    TQueryTrackerChannelConfigPtr Channel;
     NYPath::TYPath Root;
     TString User;
 

--- a/yt/yt/ytlib/query_tracker_client/helpers.cpp
+++ b/yt/yt/ytlib/query_tracker_client/helpers.cpp
@@ -1,5 +1,10 @@
 #include "helpers.h"
 
+#include <yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.pb.h>
+
+#include <yt/yt/client/api/query_tracker_client.h>
+#include <yt/yt/client/api/rpc_proxy/helpers.h>
+
 #include <yt/yt/ytlib/query_tracker_client/records/query.record.h>
 
 namespace NYT::NQueryTrackerClient {
@@ -7,6 +12,8 @@ namespace NYT::NQueryTrackerClient {
 using namespace NQueryTrackerClient::NRecords;
 using namespace NYTree;
 using namespace NYson;
+
+using NYT::FromProto;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -47,6 +54,134 @@ bool IsFinishedState(EQueryState state)
 {
     return state == EQueryState::Aborted || state == EQueryState::Failed ||
         state == EQueryState::Completed || state == EQueryState::Draft;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ToProto(NProto::TQuery* protoQuery, const NApi::TQuery& query)
+{
+    protoQuery->Clear();
+
+    ToProto(protoQuery->mutable_id(), query.Id);
+
+    if (query.Engine) {
+        protoQuery->set_engine(NApi::NRpcProxy::NProto::ConvertQueryEngineToProto(*query.Engine));
+    }
+    if (query.Query) {
+        protoQuery->set_query(*query.Query);
+    }
+    if (query.Files) {
+        protoQuery->set_files(query.Files->ToString());
+    }
+    if (query.StartTime) {
+        protoQuery->set_start_time(NYT::ToProto<i64>(*query.StartTime));
+    }
+    if (query.FinishTime) {
+        protoQuery->set_finish_time(NYT::ToProto<i64>(*query.FinishTime));
+    }
+    if (query.Settings) {
+        protoQuery->set_settings(query.Settings.ToString());
+    }
+    if (query.User) {
+        protoQuery->set_user(*query.User);
+    }
+    if (query.AccessControlObject) {
+        protoQuery->set_access_control_object(*query.AccessControlObject);
+    }
+    if (query.State) {
+        protoQuery->set_state(NApi::NRpcProxy::NProto::ConvertQueryStateToProto(*query.State));
+    }
+    if (query.ResultCount) {
+        protoQuery->set_result_count(*query.ResultCount);
+    }
+    if (query.Progress) {
+        protoQuery->set_progress(query.Progress.ToString());
+    }
+    if (query.Error) {
+        ToProto(protoQuery->mutable_error(), *query.Error);
+    }
+    if (query.Annotations) {
+        protoQuery->set_annotations(query.Annotations.ToString());
+    }
+    if (query.OtherAttributes) {
+        ToProto(protoQuery->mutable_other_attributes(), *query.OtherAttributes);
+    }
+}
+
+void FromProto(NApi::TQuery* query, const NProto::TQuery& protoQuery)
+{
+    FromProto(&query->Id, protoQuery.id());
+
+    if (protoQuery.has_engine()) {
+        query->Engine = NApi::NRpcProxy::NProto::ConvertQueryEngineFromProto(protoQuery.engine());
+    } else {
+        query->Engine.reset();
+    }
+    if (protoQuery.has_query()) {
+        query->Query = protoQuery.query();
+    } else {
+        query->Query.reset();
+    }
+    if (protoQuery.has_files()) {
+        query->Files = TYsonString(protoQuery.files());
+    } else {
+        query->Files.reset();
+    }
+    if (protoQuery.has_start_time()) {
+        query->StartTime = TInstant::FromValue(protoQuery.start_time());
+    } else {
+        query->StartTime.reset();
+    }
+    if (protoQuery.has_finish_time()) {
+        query->FinishTime = TInstant::FromValue(protoQuery.finish_time());
+    } else {
+        query->FinishTime.reset();
+    }
+    if (protoQuery.has_settings()) {
+        query->Settings = TYsonString(protoQuery.settings());
+    } else {
+        query->Settings = TYsonString{};
+    }
+    if (protoQuery.has_user()) {
+        query->User = protoQuery.user();
+    } else {
+        query->User.reset();
+    }
+    if (protoQuery.has_access_control_object()) {
+        query->AccessControlObject = protoQuery.access_control_object();
+    } else {
+        query->AccessControlObject.reset();
+    }
+    if (protoQuery.has_state()) {
+        query->State = NApi::NRpcProxy::NProto::ConvertQueryStateFromProto(protoQuery.state());
+    } else {
+        query->State.reset();
+    }
+    if (protoQuery.has_result_count()) {
+        query->ResultCount = protoQuery.result_count();
+    } else {
+        query->ResultCount.reset();
+    }
+    if (protoQuery.has_progress()) {
+        query->Progress = TYsonString(protoQuery.progress());
+    } else {
+        query->Progress = TYsonString{};
+    }
+    if (protoQuery.has_error()) {
+        query->Error = FromProto<TError>(protoQuery.error());
+    } else {
+        query->Error.reset();
+    }
+    if (protoQuery.has_annotations()) {
+        query->Annotations = TYsonString(protoQuery.annotations());
+    } else {
+        query->Annotations = TYsonString{};
+    }
+    if (protoQuery.has_other_attributes()) {
+        query->OtherAttributes = NYTree::FromProto(protoQuery.other_attributes());
+    } else if (query->OtherAttributes) {
+        query->OtherAttributes->Clear();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/helpers.cpp
+++ b/yt/yt/ytlib/query_tracker_client/helpers.cpp
@@ -1,10 +1,5 @@
 #include "helpers.h"
 
-#include <yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.pb.h>
-
-#include <yt/yt/client/api/query_tracker_client.h>
-#include <yt/yt/client/api/rpc_proxy/helpers.h>
-
 #include <yt/yt/ytlib/query_tracker_client/records/query.record.h>
 
 namespace NYT::NQueryTrackerClient {
@@ -12,8 +7,6 @@ namespace NYT::NQueryTrackerClient {
 using namespace NQueryTrackerClient::NRecords;
 using namespace NYTree;
 using namespace NYson;
-
-using NYT::FromProto;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -54,134 +47,6 @@ bool IsFinishedState(EQueryState state)
 {
     return state == EQueryState::Aborted || state == EQueryState::Failed ||
         state == EQueryState::Completed || state == EQueryState::Draft;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-void ToProto(NProto::TQuery* protoQuery, const NApi::TQuery& query)
-{
-    protoQuery->Clear();
-
-    ToProto(protoQuery->mutable_id(), query.Id);
-
-    if (query.Engine) {
-        protoQuery->set_engine(NApi::NRpcProxy::NProto::ConvertQueryEngineToProto(*query.Engine));
-    }
-    if (query.Query) {
-        protoQuery->set_query(*query.Query);
-    }
-    if (query.Files) {
-        protoQuery->set_files(query.Files->ToString());
-    }
-    if (query.StartTime) {
-        protoQuery->set_start_time(NYT::ToProto<i64>(*query.StartTime));
-    }
-    if (query.FinishTime) {
-        protoQuery->set_finish_time(NYT::ToProto<i64>(*query.FinishTime));
-    }
-    if (query.Settings) {
-        protoQuery->set_settings(query.Settings.ToString());
-    }
-    if (query.User) {
-        protoQuery->set_user(*query.User);
-    }
-    if (query.AccessControlObject) {
-        protoQuery->set_access_control_object(*query.AccessControlObject);
-    }
-    if (query.State) {
-        protoQuery->set_state(NApi::NRpcProxy::NProto::ConvertQueryStateToProto(*query.State));
-    }
-    if (query.ResultCount) {
-        protoQuery->set_result_count(*query.ResultCount);
-    }
-    if (query.Progress) {
-        protoQuery->set_progress(query.Progress.ToString());
-    }
-    if (query.Error) {
-        ToProto(protoQuery->mutable_error(), *query.Error);
-    }
-    if (query.Annotations) {
-        protoQuery->set_annotations(query.Annotations.ToString());
-    }
-    if (query.OtherAttributes) {
-        ToProto(protoQuery->mutable_other_attributes(), *query.OtherAttributes);
-    }
-}
-
-void FromProto(NApi::TQuery* query, const NProto::TQuery& protoQuery)
-{
-    FromProto(&query->Id, protoQuery.id());
-
-    if (protoQuery.has_engine()) {
-        query->Engine = NApi::NRpcProxy::NProto::ConvertQueryEngineFromProto(protoQuery.engine());
-    } else {
-        query->Engine.reset();
-    }
-    if (protoQuery.has_query()) {
-        query->Query = protoQuery.query();
-    } else {
-        query->Query.reset();
-    }
-    if (protoQuery.has_files()) {
-        query->Files = TYsonString(protoQuery.files());
-    } else {
-        query->Files.reset();
-    }
-    if (protoQuery.has_start_time()) {
-        query->StartTime = TInstant::FromValue(protoQuery.start_time());
-    } else {
-        query->StartTime.reset();
-    }
-    if (protoQuery.has_finish_time()) {
-        query->FinishTime = TInstant::FromValue(protoQuery.finish_time());
-    } else {
-        query->FinishTime.reset();
-    }
-    if (protoQuery.has_settings()) {
-        query->Settings = TYsonString(protoQuery.settings());
-    } else {
-        query->Settings = TYsonString{};
-    }
-    if (protoQuery.has_user()) {
-        query->User = protoQuery.user();
-    } else {
-        query->User.reset();
-    }
-    if (protoQuery.has_access_control_object()) {
-        query->AccessControlObject = protoQuery.access_control_object();
-    } else {
-        query->AccessControlObject.reset();
-    }
-    if (protoQuery.has_state()) {
-        query->State = NApi::NRpcProxy::NProto::ConvertQueryStateFromProto(protoQuery.state());
-    } else {
-        query->State.reset();
-    }
-    if (protoQuery.has_result_count()) {
-        query->ResultCount = protoQuery.result_count();
-    } else {
-        query->ResultCount.reset();
-    }
-    if (protoQuery.has_progress()) {
-        query->Progress = TYsonString(protoQuery.progress());
-    } else {
-        query->Progress = TYsonString{};
-    }
-    if (protoQuery.has_error()) {
-        query->Error = FromProto<TError>(protoQuery.error());
-    } else {
-        query->Error.reset();
-    }
-    if (protoQuery.has_annotations()) {
-        query->Annotations = TYsonString(protoQuery.annotations());
-    } else {
-        query->Annotations = TYsonString{};
-    }
-    if (protoQuery.has_other_attributes()) {
-        query->OtherAttributes = NYTree::FromProto(protoQuery.other_attributes());
-    } else if (query->OtherAttributes) {
-        query->OtherAttributes->Clear();
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/helpers.h
+++ b/yt/yt/ytlib/query_tracker_client/helpers.h
@@ -2,6 +2,10 @@
 
 #include "public.h"
 
+#include <yt/yt/client/api/query_tracker_client.h>
+
+#include <yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.pb.h>
+
 namespace NYT::NQueryTrackerClient {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -16,5 +20,8 @@ bool IsPreFinishedState(EQueryState state);
 bool IsFinishedState(EQueryState state);
 
 ////////////////////////////////////////////////////////////////////////////////
+
+void ToProto(NProto::TQuery* protoQuery, const NApi::TQuery& query);
+void FromProto(NApi::TQuery* query, const NProto::TQuery& protoQuery);
 
 } // namespace NYT::NQueryTrackerClient

--- a/yt/yt/ytlib/query_tracker_client/helpers.h
+++ b/yt/yt/ytlib/query_tracker_client/helpers.h
@@ -2,10 +2,6 @@
 
 #include "public.h"
 
-#include <yt/yt/client/api/query_tracker_client.h>
-
-#include <yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.pb.h>
-
 namespace NYT::NQueryTrackerClient {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -20,8 +16,5 @@ bool IsPreFinishedState(EQueryState state);
 bool IsFinishedState(EQueryState state);
 
 ////////////////////////////////////////////////////////////////////////////////
-
-void ToProto(NProto::TQuery* protoQuery, const NApi::TQuery& query);
-void FromProto(NApi::TQuery* query, const NProto::TQuery& protoQuery);
 
 } // namespace NYT::NQueryTrackerClient

--- a/yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.proto
+++ b/yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.proto
@@ -89,3 +89,15 @@ message TRspAlterQuery
 { }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+message TReqGetQueryTrackerInfo
+{
+    required NYT.NApi.NRpcProxy.NProto.TReqGetQueryTrackerInfo rpc_proxy_request = 1;
+}
+
+message TRspGetQueryTrackerInfo
+{ 
+    required NYT.NApi.NRpcProxy.NProto.TRspGetQueryTrackerInfo rpc_proxy_response = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.proto
+++ b/yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.proto
@@ -1,0 +1,147 @@
+package NYT.NQueryTrackerClient.NProto;
+
+import "yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto";
+import "yt_proto/yt/client/chunk_client/proto/data_statistics.proto";
+
+import "yt_proto/yt/core/misc/proto/guid.proto";
+import "yt_proto/yt/core/misc/proto/error.proto";
+import "yt_proto/yt/core/ytree/proto/attributes.proto";
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TReqStartQuery
+{
+    required NYT.NApi.NRpcProxy.NProto.EQueryEngine engine = 1;
+    required string query = 2;
+    optional bytes settings = 3; // YSON
+    required bool draft = 4;
+    optional bytes annotations = 5; // YSON
+    required bytes files = 6; // YSON
+    optional string access_control_object = 7;
+}
+
+message TRspStartQuery
+{
+    optional NYT.NProto.TGuid query_id = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TReqAbortQuery
+{
+    required NYT.NProto.TGuid query_id = 1;
+    optional string abort_message = 2;
+}
+
+message TRspAbortQuery
+{ }
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TReqGetQueryResult
+{
+    required NYT.NProto.TGuid query_id = 1;
+    required int64 result_index = 2;
+}
+
+message TRspGetQueryResult
+{
+    required NYT.NProto.TGuid query_id = 1;
+    required int64 result_index = 2;
+    required NYT.NProto.TError error = 3;
+    optional NYT.NApi.NRpcProxy.NProto.TTableSchema schema = 4;
+    required NYT.NChunkClient.NProto.TDataStatistics data_statistics = 5;
+    required bool is_truncated = 6;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TReqReadQueryResult
+{
+    message TColumns
+    {
+        repeated string items = 1;
+    }
+
+    required NYT.NProto.TGuid query_id = 1;
+    required int64 result_index = 2;
+    optional TColumns columns = 3;
+    optional int64 lower_row_index = 4;
+    optional int64 upper_row_index = 5;
+}
+
+// Filled with one attachment containing the query result
+message TRspReadQueryResult
+{
+    required NYT.NApi.NRpcProxy.NProto.TRowsetDescriptor rowset_descriptor = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TQuery
+{
+    required NYT.NProto.TGuid id = 1;
+    optional NYT.NApi.NRpcProxy.NProto.EQueryEngine engine = 2;
+    optional string query = 3;
+    optional bytes files = 4; // YSON
+    optional uint64 start_time = 5; // TInstant
+    optional uint64 finish_time = 6; // TInstant
+    optional bytes settings = 7; // YSON
+    optional string user = 8;
+    optional string access_control_object = 9;
+    optional NYT.NApi.NRpcProxy.NProto.EQueryState state = 10;
+    optional int64 result_count = 11;
+    optional bytes progress = 12; // YSON
+    optional NYT.NProto.TError error = 13;
+    optional bytes annotations = 14; // YSON
+    optional NYT.NYTree.NProto.TAttributeDictionary other_attributes = 15;
+}
+
+message TReqGetQuery
+{
+    required NYT.NProto.TGuid query_id = 1;
+    optional NYT.NYTree.NProto.TAttributeFilter attributes = 2;
+    optional uint64 timestamp = 3;
+}
+
+message TRspGetQuery
+{
+    optional TQuery query = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TReqListQueries
+{
+    optional uint64 from_time = 1; // TInstant
+    optional uint64 to_time = 2; // TInstant
+    optional uint64 cursor_time = 3; // TInstant
+    required NYT.NApi.NRpcProxy.NProto.EOperationSortDirection cursor_direction = 4;
+    optional string user_filter = 5;
+    optional NYT.NApi.NRpcProxy.NProto.EQueryState state_filter = 6;
+    optional NYT.NApi.NRpcProxy.NProto.EQueryEngine engine_filter = 7;
+    optional string substr_filter = 8;
+    required uint64 limit = 9;
+    optional NYT.NYTree.NProto.TAttributeFilter attributes = 10;
+}
+
+message TRspListQueries
+{
+    repeated TQuery queries = 1;
+    required bool incomplete = 2;
+    required uint64 timestamp = 3;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+message TReqAlterQuery
+{
+    required NYT.NProto.TGuid query_id = 1;
+    optional bytes annotations = 2; // YSON
+    optional string access_control_object = 3;
+}
+
+message TRspAlterQuery
+{ }
+
+////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.proto
+++ b/yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.proto
@@ -11,26 +11,19 @@ import "yt_proto/yt/core/ytree/proto/attributes.proto";
 
 message TReqStartQuery
 {
-    required NYT.NApi.NRpcProxy.NProto.EQueryEngine engine = 1;
-    required string query = 2;
-    optional bytes settings = 3; // YSON
-    required bool draft = 4;
-    optional bytes annotations = 5; // YSON
-    required bytes files = 6; // YSON
-    optional string access_control_object = 7;
+    required NYT.NApi.NRpcProxy.NProto.TReqStartQuery rpc_proxy_request = 1;
 }
 
 message TRspStartQuery
 {
-    optional NYT.NProto.TGuid query_id = 1;
+    required NYT.NApi.NRpcProxy.NProto.TRspStartQuery rpc_proxy_response = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 message TReqAbortQuery
 {
-    required NYT.NProto.TGuid query_id = 1;
-    optional string abort_message = 2;
+    required NYT.NApi.NRpcProxy.NProto.TReqAbortQuery rpc_proxy_request = 1;
 }
 
 message TRspAbortQuery
@@ -40,105 +33,56 @@ message TRspAbortQuery
 
 message TReqGetQueryResult
 {
-    required NYT.NProto.TGuid query_id = 1;
-    required int64 result_index = 2;
+    required NYT.NApi.NRpcProxy.NProto.TReqGetQueryResult rpc_proxy_request = 1;
 }
 
 message TRspGetQueryResult
 {
-    required NYT.NProto.TGuid query_id = 1;
-    required int64 result_index = 2;
-    required NYT.NProto.TError error = 3;
-    optional NYT.NApi.NRpcProxy.NProto.TTableSchema schema = 4;
-    required NYT.NChunkClient.NProto.TDataStatistics data_statistics = 5;
-    required bool is_truncated = 6;
+    required NYT.NApi.NRpcProxy.NProto.TRspGetQueryResult rpc_proxy_response = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 message TReqReadQueryResult
 {
-    message TColumns
-    {
-        repeated string items = 1;
-    }
-
-    required NYT.NProto.TGuid query_id = 1;
-    required int64 result_index = 2;
-    optional TColumns columns = 3;
-    optional int64 lower_row_index = 4;
-    optional int64 upper_row_index = 5;
+    required NYT.NApi.NRpcProxy.NProto.TReqReadQueryResult rpc_proxy_request = 1;
 }
 
 // Filled with one attachment containing the query result
 message TRspReadQueryResult
 {
-    required NYT.NApi.NRpcProxy.NProto.TRowsetDescriptor rowset_descriptor = 1;
+    required NYT.NApi.NRpcProxy.NProto.TRspReadQueryResult rpc_proxy_response = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-message TQuery
-{
-    required NYT.NProto.TGuid id = 1;
-    optional NYT.NApi.NRpcProxy.NProto.EQueryEngine engine = 2;
-    optional string query = 3;
-    optional bytes files = 4; // YSON
-    optional uint64 start_time = 5; // TInstant
-    optional uint64 finish_time = 6; // TInstant
-    optional bytes settings = 7; // YSON
-    optional string user = 8;
-    optional string access_control_object = 9;
-    optional NYT.NApi.NRpcProxy.NProto.EQueryState state = 10;
-    optional int64 result_count = 11;
-    optional bytes progress = 12; // YSON
-    optional NYT.NProto.TError error = 13;
-    optional bytes annotations = 14; // YSON
-    optional NYT.NYTree.NProto.TAttributeDictionary other_attributes = 15;
-}
-
 message TReqGetQuery
 {
-    required NYT.NProto.TGuid query_id = 1;
-    optional NYT.NYTree.NProto.TAttributeFilter attributes = 2;
-    optional uint64 timestamp = 3;
+    required NYT.NApi.NRpcProxy.NProto.TReqGetQuery rpc_proxy_request = 1;
 }
 
 message TRspGetQuery
 {
-    optional TQuery query = 1;
+    required NYT.NApi.NRpcProxy.NProto.TRspGetQuery rpc_proxy_response = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 message TReqListQueries
 {
-    optional uint64 from_time = 1; // TInstant
-    optional uint64 to_time = 2; // TInstant
-    optional uint64 cursor_time = 3; // TInstant
-    required NYT.NApi.NRpcProxy.NProto.EOperationSortDirection cursor_direction = 4;
-    optional string user_filter = 5;
-    optional NYT.NApi.NRpcProxy.NProto.EQueryState state_filter = 6;
-    optional NYT.NApi.NRpcProxy.NProto.EQueryEngine engine_filter = 7;
-    optional string substr_filter = 8;
-    required uint64 limit = 9;
-    optional NYT.NYTree.NProto.TAttributeFilter attributes = 10;
+    required NYT.NApi.NRpcProxy.NProto.TReqListQueries rpc_proxy_request = 1;
 }
 
 message TRspListQueries
 {
-    repeated TQuery queries = 1;
-    required bool incomplete = 2;
-    required uint64 timestamp = 3;
+    required NYT.NApi.NRpcProxy.NProto.TRspListQueries rpc_proxy_response = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 message TReqAlterQuery
 {
-    required NYT.NProto.TGuid query_id = 1;
-    optional bytes annotations = 2; // YSON
-    optional string access_control_object = 3;
+    required NYT.NApi.NRpcProxy.NProto.TReqAlterQuery rpc_proxy_request = 1;
 }
 
 message TRspAlterQuery

--- a/yt/yt/ytlib/query_tracker_client/public.h
+++ b/yt/yt/ytlib/query_tracker_client/public.h
@@ -21,6 +21,7 @@ struct TFinishedQueryPartial;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+DECLARE_REFCOUNTED_CLASS(TQueryTrackerChannelConfig)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerStageConfig)
 DECLARE_REFCOUNTED_CLASS(TQueryTrackerConnectionConfig)
 

--- a/yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h
+++ b/yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <yt/yt/ytlib/query_tracker_client/proto/query_tracker_service.pb.h>
+
+#include <yt/yt/core/rpc/client.h>
+
+namespace NYT::NQueryTrackerClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TQueryTrackerServiceProxy
+    : public NRpc::TProxyBase
+{
+public:
+    DEFINE_RPC_PROXY(TQueryTrackerServiceProxy, TQueryTrackerService,
+        .SetProtocolVersion(NRpc::TProtocolVersion{0, 0}));
+
+    DEFINE_RPC_PROXY_METHOD(NProto, StartQuery);
+    DEFINE_RPC_PROXY_METHOD(NProto, AbortQuery);
+    DEFINE_RPC_PROXY_METHOD(NProto, GetQueryResult);
+    DEFINE_RPC_PROXY_METHOD(NProto, ReadQueryResult);
+    DEFINE_RPC_PROXY_METHOD(NProto, GetQuery);
+    DEFINE_RPC_PROXY_METHOD(NProto, ListQueries);
+    DEFINE_RPC_PROXY_METHOD(NProto, AlterQuery);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NYqlClient

--- a/yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h
+++ b/yt/yt/ytlib/query_tracker_client/query_tracker_service_proxy.h
@@ -22,6 +22,7 @@ public:
     DEFINE_RPC_PROXY_METHOD(NProto, GetQuery);
     DEFINE_RPC_PROXY_METHOD(NProto, ListQueries);
     DEFINE_RPC_PROXY_METHOD(NProto, AlterQuery);
+    DEFINE_RPC_PROXY_METHOD(NProto, GetQueryTrackerInfo);
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/query_tracker_client/ya.make
+++ b/yt/yt/ytlib/query_tracker_client/ya.make
@@ -12,12 +12,16 @@ GENERATE_YT_RECORD(
 )
 
 SRCS(
+    proto/query_tracker_service.proto
+
     config.cpp
     helpers.cpp
 )
 
 PEERDIR(
     yt/yt/client
+    yt/yt/core
+    yt/yt_proto/yt/client
 )
 
 END()

--- a/yt/yt/ytlib/unittests/misc/test_connection.h
+++ b/yt/yt/ytlib/unittests/misc/test_connection.h
@@ -162,6 +162,7 @@ public:
     MOCK_METHOD(const NNodeTrackerClient::INodeDirectorySynchronizerPtr&, GetNodeDirectorySynchronizer, (), (override));
     MOCK_METHOD(const NChunkClient::IChunkReplicaCachePtr&, GetChunkReplicaCache, (), (override));
     MOCK_METHOD((std::pair<IClientPtr, NYPath::TYPath>), GetQueryTrackerStage, (const TString&), (override));
+    MOCK_METHOD(NRpc::IChannelPtr, GetQueryTrackerChannelOrThrow, (const TString&), (override));
     MOCK_METHOD(NRpc::IChannelPtr, GetChaosChannelByCellId, (NObjectClient::TCellId, NHydra::EPeerKind), (override));
     MOCK_METHOD(NRpc::IChannelPtr, GetChaosChannelByCellTag, (NObjectClient::TCellTag, NHydra::EPeerKind), (override));
     MOCK_METHOD(NRpc::IChannelPtr, GetChaosChannelByCardId, (NChaosClient::TReplicationCardId, NHydra::EPeerKind), (override));


### PR DESCRIPTION
Changing the architecture of communication between QT and HTTP/RPC proxies.

**Problem:**

Now we want to support multiple ACOs in a single query. This causes incompatibility between older and newer components. SDK/Proxies/QT. Therefore, we need to update all these components simultaneously, which is not an easy task. A similar problem existed when we added the first version of ACO, and possibly we will have similar problems in future developments.

**Solution:**

Step 1.
Move all complex logic from proxies to QT. After that proxies will simply resend all requests to QT service. And QT will write to state tables.
(This PR)

Step 2
Make it possible to work with RPC requests from different proxy versions. Add support for different versions of the RPC API in the QT proxy server.
(Next PR, together with multiple ACO support)

Step 3
Make it possible to work with requests from different SDK versions in proxies. Add support for different versions of the RPC API in the RPC proxy, and feature flags to the HTTP protocol.
(Next PR, together with multiple ACO support)

**Benefits:**

All communication with QT state tables will take place through the QT service. Therefore, this logic will always be delivered in the same image. This removes all starting incompatibilities and makes it possible to update mentioned components in the next order.
QT->Proxies->SDK