### PR TITLE
Handle docker image registry with port as external

### DIFF
--- a/yt/docs/en/_includes/user-guide/data-processing/layers/layer-paths.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/layers/layer-paths.md
@@ -16,7 +16,7 @@ Depending on the cluster configuration (`exec_node/slot_manager/job_environment/
 - **Docker registry**: a server for storing and distributing Docker image data and metadata.
 - **Internal Docker Registry**: a Docker registry that stores images directly in [Cypress](../../../../user-guide/storage/cypress.md).
 
-Docker images are referenced by name in the following format: `[REGISTRY/]IMAGE[:TAG|@DIGEST]`, where `REGISTRY` represents the `FQDN[:PORT]` of the Docker registry server. By default, `TAG` is set to **latest**. [More](https://docs.docker.com/engine/reference/commandline/pull/)
+Docker images are referenced by name in the following format: `[REGISTRY/]IMAGE[:TAG|@DIGEST]`, where `REGISTRY` represents the `FQDN[:PORT]` of the Docker registry server. Registry `FQDN` must has at least one "." or `PORT`. By default, `TAG` is set to **latest**. [More](https://docs.docker.com/engine/reference/commandline/pull/)
 
 Docker images without a specified `REGISTRY` are assumed to be from the **Internal Docker Registry**, where `IMAGE` corresponds to the `//IMAGE` path pointing to the directory with the image metadata in Cypress.
 

--- a/yt/docs/ru/_includes/user-guide/data-processing/layers/layer-paths.md
+++ b/yt/docs/ru/_includes/user-guide/data-processing/layers/layer-paths.md
@@ -16,7 +16,7 @@
 - **Docker Registry** — сервер, хранящий и распространяющий данные и метаданные Docker образов;
 - **Internal Docker Registry** — docker registry, хранящий образы непосредственно в [Кипарисе](../../../../user-guide/storage/cypress.md).
 
-Docker образ адресуется по имени в формате `[REGISTRY/]IMAGE[:TAG|@DIGEST]`, где `REGISTRY` это `FQDN[:PORT]` сервера Docker Registry. `TAG` по умолчанию **latest**. [Подробнее](https://docs.docker.com/engine/reference/commandline/pull/)
+Docker образ адресуется по имени в формате `[REGISTRY/]IMAGE[:TAG|@DIGEST]`, где `REGISTRY` это `FQDN[:PORT]` сервера Docker Registry. Registry `FQDN` должен иметь хотя бы одну "." или `PORT`. `TAG` по умолчанию **latest**. [Подробнее](https://docs.docker.com/engine/reference/commandline/pull/)
 
 Docker образ без указания `REGISTRY` считается образом из **Internal Docker Registry**, где `IMAGE` соответствует пути `//IMAGE` в Кипарисе до директории с метаданными образа.
 

--- a/yt/yt/server/controller_agent/controllers/helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/helpers.cpp
@@ -265,9 +265,10 @@ TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegi
 {
     TStringBuf imageTag;
 
-    // Format: [REGISTRY/]IMAGE[:TAG], where REGISTRY is FQDN[:PORT] - i.e. has at least one dot.
+    // Format: [REGISTRY/]IMAGE[:TAG], where REGISTRY is FQDN[:PORT].
+    // Registry FQDN must has at least one "." or PORT.
     if (!StringSplitter(dockerImage).Split('/').Limit(2).TryCollectInto(&Registry, &imageTag) ||
-        !Registry.Contains('.'))
+        Registry.find_first_of(".:") == TString::npos)
     {
         Registry = "";
         imageTag = dockerImage;

--- a/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
+++ b/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
@@ -43,6 +43,38 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
     }
 
     {
+        TDockerImageSpec image("localhost:5000/image", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image:tag", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image:tag", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
         TDockerImageSpec image("external.registry/image", defaultConfig);
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "image");


### PR DESCRIPTION
This allows to handle local registry like "localhost:5000" or
registry in neighbour docker container like "{container-name}:5000".
