### PR TITLE
CRI job environenment tests

### DIFF
--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -47,7 +47,7 @@ class LocalYtConfig(object):
         "mode": "simple",
         "sharding_key_length": 1,
     })
-    default_docker_image = "docker.io/library/python:2.7-slim"
+    default_docker_image = "docker.io/library/python:3.12-slim"
 
     """Feature flags"""
     enable_master_cache = attr.ib(False)

--- a/yt/yt/tests/integration/node/test_dynamic_cpu_reclaim.py
+++ b/yt/yt/tests/integration/node/test_dynamic_cpu_reclaim.py
@@ -255,7 +255,7 @@ class TestNodeAbortsJobOnLackOfMemory(YTEnvSetup):
     @pytest.mark.skip(reason="Currently broken")
     def test_node_aborts_job_on_lack_of_memory(self):
         memory_consume_command = (
-            'python -c "import time\ncount = 100*1000*1000\nx = list(range(count))\ntime.sleep(1000)"'
+            'python3 -c "import time\ncount = 100*1000*1000\nx = list(range(count))\ntime.sleep(1000)"'
         )
         op1 = run_test_vanilla(
             with_breakpoint("BREAKPOINT; " + memory_consume_command, "Op1"),

--- a/yt/yt/tests/integration/node/test_user_job.py
+++ b/yt/yt/tests/integration/node/test_user_job.py
@@ -451,7 +451,7 @@ class TestSandboxTmpfs(TestPortoJobEnvironmentBase):
         write_table("//tmp/t_input", {"foo": "bar"})
 
         op = map(
-            command="python -c 'import time; x = \"0\" * (200 * 1000 * 1000); time.sleep(2)'",
+            command="python3 -c 'import time; x = \"0\" * (200 * 1000 * 1000); time.sleep(2)'",
             in_="//tmp/t_input",
             out="//tmp/t_output",
             spec={
@@ -469,7 +469,7 @@ class TestSandboxTmpfs(TestPortoJobEnvironmentBase):
         write_table("//tmp/t_input", {"foo": "bar"})
 
         mapper = b"""
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import mmap, time
 
@@ -885,7 +885,7 @@ class TestSandboxTmpfsOverflow(TestPortoJobEnvironmentBase):
                 "dd if=/dev/zero of=tmpfs_1/file  bs=1M  count=512; ls tmpfs_1/ >&2; "
                 "dd if=/dev/zero of=tmpfs_2/file  bs=1M  count=512; ls tmpfs_2/ >&2; "
                 "BREAKPOINT; "
-                "python -c 'import time; x = \"A\" * (200 * 1024 * 1024); time.sleep(100);'"
+                "python3 -c 'import time; x = \"A\" * (200 * 1024 * 1024); time.sleep(100);'"
             ),
             in_="//tmp/t_input",
             out="//tmp/t_output",
@@ -1453,7 +1453,7 @@ class TestJobStderr(TestEachJobEnvironmentBase):
         op = map(
             in_="//tmp/t1",
             out="//tmp/t2",
-            command='cat > /dev/null; python -c \'print "head" + "0" * 10000000; print "1" * 10000000 + "tail"\' >&2;',
+            command='cat > /dev/null; python3 -c \'print("head" + "0" * 10000000); print("1" * 10000000 + "tail")\' >&2;',
             spec={"max_failed_job_count": 1, "mapper": {"max_stderr_size": 1000000}},
         )
 
@@ -3718,7 +3718,7 @@ class TestCriJobStatistics(TestCriJobEnvironmentBase):
         write_table("//tmp/t_input", {"foo": "bar"})
 
         op = map(
-            command="python -c 'import time; x = \"X\" * (200 * 1000 * 1000); time.sleep(5)'",
+            command="python3 -c 'import time; x = \"X\" * (200 * 1000 * 1000); time.sleep(5)'",
             in_="//tmp/t_input",
             out="//tmp/t_output",
             spec={


### PR DESCRIPTION
- Add user job test for each job environment
  Mix a little bit magic to duplicate test classes for each job environment.
  
- Migrate CRI job environment to python3
  There is no reason to keep any python2 compatibility.
  
