### PR TITLE
Add EProcessErrorCode::CannotStartProcess

### DIFF
--- a/yt/yt/core/misc/public.h
+++ b/yt/yt/core/misc/public.h
@@ -167,6 +167,7 @@ DEFINE_ENUM(EProcessErrorCode,
     ((NonZeroExitCode)    (10000))
     ((Signal)             (10001))
     ((CannotResolveBinary)(10002))
+    ((CannotStartProcess) (10003))
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/library/process/process.cpp
+++ b/yt/yt/library/process/process.cpp
@@ -755,7 +755,10 @@ TFuture<void> TProcessBase::Spawn()
 
         DoSpawn();
     } catch (const std::exception& ex) {
-        FinishedPromise_.TrySet(ex);
+        FinishedPromise_.TrySet(TError(EProcessErrorCode::CannotStartProcess,
+            "Cannot spawn child process (Path: %v)",
+            ResolvedPath_)
+            << ex);
     }
     return FinishedPromise_;
 }


### PR DESCRIPTION
Surprisingly there was no clear way to tell that process hasn't been started.
