### PR TITLE
classify cannot start job proxy as abort reason other

### DIFF
--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -3100,6 +3100,9 @@ std::optional<EAbortReason> TJob::DeduceAbortReason()
     }
 
     if (auto jobProxyFailedError = resultError.FindMatching(NExecNode::EErrorCode::JobProxyFailed)) {
+        if (resultError.FindMatching(EProcessErrorCode::CannotStartProcess)) {
+            return EAbortReason::Other;
+        }
         if (auto processError = resultError.FindMatching(EProcessErrorCode::NonZeroExitCode)) {
             auto exitCode = NExecNode::EJobProxyExitCode(processError->Attributes().Get<int>("exit_code"));
             switch (exitCode) {

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -2242,8 +2242,7 @@ void TJob::OnJobProxyFinished(const TError& error)
                 .Via(Invoker_));
     } else {
         if (!error.IsOK()) {
-            Finalize(TError(NExecNode::EErrorCode::JobProxyFailed, "Job proxy failed")
-                << BuildJobProxyError(error));
+            Finalize(BuildJobProxyError(error));
         } else {
             YT_VERIFY(IsFinished());
         }


### PR DESCRIPTION
- Map JobProxyFailed/CannotStartProcess to job abort reason "Other"
  If we haven't found any more specific errors it's save to assume
  that was a fluke and job should retry on this or other node.
  
- Remove duplicate EErrorCode::JobProxyFailed
  BuildJobProxyError() already wraps error with "JobProxyFailed".
  
