### PR TITLE
Data nodes disk throttlers for uncategorized load

### DIFF
--- a/yt/yt/server/node/data_node/config.cpp
+++ b/yt/yt/server/node/data_node/config.cpp
@@ -100,6 +100,9 @@ void TChunkLocationConfig::ApplyDynamicInplace(const TChunkLocationDynamicConfig
     }
     UpdateYsonStructField(ThrottleDuration, dynamicConfig.ThrottleDuration);
 
+    UpdateYsonStructField(EnableUncategorizedThrottler, dynamicConfig.EnableUncategorizedThrottler);
+    UpdateYsonStructField(UncategorizedThrottler, dynamicConfig.UncategorizedThrottler);
+
     UpdateYsonStructField(CoalescedReadMaxGapSize, dynamicConfig.CoalescedReadMaxGapSize);
 }
 
@@ -111,6 +114,12 @@ void TChunkLocationConfig::Register(TRegistrar registrar)
 
     registrar.Parameter("throttlers", &TThis::Throttlers)
         .Default();
+
+    registrar.Parameter("enable_uncategorized_throttler", &TThis::EnableUncategorizedThrottler)
+        .Default(false);
+
+    registrar.Parameter("uncategorized_throttler", &TThis::UncategorizedThrottler)
+        .DefaultNew();
 
     registrar.Parameter("io_engine_type", &TThis::IOEngineType)
         .Default(NIO::EIOEngineType::ThreadPool);
@@ -155,6 +164,10 @@ void TChunkLocationDynamicConfig::Register(TRegistrar registrar)
     registrar.Parameter("throttlers", &TThis::Throttlers)
         .Optional();
     registrar.Parameter("throttle_duration", &TThis::ThrottleDuration)
+        .Optional();
+    registrar.Parameter("enable_uncategorized_throttler", &TThis::EnableUncategorizedThrottler)
+        .Optional();
+    registrar.Parameter("uncategorized_throttler", &TThis::UncategorizedThrottler)
         .Optional();
     registrar.Parameter("coalesced_read_max_gap_size", &TThis::CoalescedReadMaxGapSize)
         .GreaterThanOrEqual(0)

--- a/yt/yt/server/node/data_node/config.h
+++ b/yt/yt/server/node/data_node/config.h
@@ -94,6 +94,10 @@ public:
     //! Configuration for various per-location throttlers.
     TEnumIndexedVector<EChunkLocationThrottlerKind, NConcurrency::TThroughputThrottlerConfigPtr> Throttlers;
 
+    //! Configuration for uncategorized throttler.
+    bool EnableUncategorizedThrottler;
+    NConcurrency::TThroughputThrottlerConfigPtr UncategorizedThrottler;
+
     //! IO engine type.
     NIO::EIOEngineType IOEngineType;
 
@@ -132,6 +136,9 @@ public:
 
     TEnumIndexedVector<EChunkLocationThrottlerKind, NConcurrency::TThroughputThrottlerConfigPtr> Throttlers;
     std::optional<TDuration> ThrottleDuration;
+
+    std::optional<bool> EnableUncategorizedThrottler;
+    NConcurrency::TThroughputThrottlerConfigPtr UncategorizedThrottler;
 
     std::optional<i64> CoalescedReadMaxGapSize;
 

--- a/yt/yt/server/node/data_node/location.h
+++ b/yt/yt/server/node/data_node/location.h
@@ -464,6 +464,10 @@ private:
     NConcurrency::IThroughputThrottlerPtr UnlimitedInThrottler_;
     NConcurrency::IThroughputThrottlerPtr UnlimitedOutThrottler_;
 
+    bool EnableUncategorizedThrottler_;
+    NConcurrency::IReconfigurableThroughputThrottlerPtr ReconfigurableUncategorizedThrottler_;
+    NConcurrency::IThroughputThrottlerPtr UncategorizedThrottler_;
+
     NIO::IDynamicIOEnginePtr DynamicIOEngine_;
     NIO::IIOEngineWorkloadModelPtr IOEngineModel_;
     NIO::IIOEnginePtr IOEngine_;


### PR DESCRIPTION
Replace unlimited disk throttlers with uncategorized disk throttlers that:
- combine in and out load
- configurable