### PR TITLE
Data nodes disk throttlers for uncategorized load

### DIFF
--- a/yt/yt/server/node/data_node/config.cpp
+++ b/yt/yt/server/node/data_node/config.cpp
@@ -100,6 +100,9 @@ void TChunkLocationConfig::ApplyDynamicInplace(const TChunkLocationDynamicConfig
     }
     UpdateYsonStructField(ThrottleDuration, dynamicConfig.ThrottleDuration);
 
+    UpdateYsonStructField(EnableUncategorizedThrottler, dynamicConfig.EnableUncategorizedThrottler);
+    UpdateYsonStructField(UncategorizedThrottler, dynamicConfig.UncategorizedThrottler);
+
     UpdateYsonStructField(CoalescedReadMaxGapSize, dynamicConfig.CoalescedReadMaxGapSize);
 
     UpdateYsonStructField(ReadMemoryLimit, dynamicConfig.ReadMemoryLimit);
@@ -121,6 +124,12 @@ void TChunkLocationConfig::Register(TRegistrar registrar)
 
     registrar.Parameter("throttlers", &TThis::Throttlers)
         .Default();
+
+    registrar.Parameter("enable_uncategorized_throttler", &TThis::EnableUncategorizedThrottler)
+        .Default(false);
+
+    registrar.Parameter("uncategorized_throttler", &TThis::UncategorizedThrottler)
+        .DefaultNew();
 
     registrar.Parameter("io_engine_type", &TThis::IOEngineType)
         .Default(NIO::EIOEngineType::ThreadPool);
@@ -178,6 +187,10 @@ void TChunkLocationDynamicConfig::Register(TRegistrar registrar)
     registrar.Parameter("throttlers", &TThis::Throttlers)
         .Optional();
     registrar.Parameter("throttle_duration", &TThis::ThrottleDuration)
+        .Optional();
+    registrar.Parameter("enable_uncategorized_throttler", &TThis::EnableUncategorizedThrottler)
+        .Optional();
+    registrar.Parameter("uncategorized_throttler", &TThis::UncategorizedThrottler)
         .Optional();
     registrar.Parameter("coalesced_read_max_gap_size", &TThis::CoalescedReadMaxGapSize)
         .GreaterThanOrEqual(0)

--- a/yt/yt/server/node/data_node/config.h
+++ b/yt/yt/server/node/data_node/config.h
@@ -94,6 +94,10 @@ public:
     //! Configuration for various per-location throttlers.
     TEnumIndexedArray<EChunkLocationThrottlerKind, NConcurrency::TThroughputThrottlerConfigPtr> Throttlers;
 
+    //! Configuration for uncategorized throttler.
+    bool EnableUncategorizedThrottler;
+    NConcurrency::TThroughputThrottlerConfigPtr UncategorizedThrottler;
+
     //! IO engine type.
     NIO::EIOEngineType IOEngineType;
 
@@ -147,6 +151,9 @@ public:
 
     TEnumIndexedArray<EChunkLocationThrottlerKind, NConcurrency::TThroughputThrottlerConfigPtr> Throttlers;
     std::optional<TDuration> ThrottleDuration;
+
+    std::optional<bool> EnableUncategorizedThrottler;
+    NConcurrency::TThroughputThrottlerConfigPtr UncategorizedThrottler;
 
     std::optional<i64> CoalescedReadMaxGapSize;
 

--- a/yt/yt/server/node/data_node/location.cpp
+++ b/yt/yt/server/node/data_node/location.cpp
@@ -399,6 +399,12 @@ TChunkLocation::TChunkLocation(
     UnlimitedOutThrottler_ = CreateNamedUnlimitedThroughputThrottler(
         "UnlimitedOutThrottler",
         diskThrottlerProfiler);
+    EnableUncategorizedThrottler_ = StaticConfig_->EnableUncategorizedThrottler;
+    UncategorizedThrottler_ = ReconfigurableUncategorizedThrottler_ = CreateNamedReconfigurableThroughputThrottler(
+        StaticConfig_->UncategorizedThrottler,
+        "uncategorized",
+        Logger,
+        diskThrottlerProfiler);
 
     HealthChecker_ = New<TDiskHealthChecker>(
         ChunkContext_->DataNodeConfig->DiskHealthChecker,
@@ -482,6 +488,10 @@ void TChunkLocation::Reconfigure(TChunkLocationConfigPtr config)
 
     for (auto kind : TEnumTraits<EChunkLocationThrottlerKind>::GetDomainValues()) {
         ReconfigurableThrottlers_[kind]->Reconfigure(config->Throttlers[kind]);
+    }
+    EnableUncategorizedThrottler_ = config->EnableUncategorizedThrottler;
+    if (EnableUncategorizedThrottler_) {
+        ReconfigurableUncategorizedThrottler_->Reconfigure(config->UncategorizedThrottler);
     }
 
     RuntimeConfig_.Store(std::move(config));
@@ -1065,7 +1075,11 @@ const IThroughputThrottlerPtr& TChunkLocation::GetInThrottler(const TWorkloadDes
             return Throttlers_[EChunkLocationThrottlerKind::TabletStoreFlushIn];
 
         default:
-            return UnlimitedInThrottler_;
+            if (EnableUncategorizedThrottler_) {
+                return UncategorizedThrottler_;
+            } else {
+                return UnlimitedInThrottler_;
+            }
     }
 }
 
@@ -1094,7 +1108,11 @@ const IThroughputThrottlerPtr& TChunkLocation::GetOutThrottler(const TWorkloadDe
             return Throttlers_[EChunkLocationThrottlerKind::TabletRecoveryOut];
 
         default:
-            return UnlimitedOutThrottler_;
+            if (EnableUncategorizedThrottler_) {
+                return UncategorizedThrottler_;
+            } else {
+                return UnlimitedOutThrottler_;
+            }
     }
 }
 

--- a/yt/yt/server/node/data_node/location.h
+++ b/yt/yt/server/node/data_node/location.h
@@ -531,6 +531,10 @@ private:
     NConcurrency::IThroughputThrottlerPtr UnlimitedInThrottler_;
     NConcurrency::IThroughputThrottlerPtr UnlimitedOutThrottler_;
 
+    bool EnableUncategorizedThrottler_;
+    NConcurrency::IReconfigurableThroughputThrottlerPtr ReconfigurableUncategorizedThrottler_;
+    NConcurrency::IThroughputThrottlerPtr UncategorizedThrottler_;
+
     NIO::IDynamicIOEnginePtr DynamicIOEngine_;
     NIO::IIOEngineWorkloadModelPtr IOEngineModel_;
     NIO::IIOEnginePtr IOEngine_;


### PR DESCRIPTION
Replace unlimited disk throttlers with uncategorized disk throttlers that:
- combine in and out load
- are configurable

Please cherry-pick it to stable/23.2 and stable/24.1