### PR TITLE
[RFC] Fiber watchdog

### DIFF
--- a/yt/yt/core/concurrency/action_queue.cpp
+++ b/yt/yt/core/concurrency/action_queue.cpp
@@ -15,6 +15,8 @@
 #include <yt/yt/core/misc/ring_queue.h>
 #include <yt/yt/core/misc/shutdown.h>
 
+#include <yt/yt/core/profiling/timing.h>
+
 #include <library/cpp/yt/misc/tls.h>
 
 #include <util/thread/lfqueue.h>
@@ -674,6 +676,53 @@ private:
 IInvokerPtr CreateCodicilGuardedInvoker(IInvokerPtr underlyingInvoker, TString codicil)
 {
     return New<TCodicilGuardedInvoker>(std::move(underlyingInvoker), std::move(codicil));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TWatchdogInvoker
+    : public TInvokerWrapper
+{
+public:
+    TWatchdogInvoker(
+        IInvokerPtr invoker,
+        const NLogging::TLogger& logger,
+        TDuration threshold)
+        : TInvokerWrapper(std::move(invoker))
+        , Logger(logger)
+        , Threshold_(DurationToCpuDuration(threshold))
+    { }
+
+    void Invoke(TClosure callback) override
+    {
+        UnderlyingInvoker_->Invoke(BIND_NO_PROPAGATE(
+            &TWatchdogInvoker::RunCallback,
+            MakeStrong(this),
+            Passed(std::move(callback))));
+    }
+
+private:
+    NLogging::TLogger Logger;
+    TCpuDuration Threshold_;
+
+    void RunCallback(TClosure callback)
+    {
+        TCurrentInvokerGuard currentInvokerGuard(this);
+        TFiberSliceTimer fiberSliceTimer(Threshold_, [&, this] (TCpuDuration execution) {
+            YT_LOG_WARNING("Callback executed for too long without interruptions (Callback: %v, Execution: %v)",
+                callback.GetHandle(),
+                CpuDurationToDuration(execution));
+        });
+        callback();
+    }
+};
+
+IInvokerPtr CreateWatchdogInvoker(
+    IInvokerPtr underlyingInvoker,
+    const NLogging::TLogger& logger,
+    TDuration threshold)
+{
+    return New<TWatchdogInvoker>(std::move(underlyingInvoker), logger, threshold);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/concurrency/action_queue.h
+++ b/yt/yt/core/concurrency/action_queue.h
@@ -4,6 +4,8 @@
 
 #include <yt/yt/core/actions/callback.h>
 
+#include <yt/yt/core/logging/public.h>
+
 #include <yt/yt/library/profiling/public.h>
 #include <yt/yt/library/profiling/tag.h>
 
@@ -97,6 +99,15 @@ ISuspendableInvokerPtr CreateSuspendableInvoker(IInvokerPtr underlyingInvoker);
 IInvokerPtr CreateCodicilGuardedInvoker(
     IInvokerPtr underlyingInvoker,
     TString codicil);
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Creates an invoker that emits warning into #logger when callback executes
+//! longer than #threshold without interruptions.
+IInvokerPtr CreateWatchdogInvoker(
+    IInvokerPtr underlyingInvoker,
+    const NLogging::TLogger& logger,
+    TDuration threshold);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/core/profiling/timing.h
+++ b/yt/yt/core/profiling/timing.h
@@ -130,6 +130,26 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Calls #callback at the end of execution slice if it was longer than #threshold.
+class TFiberSliceTimer
+    : private NConcurrency::TContextSwitchGuard
+{
+public:
+    TFiberSliceTimer(TCpuDuration threshold, std::function<void(TCpuDuration)> callback);
+    ~TFiberSliceTimer();
+
+private:
+    const TCpuDuration Threshold_;
+    const std::function<void(TCpuDuration)> Callback_;
+
+    TCpuInstant LastInTime_;
+
+    void OnIn() noexcept;
+    void OnOut() noexcept;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NProfiling
 
 #define TIMING_INL_H_

--- a/yt/yt/server/node/cluster_node/bootstrap.cpp
+++ b/yt/yt/server/node/cluster_node/bootstrap.cpp
@@ -251,7 +251,12 @@ public:
     void Initialize() override
     {
         ControlActionQueue_ = New<TActionQueue>("Control");
+
         JobActionQueue_ = New<TActionQueue>("Job");
+        JobInvoker_ = CreateWatchdogInvoker(
+            JobActionQueue_->GetInvoker(),
+            ClusterNodeLogger(),
+            TDuration::MilliSeconds(500));
 
         BIND(&TBootstrap::DoInitialize, this)
             .AsyncVia(GetControlInvoker())
@@ -366,7 +371,7 @@ public:
 
     const IInvokerPtr& GetJobInvoker() const override
     {
-        return JobActionQueue_->GetInvoker();
+        return JobInvoker_;
     }
 
     const IInvokerPtr& GetMasterConnectionInvoker() const override
@@ -655,6 +660,7 @@ private:
 
     TActionQueuePtr ControlActionQueue_;
     TActionQueuePtr JobActionQueue_;
+    IInvokerPtr JobInvoker_;
     IThreadPoolPtr ConnectionThreadPool_;
     IThreadPoolPtr StorageLightThreadPool_;
     IThreadPoolPtr StorageHeavyThreadPool_;


### PR DESCRIPTION
- Add watchdog invoker wrapper for detecting bulky callbacks
  
- Detect bulky callbacks in cluster node job invoker
  Sample usage for watchdog invoker.
  

Alternative design - maintain per-thread time of last reschedule and check them all periodically.
That's how various watchdog live in linux kernel (hung-task-detector, rcu-stale, etc).

Also it would be nice to print source code location related to current closure.
It seems implemented but not used/exported.