### PR TITLE
Do not retry execve in process spawn action

### DIFF
--- a/yt/yt/library/process/process.cpp
+++ b/yt/yt/library/process/process.cpp
@@ -62,13 +62,6 @@ YT_DEFINE_GLOBAL(const NLogging::TLogger, Logger, "Process");
 
 static constexpr pid_t InvalidProcessId = -1;
 
-#if !defined(YT_USE_POSIX_SPAWN_API)
-
-static constexpr int ExecveRetryCount = 5;
-static constexpr auto ExecveRetryTimeout = TDuration::Seconds(1);
-
-#endif
-
 static constexpr int ResolveRetryCount = 5;
 static constexpr auto ResolveRetryTimeout = TDuration::Seconds(1);
 
@@ -559,17 +552,10 @@ public:
     #else
         SpawnActions_.push_back(TSpawnAction{
             [=] {
-                for (int retryIndex = 0; retryIndex < ExecveRetryCount; ++retryIndex) {
-                    // Execve may fail, if called binary is being updated, e.g. during yandex-yt package update.
-                    // So we'd better retry several times.
-                    // For example see YT-6352.
-                    TryExecve(resolvedPath, argv, env);
-                    if (retryIndex < ExecveRetryCount - 1) {
-                        Sleep(ExecveRetryTimeout);
-                    }
-                }
-                // If we are still here, return failure.
-                return false;
+                // Execve may fail, if called binary is being updated, e.g. during yandex-yt package update
+                // with errno ETXTBSY - executable file is open for writing. For example see YT-6352.
+                // Initiator could retry after getting error EProcessErrorCode::CannotStartProcess.
+                return TryExecve(resolvedPath, argv, env);
             },
             "Error starting child process: execve failed"
         });
@@ -629,8 +615,9 @@ private:
 #else
     pid_t DoSpawnChildVFork()
     {
-        // NB: fork() will cause data corruption when run concurrently with
-        // Disk IO on O_DIRECT file descriptor. Seems like vfork don't suffer from the same issue.
+        // NB: fork() copy-on-write cause undefined behaviour when run concurrently with
+        // Disk IO on O_DIRECT file descriptor. vfork don't suffer from the same issue.
+        // NB: vfork() blocks parent until child executes new program or exits.
         int pid = vfork();
 
         if (pid < 0) {

--- a/yt/yt/library/process/process.h
+++ b/yt/yt/library/process/process.h
@@ -41,7 +41,9 @@ public:
     virtual NNet::IConnectionReaderPtr GetStdOutReader() = 0;
     virtual NNet::IConnectionReaderPtr GetStdErrReader() = 0;
 
+    //! Returns process completion future, which ends with EErrorCode::OK or EProcessErrorCode.
     TFuture<void> Spawn();
+
     virtual void Kill(int signal) = 0;
 
     TString GetPath() const;


### PR DESCRIPTION
Parent is blocked on vfork() - sleeping here for 5 seconds is a bad idea.

It's better to fail with error EProcessErrorCode::CannotStartProcess and
let initiator decide what to do: retry or abort operation.
