### PR TITLE
Allow to specify prerequisite transaction ids in client.Transaction context manager

### DIFF
--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -91,7 +91,7 @@ class YtClient(ClientState):
             self,
             timeout=None, deadline=None, attributes=None, ping=None, interrupt_on_failed=True,
             transaction_id=None, ping_ancestor_transactions=None, type='master', acquire=None, ping_period=None,
-            ping_timeout=None):
+            ping_timeout=None, prerequisite_transaction_ids=None):
         """
 
         It is designed to be used by with_statement::
@@ -116,7 +116,7 @@ class YtClient(ClientState):
             client=self,
             timeout=timeout, deadline=deadline, attributes=attributes, ping=ping, interrupt_on_failed=interrupt_on_failed,
             transaction_id=transaction_id, ping_ancestor_transactions=ping_ancestor_transactions, type=type,
-            acquire=acquire, ping_period=ping_period, ping_timeout=ping_timeout)
+            acquire=acquire, ping_period=ping_period, ping_timeout=ping_timeout, prerequisite_transaction_ids=prerequisite_transaction_ids)
 
     def abort_job(
             self,

--- a/yt/python/yt/wrapper/transaction.py
+++ b/yt/python/yt/wrapper/transaction.py
@@ -122,7 +122,7 @@ class Transaction(object):
         self._stack.init(get_command_param("transaction_id", self._client),
                          get_command_param("ping_ancestor_transactions", self._client))
 
-        if self.transaction_id is not None and self.transaction_id != null_transaction_id and prerequisite_transaction_ids:
+        if self.transaction_id is not None and prerequisite_transaction_ids:
             raise RuntimeError("prerequisite_transaction_ids={!r} must be None or empty when transaction_id is not None".format(prerequisite_transaction_ids))
 
         if self.transaction_id is None:


### PR DESCRIPTION
Now it is not very convenient to use prerequisite transactions right now, since you have to create another client for that.