### PR TITLE
Fix safe core in ordered chunk pool

### DIFF
--- a/yt/yt/server/lib/chunk_pools/ordered_chunk_pool.cpp
+++ b/yt/yt/server/lib/chunk_pools/ordered_chunk_pool.cpp
@@ -418,19 +418,18 @@ private:
         RowCountUntilJobSplit_ = 0;
         JobCarryOverDataWeight_ = 0;
 
-        IChunkPoolOutput::TCookie result = IChunkPoolOutput::NullCookie;
+        auto dataSliceCopy = CreateInputDataSlice(dataSlice);
+        dataSliceCopy->Tag = cookie;
+        CurrentJob()->AddDataSlice(dataSliceCopy, cookie, /*isPrimary*/ true);
 
         bool jobIsLargeEnough =
             CurrentJob()->GetPreliminarySliceCount() >= JobSizeConstraints_->GetMaxDataSlicesPerJob() ||
             GetCurrentJobDataWeight() >= dataSizePerJob;
         if (jobIsLargeEnough && !SingleJob_) {
-            result = EndJob();
+            return EndJob();
         }
 
-        auto dataSliceCopy = CreateInputDataSlice(dataSlice);
-        dataSliceCopy->Tag = cookie;
-        CurrentJob()->AddDataSlice(dataSliceCopy, cookie, /*isPrimary*/ true);
-        return result;
+        return IChunkPoolOutput::NullCookie;
     }
 
     bool IsDataSliceSplittable(const TLegacyDataSlicePtr& dataSlice) const
@@ -483,11 +482,20 @@ private:
         TInputChunkSlicePtr pocket;
         int chunkSliceIndex = 0;
         while (chunkSliceIndex < std::ssize(chunkSlices) || pocket) {
+            // The pocket holds the slice that should be handled before handling the next chunk slice index.
+            // It is used to store the suffix of the current slice when we only add a prefix of it to the current job.
             auto chunkSlice = pocket ? pocket : chunkSlices[chunkSliceIndex];
             pocket = nullptr;
 
+            // If the pocket is empty, we can handle the next slice in our input order.
+            // Note the continuation statements below that will lead to the execution of this code.
+            auto nextIteration = Finally([&] () {
+                if (!pocket) {
+                    ++chunkSliceIndex;
+                }
+            });
+
             if (!chunkSlice->GetRowCount()) {
-                ++chunkSliceIndex;
                 continue;
             }
 
@@ -512,16 +520,27 @@ private:
                 // NB: We use splitting here in order to get the exact same data weight we would get later on in the process.
                 JobCarryOverDataWeight_ = RowCountUntilJobSplit_ ? -chunkSlice->SplitByRowIndex(RowCountUntilJobSplit_).first->GetDataWeight() : 0;
 
-                // If batch row count is zero, there should never be any carry-over data weight,
-                // so the second value cannot be zero for non-empty slices.
-                YT_VERIFY(batchRowCount || RowCountUntilJobSplit_ > 0);
-
                 if (batchRowCount) {
                     YT_VERIFY(*batchRowCount > 0);
                     // Zero rows until split force us to look for the next acceptable split (even when batchRowCountRemainder = 0) since it usually means that a job just ended.
                     if (auto batchRowCountRemainder = (CurrentJob()->GetRowCount() + RowCountUntilJobSplit_) % *batchRowCount; !RowCountUntilJobSplit_ || batchRowCountRemainder) {
                         RowCountUntilJobSplit_ += *batchRowCount - batchRowCountRemainder;
                     }
+                } else if (RowCountUntilJobSplit_ == 0) {
+                    // We should not actually end up here, since both slice addition implementations finish jobs
+                    // as soon as the limit is hit when batch row count is not set.
+                    // However, if we do, let's reset the carry-over data weight, end the job and reprocess the current slice.
+                    YT_LOG_WARNING(
+                        "Creating ordered job prematurely (CurrentJobDataWeight: %v, JobCarryOverDataWeight: %v, ActiveSliceDataWeight: %v, ActiveSliceRowCount: %v)",
+                        GetCurrentJobDataWeight(),
+                        JobCarryOverDataWeight_,
+                        chunkSlice->GetDataWeight(),
+                        chunkSlice->GetRowCount());
+                    JobCarryOverDataWeight_ = 0;
+                    EndJob();
+                    // Current job data weight should be zero now, so we can handle the whole slice again.
+                    pocket = chunkSlice;
+                    continue;
                 }
             }
 
@@ -545,10 +564,6 @@ private:
             if (endJob && !SingleJob_) {
                 YT_VERIFY(RowCountUntilJobSplit_ == 0);
                 EndJob();
-            }
-
-            if (!pocket) {
-                ++chunkSliceIndex;
             }
         }
     }


### PR DESCRIPTION
This commit fixes a bug introduced in this [commit](https://github.com/ytsaurus/ytsaurus/commit/b688be4aa792a5367ccd11c5ad429abbb24ed99e) by the new `batch_row_count` related logic. 

The root cause was that the adding an unversioned slice now relies on the fact that the current job is not larger than `data_size_per_job`, i.e. that the job was ended after adding the previous slice.
Meanwhile, the old logic that remained for versioned/unsplittable slices did things in the opposite order: we first checked the size of the current job and added the active slice next. So we would actually end the current job when adding the next slice after the one that hit the limit.
Obviously, these two approaches don't mix well :)
Primarily a problem arises when mixing sorted dynamic and static tables in ordered operations.

I decided to fix this twice:
1. I changed the order in `AddUnsplittablePrimaryDataSlice` to add the slice first and check the current job size later. Now all slice addition methods operate the same way, so everything is fine.
2. I added a safety fallback in `AddSplittablePrimaryDataSlice` that will end the current job if it is too large and reprocess the current slice.

I also addressed new post-commit comments from #423.