### PR TITLE
Fix typo in docs: YT_ALIAS -> CHYT_ALIAS

### DIFF
--- a/yt/docs/en/_includes/user-guide/data-processing/chyt/cli-and-api-intro.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/chyt/cli-and-api-intro.md
@@ -7,7 +7,7 @@ The command line utility accepts two environment variables: `YT_PROXY` and `CHYT
 For example, you can use the following command for Linux and macOS  to set environment variables and no longer pass the `--proxy <cluster_name>` and `--alias *ch_public` parameters to all subsequent calls:
 
 ```bash
-export YT_PROXY=<cluster_name> YT_ALIAS=*ch_public
+export YT_PROXY=<cluster_name> CHYT_ALIAS=*ch_public
 ```
 
 {% cut "About using the `--alias` parameter" %}

--- a/yt/docs/en/_includes/user-guide/data-processing/chyt/cli-and-api.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/chyt/cli-and-api.md
@@ -9,7 +9,7 @@ The command line utility accepts two environment variables:
 For example, you can use the following command for Linux and macOS  to set environment variables and no longer pass the `--proxy <cluster_name>` and `--alias *ch_public` parameters to all subsequent calls:
 
 ```bash
-export YT_PROXY=<cluster_name> YT_ALIAS=*ch_public
+export YT_PROXY=<cluster_name> CHYT_ALIAS=*ch_public
 ```
 
 The process that launches the clique can sometimes be informally called a *launcher*.

--- a/yt/docs/ru/_includes/user-guide/data-processing/chyt/cli-and-api-intro.md
+++ b/yt/docs/ru/_includes/user-guide/data-processing/chyt/cli-and-api-intro.md
@@ -7,7 +7,7 @@
 Например, под Linux и macOS можно использовать следующую команду, чтобы установить переменные окружения и больше не передавать параметры `--proxy <cluster_name>` и `--alias *ch_public` во все последующие вызовы:
 
 ```bash
-export YT_PROXY=<cluster_name> YT_ALIAS=*ch_public
+export YT_PROXY=<cluster_name> CHYT_ALIAS=*ch_public
 ```
 
 {% cut "Про использование параметра `--alias`" %}


### PR DESCRIPTION
Only CHYT_ALIAS is supported:

https://github.com/ytsaurus/ytsaurus/blob/17bdbe3d2a8988f46932eb55044037bbdc4d71f3/yt/python/yt/clickhouse/helpers.py#L6-L10