### PR TITLE
Add pool and pool tree params to ListOperations

### DIFF
--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -592,6 +592,8 @@ type ListOperationsOptions struct {
 	Type     *OperationType  `http:"type,omitnil"`
 	Filter   *string         `http:"filter,omitnil"`
 	Limit    *int            `http:"limit,omitnil"`
+	Pool     *string         `http:"pool,omitnil"`
+	PoolTree *string         `http:"pool_tree,omitnil"`
 }
 
 type ListJobsOptions struct {

--- a/yt/go/yt/internal/params_gen.go
+++ b/yt/go/yt/internal/params_gen.go
@@ -544,6 +544,14 @@ func writeListOperationsOptions(w *yson.Writer, o *yt.ListOperationsOptions) {
 		w.MapKeyString("limit")
 		w.Any(o.Limit)
 	}
+	if o.Pool != nil {
+		w.MapKeyString("pool")
+		w.Any(o.Pool)
+	}
+	if o.PoolTree != nil {
+		w.MapKeyString("pool_tree")
+		w.Any(o.PoolTree)
+	}
 	writeMasterReadOptions(w, o.MasterReadOptions)
 	writeReadRetryOptions(w, o.ReadRetryOptions)
 }

--- a/yt/go/yt/internal/rpcclient/encoder.go
+++ b/yt/go/yt/internal/rpcclient/encoder.go
@@ -1801,7 +1801,8 @@ func (e *Encoder) ListOperations(
 		StateFilter:            opState,
 		TypeFilter:             opType,
 		SubstrFilter:           opts.Filter,
-		Pool:                   nil,   // todo
+		Pool:                   opts.Pool,
+		PoolTree:               opts.PoolTree,
 		IncludeArchive:         nil,   // todo
 		IncludeCounters:        nil,   // todo
 		Limit:                  limit, // todo


### PR DESCRIPTION
These parameters are long supported by the server-side and by CLI:

```
$ yt list-operations --help
...
  --pool-tree POOL_TREE
                        filter operations by pool tree
  --pool POOL           filter operations by pool. If --pool-tree is set,
                        filters operations with this pool in specified pool
                        tree
...
```

I did not any tests for them, considering that there is no convenient way of running Go SDK tests in OSS. Though I do not expect any surprises here, this PR cannot break any existing test, and the functionality should immediately work.