### PR TITLE
Detect job OOM

### DIFF
--- a/yt/yt/library/containers/cgroups_new.cpp
+++ b/yt/yt/library/containers/cgroups_new.cpp
@@ -213,6 +213,15 @@ TBlockIOStatistics TSelfCGroupsStatisticsFetcher::GetBlockIOStatistics() const
     return IsV2_ ? GetBlockIOStatisticsV2(CGroup_) : GetBlockIOStatisticsV1(CGroup_);
 }
 
+i64 TSelfCGroupsStatisticsFetcher::GetOOMKillCount() const
+{
+    auto oomEventsPath = IsV2_ ? Format("/sys/fs/cgroup/%v/memory.events", CGroup_) : Format("/sys/fs/cgroup/memory/%v/memory.oom_control", CGroup_);
+    auto statistics = ReadAndParseStatFile(oomEventsPath);
+
+    // Count of tasks killed by OOM killer in this cgroup or its children.
+    return statistics["oom_kill"];
+}
+
 void TSelfCGroupsStatisticsFetcher::DetectSelfCGroup()
 {
     // NB: There are issues with cgroup namespaces in Kubernetes

--- a/yt/yt/library/containers/cgroups_new.h
+++ b/yt/yt/library/containers/cgroups_new.h
@@ -39,6 +39,7 @@ public:
     TMemoryStatistics GetMemoryStatistics() const;
     TCpuStatistics GetCpuStatistics() const;
     TBlockIOStatistics GetBlockIOStatistics() const;
+    i64 GetOOMKillCount() const;
 
 private:
     TString CGroup_;

--- a/yt/yt/library/containers/cri/config.cpp
+++ b/yt/yt/library/containers/cri/config.cpp
@@ -25,6 +25,9 @@ void TCriExecutorConfig::Register(TRegistrar registrar)
     registrar.Parameter("cpu_period", &TThis::CpuPeriod)
         .Default(TDuration::MilliSeconds(100));
 
+    registrar.Parameter("memory_oom_group", &TThis::MemoryOOMGroup)
+        .Default(false);
+
     registrar.Parameter("retry_error_prefixes", &TThis::RetryErrorPrefixes)
         .Default({
             // https://github.com/containerd/containerd/pull/9565

--- a/yt/yt/library/containers/cri/config.h
+++ b/yt/yt/library/containers/cri/config.h
@@ -31,6 +31,9 @@ public:
     //! Cpu quota period for cpu limits.
     TDuration CpuPeriod;
 
+    //! By default at OOM kill all tasks at once. Requires cgroup-v2.
+    bool MemoryOOMGroup;
+
     //! Retry requests on generic error with these message prefixes.
     std::vector<TString> RetryErrorPrefixes;
 

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -43,8 +43,6 @@ static TError DecodeExitCode(int exitCode, const TString& reason)
         return TError();
     }
 
-    // TODO(khkebnikov) map reason == "OOMKilled"
-
     // Common bash notation for signals: 128 + signal
     if (exitCode > 128) {
         int signalNumber = exitCode - 128;
@@ -53,7 +51,8 @@ static TError DecodeExitCode(int exitCode, const TString& reason)
             "Process terminated by signal %v",
             signalNumber)
             << TErrorAttribute("signal", signalNumber)
-            << TErrorAttribute("reason", reason);
+            << TErrorAttribute("reason", reason)
+            << TErrorAttribute("oom_killed", reason == "OOMKilled");
     }
 
     // TODO(khkebnikov) check these

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -707,6 +707,10 @@ private:
             (*unified)["memory.low"] = ToString(*spec.MemoryRequest);
         }
 
+        if (spec.MemoryOOMGroup.value_or(Config_->MemoryOOMGroup)) {
+            (*unified)["memory.oom.group"] = "1";
+        }
+
         if (const auto& cpusetCpus = spec.CpusetCpus) {
             resources->set_cpuset_cpus(*cpusetCpus);
         }

--- a/yt/yt/library/containers/cri/cri_executor.h
+++ b/yt/yt/library/containers/cri/cri_executor.h
@@ -42,6 +42,9 @@ struct TCriContainerResources
     std::optional<i64> MemoryLimit;
     std::optional<i64> MemoryRequest;
 
+    //! At OOM kill all tasks at once.
+    std::optional<bool> MemoryOOMGroup;
+
     std::optional<TString> CpusetCpus;
 };
 

--- a/yt/yt/server/job_proxy/environment.h
+++ b/yt/yt/server/job_proxy/environment.h
@@ -152,6 +152,8 @@ struct IUserJobEnvironment
     virtual const std::vector<TString>& GetEnvironmentVariables() const = 0;
 
     virtual i64 GetMajorPageFaultCount() const = 0;
+
+    virtual std::optional<i64> GetJobOOMKillCount() const noexcept = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IUserJobEnvironment)
@@ -174,6 +176,7 @@ struct IJobProxyEnvironment
     virtual std::optional<TJobEnvironmentBlockIOStatistics> GetJobBlockIOStatistics() const noexcept = 0;
     virtual std::optional<TJobEnvironmentMemoryStatistics> GetJobMemoryStatistics() const noexcept = 0;
     virtual std::optional<TJobEnvironmentCpuStatistics> GetJobCpuStatistics() const noexcept = 0;
+    virtual std::optional<i64> GetJobOOMKillCount() const noexcept = 0;
 };
 
 DEFINE_REFCOUNTED_TYPE(IJobProxyEnvironment)

--- a/yt/yt/server/job_proxy/user_job.cpp
+++ b/yt/yt/server/job_proxy/user_job.cpp
@@ -394,6 +394,19 @@ public:
                 .ThrowOnError();
         }
 
+        if (Config_->CheckUserJobOOMKill) {
+            // Detect OOM kills in job environment regardless of exit status of the main process.
+            if (auto oomKillCount = UserJobEnvironment_->GetJobOOMKillCount(); oomKillCount.value_or(0)) {
+                YT_LOG_INFO("Out of memory kill detected (OOMKillCount: %v)", *oomKillCount);
+                auto error = TError(
+                    EErrorCode::MemoryLimitExceeded,
+                    "User job process killed by OOM")
+                    << TErrorAttribute("oom_kill_count", *oomKillCount)
+                    << TErrorAttribute("abort_reason", EAbortReason::ResourceOverdraft);
+                innerErrors.push_back(std::move(error));
+            }
+        }
+
         auto jobError = innerErrors.empty()
             ? TError()
             : TError(EErrorCode::UserJobFailed, "User job failed") << std::move(innerErrors);
@@ -1644,6 +1657,13 @@ private:
         }
 
         Host_->SetUserJobMemoryUsage(memoryUsage);
+
+        if (Config_->CheckUserJobOOMKill) {
+            if (auto oomKillCount = UserJobEnvironment_->GetJobOOMKillCount(); oomKillCount.value_or(0)) {
+                YT_LOG_INFO("Out of memory kill detected (OOMKillCount: %v)", *oomKillCount);
+                CleanupUserProcesses();
+            }
+        }
     }
 
     void CheckThrashing()

--- a/yt/yt/server/lib/job_proxy/config.cpp
+++ b/yt/yt/server/lib/job_proxy/config.cpp
@@ -206,6 +206,9 @@ void TJobProxyInternalConfig::Register(TRegistrar registrar)
     registrar.Parameter("check_user_job_memory_limit", &TThis::CheckUserJobMemoryLimit)
         .Default(true);
 
+    registrar.Parameter("check_user_job_oom_kill", &TThis::CheckUserJobOOMKill)
+        .Default(true);
+
     registrar.Parameter("enable_job_shell_seccomp", &TThis::EnableJobShellSeccopm)
         .Default(true);
 
@@ -285,6 +288,9 @@ void TJobProxyDynamicConfig::Register(TRegistrar registrar)
         .Default(false);
 
     registrar.Parameter("enable_stderr_and_core_live_preview", &TThis::EnableStderrAndCoreLivePreview)
+        .Default(true);
+
+    registrar.Parameter("check_user_job_oom_kill", &TThis::CheckUserJobOOMKill)
         .Default(true);
 
     registrar.Parameter("job_environment", &TThis::JobEnvironment)

--- a/yt/yt/server/lib/job_proxy/config.h
+++ b/yt/yt/server/lib/job_proxy/config.h
@@ -251,6 +251,9 @@ public:
     //! proper memory limits for asan builds.
     bool CheckUserJobMemoryLimit;
 
+    //! If set, abort user job at detecting OOM kill inside container.
+    bool CheckUserJobOOMKill;
+
     //! Compat option for urgent disable of job shell audit.
     bool EnableJobShellSeccopm;
 
@@ -311,6 +314,9 @@ public:
     bool AbortOnUncaughtException;
 
     bool EnableStderrAndCoreLivePreview;
+
+    //! If set, abort user job at detecting OOM kill inside container.
+    bool CheckUserJobOOMKill;
 
     NYTree::INodePtr JobEnvironment;
 

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -2805,6 +2805,7 @@ TJobProxyInternalConfigPtr TJob::CreateConfig()
         proxyConfig->ForceIdleCpuPolicy = proxyDynamicConfig->ForceIdleCpuPolicy;
         proxyConfig->AbortOnUncaughtException = proxyDynamicConfig->AbortOnUncaughtException;
         proxyConfig->EnableStderrAndCoreLivePreview = proxyDynamicConfig->EnableStderrAndCoreLivePreview;
+        proxyConfig->CheckUserJobOOMKill = proxyDynamicConfig->CheckUserJobOOMKill;
         if (proxyDynamicConfig->JobEnvironment) {
             proxyConfig->JobEnvironment = PatchNode(proxyConfig->JobEnvironment, proxyDynamicConfig->JobEnvironment);
         }

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -3210,6 +3210,11 @@ std::optional<EAbortReason> TJob::DeduceAbortReason()
                 }
             }
         }
+        if (auto processSignal = resultError.FindMatching(EProcessErrorCode::Signal)) {
+            if (processSignal->Attributes().Find<bool>("oom_killed").value_or(false)) {
+                return EAbortReason::ResourceOverdraft;
+            }
+        }
     }
 
     return std::nullopt;


### PR DESCRIPTION
- Detect when any process was killed by OOM killer in user job environment
  Always report here abort reason resource overdraft regardless of
  exit status of job main process - correct handing is not expected.
  
- Detect when job proxy is killed by OOM killer
  Report that abort reason is resource overdraft.
  
- Add option memory_oom_group for killing all tasks at OOM
  
