### PR TITLE
Query Tracker Engine Liveness odin check logging improvement

### DIFF
--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -13,7 +13,6 @@ class Data():
 
 
 POLL_FREQUENCY = 0.1
-LOG_FREQUENCY = 1.0
 TEMP_PATH = "//sys/admin/odin/query_tracker_liveness"
 TABLE_EXPIRATION_TIMEOUT_MILLISECONDS = 360 * 1000
 
@@ -46,7 +45,7 @@ def track_query(yt_client, logger, query_id, stage):
         state = get_query_state(yt_client, query_id, stage)
 
         current_time = time.time()
-        if current_time - last_log_time >= LOG_FREQUENCY and state != last_state:
+        if state != last_state:
             log_query(logger, query_id, state)
             last_log_time = current_time
             last_state = state

--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -42,8 +42,6 @@ def track_query(yt_client, logger, query_id, stage):
     last_state = ""
     while True:
         state = get_query_state(yt_client, query_id, stage)
-
-        current_time = time.time()
         if state != last_state:
             log_query(logger, query_id, state)
             last_state = state

--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -41,13 +41,15 @@ def log_query(logger, query_id, state):
 
 def track_query(yt_client, logger, query_id, stage):
     last_log_time = time.time()
+    last_state = ""
     while True:
         state = get_query_state(yt_client, query_id, stage)
 
         current_time = time.time()
-        if current_time - last_log_time >= LOG_FREQUENCY:
+        if current_time - last_log_time >= LOG_FREQUENCY and state != last_state:
             log_query(logger, query_id, state)
             last_log_time = current_time
+            last_state = state
 
         if check_terminal_state(state):
             return state

--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -39,7 +39,6 @@ def log_query(logger, query_id, state):
 
 
 def track_query(yt_client, logger, query_id, stage):
-    last_log_time = time.time()
     last_state = ""
     while True:
         state = get_query_state(yt_client, query_id, stage)

--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -46,7 +46,6 @@ def track_query(yt_client, logger, query_id, stage):
         current_time = time.time()
         if state != last_state:
             log_query(logger, query_id, state)
-            last_log_time = current_time
             last_state = state
 
         if check_terminal_state(state):

--- a/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
+++ b/yt/odin/checks/lib/query_tracker_engine_liveness/__init__.py
@@ -12,7 +12,7 @@ class Data():
         self.dynamic = dynamic
 
 
-POLL_FREQUENCY = 0.1
+POLL_FREQUENCY = 1.0
 TEMP_PATH = "//sys/admin/odin/query_tracker_liveness"
 TABLE_EXPIRATION_TIMEOUT_MILLISECONDS = 360 * 1000
 


### PR DESCRIPTION
Currently, for long queries we have spam in check report:
```
UTC+0000 14:25:39.985 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:41.84 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:42.163 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:43.242 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:44.328 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:45.408 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:46.497 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:47.579 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:48.658 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:49.755 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:50.841 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:51.922 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
UTC+0000 14:25:52.997 - INFO : 25bca15f	Query 1334ba2c-dfd59531-484e3a5c-849b9df1: running
```

Removing this spam here

