### PR TITLE
Fix ya make warning

### DIFF
--- a/yt/admin/ya.make
+++ b/yt/admin/ya.make
@@ -1,6 +1,5 @@
-       
+
 RECURSE(
-    cms
     dashboard_generator
     dashboards
 )
@@ -9,6 +8,7 @@ IF (NOT OPENSOURCE)
     RECURSE(
         common
         core
+        cms
         acl_dumper
         ytcfgen
         ytdyncfgen

--- a/yt/ya.make
+++ b/yt/ya.make
@@ -11,7 +11,6 @@ RECURSE(
     docs
     docker
     odin
-    spark/spark-over-yt
     styleguide
     systest
     admin
@@ -41,6 +40,7 @@ IF (NOT OPENSOURCE)
         recipe
         scripts
         skynet
+        spark/spark-over-yt
         terraform
         yt_proto
         yt_sync


### PR DESCRIPTION
```
Error[-WBadDir]: in $S/yt/ya.make: RECURSE to missing directory: $S/yt/spark/spark-over-yt
Error[-WBadDir]: in $S/yt/admin/ya.make: RECURSE to missing directory: $S/yt/admin/cms
```
