### PR TITLE
Do not crash if chunk referenced in multiplexed changelog is missing

### DIFF
--- a/yt/yt/server/node/data_node/journal_manager.cpp
+++ b/yt/yt/server/node/data_node/journal_manager.cpp
@@ -382,7 +382,7 @@ private:
             auto changelog = Callbacks_->OpenSplitChangelog(chunkId);
             if (!changelog) {
                 if (!AbsentChunkIds_.contains(chunkId)) {
-                    YT_LOG_DEBUG("Journal chunk %v is missing but has relevant records in the multiplexed changelog",
+                    YT_LOG_INFO("Journal chunk %v is missing but has relevant records in the multiplexed changelog",
                         chunkId);
                     AbsentChunkIds_.insert(chunkId);
                 }

--- a/yt/yt/server/node/data_node/journal_manager.cpp
+++ b/yt/yt/server/node/data_node/journal_manager.cpp
@@ -483,13 +483,18 @@ private:
 
         YT_VERIFY(!SplitMap_.contains(chunkId));
 
-        if (!Callbacks_->RemoveSplitChangelog(chunkId))
-            return;
+        if (Callbacks_->RemoveSplitChangelog(chunkId)) {
+            YT_LOG_INFO("Replay removed journal chunk (ChunkId: %v)",
+                chunkId);
+        }
 
-        YT_LOG_INFO("Replay removed journal chunk (ChunkId: %v)",
-            chunkId);
+        if (AbsentChunkIds_.contains(chunkId)) {
+            AbsentChunkIds_.erase(chunkId);
+
+            YT_LOG_INFO("Replay removed absent journal chunk (ChunkId: %v)",
+                chunkId);
+        }
     }
-
 };
 
 class TMultiplexedWriter

--- a/yt/yt/server/node/data_node/journal_manager.cpp
+++ b/yt/yt/server/node/data_node/journal_manager.cpp
@@ -381,10 +381,9 @@ private:
         if (it == SplitMap_.end()) {
             auto changelog = Callbacks_->OpenSplitChangelog(chunkId);
             if (!changelog) {
-                if (!AbsentChunkIds_.contains(chunkId)) {
-                    YT_LOG_INFO("Journal chunk %v is missing but has relevant records in the multiplexed changelog",
+                if (AbsentChunkIds_.insert(chunkId).second) {
+                    YT_LOG_INFO("Journal chunk is missing but has relevant records in the multiplexed changelog (ChunkId: %v)",
                         chunkId);
-                    AbsentChunkIds_.insert(chunkId);
                 }
                 return;
             }
@@ -488,9 +487,7 @@ private:
                 chunkId);
         }
 
-        if (AbsentChunkIds_.contains(chunkId)) {
-            AbsentChunkIds_.erase(chunkId);
-
+        if (AbsentChunkIds_.erase(chunkId)) {
             YT_LOG_INFO("Replay removed absent journal chunk (ChunkId: %v)",
                 chunkId);
         }


### PR DESCRIPTION
It may be removed in a multiplexed changelog after