### PR TITLE
Fix account profiling incumbency

### DIFF
--- a/yt/yt/server/master/security_server/security_manager.cpp
+++ b/yt/yt/server/master/security_server/security_manager.cpp
@@ -4883,9 +4883,7 @@ private:
 
         MaybeToggleAccountsProfiling();
 
-        if (newConfig->AccountsProfilingPeriod != oldConfig->AccountsProfilingPeriod &&
-            AccountsProfilingExecutor_)
-        {
+        if (AccountsProfilingExecutor_) {
             AccountsProfilingExecutor_->SetPeriod(newConfig->AccountsProfilingPeriod);
         }
 

--- a/yt/yt/server/master/security_server/security_manager.cpp
+++ b/yt/yt/server/master/security_server/security_manager.cpp
@@ -4864,9 +4864,8 @@ private:
         return Bootstrap_->GetConfigManager()->GetConfig()->SecurityManager;
     }
 
-    void OnDynamicConfigChanged(TDynamicClusterConfigPtr oldClusterConfig)
+    void OnDynamicConfigChanged(TDynamicClusterConfigPtr /*oldClusterConfig*/)
     {
-        const auto& oldConfig = oldClusterConfig->SecurityManager;
         const auto& newConfig = GetDynamicConfig();
 
         if (AccountStatisticsGossipExecutor_) {


### PR DESCRIPTION
Current implementation is racy for two reasons.

Firstly, the following scenario is possible:
1) Peer is a leader and profiles metrics
2) Leader is switched, profiling invoker is destroyed
3) Dynamic config changes, StartAccountsProfiling is called and new (epoch) invoker in created
4) Peer becomes leader again, invoker is not recreated while it is still bound to the finished epoch

Secondly, invoker is always stopped when some incumbency finishes, while it is possible that only a part of incumbencies should be finished (i.e. during the change of number of alive followers).

This PR fixes these problems and also does some code cleanup.