### PR TITLE
Properly handle unknown GPU device

### DIFF
--- a/yt/yt/server/lib/exec_node/gpu_helpers.cpp
+++ b/yt/yt/server/lib/exec_node/gpu_helpers.cpp
@@ -33,7 +33,7 @@ static const TString NvidiaDevicePrefix("nvidia");
 static const TString NvidiaModuleVersionPath("/sys/module/nvidia/version");
 static const THashSet<TString> MetaGpuDevices = {
     "/dev/nvidiactl",
-    "/dev/nvidia-uvm"
+    "/dev/nvidia-uvm",
 };
 static const TString DummyGpuDriverVersion = "dummy";
 
@@ -88,7 +88,7 @@ std::vector<TGpuDeviceDescriptor> ListGpuDevices()
 
     if (foundMetaDeviceCount < std::ssize(MetaGpuDevices)) {
         if (!result.empty()) {
-            THROW_ERROR_EXCEPTION("Too few Nvidia meta GPU devices found, but nvidia devices presented");
+            THROW_ERROR_EXCEPTION("Too few Nvidia meta GPU devices found, but Nvidia devices presented");
         }
         YT_LOG_INFO("Too few Nvidia meta GPU devices found; assuming no device is present (Found: %v, Needed: %v)",
             foundMetaDeviceCount,

--- a/yt/yt/server/node/exec_node/gpu_manager.h
+++ b/yt/yt/server/node/exec_node/gpu_manager.h
@@ -135,6 +135,7 @@ private:
 
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, SpinLock_);
     THashMap<int, NGpu::TGpuInfo> HealthyGpuInfoMap_;
+    THashSet<int> GpuDeviceIndices_;
     THashSet<int> LostGpuDeviceIndices_;
 
     std::vector<NGpu::TRdmaDeviceInfo> RdmaDevices_;


### PR DESCRIPTION
In case if GPU info provider returns information about the device that was not observed in `ListGpuDevices` node reacts in a weird way: newly observed GPU will be reported to a scheduler but job requiring this GPU will be aborted since no corresponding GPU slot exists. 