### PR TITLE
[24.1] Move ya-build/ytsaurus-server-override/Dockerfile into main ytsaurus/Dockerfile; squash core images

### DIFF
--- a/yt/docker/ya-build/ytsaurus-server-override/README.md
+++ b/yt/docker/ya-build/ytsaurus-server-override/README.md
@@ -1,0 +1,12 @@
+# Building the ytsaurus core image by overriding server binaries
+
+This configuration allows overriding the server binaries in an existing `ytsaurus` core image by local ones built from source.
+
+Example: `ytsaurus/ya package package.json --docker-registry my-registry.com --docker-build-arg "BASE_IMAGE=dev-24.1"`
+
+The base image used by default is `ytsaurus-nightly:latest`.
+The purpose of the base image is to provide yt python/cli packages with support for all drivers, including the native driver. The native driver is necessary if you are running YTsaurus with its k8s-operator.
+
+The `--docker-registry` parameter only impacts the resulting image name, which will be `my-registry.com/ytsaurus:local-<commit-SHA>` in this case.
+
+The `--custom-version` parameter can be used to override the version template specified in `package.json` with your custom string.

--- a/yt/docker/ya-build/ytsaurus-server-override/package.json
+++ b/yt/docker/ya-build/ytsaurus-server-override/package.json
@@ -1,0 +1,70 @@
+{
+    "meta": {
+        "name": "ytsaurus",
+        "maintainer": "YT team",
+        "description": "Core YTsaurus image built with yt client libraries from existing base image",
+        "version": "local-{revision}",
+    },
+    "params": {
+        "format": "docker",
+        "docker_target": "ytsaurus-server-override",
+    },
+    "build": {
+        "build_server_binaries": {
+            "targets": [
+                "yt/yt/server/all",
+            ],
+            "build_type": "profile",
+            "thinlto": true,
+            "target-platforms": [
+                "default-linux-x86_64",
+            ],
+            "flags": [
+                {
+                    "name": "NO_STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+    "data": [
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/Dockerfile",
+            },
+            "destination": {
+                "path": "/Dockerfile",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/python/yt/environment/init_queue_agent_state.py",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/python/yt/environment/init_operations_archive.py",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+		        "build_key": "build_server_binaries",
+                "path": "yt/yt/server/all/ytserver-all",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+    ],
+}
+

--- a/yt/docker/ya-build/ytsaurus-server-override/ya.make
+++ b/yt/docker/ya-build/ytsaurus-server-override/ya.make
@@ -1,0 +1,7 @@
+UNION()
+
+FILES(
+    package.json
+)
+
+END()

--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -1,3 +1,11 @@
+# Arguments used in FROM statemensts need to be declared before the first FROM statement.
+
+# Args for ytsaurus-server-override.
+ARG BASE_REPOSITORY="ghcr.io/ytsaurus/ytsaurus-nightly"
+ARG BASE_IMAGE="dev-24.1-2024-07-16-3a74ae83a9036cab5d95fb93ae2740d881ba80fd-relwithdebinfo"
+
+##########################################################################################
+
 FROM mirror.gcr.io/ubuntu:focal AS base
 
 USER root
@@ -27,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
 
 ##########################################################################################
 
-FROM base AS base_ytsaurus_python_packages
+FROM base AS base-ytsaurus-python-packages
 
 COPY ./ytsaurus_python /tmp/ytsaurus_python
 RUN for package in client yson local native_driver; \
@@ -43,7 +51,7 @@ RUN rm -rf /tmp/ytsaurus_python
 
 ##########################################################################################
 
-FROM base_ytsaurus_python_packages AS base_exec
+FROM base-ytsaurus-python-packages AS base-exec
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
   containerd \
@@ -58,7 +66,7 @@ RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release
 
 ##########################################################################################
 
-FROM base_exec AS ytsaurus
+FROM base-exec AS ytsaurus-bloated
 
 # YTsaurus binary.
 COPY ./ytserver-all /usr/bin/ytserver-all
@@ -85,6 +93,9 @@ COPY ./init_queue_agent_state.py /usr/bin/init_queue_agent_state
 COPY ./init_operations_archive.py /usr/bin/init_operations_archive
 RUN ln -s /usr/bin/init_operations_archive /usr/bin/init_operation_archive
 
+FROM scratch AS ytsaurus
+COPY --from=ytsaurus-bloated / /
+
 ##########################################################################################
 
 FROM base AS chyt
@@ -102,7 +113,7 @@ RUN chmod 755 /setup_cluster_for_chyt.sh
 
 ##########################################################################################
 
-FROM base_ytsaurus_python_packages AS query-tracker
+FROM base-ytsaurus-python-packages AS query-tracker-bloated
 
 # Query tracker binaries.
 COPY ./ytserver-all /usr/bin/ytserver-all
@@ -120,6 +131,9 @@ COPY ./init_query_tracker_state.py /usr/bin/init_query_tracker_state
 # Query tracker credits files.
 COPY ./credits/ytserver-all.CREDITS /usr/bin/ytserver-all.CREDITS
 
+FROM scratch AS query-tracker
+COPY --from=query-tracker-bloated / /
+
 ##########################################################################################
 
 FROM base AS strawberry
@@ -133,10 +147,15 @@ COPY ./credits/chyt-controller.CREDITS /usr/bin/strawberry-controller.CREDITS
 
 ##########################################################################################
 
-FROM base_exec AS local
+FROM base-exec AS local-bloated
 
 COPY ./ytserver-all /usr/bin/ytserver-all
 COPY ./credits/ytserver-all.CREDITS /usr/bin/ytserver-all.CREDITS
+
+FROM scratch AS local
+COPY --from=local-bloated / /
+
+WORKDIR /tmp
 
 COPY ./configure.sh .
 RUN ./configure.sh /var/lib/yt/local-cypress
@@ -148,5 +167,19 @@ VOLUME /var/lib/yt/local-cypress
 EXPOSE 80
 
 ENTRYPOINT ["bash", "/usr/bin/start.sh"]
+
+##########################################################################################
+
+FROM ${BASE_REPOSITORY}:${BASE_IMAGE} AS ytsaurus-server-override-bloated
+
+USER root
+
+# Override binaries built from source.
+COPY ./ytserver-all /usr/bin/ytserver-all
+COPY ./init_queue_agent_state.py /usr/bin/init_queue_agent_state
+COPY ./init_operations_archive.py /usr/bin/init_operations_archive
+
+FROM scratch AS ytsaurus-server-override
+COPY --from=ytsaurus-server-override-bloated / /
 
 ##########################################################################################


### PR DESCRIPTION
This PR merges `yt/docker/ya-build/ytsaurus-server-override/Dockerfile` into the common multi-stage Dockerfile introduced by @savnadya and refactors the corresponding `package.json` accordingly (along with some other minor tweaks).

This PR also improves the current `ytsaurus`, `query-tracker` and `local` images by squashing them and only leaving the final layer (along with refactoring some intermediate stage names).

Merging `yt/docker/ya-build/ytsaurus/Dockerfile` into the main Dockerfile the same way turned out to be a bit more complicated, so I will leave it for a separate PR.

---
ccd7ace26dba772faa4be759253a5b50b5db0008

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/702

