### PR TITLE
Introduce local_exported_object_count attribute and use it in the chunk teleporter

### DIFF
--- a/yt/yt/server/lib/misc/interned_attributes.h
+++ b/yt/yt/server/lib/misc/interned_attributes.h
@@ -286,6 +286,7 @@
     XX(LeaseTransactionId, lease_transaction_id) \
     XX(LeaseTransactionIds, lease_transaction_ids) \
     XX(LifeStage, life_stage) \
+    XX(LocalExportedObjectCount, local_exported_object_count) \
     XX(LocalJobs, local_jobs) \
     XX(LocalHealth, local_health) \
     XX(LocalPartLossTime, local_part_loss_time) \

--- a/yt/yt/server/master/transaction_server/transaction_proxy.cpp
+++ b/yt/yt/server/master/transaction_server/transaction_proxy.cpp
@@ -71,6 +71,8 @@ private:
             .SetOpaque(true));
         descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::ExportedObjectCount)
             .SetOpaque(true));
+        descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::LocalExportedObjectCount)
+            .SetOpaque(true));
         descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::ImportedObjectIds)
             .SetOpaque(true));
         descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::ImportedObjectCount)
@@ -207,6 +209,11 @@ private:
             case EInternedAttributeKey::LeasesState:
                 BuildYsonFluently(consumer)
                     .Value(transaction->GetTransactionLeasesState());
+                return true;
+
+            case EInternedAttributeKey::LocalExportedObjectCount:
+                BuildYsonFluently(consumer)
+                    .Value(transaction->ExportedObjects().size());
                 return true;
 
             default:

--- a/yt/yt/server/master/transaction_server/transaction_proxy.cpp
+++ b/yt/yt/server/master/transaction_server/transaction_proxy.cpp
@@ -71,8 +71,7 @@ private:
             .SetOpaque(true));
         descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::ExportedObjectCount)
             .SetOpaque(true));
-        descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::LocalExportedObjectCount)
-            .SetOpaque(true));
+        descriptors->push_back(EInternedAttributeKey::LocalExportedObjectCount);
         descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::ImportedObjectIds)
             .SetOpaque(true));
         descriptors->push_back(TAttributeDescriptor(EInternedAttributeKey::ImportedObjectCount)

--- a/yt/yt/tests/integration/controller/test_merge_operation.py
+++ b/yt/yt/tests/integration/controller/test_merge_operation.py
@@ -3658,6 +3658,19 @@ class TestSchedulerMergeCommandsMulticell(TestSchedulerMergeCommands):
 
         assert read_table("//tmp/out") == [{"value": i} for i in range(m, n)]
 
+    @authors("gritukan")
+    def test_merge_native_and_external_into_external(self):
+        create("table", "//tmp/in1", attributes={"external_cell_tag": 10})
+        write_table("//tmp/in1", [{"a": 1}])
+
+        create("table", "//tmp/in2", attributes={"external_cell_tag": 11})
+        write_table("//tmp/in2", [{"a": 2}])
+
+        create("table", "//tmp/out", attributes={"external_cell_tag": 12})
+        merge(mode="ordered", in_=["//tmp/in1", "//tmp/in2"], out="//tmp/out")
+
+        assert read_table("//tmp/out") == [{"a": 1}, {"a": 2}]
+
 
 class TestSchedulerMergeCommandsNewSortedPool(TestSchedulerMergeCommands):
     DELTA_SCHEDULER_CONFIG = {


### PR DESCRIPTION
Using exported_object_count attribute for validation of the number of teleported chunks is incorrect since the value of this attribute for primary master is a total number of exported object among all the master cells not just primary.