### PR TITLE
Change ya-build/ytsaurus-server-override build type from profile -> release

### DIFF
--- a/yt/docker/ya-build/ytsaurus-server-override/package.json
+++ b/yt/docker/ya-build/ytsaurus-server-override/package.json
@@ -14,7 +14,7 @@
             "targets": [
                 "yt/yt/server/all",
             ],
-            "build_type": "profile",
+            "build_type": "release",
             "thinlto": true,
             "target-platforms": [
                 "default-linux-x86_64",


### PR DESCRIPTION
Profile is not supported in 23.2 os ya make :(

