### PR TITLE
Add hosts path config option in go client

### DIFF
--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -43,6 +43,11 @@ type Config struct {
 	// If not set, default role is used.
 	ProxyRole string
 
+	// HostsPath specifies the path used to discover HTTP proxies.
+	//
+	// If not set, defaults to "hosts".
+	HostsPath string
+
 	// UseTLS enables TLS for all connections to cluster.
 	//
 	// This option is supported only in HTTP client.

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -91,7 +91,10 @@ func (c *httpClient) listHeavyProxies() ([]string, error) {
 	var resolveURL url.URL
 	resolveURL.Scheme = c.schema()
 	resolveURL.Host = c.clusterURL.Address
-	resolveURL.Path = "hosts"
+	resolveURL.Path = c.config.HostsPath
+	if resolveURL.Path == "" {
+		resolveURL.Path = "hosts"
+	}
 	resolveURL.RawQuery = v.Encode()
 
 	req, err := http.NewRequest("GET", resolveURL.String(), nil)


### PR DESCRIPTION
In the C++ and Python SDKs, this option can be configured. However, in the Go SDK, it is currently hard-coded to `hosts`.