### PR TITLE
Change default value of execute_udf_locally_if_possible to false

### DIFF
--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -267,7 +267,7 @@ void TYqlPluginConfig::Register(TRegistrar registrar)
         gatewayConfig->AddChild("remote_file_patterns", defaultRemoteFilePatterns);
         gatewayConfig->AddChild("mr_job_bin", BuildYsonNodeFluently().Value("./mrjob"));
         gatewayConfig->AddChild("yt_log_level", BuildYsonNodeFluently().Value("YL_DEBUG"));
-        gatewayConfig->AddChild("execute_udf_locally_if_possible", BuildYsonNodeFluently().Value(true));
+        gatewayConfig->AddChild("execute_udf_locally_if_possible", BuildYsonNodeFluently().Value(false));
 
         auto fileStorageConfig = config->FileStorageConfig->AsMap();
         fileStorageConfig->AddChild("max_files", BuildYsonNodeFluently().Value(1 << 13));

--- a/yt/yql/tests/test_simple.py
+++ b/yt/yql/tests/test_simple.py
@@ -341,7 +341,7 @@ class TestYqlAgent(TestQueriesYqlBase):
             assert len(gateway_config["remote_file_patterns"]) == 1
             assert gateway_config["remote_file_patterns"][0]["pattern"] == "yt://([a-zA-Z0-9\\-_]+)/([^&@?]+)$"
             assert gateway_config["yt_log_level"] == "YL_DEBUG"
-            assert gateway_config["execute_udf_locally_if_possible"]
+            assert not gateway_config["execute_udf_locally_if_possible"]
             assert len(gateway_config["cluster_mapping"]) == 1
             assert len(gateway_config["cluster_mapping"][0]["settings"]) == 2
             assert len(gateway_config["default_settings"]) == 58


### PR DESCRIPTION
This flag allows untrusted udfs to be executed locally (in yqlAgent). We don't want it by default since it can break yqlAgent or interfere with other queries

