### PR TITLE
Introduce enable_optimize_read_in_order in CHYT

### DIFF
--- a/yt/chyt/server/config.cpp
+++ b/yt/chyt/server/config.cpp
@@ -141,9 +141,8 @@ void TExecutionSettings::Register(TRegistrar registrar)
     registrar.Parameter("enable_min_max_filtering", &TThis::EnableMinMaxFiltering)
         .Default(true);
 
-    // TODO(achulkov2): Set to false by default. This is temporary to run all tests and verify that nothing fails.
     registrar.Parameter("enable_optimize_read_in_order", &TThis::EnableOptimizeReadInOrder)
-        .Default(true);
+        .Default(false);
     registrar.Parameter("assume_no_null_keys", &TThis::AssumeNoNullKeys)
         .Default(false);
     registrar.Parameter("assume_no_nan_keys", &TThis::AssumeNoNanKeys)

--- a/yt/chyt/server/config.cpp
+++ b/yt/chyt/server/config.cpp
@@ -140,6 +140,10 @@ void TExecutionSettings::Register(TRegistrar registrar)
 
     registrar.Parameter("enable_min_max_filtering", &TThis::EnableMinMaxFiltering)
         .Default(true);
+
+    // TODO(achulkov2): Set to false by default. This is temporary to run all tests and verify that nothing fails.
+    registrar.Parameter("enable_optimize_read_in_order", &TThis::EnableOptimizeReadInOrder)
+        .Default(true);
 }
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -280,6 +284,8 @@ void TShowTablesConfig::Register(TRegistrar registrar)
 
 void TSubqueryConfig::Register(TRegistrar registrar)
 {
+    registrar.Parameter("columnar_statistics_fetcher", &TThis::ColumnarStatisticsFetcher)
+        .DefaultNew();
     registrar.Parameter("chunk_slice_fetcher", &TThis::ChunkSliceFetcher)
         .DefaultNew();
     registrar.Parameter("max_job_count_for_pool", &TThis::MaxJobCountForPool)

--- a/yt/chyt/server/config.cpp
+++ b/yt/chyt/server/config.cpp
@@ -144,6 +144,10 @@ void TExecutionSettings::Register(TRegistrar registrar)
     // TODO(achulkov2): Set to false by default. This is temporary to run all tests and verify that nothing fails.
     registrar.Parameter("enable_optimize_read_in_order", &TThis::EnableOptimizeReadInOrder)
         .Default(true);
+    registrar.Parameter("assume_no_null_keys", &TThis::AssumeNoNullKeys)
+        .Default(false);
+    registrar.Parameter("assume_no_nan_keys", &TThis::AssumeNoNanKeys)
+        .Default(false);
 }
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/chyt/server/config.h
+++ b/yt/chyt/server/config.h
@@ -183,13 +183,37 @@ public:
     //! The optimization is not applied for queries with JOINs or aggregations.
     //! Consider disabling this option manually when running queries that specify ORDER BY, a large LIMIT and a
     //! WHERE condition that requires reading a huge amount of records before queried data is found.
-    //! NB: When using this optimization with floating-point typed key columns with NAN values, the correctness of
-    //! the result cannot be guaranteed. This has to do with the fact that NULLs and NANs are on the opposite ends
-    //! of the sort order in YT, while in CH they are always grouped together in the beginning or end of the result.
-    //! To avoid silent data corruption, you have to explicitly specify NULLS FIRST/LAST when running applicable
-    //! queries on tables with float-typed key columns and this option enabled. NULLS FIRST is required for ASC sort,
-    //! while NULLS LAST is required for DESC sort.
     bool EnableOptimizeReadInOrder;
+
+    //! NB: Using OptimizeReadInOrder with key columns that can have NULLs (non-required) or NANs (floating point columns) is complicated
+    //! by the fact that NULLs and NANs are on the opposite ends of the sort order in YT, while in CH they are always grouped together
+    //! in the beginning or end of the result.
+    //! In YT, NULL values compare less than any other values, while NAN values are larger than all other floats.
+    //! In ClickHouse their common placement is controlled by specifying NULLS FIRST or NULLS LAST for each element of the ORDER BY expression,
+    //! with NULLS LAST being used by default.
+    //!
+    //! You have multiple options to make this optimization work in such cases, they are explained below in order of preference.
+    //!
+    //! First, you should prefer to use required key columns with CHYT. This should alleviate the problem with NULLs, leaving only NAN-related
+    //! issues for floating-point key columns.
+    //!
+    //! Second, you can use the two options declared below to tell the CHYT optimizer that none of the key columns contain NULLs or NANs.
+    //!
+    //! Third, you can manually configure NULLS direction correctly in your query. The "correct" direction is the one that aligns with the sort
+    //! order of the underlying storage. I.e. it NULLS FIRST for ASC sort with NULLs, NULLS LAST (default) for DESC sort with NULLS, NULLS LAST
+    //! (default) for ASC sort with NANs and NULLS FIRST for DESC sort with NANs.
+    //!
+    //! Note that it is impossible to use optimize read in order with a floating point key column that can have both NULLs and NANs, you have
+    //! to make sure that CHYT knows that at least one of those values will not occur either by marking the column as required, or using the
+    //! options below.
+
+    //! Allows CHYT to assume that none of the key columns contain any NULL values.
+    //! Used for optimizing read in order if the corresponding option is enabled, see NB clause above.
+    bool AssumeNoNullKeys;
+    //! Allows CHYT to assume that none of the floating-point key columns contain any NAN values.
+    //! Applicable to both required and non-required columns.
+    //! Used for optimizing read in order if the corresponding option is enabled, see NB clause above.
+    bool AssumeNoNanKeys;
 
     REGISTER_YSON_STRUCT(TExecutionSettings);
 

--- a/yt/chyt/server/job_size_constraints.cpp
+++ b/yt/chyt/server/job_size_constraints.cpp
@@ -105,7 +105,7 @@ TClickHouseJobSizeSpec CreateClickHouseJobSizeSpec(
         jobCount += jobSizeTrackerOptions.LimitProgressionLength - 1;
 
         // This helps us actually produce small jobs when we need them.
-        inputSliceDataWeight = std::max<int>(1, startDataWeightPerJob * 0.1);
+        inputSliceDataWeight = std::max<i64>(1, startDataWeightPerJob * 0.1);
     }
 
     // It is important to watch the ratio of total data weight to input slice data weight, to avoid dealing with too many slices.

--- a/yt/chyt/server/job_size_constraints.cpp
+++ b/yt/chyt/server/job_size_constraints.cpp
@@ -1,33 +1,43 @@
 #include "job_size_constraints.h"
 
+#include <yt/yt/server/lib/chunk_pools/job_size_tracker.h>
+
 #include <yt/yt/server/lib/controller_agent/job_size_constraints.h>
 
 #include "config.h"
 
 namespace NYT::NClickHouseServer {
 
+using namespace NChunkPools;
 using namespace NControllerAgent;
 using namespace NLogging;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+constexpr int MaxTotalSliceCount = 1'000'000;
+
+////////////////////////////////////////////////////////////////////////////////
+
 // TODO(max42): consider introducing new job size constraints to encapsulate all these heuristics.
 
-IJobSizeConstraintsPtr CreateClickHouseJobSizeConstraints(
-    TSubqueryConfigPtr config,
+TClickHouseJobSizeSpec CreateClickHouseJobSizeSpec(
+    const TExecutionSettingsPtr& executionSettings,
+    const TSubqueryConfigPtr& subqueryConfig,
     i64 totalDataWeight,
     i64 totalRowCount,
     int jobCount,
     std::optional<double> samplingRate,
+    EReadInOrderMode readInOrderMode,
     const TLogger& logger)
 {
     const auto& Logger = logger;
 
+    YT_VERIFY(jobCount);
     auto dataWeightPerJob = totalDataWeight / jobCount;
 
     if (samplingRate) {
         double rate = samplingRate.value();
-        auto adjustedRate = std::max(rate, static_cast<double>(jobCount) / config->MaxJobCountForPool);
+        auto adjustedRate = std::max(rate, static_cast<double>(jobCount) / subqueryConfig->MaxJobCountForPool);
         auto adjustedJobCount = std::floor(jobCount / adjustedRate);
         YT_LOG_INFO("Adjusting job count and sampling rate (OldSamplingRate: %v, AdjustedSamplingRate: %v, OldJobCount: %v, AdjustedJobCount: %v)",
             rate,
@@ -38,7 +48,7 @@ IJobSizeConstraintsPtr CreateClickHouseJobSizeConstraints(
         jobCount = adjustedJobCount;
     } else {
         // Try not to form too small ranges when total data weight is small.
-        auto maxJobCount = totalDataWeight / std::max<i64>(1, config->MinDataWeightPerThread) + 1;
+        auto maxJobCount = totalDataWeight / std::max<i64>(1, subqueryConfig->MinDataWeightPerThread) + 1;
         if (maxJobCount < jobCount) {
             jobCount = maxJobCount;
             dataWeightPerJob = std::max<i64>(1, totalDataWeight / maxJobCount);
@@ -49,11 +59,78 @@ IJobSizeConstraintsPtr CreateClickHouseJobSizeConstraints(
     }
 
     auto inputSliceDataWeight = std::max<i64>(1, dataWeightPerJob * 0.1);
-    if (inputSliceDataWeight < config->MinSliceDataWeight) {
-        inputSliceDataWeight = dataWeightPerJob;
+
+    TJobSizeTrackerOptions jobSizeTrackerOptions;
+
+    if (readInOrderMode != EReadInOrderMode::None) {
+        jobSizeTrackerOptions = TJobSizeTrackerOptions{
+            .LimitProgressionRatio = 2,
+            .GeometricResources = {EResourceKind::DataWeight, EResourceKind::PrimaryDataWeight},
+            .LimitProgressionLength = 1,
+        };
+
+        // This allows configuring the size of the first subquery via query settings.
+        // We can logically use this setting, since each thread subquery forms its own
+        // secondary query when reading in order.
+        auto startDataWeightPerJob = std::max(executionSettings->MinDataWeightPerSecondaryQuery, subqueryConfig->MinDataWeightPerThread);
+        for (auto dataWeight = startDataWeightPerJob; dataWeight < dataWeightPerJob; dataWeight *= *jobSizeTrackerOptions.LimitProgressionRatio) {
+            ++jobSizeTrackerOptions.LimitProgressionLength;
+        }
+
+        switch (readInOrderMode) {
+            case EReadInOrderMode::Forward:
+                // The first range is small!
+                dataWeightPerJob = startDataWeightPerJob;
+                break;
+            case EReadInOrderMode::Backward:
+                // We will be reading these ranges backwards!
+                jobSizeTrackerOptions.LimitProgressionRatio = 0.5;
+                // We need to perform an actual split for the optimization to work.
+                if (jobCount == 1) {
+                    dataWeightPerJob /= 2;
+                    ++jobCount;
+                }
+                // This is necessary to avoid producing ranges that would be
+                // larger than they were supposed to be originally.
+                // We multiply by the ratio *after* we stage a job, so we need
+                // to do it after the second to last range.
+                jobSizeTrackerOptions.LimitProgressionOffset = jobCount - 2;
+                break;
+            default:
+                YT_ABORT();
+        }
+
+        // Account for the additional jobs.
+        // This is not exact, but the sorted pool won't use this value anyway.
+        jobCount += jobSizeTrackerOptions.LimitProgressionLength - 1;
+
+        // This helps us actually produce small jobs when we need them.
+        inputSliceDataWeight = std::max<int>(1, startDataWeightPerJob * 0.1);
     }
 
-    return CreateExplicitJobSizeConstraints(
+    // It is important to watch the ratio of total data weight to input slice data weight, to avoid dealing with too many slices.
+    // The total data weight is bounded by the maximum subquery size, so the maximum number of slices with the current defaults
+    // is 50G / 64M = 800, which is fine. Reconfigure with care.
+    inputSliceDataWeight = std::max(inputSliceDataWeight, subqueryConfig->MinSliceDataWeight);
+    YT_LOG_WARNING_IF(
+        totalDataWeight / inputSliceDataWeight > MaxTotalSliceCount,
+        "Job size constraints allow too many slices in pool (TotalDataWeight: %v, InputSliceDataWeight: %v, PotentialSliceCount: %v)",
+        totalDataWeight,
+        inputSliceDataWeight,
+        totalDataWeight / inputSliceDataWeight);
+
+    YT_LOG_INFO(
+        "Computed job size constraints for pool (JobCount: %v, DataWeightPerJob: %v, InputSliceDataWeight: %v, "
+        "LimitProgressionLength: %v, LimitProgressionOffset: %v, LimitProgressionRatio: %v, SamplingRate: %v)",
+        jobCount,
+        dataWeightPerJob,
+        inputSliceDataWeight,
+        jobSizeTrackerOptions.LimitProgressionLength,
+        jobSizeTrackerOptions.LimitProgressionOffset,
+        jobSizeTrackerOptions.LimitProgressionRatio,
+        samplingRate);
+
+    auto jobSizeConstraints = CreateExplicitJobSizeConstraints(
         /*canAdjustDataWeightPerJob*/ false,
         /*isExplicitJobCount*/ true,
         jobCount,
@@ -67,6 +144,11 @@ IJobSizeConstraintsPtr CreateClickHouseJobSizeConstraints(
         /*batchRowCount*/ {},
         /*foreignSliceDataWeight*/ 0,
         /*samplingRate*/ std::nullopt);
+
+    return {
+        .JobSizeConstraints = std::move(jobSizeConstraints),
+        .JobSizeTrackerOptions = std::move(jobSizeTrackerOptions),
+    };
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/chyt/server/job_size_constraints.h
+++ b/yt/chyt/server/job_size_constraints.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "private.h"
+#include "query_analyzer.h"
+
+#include <yt/yt/server/lib/chunk_pools/job_size_tracker.h>
 
 #include <yt/yt/server/lib/controller_agent/public.h>
 
@@ -8,12 +11,20 @@ namespace NYT::NClickHouseServer {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-NControllerAgent::IJobSizeConstraintsPtr CreateClickHouseJobSizeConstraints(
-    TSubqueryConfigPtr config,
+struct TClickHouseJobSizeSpec
+{
+    NControllerAgent::IJobSizeConstraintsPtr JobSizeConstraints;
+    NChunkPools::TJobSizeTrackerOptions JobSizeTrackerOptions;
+};
+
+TClickHouseJobSizeSpec CreateClickHouseJobSizeSpec(
+    const TExecutionSettingsPtr& executionSettings,
+    const TSubqueryConfigPtr& subqueryConfig,
     i64 totalDataWeight,
     i64 totalRowCount,
     int jobCount,
     std::optional<double> samplingRate,
+    EReadInOrderMode readInOrderMode,
     const NLogging::TLogger& logger);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/chyt/server/query_analyzer.cpp
+++ b/yt/chyt/server/query_analyzer.cpp
@@ -791,8 +791,6 @@ void TQueryAnalyzer::InferReadInOrderMode(bool assumeNoNullKeys, bool assumeNoNa
         return;
     }
 
-    std::vector<TString> floatKeyColumnsWithoutExplicitNullsDirection;
-
     for (const auto& [columnIndex, orderByElementAst] : Enumerate(selectQuery->orderBy()->children)) {
         auto orderByElement = orderByElementAst->as<DB::ASTOrderByElement>();
 

--- a/yt/chyt/server/query_analyzer.cpp
+++ b/yt/chyt/server/query_analyzer.cpp
@@ -267,7 +267,7 @@ DB::ASTPtr CreateKeyComparison(
 }
 ////////////////////////////////////////////////////////////////////////////////
 
-EReadInOrderMode GetReadInOrderMode(ESortOrder sortOrder, int direction)
+EReadInOrderMode GetReadInOrderColumnDirection(ESortOrder sortOrder, int direction)
 {
     // Descending sort order is not actually supported in CHYT, but let's prepare for the moment it is.
     switch (sortOrder) {
@@ -652,6 +652,16 @@ DB::QueryProcessingStage::Enum TQueryAnalyzer::GetOptimizedQueryProcessingStage(
     return *OptimizedQueryProcessingStage_;
 }
 
+EReadInOrderMode TQueryAnalyzer::GetReadInOrderMode() const
+{
+    if (!Prepared_) {
+        THROW_ERROR_EXCEPTION("Query analyzer is not prepared, but GetReadInOrderMode method is already called; "
+            "this is a bug; please, file an issue in the relevant queue");
+    }
+
+    return ReadInOrderMode_;
+}
+
 void TQueryAnalyzer::OptimizeQueryProcessingStage()
 {
     const auto& settings = StorageContext_->Settings;
@@ -744,26 +754,26 @@ void TQueryAnalyzer::OptimizeQueryProcessingStage()
     OptimizedQueryProcessingStage_ = DB::QueryProcessingStage::Complete;
 }
 
-EReadInOrderMode TQueryAnalyzer::InferReadInOrderMode() const
+void TQueryAnalyzer::InferReadInOrderMode(bool assumeNoNullKeys, bool assumeNoNanKeys)
 {
     auto selectQuery = QueryInfo_.query->as<DB::ASTSelectQuery>();
 
     // Read in order is forbidden in JOINs and queries with aggregation.
     // It might be useful in some of these cases, but that is a question for another day.
     if (Join_ || selectQuery->groupBy() || selectQuery->having() || selectQuery->window() || selectQuery->limitBy()) {
-        return EReadInOrderMode::None;
+        return;
     }
 
     // Read in order makes no sense without requested order.
     // Native CH optimizations will do the trick.
     if (!selectQuery->orderBy()) {
-        return EReadInOrderMode::None;
+        return;
     }
 
     // Read in order makes no sense without any limits specified.
     // The whole table will probably be read anyway.
     if (!selectQuery->limitLength() && !getContext()->getSettingsRef().limit) {
-        return EReadInOrderMode::None;
+        return;
     }
 
     YT_VERIFY(YtTableCount_ == 1);
@@ -771,14 +781,14 @@ EReadInOrderMode TQueryAnalyzer::InferReadInOrderMode() const
 
     // If the underlying table is not sorted we cannot help in any way.
     if (!schema->IsSorted()) {
-        return EReadInOrderMode::None;
+        return;
     }
 
     auto commonDirection = EReadInOrderMode::None;
 
     // Columns from the ORDER BY clause must form a prefix of the table's primary key.
     if (std::ssize(selectQuery->orderBy()->children) > schema->GetKeyColumnCount()) {
-        return EReadInOrderMode::None;
+        return;
     }
 
     std::vector<TString> floatKeyColumnsWithoutExplicitNullsDirection;
@@ -792,75 +802,65 @@ EReadInOrderMode TQueryAnalyzer::InferReadInOrderMode() const
                 "this is a bug; please contact cluster administrators");
         }
 
-        // The name can contain functions. While it is possible to support tuples
-        // and even monotonic functions, I do not think there is much use.
-        auto columnName = orderByElement->children.front()->getColumnName();
+        auto orderByElementColumnIdentifier = orderByElement->children.front()->as<DB::ASTIdentifier>();
+        // Functions are not supported. It is possible, but I do not think there is much use.
+        if (!orderByElementColumnIdentifier) {
+            return;
+        }
 
         // Correct index range and sort order presence is guaranteed by the key column count above.
         const auto& schemaColumn = schema->Columns()[columnIndex];
         YT_VERIFY(schemaColumn.SortOrder());
 
         // Columns from the ORDER BY clause must form a prefix of the table's primary key.
-        if (columnName != schemaColumn.Name()) {
-            return EReadInOrderMode::None;
+        if (orderByElementColumnIdentifier->name() != schemaColumn.Name()) {
+            return;
         }
 
         // All requested directions must align and form either a forward or backward read of the underlying table.
-        auto columnDirection = GetReadInOrderMode(*schemaColumn.SortOrder(), orderByElement->direction);
+        auto columnDirection = GetReadInOrderColumnDirection(*schemaColumn.SortOrder(), orderByElement->direction);
         if (commonDirection == EReadInOrderMode::None) {
             commonDirection = columnDirection;
         } else if (commonDirection != columnDirection) {
-            return EReadInOrderMode::None;
+            return;
         }
 
-        // See float-related comments below.
-        if (IsFloatingPointType(schemaColumn.CastToV1Type()) && !orderByElement->nulls_direction_was_explicitly_specified) {
-            floatKeyColumnsWithoutExplicitNullsDirection.push_back(schemaColumn.Name());
+        // In YT, NULL values compare less than any other values. In ClickHouse, NULL value placement
+        // depends solely on the placement requested in the query, which defaults to NULLS LAST.
+        // Since we combine both YT and CH sorting in this mode, there is only one acceptable direction
+        // depending on the requested sort order. Otherwise, we cannot use this mode, except in cases
+        // when we know that no NULLS are present. We check all of this below.
+
+        bool isFloat = IsFloatingPointType(schemaColumn.CastToV1Type());
+        bool isRequired = schemaColumn.Required();
+
+        bool couldHaveNulls = !isRequired && !assumeNoNullKeys;
+        bool couldHaveNans = isFloat && !assumeNoNanKeys;
+
+        // Sadly, with both NANs and NULLs we are just screwed. In YT NAN values are larger than any others,
+        // but in CHYT they are always placed together with NULLs. These two approaches contradict each other,
+        // so we cannot optimize.
+        if (couldHaveNulls && couldHaveNans) {
+            return;
+        }
+
+        // The value of nulls_direction is equal to direction for NULLS LAST and to the opposite
+        // of direction for NULLS FIRST.
+
+        // For ASC (d = 1), we need NULLS FIRST (nd = -d = -1).
+        // For DSC (d = -1), we need NULLS LAST (nd =  d = -1).
+        if (couldHaveNulls && orderByElement->nulls_direction != -1) {
+            return;
+        }
+
+        // For ASC (d = 1), we need NANS LAST => NULLS LAST    (nd =   d = 1).
+        // For DSC (d = -1), we need NANS FIRST => NULLS FIRST (nd =  -d = 1).
+        if (couldHaveNans && orderByElement->nulls_direction != 1) {
+            return;
         }
     }
 
-    // See the last comment in this function.
-    if (!floatKeyColumnsWithoutExplicitNullsDirection.empty()) {
-        THROW_ERROR_EXCEPTION(
-            "Nulls direction must be specified explicitly for key columns of floating-point "
-            "types when using optimize_read_in_order is enabled; see docs for more details")
-            << TErrorAttribute("problematic_columns", floatKeyColumnsWithoutExplicitNullsDirection);
-    }
-
-    // In YT, NULL values compare less than any other values. In ClickHouse, NULL value placement
-    // depends solely on the placement requested in the query, which defaults to NULLS LAST.
-    // Since we combine both YT and CH sorting in this mode, there is only one acceptable direction
-    // depending on the requested sort order. In cases when the unsupported option turns out to be
-    // the default (for ascending sorts), we tweak the query to avoid additional user turmoil.
-    if (commonDirection != EReadInOrderMode::None) {
-        for (const auto& orderByElementAst : selectQuery->orderBy()->children) {
-            auto orderByElement = orderByElementAst->as<DB::ASTOrderByElement>();
-
-            // The value of nulls_direction is equal to direction for NULLS LAST and to the opposite
-            // of direction for NULLS FIRST.
-            // For ASC (d = 1), we need NULLS FIRST (nd = -d = -1).
-            // For DSC (d = -1), we need NULLS LAST (nd =  d = -1).
-            if (orderByElement->nulls_direction != -1) {
-                THROW_ERROR_EXCEPTION_IF(
-                    orderByElement->nulls_direction_was_explicitly_specified,
-                    "Specified nulls direction is incompatible with enabled optimize_read_in_order mode; "
-                    "please turn it off via query settings, specify another nulls direction or use the default nulls direction");
-                YT_LOG_DEBUG(
-                    "Reversing ORDER BY nulls direction (ColumnName: %v, Direction: %v, NullsDirection: %v -> -1)",
-                    orderByElement->children.front()->getColumnName(),
-                    orderByElement->direction,
-                    orderByElement->nulls_direction);
-                orderByElement->nulls_direction = -1;
-                orderByElement->nulls_direction_was_explicitly_specified = true;
-            }
-        }
-    }
-    // Sadly, with NANs we are just screwed. In YT these values are larger than any others, but in
-    // CHYT they are always placed together with NULLs. These two approaches contradict each other.
-    // To warn about such cases without disabling this optimization for tables with floating-point
-    // key columns completely, we require to specify nulls direction explicitly as a green light.
-
-    return commonDirection;
+    ReadInOrderMode_ = commonDirection;
 }
 
 TQueryAnalysisResult TQueryAnalyzer::Analyze() const
@@ -913,11 +913,9 @@ TQueryAnalysisResult TQueryAnalyzer::Analyze() const
         result.TableSchemas.emplace_back(storage->GetSchema());
     }
 
-    if (settings->Execution->EnableOptimizeReadInOrder) {
-        result.ReadInOrderMode = InferReadInOrderMode();
-    }
+    result.ReadInOrderMode = ReadInOrderMode_;
 
-    if (result.ReadInOrderMode != EReadInOrderMode::None) {
+    if (ReadInOrderMode_ != EReadInOrderMode::None) {
         result.PoolKind = EPoolKind::Sorted;
         result.KeyColumnCount = Storages_[0]->GetSchema()->GetKeyColumnCount();
     } else {
@@ -1227,6 +1225,9 @@ void TQueryAnalyzer::Prepare()
     }
     if (settings->Execution->OptimizeQueryProcessingStage) {
         OptimizeQueryProcessingStage();
+    }
+    if (settings->Execution->EnableOptimizeReadInOrder) {
+        InferReadInOrderMode(settings->Execution->AssumeNoNullKeys, settings->Execution->AssumeNoNanKeys);
     }
 
     Prepared_ = true;

--- a/yt/chyt/server/query_analyzer.h
+++ b/yt/chyt/server/query_analyzer.h
@@ -17,6 +17,12 @@ DEFINE_ENUM(EPoolKind,
     (Sorted)
 );
 
+DEFINE_ENUM(EReadInOrderMode,
+    (None)
+    (Forward)
+    (Backward)
+);
+
 struct TQueryAnalysisResult
 {
     std::vector<NTableClient::TTableSchemaPtr> TableSchemas;
@@ -24,6 +30,7 @@ struct TQueryAnalysisResult
     std::vector<std::optional<DB::KeyCondition>> KeyConditions;
     std::optional<int> KeyColumnCount;
     EPoolKind PoolKind;
+    EReadInOrderMode ReadInOrderMode = EReadInOrderMode::None;
 };
 
 struct TSecondaryQuery
@@ -104,6 +111,8 @@ private:
     void InferSortedJoinKeyColumns(bool needSortedPool);
 
     void OptimizeQueryProcessingStage();
+
+    EReadInOrderMode InferReadInOrderMode() const;
 
     IStorageDistributorPtr GetStorage(const DB::ASTTableExpression* tableExpression) const;
 

--- a/yt/chyt/server/query_analyzer.h
+++ b/yt/chyt/server/query_analyzer.h
@@ -64,6 +64,9 @@ public:
     //! Prepare method should be called before GetOptimizedQueryProcessingStage.
     DB::QueryProcessingStage::Enum GetOptimizedQueryProcessingStage() const;
 
+    //! Prepare method should be called before GetReadInOrderMode.
+    EReadInOrderMode GetReadInOrderMode() const;
+
     //! Prepare method should be called before Analyze.
     TQueryAnalysisResult Analyze() const;
 
@@ -99,6 +102,8 @@ private:
 
     std::optional<DB::QueryProcessingStage::Enum> OptimizedQueryProcessingStage_;
 
+    EReadInOrderMode ReadInOrderMode_ = EReadInOrderMode::None;
+
     std::vector<DB::ASTPtr> JoinKeyRightExpressions_;
 
     NTableClient::TOwningKeyBound PreviousUpperBound_;
@@ -112,7 +117,7 @@ private:
 
     void OptimizeQueryProcessingStage();
 
-    EReadInOrderMode InferReadInOrderMode() const;
+    void InferReadInOrderMode(bool assumeNoNullKeys, bool assumeNoNanKeys);
 
     IStorageDistributorPtr GetStorage(const DB::ASTTableExpression* tableExpression) const;
 

--- a/yt/chyt/server/query_context-inl.h
+++ b/yt/chyt/server/query_context-inl.h
@@ -14,7 +14,7 @@ void TQueryContext::SetRuntimeVariable(const TString& key, const T& value)
     auto guard = Guard(QueryLogLock_);
     YT_VERIFY(RuntimeVariables_);
     if (RuntimeVariables_->Contains(key)) {
-        YT_LOG_WARNING(
+        YT_LOG_DEBUG(
             "Overwriting existing runtime variable in query context (Key: %v, OldValue: %v, NewValue: %v)",
             key,
             NYson::ConvertToYsonString(RuntimeVariables_->GetYson(key), NYson::EYsonFormat::Text),

--- a/yt/chyt/server/query_context-inl.h
+++ b/yt/chyt/server/query_context-inl.h
@@ -1,0 +1,28 @@
+#ifndef QUERY_CONTEXT_INL_H_
+#error "Direct inclusion of this file is not allowed, include format.h"
+// For the sake of sane code completion.
+#include "query_context.h"
+#endif
+
+namespace NYT::NClickHouseServer {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class T>
+void TQueryContext::SetRuntimeVariable(const TString& key, const T& value)
+{
+    auto guard = Guard(QueryLogLock_);
+    YT_VERIFY(RuntimeVariables_);
+    if (RuntimeVariables_->Contains(key)) {
+        YT_LOG_WARNING(
+            "Overwriting existing runtime variable in query context (Key: %v, OldValue: %v, NewValue: %v)",
+            key,
+            NYson::ConvertToYsonString(RuntimeVariables_->GetYson(key), NYson::EYsonFormat::Text),
+            NYson::ConvertToYsonString(value, NYson::EYsonFormat::Text));
+    }
+    RuntimeVariables_->Set(key, value);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NClickHouseServer

--- a/yt/chyt/server/query_context.cpp
+++ b/yt/chyt/server/query_context.cpp
@@ -676,6 +676,8 @@ TQueryFinishInfo TQueryContext::GetQueryFinishInfo()
     {
         auto guard = Guard(QueryLogLock_);
         result.Statistics = Statistics_;
+        // It is unlikely that the variables will change after query is finished, but let's be safe.
+        result.RuntimeVariables = RuntimeVariables_->Clone();
         result.SecondaryQueryIds = SecondaryQueryIds_;
     }
 

--- a/yt/chyt/server/query_context.h
+++ b/yt/chyt/server/query_context.h
@@ -160,6 +160,8 @@ public:
 
     void AddStatisticsSample(const NYPath::TYPath& path, i64 sample);
     void MergeStatistics(const TStatistics& statistics);
+    template <class T>
+    void SetRuntimeVariable(const TString& key, const T& value);
     void AddSecondaryQueryId(TQueryId id);
 
     class TStatisticsTimerGuard;
@@ -204,6 +206,7 @@ private:
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, QueryLogLock_);
     //! CHYT-specific query statistics.
     TStatistics Statistics_;
+    NYTree::IAttributeDictionaryPtr RuntimeVariables_ = NYTree::CreateEphemeralAttributes();
     std::vector<TQueryId> SecondaryQueryIds_;
 
     //! Spinlock controlling lazy client creation.
@@ -278,3 +281,7 @@ void InvalidateCache(
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NYT::NClickHouseServer
+
+#define QUERY_CONTEXT_INL_H_
+#include "query_context-inl.h"
+#undef QUERY_CONTEXT_INL_H_

--- a/yt/chyt/server/query_finish_info.h
+++ b/yt/chyt/server/query_finish_info.h
@@ -13,7 +13,8 @@ namespace NYT::NClickHouseServer {
 struct TQueryFinishInfo
 {
     TStatistics Statistics;
-    std::vector<TQueryId> SecondaryQueryIds;;
+    NYTree::IAttributeDictionaryPtr RuntimeVariables;
+    std::vector<TQueryId> SecondaryQueryIds;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/chyt/server/storage_distributor.cpp
+++ b/yt/chyt/server/storage_distributor.cpp
@@ -48,6 +48,7 @@
 #include <Parsers/ASTSampleRatio.h>
 #include <Parsers/ASTSelectQuery.h>
 #include <Parsers/queryToString.h>
+#include <Processors/ConcatProcessor.h>
 #include <Processors/ResizeProcessor.h>
 #include <Processors/Sinks/NullSink.h>
 #include <Processors/Sources/RemoteSource.h>
@@ -447,7 +448,8 @@ public:
         }
 
         for (size_t index = 0; index < SecondaryQueries_.size(); ++index) {
-            const auto& cliqueNode = CliqueNodes_[index];
+            // Multiple secondary queries can be executed on the same node.
+            const auto& cliqueNode = CliqueNodes_[index % CliqueNodes_.size()];
             const auto& secondaryQuery = SecondaryQueries_[index];
 
             YT_LOG_DEBUG(
@@ -472,11 +474,21 @@ public:
 
             Pipes_.emplace_back(std::move(pipe));
         }
+
+        if (QueryAnalysisResult_->ReadInOrderMode == EReadInOrderMode::Backward) {
+            std::reverse(Pipes_.begin(), Pipes_.end());
+        }
     }
 
     DB::Pipes ExtractPipes()
     {
         return std::move(Pipes_);
+    }
+
+    bool ReadInOrder() const
+    {
+        YT_VERIFY(QueryAnalysisResult_);
+        return QueryAnalysisResult_->ReadInOrderMode != EReadInOrderMode::None;
     }
 
     DB::QueryPipelineBuilderPtr ExtractPipeline(std::function<void()> commitCallback)
@@ -547,10 +559,10 @@ private:
     std::optional<TQueryAnalyzer> QueryAnalyzer_;
     std::optional<TQueryAnalysisResult> QueryAnalysisResult_;
     // TODO(max42): YT-11778.
-    // TMiscExt is used for better memory estimation in readers, but it is dropped when using
-    // TInputChunk, so for now we store it explicitly in a map and use when serializing subquery input.
-    THashMap<TChunkId, TRefCountedMiscExtPtr> MiscExtMap_;
-    NChunkPools::TChunkStripeListPtr InputStripeList_;
+    // TMiscExt is used for better memory estimation in readers, but it is dropped when using TInputChunk,
+    // so for now we store it explicitly in a map inside this struct and use when serializing subquery input.
+    // NB: The contents of this class are modified by the preparer.
+    TQueryInput QueryInput_;
     std::optional<double> SamplingRate_;
 
     TClusterNodes CliqueNodes_;
@@ -582,7 +594,10 @@ private:
         QueryAnalyzer_->Prepare();
         QueryAnalysisResult_.emplace(QueryAnalyzer_->Analyze());
 
-        auto input = FetchInput(
+        QueryContext_->SetRuntimeVariable("pool_kind", QueryAnalysisResult_->PoolKind);
+        QueryContext_->SetRuntimeVariable("read_in_order_mode", QueryAnalysisResult_->ReadInOrderMode);
+
+        QueryInput_ = FetchInput(
             StorageContext_,
             *QueryAnalysisResult_,
             RealColumnNames_,
@@ -591,17 +606,14 @@ private:
             QueryContext_->ReadTransactionId);
 
         YT_VERIFY(!SpecTemplate_.DataSourceDirectory);
-        SpecTemplate_.DataSourceDirectory = std::move(input.DataSourceDirectory);
-
-        MiscExtMap_ = std::move(input.MiscExtMap);
-        InputStripeList_ = std::move(input.StripeList);
+        SpecTemplate_.DataSourceDirectory = QueryInput_.DataSourceDirectory;
 
         const auto& selectQuery = QueryInfo_.query->as<DB::ASTSelectQuery&>();
         if (auto selectSampleSize = selectQuery.sampleSize()) {
             auto ratio = selectSampleSize->as<DB::ASTSampleRatio&>().ratio;
             auto rate = static_cast<double>(ratio.numerator) / ratio.denominator;
             if (rate > 1.0) {
-                rate /= InputStripeList_->TotalRowCount;
+                rate /= QueryInput_.StripeList->TotalRowCount;
             }
             rate = std::clamp(rate, 0.0, 1.0);
             SamplingRate_ = rate;
@@ -623,7 +635,7 @@ private:
         if (canUseBlockSampling && SamplingRate_) {
             YT_LOG_DEBUG("Using block sampling (SamplingRate: %v)",
                 SamplingRate_);
-            for (const auto& stripe : InputStripeList_->Stripes) {
+            for (const auto& stripe : QueryInput_.StripeList->Stripes) {
                 for (const auto& dataSlice : stripe->DataSlices) {
                     for (const auto& chunkSlice : dataSlice->ChunkSlices) {
                         chunkSlice->ApplySamplingSelectivityFactor(*SamplingRate_);
@@ -653,8 +665,10 @@ private:
 
         // This limit can only be applied after fetching chunk specs.
         // That's why we do it here and not in GetNodesToDistribute.
-        if (settings->MinDataWeightPerSecondaryQuery > 0) {
-            i64 nodeLimit = DivCeil(InputStripeList_->TotalDataWeight, settings->MinDataWeightPerSecondaryQuery);
+        // When reading in order we produce intentionally small thread subqueries which
+        // will not be combined, so there is no point in reducing the number of nodes.
+        if (!ReadInOrder() && settings->MinDataWeightPerSecondaryQuery > 0) {
+            i64 nodeLimit = DivCeil(QueryInput_.StripeList->TotalDataWeight, settings->MinDataWeightPerSecondaryQuery);
             nodeLimit = std::clamp<i64>(nodeLimit, 1, nodes.size());
             nodes.resize(nodeLimit);
         }
@@ -692,10 +706,8 @@ private:
             inputStreamsPerSecondaryQuery);
 
         ThreadSubqueries_ = BuildThreadSubqueries(
-            std::move(InputStripeList_),
-            QueryAnalysisResult_->KeyColumnCount,
-            QueryAnalysisResult_->PoolKind,
-            SpecTemplate_.DataSourceDirectory,
+            QueryInput_,
+            *QueryAnalysisResult_,
             std::max<int>(1, secondaryQueryCount * inputStreamsPerSecondaryQuery),
             SamplingRate_,
             StorageContext_,
@@ -734,7 +746,13 @@ private:
 
     void PrepareSecondaryQueryAsts()
     {
-        int secondaryQueryCount = std::min(ThreadSubqueries_.size(), CliqueNodes_.size());
+        int secondaryQueryCount = ThreadSubqueries_.size();
+
+        // When reading in order we produce intentionally small thread subqueries
+        // which should not be combined at this point.
+        if (!ReadInOrder()) {
+            secondaryQueryCount = std::min<int>(secondaryQueryCount, CliqueNodes_.size());
+        }
 
         if (secondaryQueryCount == 0) {
             // NB: if we make no secondary queries, there will be a tricky issue around schemas.
@@ -767,11 +785,13 @@ private:
             }
 
             YT_VERIFY(!threadSubqueries.Empty() || ThreadSubqueries_.empty());
+            // Each thread subquery will form its own secondary query when reading in order.
+            YT_VERIFY(!ReadInOrder() || std::ssize(threadSubqueries) == 1);
 
             auto secondaryQuery = QueryAnalyzer_->CreateSecondaryQuery(
                 threadSubqueries,
                 SpecTemplate_,
-                MiscExtMap_,
+                QueryInput_.MiscExtMap,
                 index,
                 index + 1 == secondaryQueryCount /*isLastSubquery*/);
 
@@ -917,6 +937,8 @@ public:
                 toString(toStage));
         }
 
+        TQueryAnalyzer analyzer(context, storageContext, queryInfo, Logger);
+
         bool isDistributedJoin = DB::hasJoin(select);
 
         if (isDistributedJoin) {
@@ -933,8 +955,6 @@ public:
                     distributeJoin = true;
                     break;
             }
-
-            TQueryAnalyzer analyzer(context, storageContext, queryInfo, Logger);
 
             if (!distributeJoin && analyzer.HasInOperator()) {
                 THROW_ERROR_EXCEPTION("IN operator with local join policy is unsupported (CHYT-1000); ",
@@ -967,17 +987,20 @@ public:
             }
         }
 
+        analyzer.Prepare();
+        auto queryAnalysisResult = analyzer.Analyze();
+
         auto nodes = GetNodesToDistribute(queryContext, DistributionSeed_, isDistributedJoin);
         // If there is only one node, then its result is final, since
         // we do not need to merge aggregation states from different streams.
-        if (nodes.size() == 1) {
+        // When reading in order we can produce more subqueries than nodes,
+        // so this optimization is not applicable.
+        if (queryAnalysisResult.ReadInOrderMode == EReadInOrderMode::None && nodes.size() == 1) {
             return DB::QueryProcessingStage::Complete;
         }
 
         // Try to process query up to advanced stages.
         if (executionSettings->OptimizeQueryProcessingStage) {
-            TQueryAnalyzer analyzer(context, storageContext, queryInfo, Logger);
-            analyzer.Prepare();
             return analyzer.GetOptimizedQueryProcessingStage();
         }
 
@@ -1005,10 +1028,16 @@ public:
             queryInfo,
             context,
             processingStage);
-
         preparer.Fire();
+
         auto pipes = preparer.ExtractPipes();
-        return DB::Pipe::unitePipes(std::move(pipes));
+        auto pipe = DB::Pipe::unitePipes(std::move(pipes));
+
+        if (preparer.ReadInOrder() && !pipe.empty() && pipe.numOutputPorts() > 1) {
+            pipe.addTransform(std::make_shared<DB::ConcatProcessor>(pipe.getHeader(), pipe.numOutputPorts()));
+        }
+
+        return pipe;
     }
 
     // Same as IStorage::read(QueryPlan &, ...), but does not resize the output pipe.

--- a/yt/chyt/server/storage_distributor.cpp
+++ b/yt/chyt/server/storage_distributor.cpp
@@ -487,8 +487,8 @@ public:
 
     bool ReadInOrder() const
     {
-        YT_VERIFY(QueryAnalysisResult_);
-        return QueryAnalysisResult_->ReadInOrderMode != EReadInOrderMode::None;
+        YT_VERIFY(QueryAnalyzer_);
+        return QueryAnalyzer_->GetReadInOrderMode() != EReadInOrderMode::None;
     }
 
     DB::QueryPipelineBuilderPtr ExtractPipeline(std::function<void()> commitCallback)
@@ -988,14 +988,13 @@ public:
         }
 
         analyzer.Prepare();
-        auto queryAnalysisResult = analyzer.Analyze();
 
         auto nodes = GetNodesToDistribute(queryContext, DistributionSeed_, isDistributedJoin);
         // If there is only one node, then its result is final, since
         // we do not need to merge aggregation states from different streams.
         // When reading in order we can produce more subqueries than nodes,
         // so this optimization is not applicable.
-        if (queryAnalysisResult.ReadInOrderMode == EReadInOrderMode::None && nodes.size() == 1) {
+        if (analyzer.GetReadInOrderMode() == EReadInOrderMode::None && nodes.size() == 1) {
             return DB::QueryProcessingStage::Complete;
         }
 

--- a/yt/chyt/server/storage_system_log_table_exporter.cpp
+++ b/yt/chyt/server/storage_system_log_table_exporter.cpp
@@ -221,6 +221,7 @@ public:
     {
         static const std::vector<TColumnSchema> queryLogExtraColumns {
             TColumnSchema("chyt_query_statistics", ESimpleLogicalValueType::Any),
+            TColumnSchema("chyt_query_runtime_variables", ESimpleLogicalValueType::Any),
             TColumnSchema("chyt_secondary_query_ids",
                 OptionalLogicalType(ListLogicalType(SimpleLogicalType(ESimpleLogicalValueType::String)))),
         };
@@ -260,6 +261,7 @@ public:
         size_t queryIndex = 0;
 
         int statisticsColumnId = nameTable->GetIdOrThrow("chyt_query_statistics");
+        int runtimeVariablesColumnId = nameTable->GetIdOrThrow("chyt_query_runtime_variables");
         int secondaryQueryIdsColumnId = nameTable->GetIdOrThrow("chyt_secondary_query_ids");
 
         for (size_t rowIndex = 0; rowIndex < rows.size(); ++rowIndex) {
@@ -267,6 +269,8 @@ public:
                 if (queryInfos[queryIndex].has_value()) {
                     auto ysonStatistics = ConvertToYsonString(
                         queryInfos[queryIndex]->Statistics);
+                    auto ysonRuntimeVariables = ConvertToYsonString(
+                        queryInfos[queryIndex]->RuntimeVariables);
                     auto ysonSecondaryQueryIds = ConvertToYsonString(
                         queryInfos[queryIndex]->SecondaryQueryIds);
 
@@ -274,6 +278,10 @@ public:
                         MakeUnversionedAnyValue(
                             ysonStatistics.AsStringBuf(),
                             statisticsColumnId)));
+                    rows[rowIndex].PushBack(rowBuffer->CaptureValue(
+                        MakeUnversionedAnyValue(
+                            ysonRuntimeVariables.AsStringBuf(),
+                            runtimeVariablesColumnId)));
                     rows[rowIndex].PushBack(rowBuffer->CaptureValue(
                         MakeUnversionedCompositeValue(
                             ysonSecondaryQueryIds.AsStringBuf(),

--- a/yt/chyt/tests/server/base.py
+++ b/yt/chyt/tests/server/base.py
@@ -378,6 +378,7 @@ class Clique(object):
             query = query + " format " + format
 
         params["output_format_json_quote_64bit_integers"] = 0
+        params["output_format_json_quote_denormals"] = 1
 
         result = requests.post(url, data=query, headers=headers, params=params, timeout=timeout, verify=False)
 

--- a/yt/yt/client/table_client/row_base.h
+++ b/yt/yt/client/table_client/row_base.h
@@ -117,6 +117,17 @@ inline bool IsIntegralType(ESimpleLogicalValueType type)
     }
 }
 
+inline bool IsFloatingPointType(ESimpleLogicalValueType type)
+{
+    switch (type) {
+        case ESimpleLogicalValueType::Double:
+        case ESimpleLogicalValueType::Float:
+            return true;
+        default:
+            return false;
+    }
+}
+
 inline bool IsStringLikeType(ESimpleLogicalValueType type)
 {
     switch (type) {

--- a/yt/yt/server/lib/chunk_pools/job_size_tracker.h
+++ b/yt/yt/server/lib/chunk_pools/job_size_tracker.h
@@ -7,6 +7,18 @@ namespace NYT::NChunkPools {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TJobSizeTrackerOptions
+{
+    //! The options below control a special size overflow mode in which limits increase in a geometric progression.
+    //! This mode is used in CHYT for early exit-like optimizations.
+    //! If ratio is set, resources specified in the geometric resource vector are multiplied by the ratio during
+    //! each flush at most `LimitProgressionLength` times, skipping the first `LimitProgressionOffset` flushes.
+    std::optional<double> LimitProgressionRatio;
+    std::vector<EResourceKind> GeometricResources;
+    int LimitProgressionLength = 1;
+    int LimitProgressionOffset = 0;
+};
+
 struct IJobSizeTracker
     : public TRefCounted
 {
@@ -30,7 +42,7 @@ DEFINE_REFCOUNTED_TYPE(IJobSizeTracker)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IJobSizeTrackerPtr CreateJobSizeTracker(TResourceVector limitVector, const NLogging::TLogger& logger);
+IJobSizeTrackerPtr CreateJobSizeTracker(TResourceVector limitVector, TJobSizeTrackerOptions options, const NLogging::TLogger& logger);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/lib/chunk_pools/new_sorted_job_builder.cpp
+++ b/yt/yt/server/lib/chunk_pools/new_sorted_job_builder.cpp
@@ -94,7 +94,7 @@ public:
 
             LimitVector_.Values[EResourceKind::DataSliceCount] = JobSizeConstraints_->GetMaxDataSlicesPerJob();
 
-            JobSizeTracker_ = CreateJobSizeTracker(LimitVector_, Logger);
+            JobSizeTracker_ = CreateJobSizeTracker(LimitVector_, Options_.JobSizeTrackerOptions, Logger);
         }
 
         if (Options_.EnablePeriodicYielder) {

--- a/yt/yt/server/lib/chunk_pools/resource.cpp
+++ b/yt/yt/server/lib/chunk_pools/resource.cpp
@@ -67,6 +67,17 @@ TResourceVector TResourceVector::operator*(double scale) const
     return result;
 }
 
+TResourceVector& TResourceVector::PartialMultiply(double scale, const std::vector<EResourceKind>& resourceKinds, i64 clampValue)
+{
+    i64 smallClamp = clampValue / scale;
+
+    for (auto kind : resourceKinds) {
+        Values[kind] = std::clamp(Values[kind], -smallClamp, smallClamp) * scale;
+    }
+
+    return *this;
+}
+
 bool TResourceVector::Violates(const TResourceVector& limits) const
 {
     for (auto kind : TEnumTraits<EResourceKind>::GetDomainValues()) {

--- a/yt/yt/server/lib/chunk_pools/resource.h
+++ b/yt/yt/server/lib/chunk_pools/resource.h
@@ -29,6 +29,8 @@ struct TResourceVector
 
     TResourceVector operator*(double scale) const;
 
+    TResourceVector& PartialMultiply(double scale, const std::vector<EResourceKind>& resourceKinds, i64 clampValue);
+
     bool Violates(const TResourceVector& limits) const;
     THashSet<EResourceKind> ViolatedResources(const TResourceVector& limits) const;
 

--- a/yt/yt/server/lib/chunk_pools/sorted_job_builder.h
+++ b/yt/yt/server/lib/chunk_pools/sorted_job_builder.h
@@ -4,6 +4,7 @@
 
 #include "chunk_pool.h"
 #include "new_job_manager.h"
+#include "job_size_tracker.h"
 
 #include <yt/yt/client/table_client/comparator.h>
 
@@ -32,6 +33,8 @@ struct TSortedJobOptions
     //! An upper bound for a total number of slices that is allowed. If this value
     //! is exceeded, an exception is thrown.
     i64 MaxTotalSliceCount;
+
+    TJobSizeTrackerOptions JobSizeTrackerOptions;
 
     void Persist(const TPersistenceContext& context);
 };


### PR DESCRIPTION
This PR introduces a new mode in CHYT that aims to mimic the behaviour of [optimize_read_in_order](https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#optimization-of-data-reading) in native ClickHouse. This PR implements #451, albeit using a different approach.
It works by using a sorted pool to produce jobs of exponentially increasing/decreasing sizes, which turn into subqueries that are processed combined sequentially without additional sorting steps. This should allow queries described in #451 to execute without reading the whole table. 
Notable modifications with generic impact:
* Support for exponentially increasing job sizes in new sorted pool and related classes.
* Chunk slice fetcher is now used when creating a sorted pool in CHYT.
* New column in query log table exporter.