### PR TITLE
Include yt/yt/library/query/base/parser.h by full path

### DIFF
--- a/yt/yt/library/query/base/lexer.h
+++ b/yt/yt/library/query/base/lexer.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "ast.h"
-#include "parser.h"
+
+#include <yt/yt/library/query/base/parser.h>
 
 namespace NYT::NQueryClient::NAst {
 

--- a/yt/yt/library/query/base/query_preparer.cpp
+++ b/yt/yt/library/query/base/query_preparer.cpp
@@ -4,7 +4,6 @@
 #include "functions.h"
 #include "helpers.h"
 #include "lexer.h"
-#include "parser.h"
 #include "query_helpers.h"
 
 #include <yt/yt_proto/yt/client/chunk_client/proto/chunk_spec.pb.h>


### PR DESCRIPTION
Short include could sometimes pick "result" file from current directory
instead of generated file from build directory.

In file included from ytsurus/yt/yt/library/query/base/parser.ypp:39:
In file included from ytsurus/yt/yt/library/query/base/lexer.h:4:
build_root/ksqf/001219/yt/yt/library/query/base/parser.h:215:9: error: redefinition of 'TParser'
  class TParser
        ^
build_root/g6w1/00001b/yt/yt/library/query/base/parser.h:215:9: note: previous definition is here
  class TParser
        ^
1 error generated.
