### PR TITLE
Make a few improvements to component version discovery

### DIFF
--- a/yt/yt/server/http_proxy/bootstrap.cpp
+++ b/yt/yt/server/http_proxy/bootstrap.cpp
@@ -359,7 +359,7 @@ TBootstrap::~TBootstrap() = default;
 void TBootstrap::SetupClients()
 {
     auto options = TClientOptions::FromUser(NSecurityClient::RootUserName);
-    RootClient_ = Connection_->CreateClient(options);
+    RootClient_ = Connection_->CreateNativeClient(options);
 
     NLogging::GetDynamicTableLogWriterFactory()->SetClient(RootClient_);
 }
@@ -452,7 +452,7 @@ TProxyDynamicConfigPtr TBootstrap::GetDynamicConfig() const
     return DynamicConfig_.Acquire();
 }
 
-const NApi::IClientPtr& TBootstrap::GetRootClient() const
+const NApi::NNative::IClientPtr& TBootstrap::GetRootClient() const
 {
     return RootClient_;
 }

--- a/yt/yt/server/http_proxy/bootstrap.h
+++ b/yt/yt/server/http_proxy/bootstrap.h
@@ -63,7 +63,7 @@ public:
 
     const TProxyConfigPtr& GetConfig() const;
     TProxyDynamicConfigPtr GetDynamicConfig() const;
-    const NApi::IClientPtr& GetRootClient() const;
+    const NApi::NNative::IClientPtr& GetRootClient() const;
     const NApi::NNative::IConnectionPtr& GetNativeConnection() const;
     const NDriver::IDriverPtr& GetDriverV3() const;
     const NDriver::IDriverPtr& GetDriverV4() const;
@@ -99,8 +99,7 @@ private:
     NHttp::IServerPtr MonitoringServer_;
 
     NApi::NNative::IConnectionPtr Connection_;
-    NApi::IClientPtr RootClient_;
-    NApi::NNative::IClientPtr NativeClient_;
+    NApi::NNative::IClientPtr RootClient_;
     NDriver::IDriverPtr DriverV3_;
     NDriver::IDriverPtr DriverV4_;
 

--- a/yt/yt/server/http_proxy/clickhouse/handler.cpp
+++ b/yt/yt/server/http_proxy/clickhouse/handler.cpp
@@ -7,6 +7,7 @@
 #include <yt/yt/server/http_proxy/coordinator.h>
 #include <yt/yt/server/http_proxy/http_authenticator.h>
 
+#include <yt/yt/ytlib/api/native/client.h>
 #include <yt/yt/ytlib/api/native/config.h>
 #include <yt/yt/ytlib/api/native/connection.h>
 

--- a/yt/yt/server/http_proxy/component_discovery.h
+++ b/yt/yt/server/http_proxy/component_discovery.h
@@ -11,12 +11,14 @@ namespace NYT::NHttpProxy {
 
 //! Singular (!) names of cluster components.
 DEFINE_ENUM(EClusterComponentType,
-    ((PrimaryMaster)            (0))
-    ((SecondaryMaster)          (1))
+    //! All masters (primary and secondary).
+    ((ClusterMaster)            (0))
+    ((PrimaryMaster)            (1))
 
     ((Scheduler)                (2))
     ((ControllerAgent)          (3))
 
+    //! All nodes (data, tablet and exec).
     ((ClusterNode)              (4))
     ((DataNode)                 (5))
     ((TabletNode)               (6))
@@ -69,6 +71,8 @@ struct TComponentDiscoveryOptions
     //! This callback *must* be provided and should return a duration after
     //! which a HTTP proxy is considered offline by the discovery mechanism.
     TCallback<TDuration()> ProxyDeathAgeCallback;
+    //! Timeout used for batch requests to master.
+    TDuration BatchRequestTimeout = TDuration::Seconds(5);
 };
 
 //! This class encapsulates everything related to the discovery of YT component instances from Cypress virtual maps and orchids.
@@ -77,7 +81,7 @@ class TComponentDiscoverer
 public:
     //! The provided master read options will be used for all Get/List requests performed for discovery.
     TComponentDiscoverer(
-        NApi::IClientPtr client,
+        NApi::NNative::IClientPtr client,
         NApi::TMasterReadOptions masterReadOptions,
         TComponentDiscoveryOptions componentDiscoveryOptions);
 
@@ -89,7 +93,7 @@ public:
     static std::vector<NYPath::TYPath> GetCypressPaths(const NApi::IClientPtr& client, const NApi::TMasterReadOptions& masterReadOptions, EClusterComponentType component);
 
 private:
-    const NApi::IClientPtr Client_;
+    const NApi::NNative::IClientPtr Client_;
     const NApi::TMasterReadOptions MasterReadOptions_;
     const TComponentDiscoveryOptions ComponentDiscoveryOptions_;
 

--- a/yt/yt/server/http_proxy/coordinator.cpp
+++ b/yt/yt/server/http_proxy/coordinator.cpp
@@ -10,6 +10,7 @@
 
 #include <yt/yt/server/lib/misc/address_helpers.h>
 
+#include <yt/yt/ytlib/api/native/client.h>
 #include <yt/yt/ytlib/api/native/connection.h>
 
 #include <yt/yt/ytlib/object_client/object_service_proxy.h>
@@ -633,10 +634,10 @@ void Serialize(const TVersionCounter& counter, IYsonConsumer* consumer)
         .EndMap();
 }
 
-TDiscoverVersionsHandler::TDiscoverVersionsHandler(NApi::IClientPtr client, TComponentDiscoveryOptions componentDiscoveryOptions)
+TDiscoverVersionsHandler::TDiscoverVersionsHandler(NApi::NNative::IClientPtr client, TComponentDiscoveryOptions componentDiscoveryOptions)
     : TComponentDiscoverer(
         std::move(client),
-        TMasterReadOptions{.ReadFrom = EMasterChannelKind::Follower},
+        TMasterReadOptions{.ReadFrom = EMasterChannelKind::MasterCache},
         std::move(componentDiscoveryOptions))
 { }
 

--- a/yt/yt/server/http_proxy/coordinator.h
+++ b/yt/yt/server/http_proxy/coordinator.h
@@ -195,7 +195,7 @@ class TDiscoverVersionsHandler
     , public TComponentDiscoverer
 {
 public:
-    TDiscoverVersionsHandler(NApi::IClientPtr client, TComponentDiscoveryOptions componentDiscoveryOptions);
+    TDiscoverVersionsHandler(NApi::NNative::IClientPtr client, TComponentDiscoveryOptions componentDiscoveryOptions);
 
     void HandleRequest(
         const NHttp::IRequestPtr& req,

--- a/yt/yt/server/http_proxy/solomon_proxy.cpp
+++ b/yt/yt/server/http_proxy/solomon_proxy.cpp
@@ -31,7 +31,7 @@ class TProfilingEndpointProvider
 {
 public:
     TProfilingEndpointProvider(
-        NApi::IClientPtr client,
+        NApi::NNative::IClientPtr client,
         TProfilingEndpointProviderConfigPtr config,
         TComponentDiscoveryOptions componentDiscoveryOptions)
         : TComponentDiscoverer(
@@ -85,7 +85,7 @@ private:
 TSolomonProxyPtr CreateSolomonProxy(
     const NHttpProxy::TSolomonProxyConfigPtr& config,
     const TComponentDiscoveryOptions& componentDiscoveryOptions,
-    const NApi::IClientPtr& client,
+    const NApi::NNative::IClientPtr& client,
     NConcurrency::IPollerPtr poller)
 {
     auto solomonProxy = New<TSolomonProxy>(config, std::move(poller));

--- a/yt/yt/server/http_proxy/solomon_proxy.h
+++ b/yt/yt/server/http_proxy/solomon_proxy.h
@@ -13,7 +13,7 @@ namespace NYT::NHttpProxy {
 NProfiling::TSolomonProxyPtr CreateSolomonProxy(
     const TSolomonProxyConfigPtr& config,
     const TComponentDiscoveryOptions& componentDiscoveryOptions,
-    const NApi::IClientPtr& client,
+    const NApi::NNative::IClientPtr& client,
     NConcurrency::IPollerPtr poller);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/tests/integration/proxies/test_http_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_http_proxy.py
@@ -230,9 +230,13 @@ class TestHttpProxy(HttpProxyTestBase):
                 assert component_summary["banned"] == 0
                 assert component_summary["offline"] == 0
 
+        assert counts["cluster_master"] == 3
         assert counts["primary_master"] == 1
-        assert counts["secondary_master"] == 2
         assert counts["cluster_node"] == 5
+        assert counts["data_node"] == 5
+        assert counts["tablet_node"] == 5
+        assert counts["exec_node"] == 5
+        assert counts["job_proxy"] == 5
         assert counts["scheduler"] == 1
         assert counts["controller_agent"] == 1
         assert counts["http_proxy"] == 1
@@ -386,9 +390,13 @@ class TestFullDiscoverVersions(HttpProxyTestBase):
                 assert component_summary["banned"] == 0
                 assert component_summary["offline"] == 0
 
+        assert counts["cluster_master"] == 3
         assert counts["primary_master"] == 1
-        assert counts["secondary_master"] == 2
         assert counts["cluster_node"] == 5
+        assert counts["data_node"] == 5
+        assert counts["tablet_node"] == 5
+        assert counts["exec_node"] == 5
+        assert counts["job_proxy"] == 5
         assert counts["scheduler"] == 1
         assert counts["controller_agent"] == 1
         assert counts["http_proxy"] == 1
@@ -416,7 +424,7 @@ class TestSolomonProxy(HttpProxyTestBase):
 
     DELTA_PROXY_CONFIG = {
         "solomon_proxy": {
-            "public_component_names": ["rpc_proxy", "primary_master", "http_proxy"],
+            "public_component_names": ["rpc_proxy", "cluster_master", "http_proxy"],
             # We will configure the endpoint providers later, since monitoring ports are not yet generated at this point.
         }
     }
@@ -426,15 +434,15 @@ class TestSolomonProxy(HttpProxyTestBase):
     def apply_config_patches(cls, configs, ytserver_version, cluster_index, cluster_path):
         super(TestSolomonProxy, cls).apply_config_patches(configs, ytserver_version, cluster_index, cluster_path)
 
-        primary_master_config = list(configs["master"].values())[0][0]
+        master_config = list(configs["master"].values())[0][0]
         rpc_proxy_config = configs["rpc_proxy"][0]
         http_proxy_config = configs["http_proxy"][0]
         scheduler_config = configs["scheduler"][0]
 
         configs["http_proxy"][0]["solomon_proxy"]["endpoint_providers"] = [
             {
-                "component_type": "primary_master",
-                "monitoring_port": primary_master_config["monitoring_port"],
+                "component_type": "cluster_master",
+                "monitoring_port": master_config["monitoring_port"],
                 # We use this to distinguish instances based on their name.
                 "include_port_in_instance_name": True,
             },
@@ -458,7 +466,7 @@ class TestSolomonProxy(HttpProxyTestBase):
 
         # This isn't very pretty either, but it will do for now.
         # TODO(achulkov2): Initialize host for all components similar to jaeger init?
-        primary_master_config["solomon_exporter"]["host"] = "master.yt.test"
+        master_config["solomon_exporter"]["host"] = "master.yt.test"
         rpc_proxy_config["solomon_exporter"]["host"] = "rpc-proxy.yt.test"
         http_proxy_config["solomon_exporter"]["host"] = "http-proxy.yt.test"
         scheduler_config["solomon_exporter"]["host"] = "scheduler.yt.test"


### PR DESCRIPTION
Implements enhancements requested in #652:
* No more distinction between primary and secondary masters in favor of using the flat list of masters.
* Accounts for the possibility of incomplete results in master Get/List (and sets a large MaxSize).
* Uses native batch requests for fetching the contents of many orchids.
* Cleans up some compats.
* **Starts using MasterCache for version discovery**.

I decided to go with batch requests instead of direct RPC calls to orchids because this allows us to use master caches (now) and add some rate-limiting safeguards (later) by using a separate non-root user for discovery. Direct RPC calls much harder to rate-limit and do not have native caching, and I am more concerned about proxies (which there could be a lot of) making these kind of requests to *all* services. At least with masters we know our enemy in the face. Direct RPC calls are also harder to implement, since the current proxy bootstrap doesn't have any configured bus config, channel factory, etc. 