### PR TITLE
Add ya package builds for strawberry and chyt

### DIFF
--- a/yt/docker/ya-build/chyt/README.md
+++ b/yt/docker/ya-build/chyt/README.md
@@ -1,0 +1,9 @@
+# Building the chyt core image from source
+
+This configuration allows building the `chyt` image from source.
+
+Example: `ytsaurus/ya package package.json --docker-registry my-registry.com`
+
+The `--docker-registry` parameter only impacts the resulting image name, which will be `my-registry.com/ytsaurus:local-<commit-SHA>` in this case.
+
+The `--custom-version` parameter can be used to override the version template specified in `package.json` with your custom string.

--- a/yt/docker/ya-build/chyt/package.json
+++ b/yt/docker/ya-build/chyt/package.json
@@ -1,0 +1,78 @@
+{
+    "meta": {
+        "name": "chyt",
+        "maintainer": "YT team",
+        "description": "Strawberry image built from source files",
+        "version": "local-{revision}",
+    },
+    "params": {
+        "format": "docker",
+        "docker_target": "chyt",
+    },
+    "build": {
+        "build_server_binaries": {
+            "targets": [
+                "yt/chyt/server/bin",
+            ],
+            "build_type": "profile",
+            "thinlto": true,
+            "target-platforms": [
+                "default-linux-x86_64",
+            ],
+            "flags": [
+                {
+                    "name": "NO_STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+    "data": [
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/Dockerfile",
+            },
+            "destination": {
+                "path": "/Dockerfile",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/credits/chyt",
+            },
+            "destination": {
+                "path": "/credits",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/setup_cluster_for_chyt.sh",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/chyt/trampoline/clickhouse-trampoline.py",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+                "build_key": "build_server_binaries",
+                "path": "yt/chyt/server/bin/ytserver-clickhouse",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+    ],
+}

--- a/yt/docker/ya-build/chyt/ya.make
+++ b/yt/docker/ya-build/chyt/ya.make
@@ -1,0 +1,7 @@
+UNION()
+
+FILES(
+    package.json
+)
+
+END()

--- a/yt/docker/ya-build/strawberry/README.md
+++ b/yt/docker/ya-build/strawberry/README.md
@@ -1,0 +1,9 @@
+# Building the strawberry core image from source
+
+This configuration allows building the `strawberry` image from source.
+
+Example: `ytsaurus/ya package package.json --docker-registry my-registry.com`
+
+The `--docker-registry` parameter only impacts the resulting image name, which will be `my-registry.com/ytsaurus:local-<commit-SHA>` in this case.
+
+The `--custom-version` parameter can be used to override the version template specified in `package.json` with your custom string.

--- a/yt/docker/ya-build/strawberry/package.json
+++ b/yt/docker/ya-build/strawberry/package.json
@@ -1,0 +1,59 @@
+{
+    "meta": {
+        "name": "strawberry",
+        "maintainer": "YT team",
+        "description": "Strawberry image built from source files",
+        "version": "local-{revision}",
+    },
+    "params": {
+        "format": "docker",
+        "docker_target": "strawberry",
+    },
+    "build": {
+        "build_server_binaries": {
+            "targets": [
+                "yt/chyt/controller/cmd/chyt-controller",
+            ],
+            "build_type": "profile",
+            "target-platforms": [
+                "default-linux-x86_64",
+            ],
+            "flags": [
+                {
+                    "name": "NO_STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+    "data": [
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/Dockerfile",
+            },
+            "destination": {
+                "path": "/Dockerfile",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/credits/strawberry",
+            },
+            "destination": {
+                "path": "/credits",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+                "build_key": "build_server_binaries",
+                "path": "yt/chyt/controller/cmd/chyt-controller/chyt-controller",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+    ],
+}

--- a/yt/docker/ya-build/strawberry/ya.make
+++ b/yt/docker/ya-build/strawberry/ya.make
@@ -1,0 +1,7 @@
+UNION()
+
+FILES(
+    package.json
+)
+
+END()

--- a/yt/docker/ya-build/ya.make
+++ b/yt/docker/ya-build/ya.make
@@ -7,6 +7,8 @@ FILES(
 END()
 
 RECURSE(
+    chyt
+    strawberry
     ytsaurus
     ytsaurus-server-override
 )

--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -108,6 +108,10 @@ COPY ./ytserver-clickhouse /usr/bin/ytserver-clickhouse
 # CHYT credits files.
 COPY ./credits/ytserver-clickhouse.CREDITS /usr/bin/ytserver-clickhouse.CREDITS
 
+# Install YT client for setup script.
+RUN python3.8 -m pip install ytsaurus-client
+RUN ln -s /usr/local/bin/yt /usr/bin/yt -f
+
 # Setup script.
 COPY ./setup_cluster_for_chyt.sh /setup_cluster_for_chyt.sh
 RUN chmod 755 /setup_cluster_for_chyt.sh


### PR DESCRIPTION
This is useful for building custom chyt/strawberry images manually, without writing your own build.sh/Dockerfile.