### PR TITLE
Fix: Logs compression broken in YQL agent

### DIFF
--- a/yt/yql/agent/yql_agent.cpp
+++ b/yt/yql/agent/yql_agent.cpp
@@ -122,12 +122,12 @@ public:
 
         auto clustersConfig = Config_->GatewayConfig->AsMap()->GetChildOrThrow("cluster_mapping")->AsList();
 
-        auto SingletonsConfigDefaultLogging = CloneYsonStruct(SingletonsConfig_);
+        auto singletonsConfigDefaultLogging = CloneYsonStruct(SingletonsConfig_);
         // Compressed logs is broken if plugin tries to open and write to them.
-        SingletonsConfigDefaultLogging->Logging = TLogManagerConfig::CreateDefault();
+        singletonsConfigDefaultLogging->Logging = TLogManagerConfig::CreateDefault();
 
-        auto singletonsConfigString = SingletonsConfigDefaultLogging
-            ? ConvertToYsonString(SingletonsConfigDefaultLogging)
+        auto singletonsConfigString = singletonsConfigDefaultLogging
+            ? ConvertToYsonString(singletonsConfigDefaultLogging)
             : EmptyMap;
 
         THashSet<TString> presentClusters;

--- a/yt/yql/agent/yql_agent.cpp
+++ b/yt/yql/agent/yql_agent.cpp
@@ -122,8 +122,12 @@ public:
 
         auto clustersConfig = Config_->GatewayConfig->AsMap()->GetChildOrThrow("cluster_mapping")->AsList();
 
-        auto singletonsConfigString = SingletonsConfig_
-            ? ConvertToYsonString(*SingletonsConfig_)
+        auto SingletonsConfigDefaultLogging = CloneYsonStruct(SingletonsConfig_);
+        // Compressed logs is broken if plugin tries to open and write to them.
+        SingletonsConfigDefaultLogging->Logging = TLogManagerConfig::CreateDefault();
+
+        auto singletonsConfigString = SingletonsConfigDefaultLogging
+            ? ConvertToYsonString(SingletonsConfigDefaultLogging)
             : EmptyMap;
 
         THashSet<TString> presentClusters;


### PR DESCRIPTION
https://github.com/ytsaurus/ytsaurus/issues/623


How to find broken zstds:
```
~/.ya/build/build_root/9bq0/00027b/yt/yql/tests/test-results/py3test$ find . -name '*.zst' -exec bash -xc " zstdcat $(realpath {}) > /dev/null " \; 2>&1 | grep -B1 Corrupted
```
gz's:
```
~/ytsaurus/yt/yql/tests/test-results$ find . -name '*.gz' -exec bash -xc " gzip -dc $(realpath {}) > /dev/null " \; 2>&1 | grep -B2 invalid
```