### PR TITLE
Some grafana-related improvements for dashboard generator

### DIFF
--- a/yt/admin/dashboard_generator/yt_dashboard_generator/backends/grafana/__init__.py
+++ b/yt/admin/dashboard_generator/yt_dashboard_generator/backends/grafana/__init__.py
@@ -9,6 +9,11 @@ from ...postprocessors import DollarTemplateTagPostprocessor
 import requests
 import enum
 import lark
+import logging
+
+##################################################################
+
+logger = logging.getLogger()
 
 ##################################################################
 
@@ -67,20 +72,28 @@ class GrafanaProxy():
 
     def submit_dashboard(self, serialized_dashboard, dashboard_id):
         try:
-            current = self.fetch_dashboard(dashboard_id)["dashboard"]
-            print("Current version:", current["version"])
-        except BaseException:
+            current = self.fetch_dashboard(dashboard_id)
+            current_dashboard = current["dashboard"]
+            logger.info("Current version:", current_dashboard["version"])
+        except BaseException as ex:
+            logger.exception("Failed to retrieve current dashboard configuration, using plain configuration")
             current = {}
+            current_dashboard = {}
 
         request = serialized_dashboard
         if dashboard_id is not None:
             request["uid"] = dashboard_id
-        request.setdefault("title", current.get("title", "some default title"))
-        request.setdefault("title", "arusntarstrst")
-        request.setdefault("templating", current.get("templating", {}))
-        request["version"] = current.get("version", 1)
+        request.setdefault("title", current_dashboard.get("title", "some default title"))
+        request.setdefault("templating", current_dashboard.get("templating", {}))
+        request["version"] = current_dashboard.get("version", 1)
 
         request = {"dashboard": request}
+
+        folder_id = current.get("meta", {}).get("folderUid")
+        if folder_id is not None:
+            request["folderUid"] = folder_id
+        elif not current:
+            logger.warning("Submitting Grafana dashboard without specified folder and knowledge about current dashboard, this might cause the dashboard to move to your root folder")
 
         rsp = requests.post(
             f"{self.base_url}/api/dashboards/db",
@@ -146,6 +159,16 @@ class GrafanaSerializerBase(SerializerBase):
             regex.append(c)
         return "".join(regex)
 
+    # This is a bit hacky, but should work for most reasonable cases of non-regex values and variables.
+    def _is_exact(self, value):
+        return all(c.isalnum() or c in "-_<>" for c in value.removeprefix("$"))
+
+    def _get_comparison_operator(self, negate, exact):
+        if exact:
+            return "!=" if negate else "="
+        else:
+            return "!~" if negate else "=~"
+
     def _prepare_bin_op_expr_query(self, expression):
         assert expression.args[0] in "+-*/", f"Binary operation {expression.args[0]} is not supported. Expression: {expression}, expression type: {type(expression)}"
         left_query, left_tags = self._prepare_expr_query(expression.args[1])
@@ -194,7 +217,7 @@ class GrafanaSerializerBase(SerializerBase):
         if not issubclass(type(sensor), Sensor):
             raise Exception(f"Cannot serialize cell content of type {type(sensor)}")
 
-        tags = list(sensor.get_tags().items())
+        tags = sensor.get_tags()
         sensor_name = sensor.sensor
 
         if self.tag_postprocessor is not None:
@@ -204,7 +227,7 @@ class GrafanaSerializerBase(SerializerBase):
 
         string_tags = []
         other_tags = {}
-        for k, v in tags:
+        for k, v in tags.items():
             if k == sensor.sensor_tag_name:
                 continue
 
@@ -237,10 +260,13 @@ class GrafanaSerializerBase(SerializerBase):
             if not regex:
                 v = self._glob_to_regex(v)
 
-            if negate:
-                query_parts.append(f'{k}!~"{v}"')
-            else:
-                query_parts.append(f'{k}=~"{v}"')
+            # This is a workaround for labels that cannot be specified as a regex.
+            # It is often the case for workspace-like "required" labels.
+            # We use normal comparison operators for all values that do not contain regex-related symbols.
+            # See the definition of the function below for specifics.
+            exact = self._is_exact(v)
+            op = self._get_comparison_operator(negate=negate, exact=exact)
+            query_parts.append(f'{k}{op}"{v}"')
 
         return (query_parts, other_tags)
 
@@ -447,7 +473,7 @@ class GrafanaDebugSerializer(GrafanaSerializerBase):
             return break_long_lines_in_multiline_cell(content.title)
 
         query_parts, other_tags = self._prepare_expr_query(content)
-        _, name = self.tag_postprocessor.postprocess(content.get_tags().items(), content.sensor)
+        _, name = self.tag_postprocessor.postprocess(content.get_tags(), content.sensor)
 
         if other_tags.get(GrafanaSystemTags.Rate, False):
             query_parts.append("$rate=True")

--- a/yt/admin/dashboard_generator/yt_dashboard_generator/backends/monitoring/__init__.py
+++ b/yt/admin/dashboard_generator/yt_dashboard_generator/backends/monitoring/__init__.py
@@ -127,7 +127,7 @@ class MonitoringSerializerBase(SerializerBase):
 
         assert issubclass(type(sensor), Sensor)
 
-        tags = list(sensor.get_tags().items())
+        tags = sensor.get_tags()
         if self.tag_postprocessor is not None:
             tags, _ = self.tag_postprocessor.postprocess(tags, None)
 
@@ -135,7 +135,7 @@ class MonitoringSerializerBase(SerializerBase):
 
         string_tags = []
         other_tags = {}
-        for k, v in tags:
+        for k, v in tags.items():
             if isinstance(k, MonitoringTag):
                 k = str(k)
             # TODO: rewrite system tag expansion.

--- a/yt/admin/dashboard_generator/yt_dashboard_generator/cli.py
+++ b/yt/admin/dashboard_generator/yt_dashboard_generator/cli.py
@@ -139,17 +139,21 @@ class Cli():
                 headers="firstrow"))
             return
 
+        def is_selected_backend(backend):
+            return args.backend is None or backend in args.backend
+
         for cls in self.backend_classes.values():
-            cls.on_args_parsed(args)
+            if is_selected_backend(cls.get_backend_name()):
+                cls.on_args_parsed(args)
 
         selected_dashboards = []
         if "all" in args.dashboards:
             for slug, backend in self.dashboards:
-                if args.backend is None or backend.get_backend_name() in args.backend:
+                if is_selected_backend(backend.get_backend_name()):
                     selected_dashboards.append(backend)
         else:
             for slug, backend in self.dashboards:
-                if slug in args.dashboards and (args.backend is None or backend.get_backend_name() in args.backend):
+                if slug in args.dashboards and is_selected_backend(backend.get_backend_name()):
                     selected_dashboards.append(backend)
 
         if not selected_dashboards:

--- a/yt/admin/dashboard_generator/yt_dashboard_generator/postprocessors.py
+++ b/yt/admin/dashboard_generator/yt_dashboard_generator/postprocessors.py
@@ -1,14 +1,20 @@
 import abc
-from typing import Dict, Any, Optional, Iterable
+from typing import Dict, Any, Optional, Iterable, Tuple
 import copy
 
 from .specific_tags.tags import TemplateTag, BackendTag
 
 
 class TagPostprocessorBase(abc.ABC):
+    # Please make sure that the returned tags as a dict, as is required
+    # by the type specifications of the abstract method.
+    # Duplicate tags are thus forbidden.
+    # Dictionaries are ordered by default since python 3.7, and the
+    # order should be preserved even when creating from a list, so
+    # sorting postprocessors will work fine.
     @abc.abstractmethod
     def postprocess(self, tags: Dict[str, Any], sensor_name: Optional[str]) \
-            -> (Dict[str, Any], Optional[str]):
+            -> Tuple[Dict[str, Any], Optional[str]]:
         raise NotImplementedError
 
 
@@ -19,7 +25,7 @@ class SimpleTagPostprocessor(TagPostprocessorBase):
 
     def postprocess(self, tags, sensor_name):
         result = []
-        for k, v in tags:
+        for k, v in tags.items():
             new_tags = self.process_tag(k, v)
             if new_tags is None:
                 continue
@@ -31,7 +37,7 @@ class SimpleTagPostprocessor(TagPostprocessorBase):
                 result.extend(new_tags)
             else:
                 result.append(new_tags)
-        return result, sensor_name
+        return dict(result), sensor_name
 
 
 class MultiTagPostprocessor(TagPostprocessorBase):

--- a/yt/admin/dashboard_generator/yt_dashboard_generator/serializer.py
+++ b/yt/admin/dashboard_generator/yt_dashboard_generator/serializer.py
@@ -31,7 +31,7 @@ class DebugTagPostprocessor():
 
     def _unpack_system_tags(self, tags):
         res = []
-        for k, v in tags:
+        for k, v in tags.items():
             if k == SystemFields.Top:
                 res.append(("Top", v))
             elif k == SystemFields.Stack:
@@ -39,7 +39,7 @@ class DebugTagPostprocessor():
             else:
                 assert isinstance(k, str)
                 res.append((k, v))
-        return res
+        return dict(res)
 
 
 class DebugSerializer(SerializerBase):
@@ -54,7 +54,7 @@ class DebugSerializer(SerializerBase):
             return content.text
         if not issubclass(type(content), Sensor):
             raise Exception(f"Cannot serialize cell content of type {type(content)}")
-        tags = list(content.get_tags().items())
+        tags = content.get_tags()
         if self.tag_postprocessor is not None:
             tags, _ = self.tag_postprocessor.postprocess(tags)
-        return "\n".join("{}={}".format(k, str(v)) for k, v in tags)
+        return "\n".join("{}={}".format(k, str(v)) for k, v in tags.items())

--- a/yt/admin/dashboards/yt_dashboards/common/postprocessors.py
+++ b/yt/admin/dashboards/yt_dashboards/common/postprocessors.py
@@ -1,6 +1,6 @@
 from yt_dashboard_generator.taggable import SystemFields, NotEquals
 from yt_dashboard_generator.specific_tags.tags import TemplateTag
-from yt_dashboard_generator.postprocessors import TagPostprocessorBase
+from yt_dashboard_generator.postprocessors import TagPostprocessorBase, SimpleTagPostprocessor
 from yt_dashboard_generator.backends.grafana import GrafanaSystemTags
 from yt_dashboard_generator.specific_tags.tags import SpecificTag, Regex
 
@@ -8,18 +8,22 @@ from . import sensors
 
 from functools import cmp_to_key
 
+from typing import Iterable
+
+##################################################################
+
 
 class HostAggrTagPostprocessor(TagPostprocessorBase):
     def postprocess(self, tags, sensor_name=None):
         res = []
-        for (k, v) in tags:
+        for k, v in tags.items():
             if str(k) in ("host", "l.host"):
                 if v == SystemFields.Aggr:
                     v = "Aggr"
                 elif v == SystemFields.All:
                     v = "!Aggr*"
             res.append((k, v))
-        return res, sensor_name
+        return dict(res), sensor_name
 
 
 class SortingTagPostprocessor(TagPostprocessorBase):
@@ -78,7 +82,7 @@ class SortingTagPostprocessor(TagPostprocessorBase):
         return 1
 
     def postprocess(self, tags, sensor_name=None):
-        tags.sort(key=cmp_to_key(lambda *args: self._cmp(*args)))
+        tags = dict(sorted(tags.items(), key=cmp_to_key(lambda *args: self._cmp(*args))))
         return tags, sensor_name
 
 
@@ -87,7 +91,6 @@ class GrafanaTagPostprocessor(TagPostprocessorBase):
         self.active = backend == "grafana"
 
     def postprocess(self, tags, sensor_name=None):
-        tags = dict(tags)
         if not self.active:
             return tags, sensor_name
         if sensor_name.endswith(".rate"):
@@ -103,8 +106,6 @@ class YtTagPostprocessor(TagPostprocessorBase):
         self.backend = backend
 
     def postprocess(self, tags, sensor_name=None):
-        tags = dict(tags)
-
         if self.backend in ("monitoring",):
             tags.setdefault("project", "yt")
             tags.setdefault("cluster", TemplateTag("cluster"))
@@ -119,14 +120,9 @@ class YtTagPostprocessor(TagPostprocessorBase):
                         '"yt_host" label should be used either with .all() or with .aggr(), '
                         f'got "{value}" of type {type(value)}')
 
-        tags, sensor_name = HostAggrTagPostprocessor().postprocess(
-            tags.items(), sensor_name)
-        tags = dict(tags)
+        tags, sensor_name = HostAggrTagPostprocessor().postprocess(tags, sensor_name)
 
-        tags, sensor_name = GrafanaTagPostprocessor(self.backend).postprocess(
-            tags.items(), sensor_name
-        )
-        tags = dict(tags)
+        tags, sensor_name = GrafanaTagPostprocessor(self.backend).postprocess(tags, sensor_name)
 
         key_replacements = []
         for k, v in tags.items():
@@ -139,11 +135,77 @@ class YtTagPostprocessor(TagPostprocessorBase):
         for before, after in key_replacements:
             tags[after] = tags.pop(before)
 
-        tags = list(tags.items())
-
         tags = self.sort(tags)
 
         return tags, sensor_name
 
     def sort(self, tags):
         return SortingTagPostprocessor().postprocess(tags)[0]
+
+
+##################################################################
+
+
+# The stubs below should not be used in dashboard configuration.
+class AddTagPostprocessorStub(TagPostprocessorBase):
+    def __init__(self, underlying, extra_tags, mode="append"):
+        super().__init__()
+
+        self.underlying = underlying
+        # This preserves order since version 3.7.
+        self.extra_tags = dict(extra_tags)
+        self.mode = mode
+
+    def postprocess(self, tags, sensor_name=None):
+        tags, sensor_name = self.underlying.postprocess(tags, sensor_name)
+
+        assert not (set(self.extra_tags.keys()) & set(tags.keys())), "Additional tags should not intersect with any existing tags"
+
+        if self.mode == "append":
+            return (tags | self.extra_tags), sensor_name
+        elif self.mode == "prepend":
+            return (self.extra_tags | tags), sensor_name
+        else:
+            assert False, f'Unknown mode {self.mode}, use either "append" or "prepend"'
+
+
+class MapTagPostprocessorStub(SimpleTagPostprocessor):
+    def __init__(self, underlying, old_key, new_key=None, value_mapping=None):
+        super().__init__()
+
+        self.underlying = underlying
+        self.old_key = old_key
+        self.new_key = new_key or old_key
+        self.value_mapping = value_mapping or {}
+
+    def process_tag(self, k, v):
+        if k == self.old_key:
+            return self.new_key, self.value_mapping.get(v, v)
+        return k, v
+
+    def postprocess(self, tags, sensor_name):
+        tags, sensor_name = self.underlying.postprocess(tags, sensor_name)
+        return super().postprocess(tags, sensor_name)
+
+
+def define_postprocessor(stub):
+    return lambda *args, **kwargs: lambda underlying: stub(underlying, *args, **kwargs)
+
+
+##################################################################
+
+
+# These postprocessors can be used in the `postprocessor` parameter in dashboard configuration.
+AddTagPostprocessor = define_postprocessor(AddTagPostprocessorStub)
+MapTagPostprocessor = define_postprocessor(MapTagPostprocessorStub)
+
+
+# Combines postprocessors like the ones defined above in the following fashion: P1(P2(...P_k(underlying))).
+def combine_postprocessors(*args):
+    def combined_postprocessor(underlying):
+        current_underlying = underlying
+        for postprocessor in args[::-1]:
+            current_underlying = postprocessor(current_underlying)
+        return current_underlying
+
+    return combined_postprocessor

--- a/yt/admin/dashboards/yt_dashboards/common/sensors.py
+++ b/yt/admin/dashboards/yt_dashboards/common/sensors.py
@@ -13,6 +13,10 @@ class YtSystemTags(Enum):
 
 yt_host = YtSystemTags.HostContainer
 
+MonitoringServiceTag = MonitoringTag("service")
+# TODO(achulkov): This is actually promised to be "job" in README. Should we change it?
+GrafanaServiceTag = GrafanaTag("service")
+
 ##################################################################
 
 
@@ -20,9 +24,9 @@ class ProjectSensorBase:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self.cls_monitoring_service is not None:
-            self.tags[MonitoringTag("service")] = self.cls_monitoring_service
+            self.tags[MonitoringServiceTag] = self.cls_monitoring_service
         if self.cls_grafana_service is not None:
-            self.tags[GrafanaTag("service")] = self.cls_grafana_service
+            self.tags[GrafanaServiceTag] = self.cls_grafana_service
 
 
 def ProjectSensor(monitoring_service=None, grafana_service=None, base=Sensor):
@@ -116,21 +120,21 @@ MasterRpc =        ProjectSensor("master_rpc",        "yt-master")  # noqa: E222
 MasterRpcClient =  ProjectSensor("master_rpc_client", "yt-master")  # noqa: E222
 
 # Misc.
-HttpProxy = ProjectSensor("http_proxy", "yt_proxies")
-RpcProxy = ProjectSensor("rpc_proxy", "yt_rpc_proxies")
-RpcProxyRpc = ProjectSensor("rpc_proxy_rpc", "yt_rpc_proxies", base=RpcBase)
-RpcProxyInternal = ProjectSensor("rpc_proxy_internal", "yt_rpc_proxies")
-RpcProxyCpu = ProjectSensor("rpc_proxy_cpu", "yt_rpc_proxies")
+HttpProxy = ProjectSensor("http_proxy", "yt-http-proxy")
+RpcProxy = ProjectSensor("rpc_proxy", "yt-rpc-proxy")
+RpcProxyRpc = ProjectSensor("rpc_proxy_rpc", "yt-rpc-proxy", base=RpcBase)
+RpcProxyInternal = ProjectSensor("rpc_proxy_internal", "yt-rpc-proxy")
+RpcProxyCpu = ProjectSensor("rpc_proxy_cpu", "yt-rpc-proxy")
 RpcProxyPorto =  ProjectSensor("rpc_proxy_porto", base=RpcBase)  # noqa: E222
 
 # BundleController
-BundleController = ProjectSensor("bundle_controller", "yt_bundle_controller")  # noqa: E222
+BundleController = ProjectSensor("bundle_controller", "yt-bundle-controller")  # noqa: E222
 
 # TabletBalancer
-TabletBalancer = ProjectSensor("tablet_balancer", "yt_tablet_balancer")  # noqa: E222
+TabletBalancer = ProjectSensor("tablet_balancer", "yt-tablet-balancer")  # noqa: E222
 
 # CHYT
-Chyt = ProjectSensor("clickhouse", "chyt")
+Chyt = ProjectSensor("clickhouse", "yt-chyt")
 
 # Flow
 FlowController = ProjectSensor("controller")  # noqa: E222


### PR DESCRIPTION
This PR contains the following changes:
* New user-provided/user-defined postprocessors are introduced, along with few general-purposes custom postprocessor useful for grafana installations + usage examples.
* Grafana backend tries to use exact comparison operators where possible.
* Postprocessors are refactored to use dicts.
* When a backend is explicitly specified via CLI, all other configured backends are ignored. 
* Some grafana project service names are renamed to follow a common pattern.

TODO in future PRs:
* Generalize dashboard parameters with suggested values across both backends. It should be implemented via `label_values(query, label_name)` in Grafana. 
* Gradually work through dashboards and make sure they actually work in Grafana.
* Support dashboard creation (vs existing dashboard) in specific folders for Grafana.