### PR TITLE
Fix flaky dynamic table logger test (hopefully)

### DIFF
--- a/yt/yt/tests/integration/misc/test_logging.py
+++ b/yt/yt/tests/integration/misc/test_logging.py
@@ -23,7 +23,7 @@ class TestDynamicTableLogger(YTEnvSetup):
                 {
                     "family": "plain_text",
                     "min_level": "debug",
-                    "exclude_categories": ["Bus"],
+                    "include_categories": ["ObjectServer", "Bootstrap", "Concurrency"],
                     "writers": ["debug_dynamic_table"],
                 },
                 {


### PR DESCRIPTION
We write too many logs and local YT cannot handle it. I left only a few categories for the test to work better. Ran them in a loop for a few hours without failures, so hopefully this will help. 

P.S. We include Concurrency deliberately because we filter it out using rate limiters.