### PR TITLE
Fix read_query_result always returning raw results.

### DIFF
--- a/yt/python/yt/wrapper/query_commands.py
+++ b/yt/python/yt/wrapper/query_commands.py
@@ -91,12 +91,17 @@ def read_query_result(query_id, result_index=None, stage=None, format=None, raw=
         "stage": get_value(stage, "production"),
     }
 
-    return make_request(
+    response = make_request(
         "read_query_result",
         params=params,
         return_content=False,
         use_heavy_proxy=True,
         client=client)
+
+    if raw:
+        return response
+    else:
+        return format.load_rows(response)
 
 
 def get_query_result(query_id, result_index=None, stage=None, format=None, client=None):


### PR DESCRIPTION
Currently, read_query_result always acts as if raw = True, since
the implementation does not care to load rows from the specified
format. I fix that similar to how read_table is implemented.

This is an obvious mistake that would not happen if we had tests
on Python SDK for query methods, but we do not have them, and
obtaining them is considerably hard (due to QT not being supported
by yt_local).

I tested the fixed implementation locally, it seems working correctly.
