### PR TITLE
Fix PEERDIRS to unavailable libraries in OSS.

### DIFF
--- a/yt/python/yt/environment/api/ya.make
+++ b/yt/python/yt/environment/api/ya.make
@@ -1,7 +1,9 @@
 PY23_LIBRARY()
 
 IF (PYTHON2)
-    PEERDIR(yt/python_py2/yt/environment/api)
+    IF (NOT OPENSOURCE)
+        PEERDIR(yt/python_py2/yt/environment/api)
+    ENDIF()
 ELSE()
     PEERDIR(
         contrib/python/attrs

--- a/yt/python/yt/environment/migrationlib/ya.make
+++ b/yt/python/yt/environment/migrationlib/ya.make
@@ -1,7 +1,9 @@
 PY23_LIBRARY()
 
 IF (PYTHON2)
-    PEERDIR(yt/python_py2/yt/environment/migrationlib)
+    IF (NOT OPENSOURCE)
+        PEERDIR(yt/python_py2/yt/environment/migrationlib)
+    ENDIF()
 ELSE()
     PEERDIR(
         yt/python/yt


### PR DESCRIPTION
Fixing the following error:
```
~/ytsaurus/yt/python/yt/environment $ ~/ytsaurus/ya make -t --style
Error[-WBadDir]: in $B/yt/python/yt/environment/api/libpyyt-environment-api.a: PEERDIR to missing directory: $S/yt/python_py2/yt/environment/api
Error[-WBadDir]: in $B/yt/python/yt/environment/migrationlib/libpyyt-environment-migrationlib.a: PEERDIR to missing directory: $S/yt/python_py2/yt/environment/migrationlib
Configure error (use -k to proceed)
```
