### PR TITLE
Move query tracker docs to a separate section

### DIFF
--- a/yt/docs/README.md
+++ b/yt/docs/README.md
@@ -296,38 +296,41 @@ For documents located in the `_includes` folder, consider the following when add
 - A link path should be set relativelly to the document located in the `_includes` folder, but not in the original folder. What is original folder, see the example below.
 - You should never link to the `_includes` folder. A link should always refer to the document located in the original folder. 
 
-For an example, take a look at the [Query Tracker](https://ytsaurus.tech/docs/en/user-guide/query-tracker) article. Its source is stored in the [en/user-guide/query-tracker.md](https://github.com/ytsaurus/ytsaurus/edit/main/yt/docs/en/user-guide/query-tracker.md) file:
+For an example, take a look at the [Query Tracker](https://ytsaurus.tech/docs/en/user-guide/query-tracker/about) article. Its source is stored in the [en/user-guide/query-tracker/about.md](https://github.com/ytsaurus/ytsaurus/edit/main/yt/docs/en/user-guide/query-tracker/about.md) file:
 
 ```
 |-- ytsaurus/yt/docs
     |-- en/
         |-- user-guide/             # The original folder.
-            |-- query-tracker.md    
-        |-- dynamic-tables/  
+            |-- query-tracker/
+                |-- about.md
+        |-- dynamic-tables/
             |-- dyn-query-language.md
         |-- _includes/              # The "_includes" folder, where the shared content is stored.
-           |-- user-guide/
-               |-- query-tracker.md 
-           |-- dynamic-tables/  
-               |-- dyn-query-language.md
-                   
-```
-
-Text of this article is included from the `en/_includes/user-guide/query-tracker.md` file:
+            |-- user-guide/
+                |-- query-tracker/
+                    |-- about.md
+            |-- dynamic-tables/
+                |-- dyn-query-language.md
 
 ```
-{% include [Query Tracker](../_includes/user-guide/query-tracker.md) %}
+
+Text of this article is included from the `en/_includes/user-guide/query-tracker/about.md` file:
+
+```
+{% include [Query Tracker](../../_includes/user-guide/query-tracker/about.md) %}
 ```
 
-Now, open the [en/_includes/user-guide/query-tracker.md](https://github.com/ytsaurus/ytsaurus/edit/main/yt/docs/en/_includes/user-guide/query-tracker.md) file. There, you can find the link to the "YT Query Language" article:
+Now, open the [en/_includes/user-guide/query-tracker/about.md](https://github.com/ytsaurus/ytsaurus/edit/main/yt/docs/en/_includes/user-guide/query-tracker/about.md) file. There, you can find the link to the "YT Query Language" article:
 
 ```
 Currently supported execution engines:
-+ [YT QL](../../user-guide/dynamic-tables/dyn-query-language.md).
++ [YT QL](../../../user-guide/dynamic-tables/dyn-query-language.md).
 ```
 
 Note the following:
-- The "YT QL" link path is set relativelly to the `query-tracker.md` document located in `_includes` folder (see the `../../` operands in a link path).
+
+- The "YT QL" link path is set relativelly to the `about.md` document located in `_includes` folder (see the `../../../` operands in a link path).
 - If you open the [en/user-guide/dynamic-tables/dyn-query-language.md](https://github.com/ytsaurus/ytsaurus/edit/main/yt/docs/en/user-guide/dynamic-tables/dyn-query-language.md), you will see that this article reuses content as well. Though, the "YT QL" link refers to the original `dyn-query-language.md` file that located in `en/user-guide/dynamic-tables/` folder, but not to the `en/_includes/user-guide/dynamic-tables/dyn-query-language.md`.
 
 > If you encounter issues with cross-link usage, feel free to ask questions in YTsaurus [community chat](#need-help).

--- a/yt/docs/en/_includes/user-guide/data-processing/spyt/cluster/livy.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/spyt/cluster/livy.md
@@ -1,6 +1,6 @@
 # Livy server
 
-Starting with version 1.74.0, SPYT comes with [Livy](https://livy.apache.org/), a service that allows communication between the client and a Spark cluster over a REST interface. The [Query tracker](../../../../../user-guide/query-tracker.md) module uses this functionality to execute Spark SQL queries in {{product-name}}.
+Starting with version 1.74.0, SPYT comes with [Livy](https://livy.apache.org/), a service that allows communication between the client and a Spark cluster over a REST interface. The [Query tracker](../../../../../user-guide/query-tracker/about.md) module uses this functionality to execute Spark SQL queries in {{product-name}}.
 
 The Livy distribution is already included in the release image of SPYT and can be found on the {{product-name}} cluster at the path `//home/spark/livy/livy.tgz`.
 

--- a/yt/docs/en/_includes/user-guide/data-processing/spyt/spark-sql.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/spyt/spark-sql.md
@@ -1,6 +1,6 @@
 # Spark SQL
 
-You can work with {{product-name}} tables from [Spark SQL](https://spark.apache.org/docs/latest/sql-ref-syntax.html). This SQL dialect is used for queries in [Query Tracker](../../../../user-guide/query-tracker.md) using SPYT.
+You can work with {{product-name}} tables from [Spark SQL](https://spark.apache.org/docs/latest/sql-ref-syntax.html). This SQL dialect is used for queries in [Query Tracker](../../../../user-guide/query-tracker/about.md) using SPYT.
 
 When working with {{product-name}}, `yt` is used as a database ID, and `ytTable:/` is used as a file system. The latter can be omitted, so the below pair of queries is equivalent:
 

--- a/yt/docs/en/_includes/user-guide/query-tracker/about.md
+++ b/yt/docs/en/_includes/user-guide/query-tracker/about.md
@@ -19,13 +19,13 @@ In this way, you can process data using different languages and runtime environm
 
 Currently supported execution engines include:
 
-+ [YT QL](../../user-guide/dynamic-tables/dyn-query-language.md)
++ [YT QL](../../../user-guide/dynamic-tables/dyn-query-language.md)
    + A query language built in YT. Only supports dynamic tables.
-+ [YQL](../../yql/index.md)
++ [YQL](../../../yql/index.md)
    + Executes the query on YQL agents, which break the query into individual YT operations (map, reduce, ...), start them, then retrieve and return the result.
-+ [CHYT](../../user-guide/data-processing/chyt/about-chyt.md)
++ [CHYT](../../../user-guide/data-processing/chyt/about-chyt.md)
    + Executes the query on a clique.
-+ [SPYT](../../user-guide/data-processing/spyt/overview.md)
++ [SPYT](../../../user-guide/data-processing/spyt/overview.md)
    + Executes the query on the Spark cluster.
 
 ## API {#api}
@@ -45,8 +45,8 @@ Optional parameters:
 
 + `files`: List of files for the query in YSON format.
 + `settings`: Additional query parameters in YSON format.
-   + For [CHYT](../../user-guide/data-processing/chyt/about-chyt.md), you must set a clique alias using the `clique` parameter. Default value is the public clique.
-   + For [SPYT](../../user-guide/data-processing/spyt/overview.md), you must set the housekeeping directory of an existing Spark cluster using the `discovery_path` parameter.
+   + For [CHYT](../../../user-guide/data-processing/chyt/about-chyt.md), you must set a clique alias using the `clique` parameter. Default value is the public clique.
+   + For [SPYT](../../../user-guide/data-processing/spyt/overview.md), you must set the housekeeping directory of an existing Spark cluster using the `discovery_path` parameter.
 + `draft`: Used to mark draft queries. These queries are terminated automatically without execution.
 + `annotations`: Arbitrary annotations to the query. They can make it easier to search for queries. Specified in YSON format.
 + `access_control_object`: Name of the object at `//sys/access_control_object_namespaces/queries/` that controls access to the query for other users.
@@ -148,9 +148,9 @@ Example: `alter_query(query_id="my_query_id", access_control_object="my_new_aco"
 
 To manage access to queries and their results, the query can store an optional `access_control_object` string that points to `//sys/access_control_object_namespaces/queries/[access_control_object]`.
 
-An Access Control Object (ACO) is an object with the `@principal_acl` attribute. It sets access rules in the same manner as `@acl` does for Cypress nodes. For more information, see [Access control](../../user-guide/storage/access-control.md).
+An Access Control Object (ACO) is an object with the `@principal_acl` attribute. It sets access rules in the same manner as `@acl` does for Cypress nodes. For more information, see [Access control](../../../user-guide/storage/access-control.md).
 
-You can create an ACO through the user interface or by calling the [create](../../user-guide/storage/cypress-example.md#create) command:
+You can create an ACO through the user interface or by calling the [create](../../../user-guide/storage/cypress-example.md#create) command:
 
 `yt create access_control_object --attr '{namespace=queries;name=my_aco}'`.
 

--- a/yt/docs/en/toc.yaml
+++ b/yt/docs/en/toc.yaml
@@ -356,7 +356,9 @@ items:
              href: user-guide/excel.md
        - name: Query Tracker
          when: audience == "public"
-         href: user-guide/query-tracker.md
+         items:
+           - name: Overview
+             href: user-guide/query-tracker/about.md
        - name: Jupyter Notebooks
          when: audience == "public"
          href: user-guide/jupyt.md

--- a/yt/docs/en/user-guide/query-tracker.md
+++ b/yt/docs/en/user-guide/query-tracker.md
@@ -1,1 +1,0 @@
-{% include [Query Tracker](../_includes/user-guide/query-tracker.md) %}

--- a/yt/docs/en/user-guide/query-tracker/about.md
+++ b/yt/docs/en/user-guide/query-tracker/about.md
@@ -1,0 +1,1 @@
+{% include [Query Tracker](../../_includes/user-guide/query-tracker/about.md) %}

--- a/yt/docs/ru/_includes/user-guide/data-processing/spyt/cluster/livy.md
+++ b/yt/docs/ru/_includes/user-guide/data-processing/spyt/cluster/livy.md
@@ -1,6 +1,6 @@
 # Livy сервер
 
-Начиная с версии 1.74.0 в SPYT доступен сервис [Livy](https://livy.apache.org/), который позволяет осуществлять общение между клиентом и Spark кластером через REST интерфейс. Этот функционал используется в модуле [Query tracker](../../../../../user-guide/query-tracker.md) для выполнения Spark SQL запросов в {{product-name}}.
+Начиная с версии 1.74.0 в SPYT доступен сервис [Livy](https://livy.apache.org/), который позволяет осуществлять общение между клиентом и Spark кластером через REST интерфейс. Этот функционал используется в модуле [Query tracker](../../../../../user-guide/query-tracker/about.md) для выполнения Spark SQL запросов в {{product-name}}.
 
 Дистрибутив Livy уже включен в релизный образ SPYT и помещается на кластер {{product-name}} по пути `//home/spark/livy/livy.tgz`.
 

--- a/yt/docs/ru/_includes/user-guide/data-processing/spyt/spark-sql.md
+++ b/yt/docs/ru/_includes/user-guide/data-processing/spyt/spark-sql.md
@@ -1,6 +1,6 @@
 # Spark SQL
 
-С таблицами {{product-name}} возможно работать из [Spark SQL](https://spark.apache.org/docs/latest/sql-ref-syntax.html). Этот диалект SQL используется для запросов в [Query tracker](../../../../user-guide/query-tracker.md) с использованием SPYT.
+С таблицами {{product-name}} возможно работать из [Spark SQL](https://spark.apache.org/docs/latest/sql-ref-syntax.html). Этот диалект SQL используется для запросов в [Query tracker](../../../../user-guide/query-tracker/about.md) с использованием SPYT.
 
 При работе с {{product-name}} в качестве идентификатора базы данных используется `yt`, а в качестве файловой системы — `ytTable:/`. Второе можно опускать, поэтому приведенная пара запросов эквивалентна:
 

--- a/yt/docs/ru/_includes/user-guide/query-tracker/about.md
+++ b/yt/docs/ru/_includes/user-guide/query-tracker/about.md
@@ -20,13 +20,13 @@ Query tracker позволяет:
 
 На текущий момент поддерживаются следующие движки исполнения:
 
-+ [YT QL](../../user-guide/dynamic-tables/dyn-query-language.md)
++ [YT QL](../../../user-guide/dynamic-tables/dyn-query-language.md)
   + Встроенный в YT язык запросов. Поддерживает только динамические таблицы.
-+ [YQL](../../yql/index.md)
++ [YQL](../../../yql/index.md)
   + Запрос исполняется в YQL агентах. Они разбивают запрос в YT операции (map, reduce, ...), запускают их, собирают и возвращают результат.
-+ [CHYT](../../user-guide/data-processing/chyt/about-chyt.md)
++ [CHYT](../../../user-guide/data-processing/chyt/about-chyt.md)
   + Запрос исполняется в клике.
-+ [SPYT](../../user-guide/data-processing/spyt/overview.md)
++ [SPYT](../../../user-guide/data-processing/spyt/overview.md)
   + Запрос исполняется в Spark кластере.
 
 ## API {#api}
@@ -46,8 +46,8 @@ Query tracker позволяет:
 
 + `files` — список файлов для запроса в формате YSON.
 + `settings` — дополнительные параметры для запроса в формате YSON.
-  + В [CHYT](../../user-guide/data-processing/chyt/about-chyt.md) необходимо указывать параметр `clique` — алиас клики. По умолчанию используется публичная клика.
-  + В [SPYT](../../user-guide/data-processing/spyt/overview.md) необходимо указывать параметр `discovery_path` — директория для служебных данных существующего кластера Spark.
+  + В [CHYT](../../../user-guide/data-processing/chyt/about-chyt.md) необходимо указывать параметр `clique` — алиас клики. По умолчанию используется публичная клика.
+  + В [SPYT](../../../user-guide/data-processing/spyt/overview.md) необходимо указывать параметр `discovery_path` — директория для служебных данных существующего кластера Spark.
 + `draft` — является ли запрос черновиком. Такие запросы завершаются автоматически без исполнения.
 + `annotations` — произвольные аннотации к запросу. Позволяют осуществлять удобный поиск по запросам. В формате YSON.
 + `access_control_objects` — список объектов в `//sys/access_control_object_namespaces/queries/`, который определяет доступ к запросу для других пользователей.
@@ -149,9 +149,9 @@ Query tracker позволяет:
 
 Для управления доступом к запросам и их результатам, в запрос сохраняется список строк `access_control_objects`, которые указывают на `//sys/access_control_object_namespaces/queries/[access_control_object]`.
 
-Access Control Object (ACO) — это объект с атрибутом `@principal_acl`, который задаёт правила доступа тем же способом, что и `@acl` для нод Кипариса. Подробнее можно почитать в разделе [Контроль доступа](../../user-guide/storage/access-control.md).
+Access Control Object (ACO) — это объект с атрибутом `@principal_acl`, который задаёт правила доступа тем же способом, что и `@acl` для нод Кипариса. Подробнее можно почитать в разделе [Контроль доступа](../../../user-guide/storage/access-control.md).
 
-Создание ACO возможно через пользовательский интерфейс, либо с помощью вызова команды [create](../../user-guide/storage/cypress-example.md#create):
+Создание ACO возможно через пользовательский интерфейс, либо с помощью вызова команды [create](../../../user-guide/storage/cypress-example.md#create):
 
 `yt create access_control_object --attr '{namespace=queries;name=my_aco}'`.
 

--- a/yt/docs/ru/toc.yaml
+++ b/yt/docs/ru/toc.yaml
@@ -369,7 +369,9 @@ items:
             href: user-guide/excel.md
       - name: Query tracker
         when: audience == "public"
-        href: user-guide/query-tracker.md
+        items:
+          - name: Обзор
+            href: user-guide/query-tracker/about.md
       - name: Работа с Jupyter Notebooks
         when: audience == "public"
         href: user-guide/jupyt.md

--- a/yt/docs/ru/user-guide/query-tracker.md
+++ b/yt/docs/ru/user-guide/query-tracker.md
@@ -1,1 +1,0 @@
-{% include [Query Tracker](../_includes/user-guide/query-tracker.md) %}

--- a/yt/docs/ru/user-guide/query-tracker/about.md
+++ b/yt/docs/ru/user-guide/query-tracker/about.md
@@ -1,0 +1,1 @@
+{% include [Query Tracker](../../_includes/user-guide/query-tracker/about.md) %}


### PR DESCRIPTION
This is needed for growing documentation about query tracker. DQ and Python UDF articles will be added to this section

Checked locally. All as expected