### PR TITLE
Disable DQ engine for query_tracker_yql_liveness odin check

### DIFF
--- a/yt/odin/checks/bin/query_tracker_yql_liveness/__main__.py
+++ b/yt/odin/checks/bin/query_tracker_yql_liveness/__main__.py
@@ -21,7 +21,7 @@ def run_check(yt_client, logger, options, states):
         states,
         soft_timeout,
         "yql",
-        "select x + 1 as result from `{table}`",
+        "pragma DqEngine = 'disable'; select x + 1 as result from `{table}`;",
         Data(SCHEMA, SOURCE_DATA, RESULT_DATA),
     )
 


### PR DESCRIPTION
With DQ enabled this odin check tests DQ only

I saw a situation (with custom QT and YQLA) where DQ works, but YQL doesn't

Let's explicitly disable DQ in `yql liveness check` and maybe introduce `dq liveness check` later