### PR TITLE
MultiExecutorCallback to monitor MultiExecutor progress

### DIFF
--- a/yt/java/ytsaurus-client/src/main/java/tech/ytsaurus/client/MultiExecutorCallback.java
+++ b/yt/java/ytsaurus-client/src/main/java/tech/ytsaurus/client/MultiExecutorCallback.java
@@ -1,0 +1,44 @@
+package tech.ytsaurus.client;
+
+import java.time.Duration;
+
+public interface MultiExecutorCallback {
+    /**
+     * Report successful request execution.
+     *
+     * @param clusterName cluster which was first to respond successfully
+     * @param time        that was spent to execute request
+     */
+    void reportRequestSuccess(String clusterName, Duration time);
+
+    /**
+     * Report failed request execution.
+     *
+     * @param time spent to poll all clusters and fail
+     */
+    void reportRequestFailure(Duration time);
+
+    /**
+     * Report that specific cluster has failed to process the request.
+     *
+     * @param clusterName cluster which has failed
+     * @param time        time within which exactly this one hedging request has failed
+     */
+    void reportRequestHedgingFailure(String clusterName, Duration time);
+}
+
+class NoopMultiExecutorCallback implements MultiExecutorCallback {
+
+    @Override
+    public void reportRequestSuccess(String clusterName, Duration time) {
+    }
+
+    @Override
+    public void reportRequestFailure(Duration time) {
+    }
+
+    @Override
+    public void reportRequestHedgingFailure(String clusterName, Duration time) {
+    }
+
+}

--- a/yt/java/ytsaurus-client/src/main/java/tech/ytsaurus/client/MultiExecutorMonitoring.java
+++ b/yt/java/ytsaurus-client/src/main/java/tech/ytsaurus/client/MultiExecutorMonitoring.java
@@ -2,7 +2,7 @@ package tech.ytsaurus.client;
 
 import java.time.Duration;
 
-public interface MultiExecutorCallback {
+public interface MultiExecutorMonitoring {
     /**
      * Report successful request execution.
      *
@@ -27,7 +27,7 @@ public interface MultiExecutorCallback {
     void reportRequestHedgingFailure(String clusterName, Duration time);
 }
 
-class NoopMultiExecutorCallback implements MultiExecutorCallback {
+class NoopMultiExecutorCallback implements MultiExecutorMonitoring {
 
     @Override
     public void reportRequestSuccess(String clusterName, Duration time) {

--- a/yt/java/ytsaurus-client/src/main/java/tech/ytsaurus/client/MultiExecutorMonitoring.java
+++ b/yt/java/ytsaurus-client/src/main/java/tech/ytsaurus/client/MultiExecutorMonitoring.java
@@ -27,7 +27,7 @@ public interface MultiExecutorMonitoring {
     void reportRequestHedgingFailure(String clusterName, Duration time);
 }
 
-class NoopMultiExecutorCallback implements MultiExecutorMonitoring {
+class NoopMultiExecutorMonitoring implements MultiExecutorMonitoring {
 
     @Override
     public void reportRequestSuccess(String clusterName, Duration time) {


### PR DESCRIPTION
For metrics and monitoring it is really important to follow hedging client execution, so it would be evident which clusters fail. I suggest the following API to extend current MultiYtClient functionality