### PR TITLE
yt-local: fix tls

### DIFF
--- a/yt/python/yt/environment/tls_helpers.py
+++ b/yt/python/yt/environment/tls_helpers.py
@@ -4,8 +4,11 @@ import tempfile
 
 
 def openssl_binary():
-    from yt.environment.arcadia_interop import search_binary_path
-    return search_binary_path("openssl")
+    try:
+        from yt.environment.arcadia_interop import search_binary_path
+        return search_binary_path("openssl")
+    except ImportError:
+        return "openssl"
 
 
 def create_ca(ca_cert, ca_cert_key, subj="/CN=Fake CA", key_type="rsa:2048"):


### PR DESCRIPTION
2024-08-29 12:16:59,659 INFO Preparing certificates
Traceback (most recent call last):
  File "yt/python/yt/wrapper/cli_helpers.py", line 73, in run_main
    main_func()
  File "__main__.py", line 321, in main
    args.func(**func_args)
  File "__main__.py", line 108, in start_func
    environment = start(**kwargs)
                  ^^^^^^^^^^^^^^^
  File "yt/python/yt/local/commands.py", line 285, in start
    environment = YTInstance(
                  ^^^^^^^^^^^
  File "yt/python/yt/environment/yt_env.py", line 293, in __init__
    self._prepare_builtin_environment(
  File "yt/python/yt/environment/yt_env.py", line 449, in _prepare_builtin_environment
    self._prepare_certificates()
  File "yt/python/yt/environment/yt_env.py", line 389, in _prepare_certificates
    create_ca(ca_cert=self.yt_config.ca_cert, ca_cert_key=self.yt_config.ca_cert_key)
  File "yt/python/yt/environment/tls_helpers.py", line 19, in create_ca
    openssl_binary(), "req", "-batch", "-x509", "-config", cfg.name,
    ^^^^^^^^^^^^^^^^
  File "yt/python/yt/environment/tls_helpers.py", line 7, in openssl_binary
    from yt.environment.arcadia_interop import search_binary_path
ModuleNotFoundError: No module named 'yt.environment.arcadia_interop'
