### PR TITLE
yt-local: look at file name extension for http-proxy config

### DIFF
--- a/yt/python/yt/local/commands.py
+++ b/yt/python/yt/local/commands.py
@@ -43,7 +43,7 @@ def _load_config(config, is_proxy_config=False):
 
     path = config
     with open(path, "rb") as fin:
-        if not is_proxy_config:
+        if not is_proxy_config or os.path.splitext(path)[1] == ".yson":
             return yson.load(fin)
         else:
             return json.load(codecs.getreader("utf-8")(fin))


### PR DESCRIPTION
Historically it was in json format.
