### PR TITLE
Disable FullResultWrite in DQ by default

### DIFF
--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -93,7 +93,7 @@ constexpr auto DefaultDqGatewaySettings = std::to_array<std::pair<TStringBuf, TS
     {"MaxTasksPerOperation", "100"},
     {"MaxTasksPerStage", "30"},
     {"AnalyzeQuery", "true"},
-    {"EnableFullResultWrite", "true"},
+    {"EnableFullResultWrite", "false"},
     {"_FallbackOnRuntimeErrors", "DQ computation exceeds the memory limit,requirement data.GetRaw().size(),_Unwind_Resume,Cannot load time zone"},
     {"MemoryLimit", "3G"},
     {"_EnablePrecompute", "1"},


### PR DESCRIPTION
We see that queries fail sometimes with this setting enabled with an error:
```
{
    "code": 500,
    "message": "Error resolving path //tmp/yql/aleksandr.gaev/910caf6a-9a0b2b92-dd29139a-b1f3f662/@dynamic",
    "attributes": {
        "host": "",
        "pid": 1,
        "tid": 4244328785370468400,
        "thread": "Automaton",
        "fid": 18444399962781655000,
        "datetime": "2024-09-02T08:38:22.326511Z",
        "trace_id": "db6092f9-69f2f06e-9ce9cd4d-7333e9cc",
        "span_id": 6913744420665213000,
        "method": "Get"
    },
    "inner_errors": [
        {
            "code": 500,
            "message": "Node //tmp/yql has no child with key \"aleksandr.gaev\"",
            "attributes": {
                "host": "",
                "pid": 1,
                "tid": 4244328785370468400,
                "thread": "Automaton",
                "fid": 18444399962781655000,
                "datetime": "2024-09-02T08:38:22.326487Z",
                "trace_id": "db6092f9-69f2f06e-9ce9cd4d-7333e9cc",
                "span_id": 6913744420665213000
            }
        }
    ]
}
```

Somehow DQ says that result should be in a table and never creates it.

Somehow it is flaky. Resending query multiple times fixes it, although logs for the query are the same except pulling the result part.