### PR TITLE
Add whoami method to Go SDK

### DIFF
--- a/yt/go/yt/integration/auth_client_test.go
+++ b/yt/go/yt/integration/auth_client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"go.ytsaurus.tech/yt/go/yt/ythttp"
 	"os"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yt/ythttp"
 )
 
 func TestAuthClient(t *testing.T) {

--- a/yt/go/yt/integration/auth_client_test.go
+++ b/yt/go/yt/integration/auth_client_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"go.ytsaurus.tech/yt/go/yt/ythttp"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,6 +21,7 @@ func TestAuthClient(t *testing.T) {
 	suite.RunClientTests(t, []ClientTest{
 		{Name: "SetUserPassword", Test: suite.TestSetUserPassword, SkipRPC: true},
 		{Name: "IssueListRevokeToken", Test: suite.TestIssueListRevokeToken, SkipRPC: true},
+		{Name: "WhoAmI", Test: suite.TestWhoAmI, SkipRPC: true},
 	})
 }
 
@@ -63,6 +66,22 @@ func (s *Suite) TestIssueListRevokeToken(ctx context.Context, t *testing.T, yc y
 	tokens, err = yc.ListUserTokens(ctx, user, "", nil)
 	require.NoError(t, err)
 	require.Empty(t, tokens)
+}
+
+func (s *Suite) TestWhoAmI(ctx context.Context, t *testing.T, yc yt.Client) {
+	user := "user-" + guid.New().String()
+	_ = s.CreateUser(ctx, t, user)
+	token, err := yc.IssueToken(ctx, user, "", nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	userClient, err := ythttp.NewClient(&yt.Config{Proxy: os.Getenv("YT_PROXY"), Logger: s.Env.L, Token: token})
+	require.NoError(t, err)
+	res, err := userClient.WhoAmI(ctx, nil)
+	require.NoError(t, err)
+
+	// TODO(wilwell) Remove "root" from the acceptable options. It's either "root" if auth is disabled, or user otherwise.
+	require.Contains(t, []string{"root", user}, res.Login)
 }
 
 func encodeSHA256(input string) string {

--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -660,6 +660,12 @@ type OperationResult struct {
 	Error *yterrors.Error `yson:"error"`
 }
 
+type WhoAmIResult struct {
+	Login     string `json:"login"`
+	Realm     string `json:"realm"`
+	CSRFToken string `json:"csrf_token"`
+}
+
 type OperationRuntimeParameters struct {
 	ACL                          []ACE          `yson:"acl"`
 	SchedulingOptionsPerPoolTree map[string]any `yson:"scheduling_options_per_pool_tree"`
@@ -819,6 +825,8 @@ type IssueTokenOptions struct{}
 type RevokeTokenOptions struct{}
 
 type ListUserTokensOptions struct{}
+
+type WhoAmIOptions struct{}
 
 type AddMaintenanceOptions struct {
 }
@@ -1682,6 +1690,12 @@ type AuthClient interface {
 		password string,
 		options *ListUserTokensOptions,
 	) (tokens []string, err error)
+
+	// http:verb:"whoami"
+	WhoAmI(
+		ctx context.Context,
+		options *WhoAmIOptions,
+	) (r *WhoAmIResult, err error)
 }
 
 type Client interface {

--- a/yt/go/yt/internal/call.go
+++ b/yt/go/yt/internal/call.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 
 	"go.ytsaurus.tech/library/go/core/log"
+
 	"go.ytsaurus.tech/yt/go/guid"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yson"
@@ -59,7 +60,7 @@ func (res *CallResult) decode(value any) (err error) {
 }
 
 func (res *CallResult) decodeJSON(value any) (err error) {
-	// YSONValue contains the body of the response, it's not necessary YSON format, e.g. for whoami request
+	// YSONValue contains the body of the response, it's not necessary YSON format, e.g. for whoami request.
 	err = json.Unmarshal(res.YSONValue, value)
 	return
 }

--- a/yt/go/yt/internal/call.go
+++ b/yt/go/yt/internal/call.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/cenkalti/backoff/v4"
@@ -23,8 +24,9 @@ type Params interface {
 }
 
 type Call struct {
-	Params Params
-	CallID guid.GUID
+	Params  Params
+	CallID  guid.GUID
+	APIPath string
 
 	YSONValue    []byte
 	RowBatch     yt.RowBatch
@@ -53,6 +55,11 @@ func (res *CallResult) decodeValue(value any) (err error) {
 
 func (res *CallResult) decode(value any) (err error) {
 	err = yson.Unmarshal(res.YSONValue, value)
+	return
+}
+
+func (res *CallResult) decodeJSON(value any) (err error) {
+	err = json.Unmarshal(res.YSONValue, value)
 	return
 }
 

--- a/yt/go/yt/internal/call.go
+++ b/yt/go/yt/internal/call.go
@@ -59,6 +59,7 @@ func (res *CallResult) decode(value any) (err error) {
 }
 
 func (res *CallResult) decodeJSON(value any) (err error) {
+	// YSONValue contains the body of the response, it's not necessary YSON format, e.g. for whoami request
 	err = json.Unmarshal(res.YSONValue, value)
 	return
 }

--- a/yt/go/yt/internal/encoder.go
+++ b/yt/go/yt/internal/encoder.go
@@ -28,6 +28,15 @@ type Encoder struct {
 func (e *Encoder) newCall(p Params) *Call {
 	call := e.StartCall()
 	call.Params = p
+	call.APIPath = "/api/v4/"
+	call.CallID = guid.New()
+	return call
+}
+
+func (e *Encoder) newAuthCall(p Params) *Call {
+	call := e.StartCall()
+	call.Params = p
+	call.APIPath = "/auth/"
 	call.CallID = guid.New()
 	return call
 }
@@ -242,6 +251,17 @@ func (e *Encoder) RemoveMember(
 	call := e.newCall(NewRemoveMemberParams(group, member, options))
 	err = e.do(ctx, call, func(res *CallResult) error {
 		return nil
+	})
+	return
+}
+
+func (e *Encoder) WhoAmI(
+	ctx context.Context,
+	options *yt.WhoAmIOptions,
+) (result *yt.WhoAmIResult, err error) {
+	call := e.newAuthCall(NewWhoAmIParams(options))
+	err = e.do(ctx, call, func(res *CallResult) error {
+		return res.decodeJSON(&result)
 	})
 	return
 }

--- a/yt/go/yt/internal/encoder.go
+++ b/yt/go/yt/internal/encoder.go
@@ -261,6 +261,7 @@ func (e *Encoder) WhoAmI(
 ) (result *yt.WhoAmIResult, err error) {
 	call := e.newAuthCall(NewWhoAmIParams(options))
 	err = e.do(ctx, call, func(res *CallResult) error {
+		// The whoami method returns JSON value, not YSON, so we need to specify the decoding.
 		return res.decodeJSON(&result)
 	})
 	return

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -210,7 +210,7 @@ func (c *httpClient) newHTTPRequest(ctx context.Context, call *internal.Call, bo
 	}
 
 	verb := call.Params.HTTPVerb()
-	req, err = http.NewRequest(verb.HTTPMethod(), c.schema()+"://"+address+"/api/v4/"+verb.String(), body)
+	req, err = http.NewRequest(verb.HTTPMethod(), c.schema()+"://"+address+call.APIPath+verb.String(), body)
 	if err != nil {
 		return
 	}

--- a/yt/go/yt/internal/params_gen.go
+++ b/yt/go/yt/internal/params_gen.go
@@ -707,6 +707,12 @@ func writeListUserTokensOptions(w *yson.Writer, o *yt.ListUserTokensOptions) {
 	}
 }
 
+func writeWhoAmIOptions(w *yson.Writer, o *yt.WhoAmIOptions) {
+	if o == nil {
+		return
+	}
+}
+
 func writeAddMaintenanceOptions(w *yson.Writer, o *yt.AddMaintenanceOptions) {
 	if o == nil {
 		return
@@ -920,6 +926,12 @@ func writeAlterTableReplicaOptions(w *yson.Writer, o *yt.AlterTableReplicaOption
 	if o.Mode != nil {
 		w.MapKeyString("mode")
 		w.Any(o.Mode)
+	}
+}
+
+func writeAttachTxOptions(w *yson.Writer, o *yt.AttachTxOptions) {
+	if o == nil {
+		return
 	}
 }
 
@@ -3884,9 +3896,9 @@ func (p *DeleteRowsParams) TransactionOptions() **yt.TransactionOptions {
 type PushQueueProducerParams struct {
 	verb         Verb
 	producerPath ypath.Path
-	queuePath ypath.Path
-	sessionID string
-	epoch     int64
+	queuePath    ypath.Path
+	sessionID    string
+	epoch        int64
 	options      *yt.PushQueueProducerOptions
 }
 
@@ -3945,9 +3957,9 @@ func (p *PushQueueProducerParams) TransactionOptions() **yt.TransactionOptions {
 type CreateQueueProducerSessionParams struct {
 	verb         Verb
 	producerPath ypath.Path
-	queuePath ypath.Path
-	sessionID string
-	options   *yt.CreateQueueProducerSessionOptions
+	queuePath    ypath.Path
+	sessionID    string
+	options      *yt.CreateQueueProducerSessionOptions
 }
 
 func NewCreateQueueProducerSessionParams(
@@ -4000,9 +4012,9 @@ func (p *CreateQueueProducerSessionParams) TimeoutOptions() **yt.TimeoutOptions 
 type RemoveQueueProducerSessionParams struct {
 	verb         Verb
 	producerPath ypath.Path
-	queuePath ypath.Path
-	sessionID string
-	options   *yt.RemoveQueueProducerSessionOptions
+	queuePath    ypath.Path
+	sessionID    string
+	options      *yt.RemoveQueueProducerSessionOptions
 }
 
 func NewRemoveQueueProducerSessionParams(
@@ -5004,6 +5016,38 @@ func (p *ListUserTokensParams) MarshalHTTP(w *yson.Writer) {
 	w.MapKeyString("password_sha256")
 	w.Any(p.password)
 	writeListUserTokensOptions(w, p.options)
+}
+
+type WhoAmIParams struct {
+	verb    Verb
+	options *yt.WhoAmIOptions
+}
+
+func NewWhoAmIParams(
+	options *yt.WhoAmIOptions,
+) *WhoAmIParams {
+	if options == nil {
+		options = &yt.WhoAmIOptions{}
+	}
+	optionsCopy := *options
+	return &WhoAmIParams{
+		Verb("whoami"),
+		&optionsCopy,
+	}
+}
+
+func (p *WhoAmIParams) HTTPVerb() Verb {
+	return p.verb
+}
+func (p *WhoAmIParams) YPath() (ypath.YPath, bool) {
+	return nil, false
+}
+func (p *WhoAmIParams) Log() []log.Field {
+	return []log.Field{}
+}
+
+func (p *WhoAmIParams) MarshalHTTP(w *yson.Writer) {
+	writeWhoAmIOptions(w, p.options)
 }
 
 type GenerateTimestampParams struct {

--- a/yt/go/yt/internal/rpcclient/encoder.go
+++ b/yt/go/yt/internal/rpcclient/encoder.go
@@ -1315,6 +1315,13 @@ func (e *Encoder) ListUserTokens(
 	return nil, xerrors.Errorf("Unimplemented method: ListUserTokens")
 }
 
+func (e *Encoder) WhoAmI(
+	ctx context.Context,
+	opts *yt.WhoAmIOptions,
+) (r *yt.WhoAmIResult, err error) {
+	return nil, xerrors.Errorf("Unimplemented method: WhoAmI")
+}
+
 func (e *Encoder) RemoveMember(
 	ctx context.Context,
 	group string,


### PR DESCRIPTION
Add method `whoami` added to the Go SDK functionality. 

To invoke the method user only need to create a client with correct credentials (Cookie or Token for example). Unlike other yt methods, `whoami `response is JSON not YSON, and uses another handler path: `/auth/` instead of `api/v4`.

Right now the *testing* docker container of YT doesn't support the authentication, so for every request `whoami` we are getting `root` response. When the testing docker container will be fixed, the auth test also could be fixed.


Closes #760 