### PR TITLE
Increase default rate_limit for caching_object_service

### DIFF
--- a/yt/yt/ytlib/object_client/config.cpp
+++ b/yt/yt/ytlib/object_client/config.cpp
@@ -73,8 +73,13 @@ void TObjectServiceCacheDynamicConfig::Register(TRegistrar registrar)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void TCachingObjectServiceConfig::Register(TRegistrar /*registrar*/)
-{ }
+void TCachingObjectServiceConfig::Register(TRegistrar registrar)
+{
+    registrar.Preprocessor([] (TThis* config) {
+        // The default value of 10 is too low for most caching object service instances.
+        config->RateLimit = 1000;
+    });
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The current default of 10 is impractical for master caches. For example, we make 16 * 16 requests to Cypress when listing operations, which would take 30 seconds to complete with this rate limit. We increase it to 1000, which is more commonly used for production YT installations. 