### PR TITLE
Improve/fix rowlet size estimation for operations archive

### DIFF
--- a/yt/yt/server/lib/misc/estimate_size_helpers-inl.h
+++ b/yt/yt/server/lib/misc/estimate_size_helpers-inl.h
@@ -8,10 +8,35 @@ namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+template <typename I>
+    requires std::integral<I>
+size_t EstimateSize(const I& /*value*/)
+{
+    return EstimatedValueSize;
+}
+
+template <typename F>
+    requires std::floating_point<F>
+size_t EstimateSize(const F& /*value*/)
+{
+    return EstimatedValueSize * 2;
+}
+
 template <typename T>
 size_t EstimateSize(const std::optional<T>& v)
 {
     return v ? EstimateSize(*v) : 0;
+}
+
+template <typename C>
+    requires std::ranges::range<C>
+size_t EstimateSize(const C& value)
+{
+    size_t result = EstimatedValueSize;
+    for (const auto& elem : value) {
+        result += EstimateSize(elem);
+    }
+    return result;
 }
 
 template <typename E>

--- a/yt/yt/server/lib/misc/estimate_size_helpers.cpp
+++ b/yt/yt/server/lib/misc/estimate_size_helpers.cpp
@@ -7,6 +7,11 @@ namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+size_t EstimateSize(const std::string& value)
+{
+    return EstimatedValueSize + value.size();
+}
+
 size_t EstimateSize(const TString& value)
 {
     return EstimatedValueSize + value.size();
@@ -30,6 +35,21 @@ size_t EstimateSize(TGuid value)
 size_t EstimateSize(TInstant /*value*/)
 {
     return EstimatedValueSize;
+}
+
+size_t EstimateSize(TDuration /*value*/)
+{
+    return EstimatedValueSize;
+}
+
+size_t EstimateSize(double /*value*/)
+{
+    return EstimatedValueSize * 2;
+}
+
+size_t EstimateSize(const ::google::protobuf::Message& value)
+{
+    return value.ByteSizeLong();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/misc/estimate_size_helpers.cpp
+++ b/yt/yt/server/lib/misc/estimate_size_helpers.cpp
@@ -22,11 +22,6 @@ size_t EstimateSize(const NYson::TYsonString& value)
     return value ? EstimatedValueSize + value.AsStringBuf().size() : 0;
 }
 
-size_t EstimateSize(i64 /*value*/)
-{
-    return EstimatedValueSize;
-}
-
 size_t EstimateSize(TGuid value)
 {
     return value.IsEmpty() ? 0 : EstimatedValueSize * 2;
@@ -40,11 +35,6 @@ size_t EstimateSize(TInstant /*value*/)
 size_t EstimateSize(TDuration /*value*/)
 {
     return EstimatedValueSize;
-}
-
-size_t EstimateSize(double /*value*/)
-{
-    return EstimatedValueSize * 2;
 }
 
 size_t EstimateSize(const ::google::protobuf::Message& value)

--- a/yt/yt/server/lib/misc/estimate_size_helpers.h
+++ b/yt/yt/server/lib/misc/estimate_size_helpers.h
@@ -4,20 +4,36 @@
 
 #include <yt/yt/core/yson/public.h>
 
+#include <google/protobuf/message.h>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 constexpr size_t EstimatedValueSize = 16;
 
+size_t EstimateSize(const std::string& value);
 size_t EstimateSize(const TString& value);
 size_t EstimateSize(const NYson::TYsonString& value);
-size_t EstimateSize(i64 value);
 size_t EstimateSize(TGuid value);
 size_t EstimateSize(TInstant value);
+size_t EstimateSize(TDuration value);
+size_t EstimateSize(const ::google::protobuf::Message& value);
+
+template <typename I>
+    requires std::integral<I>
+size_t EstimateSize(const I& value);
+
+template <typename F>
+    requires std::floating_point<F>
+size_t EstimateSize(const F& value);
 
 template <typename T>
 size_t EstimateSize(const std::optional<T>& value);
+
+template <typename C>
+    requires std::ranges::range<C>
+size_t EstimateSize(const C& value);
 
 template <typename E>
     requires TEnumTraits<E>::IsEnum

--- a/yt/yt/server/lib/misc/job_report.cpp
+++ b/yt/yt/server/lib/misc/job_report.cpp
@@ -66,24 +66,6 @@ void Serialize(const TJobInterruptionInfo& interruptionInfo, NYson::IYsonConsume
 
 ////////////////////////////////////////////////////////////////////////////////
 
-size_t TJobReport::EstimateSize() const
-{
-    return ::NYT::EstimateSizes(
-        OperationId_.Underlying(),
-        JobId_.Underlying(),
-        Type_,
-        State_,
-        StartTime_,
-        FinishTime_,
-        Error_,
-        Spec_,
-        SpecVersion_,
-        Statistics_,
-        Events_,
-        InterruptionInfo_,
-        Profile_.value_or(NJobAgent::TJobProfile{}).Blob);
-}
-
 TJobReport TJobReport::ExtractSpec() const
 {
     TJobReport copy;

--- a/yt/yt/server/lib/misc/job_report.h
+++ b/yt/yt/server/lib/misc/job_report.h
@@ -70,8 +70,6 @@ void Serialize(const TJobInterruptionInfo& interruptionInfo, NYson::IYsonConsume
 class TJobReport
 {
 public:
-    size_t EstimateSize() const;
-
     TJobReport ExtractSpec() const;
     TJobReport ExtractStderr() const;
     TJobReport ExtractFailContext() const;

--- a/yt/yt/server/lib/misc/job_reporter.cpp
+++ b/yt/yt/server/lib/misc/job_reporter.cpp
@@ -1,6 +1,7 @@
 #include "job_reporter.h"
 
 #include "config.h"
+#include "estimate_size_helpers.h"
 
 #include <yt/yt/server/lib/job_agent/config.h>
 
@@ -74,7 +75,35 @@ public:
 
     size_t EstimateSize() const override
     {
-        return Report_.EstimateSize();
+        return ::NYT::EstimateSizes(
+            Report_.OperationId().Underlying(),
+            Report_.JobId().Underlying(),
+            Report_.State(),
+            Report_.StartTime(),
+            Report_.FinishTime(),
+            TInstant::Now().MicroSeconds(), // UpdateTime.
+            Report_.Address(),
+            Report_.StderrSize(),
+            Report_.HasCompetitors(),
+            Report_.HasProbingCompetitors(),
+            Report_.TaskName(),
+            Report_.TreeId(),
+            Report_.MonitoringDescriptor(),
+            Report_.Type(),
+            Report_.Error(),
+            Report_.InterruptionInfo(),
+            Report_.Statistics(),
+            Report_.Events(),
+            Report_.Spec().has_value(),
+            i64{0}, // FailContextSize.
+            Report_.CoreInfos(),
+            Report_.JobCompetitionId().Underlying(),
+            Report_.ProbingJobCompetitionId().Underlying(),
+            Report_.ExecAttributes(),
+            Report_.JobCookie(),
+            Report_.ControllerState(),
+            Report_.ArchiveFeatures(),
+            Report_.Ttl());
     }
 
     TUnversionedOwningRow ToRow(int archiveVersion) const override
@@ -179,7 +208,9 @@ public:
 
     size_t EstimateSize() const override
     {
-        return Report_.EstimateSize();
+        return ::NYT::EstimateSizes(
+            Report_.OperationId().Underlying(),
+            Report_.JobId().Underlying());
     }
 
     TUnversionedOwningRow ToRow(int /*archiveVersion*/) const override
@@ -212,7 +243,11 @@ public:
 
     size_t EstimateSize() const override
     {
-        return Report_.EstimateSize();
+        return ::NYT::EstimateSizes(
+            Report_.OperationId().Underlying(),
+            Report_.JobId().Underlying(),
+            Report_.Spec(),
+            Report_.SpecVersion());
     }
 
     TUnversionedOwningRow ToRow(int /*archiveVersion*/) const override
@@ -248,7 +283,10 @@ public:
 
     size_t EstimateSize() const override
     {
-        return Report_.EstimateSize();
+        return ::NYT::EstimateSizes(
+            Report_.OperationId().Underlying(),
+            Report_.JobId().Underlying(),
+            Report_.Stderr());
     }
 
     TUnversionedOwningRow ToRow(int /*archiveVersion*/) const override
@@ -287,7 +325,10 @@ public:
 
     size_t EstimateSize() const override
     {
-        return Report_.EstimateSize();
+        return ::NYT::EstimateSizes(
+            Report_.OperationId().Underlying(),
+            Report_.JobId().Underlying(),
+            Report_.FailContext());
     }
 
     TUnversionedOwningRow ToRow(int archiveVersion) const override
@@ -326,7 +367,13 @@ public:
 
     size_t EstimateSize() const override
     {
-        return Report_.EstimateSize();
+        return ::NYT::EstimateSizes(
+            Report_.OperationId().Underlying(),
+            Report_.JobId().Underlying(),
+            Report_.Profile().value_or(NJobAgent::TJobProfile{}).Type,
+            int{0}, // PartIndex.
+            Report_.Profile().value_or(NJobAgent::TJobProfile{}).Blob,
+            Report_.Profile().value_or(NJobAgent::TJobProfile{}).ProfilingProbability);
     }
 
     TUnversionedOwningRow ToRow(int archiveVersion) const override

--- a/yt/yt/server/lib/misc/job_reporter.cpp
+++ b/yt/yt/server/lib/misc/job_reporter.cpp
@@ -81,7 +81,7 @@ public:
             Report_.State(),
             Report_.StartTime(),
             Report_.FinishTime(),
-            TInstant::Now().MicroSeconds(), // UpdateTime.
+            /*updateTime*/ TInstant::Now().MicroSeconds(),
             Report_.Address(),
             Report_.StderrSize(),
             Report_.HasCompetitors(),
@@ -95,7 +95,7 @@ public:
             Report_.Statistics(),
             Report_.Events(),
             Report_.Spec().has_value(),
-            i64{0}, // FailContextSize.
+            /*failContextSize*/ i64{0},
             Report_.CoreInfos(),
             Report_.JobCompetitionId().Underlying(),
             Report_.ProbingJobCompetitionId().Underlying(),
@@ -371,7 +371,7 @@ public:
             Report_.OperationId().Underlying(),
             Report_.JobId().Underlying(),
             Report_.Profile().value_or(NJobAgent::TJobProfile{}).Type,
-            int{0}, // PartIndex.
+            /*partIndex*/ int{0},
             Report_.Profile().value_or(NJobAgent::TJobProfile{}).Blob,
             Report_.Profile().value_or(NJobAgent::TJobProfile{}).ProfilingProbability);
     }


### PR DESCRIPTION
Previously, TJobReport had a single `EstimateSize` method, which didn't account all its fields. This made rate limiting in archive reporter ineffective when dealing with large stderrs/fail contexts. This PR implements separate estimation methods for each job table, which will handle these issues correctly.