### PR TITLE
Split attribute update and removal validation

### DIFF
--- a/yt/yt/server/master/cypress_server/node_proxy_detail.cpp
+++ b/yt/yt/server/master/cypress_server/node_proxy_detail.cpp
@@ -331,8 +331,7 @@ void TNontemplateCypressNodeProxyBase::TCustomAttributeDictionary::SetYson(const
 {
     YT_ASSERT(value);
 
-    auto oldValue = FindYson(key);
-    Proxy_->GuardedValidateCustomAttributeUpdate(key, oldValue, value);
+    Proxy_->GuardedValidateCustomAttributeUpdate(key, value);
 
     const auto& cypressManager = Proxy_->Bootstrap_->GetCypressManager();
     auto* node = cypressManager->LockNode(
@@ -359,12 +358,11 @@ void TNontemplateCypressNodeProxyBase::TCustomAttributeDictionary::SetYson(const
 
 bool TNontemplateCypressNodeProxyBase::TCustomAttributeDictionary::Remove(const TString& key)
 {
-    auto oldValue = FindYson(key);
-    if (!oldValue) {
+    if (!FindYson(key)) {
         return false;
     }
 
-    Proxy_->GuardedValidateCustomAttributeUpdate(key, oldValue, {});
+    Proxy_->GuardedValidateCustomAttributeRemoval(key);
 
     const auto& cypressManager = Proxy_->Bootstrap_->GetCypressManager();
     auto* node = cypressManager->LockNode(

--- a/yt/yt/server/master/file_server/file_node_proxy.cpp
+++ b/yt/yt/server/master/file_server/file_node_proxy.cpp
@@ -76,23 +76,16 @@ private:
 
     void ValidateCustomAttributeUpdate(
         const TString& key,
-        const TYsonString& oldValue,
         const TYsonString& newValue) override
     {
         auto internedKey = TInternedAttributeKey::Lookup(key);
 
         switch (internedKey) {
             case EInternedAttributeKey::Executable:
-                if (!newValue) {
-                    break;
-                }
                 ConvertTo<bool>(newValue);
                 return;
 
             case EInternedAttributeKey::FileName:
-                if (!newValue) {
-                    break;
-                }
                 ConvertTo<TString>(newValue);
                 return;
 
@@ -100,7 +93,7 @@ private:
                 break;
         }
 
-        TBase::ValidateCustomAttributeUpdate(key, oldValue, newValue);
+        TBase::ValidateCustomAttributeUpdate(key, newValue);
     }
 
     void ValidateReadLimit(const NChunkClient::NProto::TReadLimit& readLimit) const override

--- a/yt/yt/server/master/object_server/object_detail.cpp
+++ b/yt/yt/server/master/object_server/object_detail.cpp
@@ -782,13 +782,8 @@ void TObjectProxyBase::LogAcdUpdate(TInternedAttributeKey /*key*/, const TYsonSt
 
 void TObjectProxyBase::ValidateCustomAttributeUpdate(
     const TString& key,
-    const TYsonString& /*oldValue*/,
-    const TYsonString& newValue)
+    const TYsonString& /*newValue*/)
 {
-    if (!newValue) {
-        return;
-    }
-
     const auto& config = Bootstrap_->GetConfigManager()->GetConfig()->ObjectManager;
     const auto& reservedAttributes = config->ReservedAttributes;
 
@@ -807,24 +802,29 @@ void TObjectProxyBase::ValidateCustomAttributeUpdate(
 
 void TObjectProxyBase::GuardedValidateCustomAttributeUpdate(
     const TString& key,
-    const TYsonString& oldValue,
     const TYsonString& newValue)
 {
     try {
-        if (newValue) {
-            ValidateCustomAttributeLength(newValue);
-        }
-        ValidateCustomAttributeUpdate(key, oldValue, newValue);
+        ValidateCustomAttributeLength(newValue);
+        ValidateCustomAttributeUpdate(key, newValue);
     } catch (const std::exception& ex) {
-        if (newValue) {
-            THROW_ERROR_EXCEPTION("Error setting custom attribute %Qv",
-                ToYPathLiteral(key))
-                << ex;
-        } else {
-            THROW_ERROR_EXCEPTION("Error removing custom attribute %Qv",
-                ToYPathLiteral(key))
-                << ex;
-        }
+        THROW_ERROR_EXCEPTION("Error setting custom attribute %Qv",
+            ToYPathLiteral(key))
+            << ex;
+    }
+}
+
+void TObjectProxyBase::ValidateCustomAttributeRemoval(const TString& /*key*/)
+{ }
+
+void TObjectProxyBase::GuardedValidateCustomAttributeRemoval(const TString& key)
+{
+    try {
+        ValidateCustomAttributeRemoval(key);
+    } catch (const std::exception& ex) {
+        THROW_ERROR_EXCEPTION("Error removing custom attribute %Qv",
+            ToYPathLiteral(key))
+            << ex;
     }
 }
 
@@ -1058,8 +1058,7 @@ TYsonString TNontemplateNonversionedObjectProxyBase::TCustomAttributeDictionary:
 
 void TNontemplateNonversionedObjectProxyBase::TCustomAttributeDictionary::SetYson(const TString& key, const TYsonString& value)
 {
-    auto oldValue = FindYson(key);
-    Proxy_->GuardedValidateCustomAttributeUpdate(key, oldValue, value);
+    Proxy_->GuardedValidateCustomAttributeUpdate(key, value);
 
     auto* object = Proxy_->Object_;
     auto* attributes = object->GetMutableAttributes();
@@ -1071,8 +1070,7 @@ void TNontemplateNonversionedObjectProxyBase::TCustomAttributeDictionary::SetYso
 
 bool TNontemplateNonversionedObjectProxyBase::TCustomAttributeDictionary::Remove(const TString& key)
 {
-    auto oldValue = FindYson(key);
-    Proxy_->GuardedValidateCustomAttributeUpdate(key, oldValue, TYsonString());
+    Proxy_->GuardedValidateCustomAttributeRemoval(key);
 
     auto* object = Proxy_->Object_;
     if (!object->GetAttributes()) {

--- a/yt/yt/server/master/object_server/object_detail.h
+++ b/yt/yt/server/master/object_server/object_detail.h
@@ -129,19 +129,24 @@ protected:
 
     virtual void LogAcdUpdate(NYTree::TInternedAttributeKey key, const NYson::TYsonString& value);
 
-    //! Called before attribute #key is updated (added, removed or changed).
+    //! Called before attribute #key is added or changed.
+    //! Not called for removals, thus `newValue` is always non-null.
     virtual void ValidateCustomAttributeUpdate(
         const TString& key,
-        const NYson::TYsonString& oldValue,
         const NYson::TYsonString& newValue);
-
-    void ValidateCustomAttributeLength(const NYson::TYsonString& value);
 
     //! Same as #ValidateCustomAttributeUpdate but wraps the exceptions.
     void GuardedValidateCustomAttributeUpdate(
         const TString& key,
-        const NYson::TYsonString& oldValue,
         const NYson::TYsonString& newValue);
+
+    //! Called before attribute #key is removed.
+    virtual void ValidateCustomAttributeRemoval(const TString& key);
+
+    //! Same as #ValidateCustomAttributeRemoval but wraps the exceptions.
+    void GuardedValidateCustomAttributeRemoval(const TString& key);
+
+    void ValidateCustomAttributeLength(const NYson::TYsonString& value);
 
     void DeclareMutating();
     void DeclareNonMutating();

--- a/yt/yt/server/master/object_server/sys_node_proxy.cpp
+++ b/yt/yt/server/master/object_server/sys_node_proxy.cpp
@@ -91,7 +91,6 @@ private:
 
     void ValidateCustomAttributeUpdate(
         const TString& key,
-        const TYsonString& oldValue,
         const TYsonString& newValue) override
     {
         auto internedKey = TInternedAttributeKey::Lookup(key);
@@ -115,7 +114,7 @@ private:
                 break;
         }
 
-        return TBase::ValidateCustomAttributeUpdate(key, oldValue, newValue);
+        return TBase::ValidateCustomAttributeUpdate(key, newValue);
     }
 
     bool GetBuiltinAttribute(TInternedAttributeKey key, IYsonConsumer* consumer) override

--- a/yt/yt/server/master/table_server/table_node_proxy_detail.cpp
+++ b/yt/yt/server/master/table_server/table_node_proxy_detail.cpp
@@ -1783,37 +1783,24 @@ bool TTableNodeProxy::SetBuiltinAttribute(TInternedAttributeKey key, const TYson
 
 void TTableNodeProxy::ValidateCustomAttributeUpdate(
     const TString& key,
-    const TYsonString& oldValue,
     const TYsonString& newValue)
 {
     auto internedKey = TInternedAttributeKey::Lookup(key);
 
     switch (internedKey) {
         case EInternedAttributeKey::ChunkWriter:
-            if (!newValue) {
-                break;
-            }
             ConvertTo<NTabletNode::TTabletStoreWriterConfigPtr>(newValue);
             return;
 
         case EInternedAttributeKey::HunkChunkWriter:
-            if (!newValue) {
-                break;
-            }
             ConvertTo<NTabletNode::TTabletHunkWriterConfigPtr>(newValue);
             return;
 
         case EInternedAttributeKey::ChunkReader:
-            if (!newValue) {
-                break;
-            }
             ConvertTo<NTabletNode::TTabletStoreReaderConfigPtr>(newValue);
             return;
 
         case EInternedAttributeKey::HunkChunkReader:
-            if (!newValue) {
-                break;
-            }
             ConvertTo<NTabletNode::TTabletHunkReaderConfigPtr>(newValue);
             return;
 
@@ -1821,7 +1808,7 @@ void TTableNodeProxy::ValidateCustomAttributeUpdate(
             break;
     }
 
-    TBase::ValidateCustomAttributeUpdate(key, oldValue, newValue);
+    TBase::ValidateCustomAttributeUpdate(key, newValue);
 }
 
 void TTableNodeProxy::ValidateReadLimit(const NChunkClient::NProto::TReadLimit& readLimit) const

--- a/yt/yt/server/master/table_server/table_node_proxy_detail.h
+++ b/yt/yt/server/master/table_server/table_node_proxy_detail.h
@@ -38,7 +38,6 @@ protected:
     bool SetBuiltinAttribute(NYTree::TInternedAttributeKey key, const NYson::TYsonString& value, bool force) override;
     void ValidateCustomAttributeUpdate(
         const TString& key,
-        const NYson::TYsonString& oldValue,
         const NYson::TYsonString& newValue) override;
     void ValidateReadLimit(const NChunkClient::NProto::TReadLimit& context) const override;
     NTableClient::TComparator GetComparator() const override;

--- a/yt/yt/tests/integration/cypress/test_cypress.py
+++ b/yt/yt/tests/integration/cypress/test_cypress.py
@@ -3957,6 +3957,8 @@ class TestCypress(YTEnvSetup):
         assert {"default_input_row_limit": 1024} == get("//sys/@cluster_connection")
         set("//sys/@cluster_connection", yson.YsonEntity())
         assert isinstance(get("//sys/@cluster_connection"), yson.YsonEntity)
+        remove("//sys/@cluster_connection")
+        assert not exists("//sys/@cluster_connection")
 
     @authors("kvk1920")
     @not_implemented_in_sequoia
@@ -3967,6 +3969,8 @@ class TestCypress(YTEnvSetup):
         assert "a" * 128 == get("//sys/@cluster_name")
         with raises_yt_error("ASCII"):
             set("//sys/@cluster_name", "кириллица")
+        remove("//sys/@cluster_name")
+        assert not exists("//sys/@cluster_name")
 
     @authors("h0pless")
     @not_implemented_in_sequoia


### PR DESCRIPTION
Prior to this change, `ValidateCustomAttributeUpdate` was responsible both for the attribute update and removal validation. This is error-prone since having null `newValue` in the `Validate...Update` function may be unexpected. This issue happened in the `//sys/@cluster_name` and `//sys/@cluster_connection` attributes whose removal led to master crash prior to this change.

To address these issues, `ValidateCustomAttributeUpdate` is split here into `ValidateCustomAttributeUpdate` that is called only during attribute set or update and thus new value is always non-null and `ValidateCustomAttributeRemoval`. Also, `oldValue` is not passed to `ValidateCustomAttributeUpdate` after this change since stateful validation may be tricky and is not used for now.