### PR TITLE
Move custom signal handler stack from TLS

### DIFF
--- a/yt/yt/core/threading/thread.cpp
+++ b/yt/yt/core/threading/thread.cpp
@@ -295,10 +295,10 @@ YT_PREVENT_TLS_CACHING void TThread::ConfigureSignalHandlerStack()
 
     // The size of of the custom stack to be provided for signal handlers.
     constexpr size_t SignalHandlerStackSize = 16_KB;
-    thread_local std::unique_ptr<char[]> Stack = std::make_unique<char[]>(SignalHandlerStackSize);
+    SignalHandlerStack_ = std::make_unique<char[]>(SignalHandlerStackSize);
 
     stack_t stack{
-        .ss_sp = Stack.get(),
+        .ss_sp = SignalHandlerStack_.get(),
         .ss_flags = 0,
         .ss_size = SignalHandlerStackSize,
     };

--- a/yt/yt/core/threading/thread.h
+++ b/yt/yt/core/threading/thread.h
@@ -75,6 +75,7 @@ private:
 
     TThreadId ThreadId_ = InvalidThreadId;
     ::TThread UnderlyingThread_;
+    std::unique_ptr<char[]> SignalHandlerStack_;
 
     void SetThreadPriority();
     void ConfigureSignalHandlerStack();


### PR DESCRIPTION
Fix deadlock on GL(dl_load_lock) when code is build as a shared library.

At loading library static initializers are called under GL(dl_load_lock).
Some of them want to start new thread and wait it up and running.
New thread in its turn registers non-POD TLS destructor for signal stack,
(__cxa_thread_atexit) which takes the same lock: GL(dl_load_lock). Boom.
