### PR TITLE
Use `cp -n` in QT build script to work better in case build directory exists

### DIFF
--- a/yt/docker/ya-build/query-tracker/build_yql_agent.sh
+++ b/yt/docker/ya-build/query-tracker/build_yql_agent.sh
@@ -83,4 +83,4 @@ fi
 
 # Copy all shared libraries to a single directory
 mkdir -p ${YQL_BUILD_PATH}/yql_shared_libraries/yql
-find ${YQL_BUILD_PATH} -name 'lib*.so' -print0 | xargs -0 -I '{}' cp '{}' ${YQL_BUILD_PATH}/yql_shared_libraries/yql
+find ${YQL_BUILD_PATH} -name 'lib*.so' -print0 | xargs -0 -I '{}' cp -n '{}' ${YQL_BUILD_PATH}/yql_shared_libraries/yql


### PR DESCRIPTION
Without `-n` cp fails with
```
cp: '/home/aleksandr.gaev/ytsaurus/build_yql/yql_shared_libraries/yql/libjson_udf.so' and '/home/aleksandr.gaev/ytsaurus/build_yql/yql_shared_libraries/yql/libjson_udf.so' are the same file
```

