### PR TITLE
Fix bug in http proxy liveness during read-only introduced after refactoring

### DIFF
--- a/yt/yt/server/http_proxy/component_discovery.cpp
+++ b/yt/yt/server/http_proxy/component_discovery.cpp
@@ -231,7 +231,7 @@ std::vector<TString> TComponentDiscoverer::GetCypressPaths(NApi::IClientPtr clie
     auto cypressDirectory = GetCypressDirectory(component);
 
     for (auto& path : paths) {
-        path = cypressDirectory + path;
+        path = Format("%v/%v", cypressDirectory, path);
     }
 
     return paths;


### PR DESCRIPTION
Fun fact: if all orchids return error, we will consider masters to be in read-only and keep the proxies alive for longer. I don't really see too much harm in that.