### PR TITLE
Fair IO PoC

### DIFF
--- a/yt/yt/client/misc/workload.h
+++ b/yt/yt/client/misc/workload.h
@@ -23,7 +23,9 @@ struct TWorkloadDescriptor
         int band = 0,
         TInstant instant = {},
         std::vector<TString> annotations = {},
-        std::optional<NConcurrency::TFairShareThreadPoolTag> compressionFairShareTag = {});
+        std::optional<NConcurrency::TFairShareThreadPoolTag> compressionFairShareTag = {},
+        std::optional<TString> diskFairShareBucketTag = {},
+        std::optional<double> diskFairShareBucketWeight = {});
 
     //! The type of the workload defining its basic priority.
     EWorkloadCategory Category;
@@ -42,6 +44,12 @@ struct TWorkloadDescriptor
 
     //! If present, invoker from fair share thread pool will be used for decompression.
     std::optional<NConcurrency::TFairShareThreadPoolTag> CompressionFairShareTag;
+
+    //! Importance of the workload for disks.
+    //! All the workload in the same DiskFairShareBucketTag gets fair share of disks according to DiskFairShareBucketWeight.
+    //! DiskFairShareBucketWeight should be positive. 1 is the default value. Larger is better.
+    std::optional<TString> DiskFairShareBucketTag;
+    std::optional<double> DiskFairShareBucketWeight;
 
     //! Updates the instant field with the current time.
     TWorkloadDescriptor SetCurrentInstant() const;

--- a/yt/yt/core/CMakeLists.txt
+++ b/yt/yt/core/CMakeLists.txt
@@ -128,6 +128,7 @@ target_sources(yt-yt-core PRIVATE
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/invoker_queue.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/lease_manager.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/new_fair_share_thread_pool.cpp
+  ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/new_new_fair_share_thread_pool.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/nonblocking_batcher.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/notify_manager.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/periodic_executor.cpp

--- a/yt/yt/core/actions/invoker.h
+++ b/yt/yt/core/actions/invoker.h
@@ -40,6 +40,15 @@ struct IInvoker
 
 DEFINE_REFCOUNTED_TYPE(IInvoker)
 
+struct IInvokerWithExpectedBytes
+    : public virtual IInvoker
+{
+    virtual void InvokeWithExpectedBytes(TClosure callback, i64 expectedBytes) = 0;
+    virtual void InvokeWithExpectedBytes(TMutableRange<std::pair<TClosure, i64>> callbacks) = 0;
+};
+
+DEFINE_REFCOUNTED_TYPE(IInvokerWithExpectedBytes)
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct IPrioritizedInvoker

--- a/yt/yt/core/actions/public.h
+++ b/yt/yt/core/actions/public.h
@@ -30,6 +30,7 @@ template <class T>
 class TFutureHolder;
 
 DECLARE_REFCOUNTED_STRUCT(IInvoker)
+DECLARE_REFCOUNTED_STRUCT(IInvokerWithExpectedBytes)
 DECLARE_REFCOUNTED_STRUCT(IPrioritizedInvoker)
 DECLARE_REFCOUNTED_STRUCT(ISuspendableInvoker)
 

--- a/yt/yt/core/concurrency/new_new_fair_share_thread_pool.cpp
+++ b/yt/yt/core/concurrency/new_new_fair_share_thread_pool.cpp
@@ -1,5 +1,5 @@
 #include "two_level_fair_share_thread_pool.h"
-#include "new_fair_share_thread_pool.h"
+#include "new_new_fair_share_thread_pool.h"
 #include "private.h"
 #include "notify_manager.h"
 #include "profiling_helpers.h"
@@ -19,8 +19,6 @@
 #include <library/cpp/yt/containers/intrusive_linked_list.h>
 
 #include <library/cpp/yt/memory/public.h>
-
-#include <library/cpp/yt/misc/tls.h>
 
 #include <util/system/spinlock.h>
 
@@ -43,7 +41,7 @@ DECLARE_REFCOUNTED_CLASS(TBucket)
 struct TExecutionPool;
 
 // High 16 bits is thread index and 48 bits for thread pool ptr.
-YT_DEFINE_THREAD_LOCAL(TPackedPtr, ThreadCookie, 0);
+thread_local TPackedPtr ThreadCookie = 0;
 
 static constexpr auto LogDurationThreshold = TDuration::Seconds(1);
 
@@ -222,6 +220,7 @@ struct TAction
 {
     TCpuInstant EnqueuedAt = 0;
     TCpuInstant StartedAt = 0;
+    TCpuInstant ExpectedBytes = 0;
 
     // Callback keeps raw ptr to bucket to minimize bucket ref count.
     TClosure Callback;
@@ -324,7 +323,7 @@ bool operator < (const TBucketBase& lhs, const TBucketBase& rhs)
 ////////////////////////////////////////////////////////////////////////////////
 
 class TBucket
-    : public IInvoker
+    : public IInvokerWithExpectedBytes
     , public THeapItemBase<TBucket>
     , public TBucketBase
 {
@@ -354,6 +353,15 @@ public:
     {
         for (auto& callback : callbacks) {
             Invoke(std::move(callback));
+        }
+    }
+
+    void InvokeWithExpectedBytes(TClosure callback, i64 expectedBytes) override;
+
+    void InvokeWithExpectedBytes(TMutableRange<std::pair<TClosure, i64>> callbacks) override
+    {
+        for (auto& callback : callbacks) {
+            InvokeWithExpectedBytes(std::move(callback.first), std::move(callback.second));
         }
     }
 
@@ -414,15 +422,15 @@ public:
 
     virtual TProfiler GetPoolProfiler(const TString& poolName) = 0;
 
-    virtual void Invoke(TClosure callback, TBucket* bucket) = 0;
+    virtual void Invoke(TClosure callback, i64 expectedBytes, TBucket* bucket) = 0;
 
     // GetInvoker is protected by mapping lock (can be sharded).
-    IInvokerPtr GetInvoker(const TString& poolName, const TString& bucketName, double bucketWeight)
+    IInvokerWithExpectedBytesPtr GetInvoker(const TString& poolName, const TString& bucketName, double bucketWeight)
     {
         // TODO(lukyan): Use reader guard and update it to writer if needed.
         auto guard = Guard(MappingLock_);
 
-        auto [bucketIt, bucketInserted] = BucketMapping_.emplace(std::pair(poolName, bucketName), nullptr);
+        auto [bucketIt, bucketInserted] = BucketMapping_.emplace(std::make_pair(poolName, bucketName), nullptr);
 
         auto bucket = bucketIt->second ? DangerousGetPtr(bucketIt->second) : nullptr;
         if (!bucket) {
@@ -438,7 +446,7 @@ public:
     void RemoveBucket(TBucket* bucket)
     {
         auto guard = Guard(MappingLock_);
-        auto bucketIt = BucketMapping_.find(std::pair(bucket->PoolName, bucket->BucketName));
+        auto bucketIt = BucketMapping_.find(std::make_pair(bucket->PoolName, bucket->BucketName));
 
         if (bucketIt != BucketMapping_.end() && bucketIt->second == bucket) {
             BucketMapping_.erase(bucketIt);
@@ -571,7 +579,12 @@ DEFINE_REFCOUNTED_TYPE(TBucketMapping)
 
 void TBucket::Invoke(TClosure callback)
 {
-    Parent_->Invoke(std::move(callback), this);
+    Parent_->Invoke(std::move(callback), 0, this);
+}
+
+void TBucket::InvokeWithExpectedBytes(TClosure callback, i64 expectedBytes)
+{
+    Parent_->Invoke(std::move(callback), expectedBytes, this);
 }
 
 TBucket::~TBucket()
@@ -597,7 +610,7 @@ public:
     TTwoLevelFairShareQueue(
         TIntrusivePtr<NThreading::TEventCount> callbackEventCount,
         const TString& threadNamePrefix,
-        const TNewTwoLevelFairShareThreadPoolOptions& options)
+        const TNewNewTwoLevelFairShareThreadPoolOptions& options)
         : TNotifyManager(std::move(callbackEventCount), GetThreadTags(threadNamePrefix), options.PollingPeriod)
         , TBucketMapping(options.PoolRetentionTime)
         , ThreadNamePrefix_(threadNamePrefix)
@@ -621,7 +634,7 @@ public:
     }
 
     // Invoke is lock free.
-    void Invoke(TClosure callback, TBucket* bucket) override
+    void Invoke(TClosure callback, i64 expectedBytes, TBucket* bucket) override
     {
         if (Stopped_.load()) {
             return;
@@ -635,10 +648,11 @@ public:
 
         TAction action;
         action.EnqueuedAt = cpuInstant;
+        action.ExpectedBytes = expectedBytes;
         // Callback keeps raw ptr to bucket to minimize bucket ref count.
         action.Callback = BIND(&TBucket::RunCallback, Unretained(bucket), std::move(callback), cpuInstant);
         action.BucketHolder = MakeStrong(bucket);
-        action.EnqueuedThreadCookie = ThreadCookie();
+        action.EnqueuedThreadCookie = ThreadCookie;
 
         InvokeQueue_.Enqueue(std::move(action));
 
@@ -1000,7 +1014,9 @@ private:
             if (auto* bucket = threadState.Action.BucketHolder.Get()) {
 
                 // TODO(lukyan): Update last excess time for pool without active buckets.
-                UpdateExcessTime(bucket, currentInstant - threadState.AccountedAt, currentInstant);
+                auto bytesConsumed = threadState.Action.ExpectedBytes;
+                threadState.Action.ExpectedBytes = 0;
+                UpdateExcessTime(bucket, bytesConsumed, currentInstant);
                 threadState.AccountedAt = currentInstant;
             }
 
@@ -1205,7 +1221,7 @@ protected:
 
     void OnStart() override
     {
-        ThreadCookie() = TTaggedPtr(Queue_.Get(), static_cast<ui16>(Index_)).Pack();
+        ThreadCookie = TTaggedPtr(Queue_.Get(), static_cast<ui16>(Index_)).Pack();
     }
 
     void StopPrologue() override
@@ -1238,14 +1254,14 @@ DEFINE_REFCOUNTED_TYPE(TFairShareThread)
 ////////////////////////////////////////////////////////////////////////////////
 
 class TTwoLevelFairShareThreadPool
-    : public ITwoLevelFairShareThreadPool
+    : public INewNewTwoLevelFairShareThreadPool
     , public TThreadPoolBase
 {
 public:
     TTwoLevelFairShareThreadPool(
         int threadCount,
         const TString& threadNamePrefix,
-        const TNewTwoLevelFairShareThreadPoolOptions& options)
+        const TNewNewTwoLevelFairShareThreadPoolOptions& options)
         : TThreadPoolBase(threadNamePrefix)
         , Queue_(New<TTwoLevelFairShareQueue>(
             CallbackEventCount_,
@@ -1266,6 +1282,15 @@ public:
     }
 
     IInvokerPtr GetInvoker(
+        const TString& poolName,
+        const TFairShareThreadPoolTag& bucketName,
+        double bucketWeight) override
+    {
+        EnsureStarted();
+        return Queue_->GetInvoker(poolName, bucketName, bucketWeight);
+    }
+
+    IInvokerWithExpectedBytesPtr GetInvokerWithExpectedBytes(
         const TString& poolName,
         const TFairShareThreadPoolTag& bucketName,
         double bucketWeight) override
@@ -1327,10 +1352,10 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ITwoLevelFairShareThreadPoolPtr CreateNewTwoLevelFairShareThreadPool(
+INewNewTwoLevelFairShareThreadPoolPtr CreateNewNewTwoLevelFairShareThreadPool(
     int threadCount,
     const TString& threadNamePrefix,
-    const TNewTwoLevelFairShareThreadPoolOptions& options)
+    const TNewNewTwoLevelFairShareThreadPoolOptions& options)
 {
     return New<TTwoLevelFairShareThreadPool>(
         threadCount,

--- a/yt/yt/core/concurrency/new_new_fair_share_thread_pool.h
+++ b/yt/yt/core/concurrency/new_new_fair_share_thread_pool.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "public.h"
+
+#include <yt/yt/core/actions/public.h>
+
+namespace NYT::NConcurrency {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TNewNewTwoLevelFairShareThreadPoolOptions
+{
+    IPoolWeightProviderPtr PoolWeightProvider = nullptr;
+    bool VerboseLogging = false;
+    TDuration PollingPeriod = TDuration::MilliSeconds(10);
+    TDuration PoolRetentionTime = TDuration::Seconds(30);
+};
+
+INewNewTwoLevelFairShareThreadPoolPtr CreateNewNewTwoLevelFairShareThreadPool(
+    int threadCount,
+    const TString& threadNamePrefix,
+    const TNewNewTwoLevelFairShareThreadPoolOptions& options = {});
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NConcurrency

--- a/yt/yt/core/concurrency/public.h
+++ b/yt/yt/core/concurrency/public.h
@@ -109,6 +109,7 @@ using TFairShareThreadPoolTag = TString;
 DECLARE_REFCOUNTED_STRUCT(IPoolWeightProvider)
 
 DECLARE_REFCOUNTED_STRUCT(ITwoLevelFairShareThreadPool)
+DECLARE_REFCOUNTED_STRUCT(INewNewTwoLevelFairShareThreadPool)
 
 DECLARE_REFCOUNTED_CLASS(TFiber)
 

--- a/yt/yt/core/concurrency/two_level_fair_share_thread_pool.h
+++ b/yt/yt/core/concurrency/two_level_fair_share_thread_pool.h
@@ -26,7 +26,8 @@ struct ITwoLevelFairShareThreadPool
 
     virtual IInvokerPtr GetInvoker(
         const TString& poolName,
-        const TFairShareThreadPoolTag& tag) = 0;
+        const TFairShareThreadPoolTag& tag,
+        double bucketWeight = 1.0) = 0;
 
     virtual void Shutdown() = 0;
 
@@ -35,6 +36,17 @@ struct ITwoLevelFairShareThreadPool
 };
 
 DEFINE_REFCOUNTED_TYPE(ITwoLevelFairShareThreadPool)
+
+struct INewNewTwoLevelFairShareThreadPool
+    : public virtual ITwoLevelFairShareThreadPool
+{
+    virtual IInvokerWithExpectedBytesPtr GetInvokerWithExpectedBytes(
+        const TString& poolName,
+        const TFairShareThreadPoolTag& tag,
+        double bucketWeight = 1.0) = 0;
+};
+
+DEFINE_REFCOUNTED_TYPE(INewNewTwoLevelFairShareThreadPool)
 
 ITwoLevelFairShareThreadPoolPtr CreateTwoLevelFairShareThreadPool(
     int threadCount,

--- a/yt/yt/core/ya.make
+++ b/yt/yt/core/ya.make
@@ -67,6 +67,7 @@ SRCS(
     concurrency/invoker_queue.cpp
     concurrency/lease_manager.cpp
     concurrency/new_fair_share_thread_pool.cpp
+    concurrency/new_new_fair_share_thread_pool.cpp
     concurrency/nonblocking_batcher.cpp
     concurrency/notify_manager.cpp
     concurrency/periodic_executor.cpp

--- a/yt/yt/server/job_proxy/job_proxy.cpp
+++ b/yt/yt/server/job_proxy/job_proxy.cpp
@@ -512,6 +512,8 @@ void TJobProxy::RetrieveJobSpec()
             descriptor->Annotations.end(),
             annotations.begin(),
             annotations.end());
+        descriptor->DiskFairShareBucketTag = ToString(JobId_);
+        descriptor->DiskFairShareBucketWeight = CpuGuarantee_;
     }
 
     {

--- a/yt/yt/server/lib/hydra/local_changelog_store.cpp
+++ b/yt/yt/server/lib/hydra/local_changelog_store.cpp
@@ -377,7 +377,7 @@ private:
     void DoWriteTerm(int term)
     {
         WaitFor(BIND(&TLocalChangelogStoreFactory::WriteTermImpl, MakeStrong(this))
-            .AsyncVia(IOEngine_->GetAuxPoolInvoker())
+            .AsyncVia(IOEngine_->GetAuxPoolInvoker(EWorkloadCategory::UserBatch, {})) // TODO what to pass here
             .Run(term))
             .ThrowOnError();
     }
@@ -462,7 +462,7 @@ private:
         try {
             if (!Initialized_) {
                 WaitFor(BIND(&TLocalChangelogStoreFactory::InitializeImpl, MakeStrong(this))
-                    .AsyncVia(IOEngine_->GetAuxPoolInvoker())
+                    .AsyncVia(IOEngine_->GetAuxPoolInvoker(EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                     .Run())
                     .ThrowOnError();
                 Initialized_ = true;
@@ -476,7 +476,7 @@ private:
             auto epoch = Lock_->Acquire();
 
             int term = WaitFor(BIND(&TLocalChangelogStoreFactory::ReadTermImpl, MakeStrong(this))
-                .AsyncVia(IOEngine_->GetAuxPoolInvoker())
+                .AsyncVia(IOEngine_->GetAuxPoolInvoker(EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                 .Run())
                 .ValueOrThrow();
 

--- a/yt/yt/server/lib/hydra/unbuffered_file_changelog.cpp
+++ b/yt/yt/server/lib/hydra/unbuffered_file_changelog.cpp
@@ -88,7 +88,7 @@ public:
 
         try {
             NFS::WrapIOErrors([&] {
-                DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}))
+                DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                     .ValueOrThrow();
                 LockDataFile();
 
@@ -98,7 +98,8 @@ public:
                         {{.Handle = DataFileHandle_, .Offset = 0, .Size = headerBufferSize}},
                         // TODO(babenko): better workload category?
                         EWorkloadCategory::UserBatch,
-                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                        {})) // TODO what to pass here
                     .ValueOrThrow()
                     .OutputBuffers[0];
 
@@ -138,7 +139,8 @@ public:
                         {{.Handle = DataFileHandle_, .Offset = FileHeaderSize_, .Size = header->MetaSize}},
                         // TODO(babenko): better workload category?
                         EWorkloadCategory::UserBatch,
-                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                        {})) // TODO what to pass here
                     .ValueOrThrow()
                     .OutputBuffers[0];
                 DeserializeProto(&Meta_, SerializedMeta_);
@@ -189,10 +191,10 @@ public:
                 }
 
                 if (currentDataOffset < dataFileLength) {
-                    WaitFor(IOEngine_->Resize({.Handle = DataFileHandle_, .Size = currentDataOffset}))
+                    WaitFor(IOEngine_->Resize({.Handle = DataFileHandle_, .Size = currentDataOffset}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                         .ThrowOnError();
 
-                    WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::All}))
+                    WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::All}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                         .ThrowOnError();
 
                     YT_LOG_DEBUG("Changelog data file truncated (RecordCount: %v, DataFileLength: %v)",
@@ -240,7 +242,7 @@ public:
 
         try {
             NFS::WrapIOErrors([&] {
-                WaitFor(IOEngine_->Close({.Handle = std::exchange(DataFileHandle_, nullptr), .Flush = true}))
+                WaitFor(IOEngine_->Close({.Handle = std::exchange(DataFileHandle_, nullptr), .Flush = true}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                     .ThrowOnError();
 
                 Index_->SetFlushedDataRecordCount(recordCount);
@@ -355,7 +357,7 @@ public:
             withIndex);
 
         try {
-            WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::Data}))
+            WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::Data}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                 .ThrowOnError();
 
             Index_->SetFlushedDataRecordCount(GetRecordCount());
@@ -588,7 +590,7 @@ private:
         while (true) {
             YT_LOG_DEBUG("Locking data file");
 
-            auto error = WaitFor(IOEngine_->Lock({.Handle = DataFileHandle_, .Mode = ELockFileMode::Exclusive, .Nonblocking = true}));
+            auto error = WaitFor(IOEngine_->Lock({.Handle = DataFileHandle_, .Mode = ELockFileMode::Exclusive, .Nonblocking = true}, EWorkloadCategory::UserBatch, {})); // TODO what to pass here
             if (error.IsOK()) {
                 break;
             }
@@ -642,7 +644,7 @@ private:
         NFS::WrapIOErrors([&] {
             auto tempFileName = FileName_ + NFS::TempFileSuffix;
 
-            auto dataFile = WaitFor(IOEngine_->Open({.Path = tempFileName, .Mode = WrOnly | CloseOnExec | CreateAlways}))
+            auto dataFile = WaitFor(IOEngine_->Open({.Path = tempFileName, .Mode = WrOnly | CloseOnExec | CreateAlways}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                 .ValueOrThrow();
 
             WaitFor(IOEngine_->Write({
@@ -650,16 +652,17 @@ private:
                     .Offset = 0,
                     .Buffers = {std::move(buffer)}
                 },
-                EWorkloadCategory::UserBatch))
+                EWorkloadCategory::UserBatch,
+                {})) // TODO what to pass here
                 .ThrowOnError();
 
-            WaitFor(IOEngine_->Close({.Handle = dataFile, .Flush = true}))
+            WaitFor(IOEngine_->Close({.Handle = dataFile, .Flush = true}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                 .ThrowOnError();
 
             // TODO(babenko): use IO engine
             NFS::Replace(tempFileName, FileName_);
 
-            DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}))
+            DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                 .ValueOrThrow();
         });
     }
@@ -747,7 +750,7 @@ private:
             // Preallocate file if needed.
             if (Config_->PreallocateSize && currentFileOffset > CurrentFileSize_) {
                 auto newFileSize = std::max(CurrentFileSize_ + *Config_->PreallocateSize, currentFileOffset);
-                WaitFor(IOEngine_->Allocate({.Handle = DataFileHandle_, .Size = newFileSize}))
+                WaitFor(IOEngine_->Allocate({.Handle = DataFileHandle_, .Size = newFileSize}, EWorkloadCategory::UserBatch, {})) // TODO what to pass here
                     .ThrowOnError();
                 CurrentFileSize_ = newFileSize;
             }
@@ -758,7 +761,8 @@ private:
                     .Offset = CurrentFileOffset_.load(),
                     .Buffers = std::move(buffers)
                 },
-                EWorkloadCategory::UserBatch))
+                EWorkloadCategory::UserBatch,
+                {})) // TODO what to pass here
                 .ThrowOnError();
 
             RecordCount_ += std::ssize(records);
@@ -902,7 +906,8 @@ private:
                 {{.Handle = DataFileHandle_, .Offset = offset, .Size = sizeof(TRecordHeader)}},
                 // TODO(babenko): better workload category?
                 EWorkloadCategory::UserBatch,
-                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                {})) // TODO what to pass here
             .ValueOrThrow()
             .OutputBuffers[0];
 
@@ -951,7 +956,8 @@ private:
                 {{.Handle = DataFileHandle_, .Offset = range.first, .Size = range.second - range.first}},
                 // TODO(babenko): better workload category?
                 EWorkloadCategory::UserBatch,
-                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                {})) // TODO what to pass here
             .ValueOrThrow()
             .OutputBuffers[0];
 
@@ -1098,7 +1104,8 @@ private:
                     .Offset = currentOffset,
                     .Buffers = {std::move(currentBuffer)}
                 },
-                EWorkloadCategory::UserBatch))
+                EWorkloadCategory::UserBatch,
+                {})) // TODO what to pass here
                 .ThrowOnError();
             currentOffset += currentSize;
         }

--- a/yt/yt/server/lib/io/CMakeLists.txt
+++ b/yt/yt/server/lib/io/CMakeLists.txt
@@ -40,4 +40,5 @@ target_sources(server-lib-io PRIVATE
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/dynamic_io_engine.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/io_engine_base.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/io_engine_uring.cpp
+  ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/io_engine_fair.cpp
 )

--- a/yt/yt/server/lib/io/chunk_file_reader.cpp
+++ b/yt/yt/server/lib/io/chunk_file_reader.cpp
@@ -369,7 +369,7 @@ TFuture<std::vector<TBlock>> TChunkFileReader::DoReadBlocks(
             firstBlockInfo.Offset,
             totalSize
         }},
-        options.WorkloadDescriptor.Category,
+        options.WorkloadDescriptor,
         GetRefCountedTypeCookie<TChunkFileReaderBufferTag>(),
         options.ReadSessionId,
         options.UseDedicatedAllocations)
@@ -390,7 +390,7 @@ TFuture<TRefCountedChunkMetaPtr> TChunkFileReader::DoReadMeta(
     YT_LOG_DEBUG("Started reading chunk meta file (FileName: %v)",
         metaFileName);
 
-    return IOEngine_->ReadAll(metaFileName, options.WorkloadDescriptor.Category, options.ReadSessionId)
+    return IOEngine_->ReadAll(metaFileName, options.WorkloadDescriptor, options.ReadSessionId)
         .Apply(BIND(&TChunkFileReader::OnMetaRead, MakeStrong(this), metaFileName, options.ChunkReaderStatistics));
 }
 
@@ -476,7 +476,7 @@ TFuture<TIOEngineHandlePtr> TChunkFileReader::OpenDataFile(EDirectIOFlag useDire
         if (useDirectIO == EDirectIOFlag::On) {
             TIOEngineHandle::MarkOpenForDirectIO(&mode);
         }
-        DataFileHandleFuture_[useDirectIO] = IOEngine_->Open({FileName_, mode})
+        DataFileHandleFuture_[useDirectIO] = IOEngine_->Open({FileName_, mode}, EWorkloadCategory::UserInteractive, {}) // TODO what can we pass here
             .ToUncancelable()
             .Apply(BIND(&TChunkFileReader::OnDataFileOpened, MakeStrong(this), useDirectIO));
     }

--- a/yt/yt/server/lib/io/chunk_file_writer.cpp
+++ b/yt/yt/server/lib/io/chunk_file_writer.cpp
@@ -6,6 +6,7 @@
 #include <yt/yt/ytlib/chunk_client/deferred_chunk_meta.h>
 #include <yt/yt/ytlib/chunk_client/format.h>
 #include <yt/yt/ytlib/chunk_client/block.h>
+#include <yt/yt/ytlib/chunk_client/session_id.h>
 
 #include <yt/yt/client/chunk_client/chunk_replica.h>
 
@@ -69,7 +70,7 @@ void TChunkFileWriter::TryLockDataFile(TPromise<void> promise)
     TDelayedExecutor::Submit(
         BIND(&TChunkFileWriter::TryLockDataFile, MakeStrong(this), promise),
         TDuration::MilliSeconds(10),
-        IOEngine_->GetAuxPoolInvoker());
+        IOEngine_->GetAuxPoolInvoker(EWorkloadCategory::UserInteractive, {})); // TODO what can we pass here
 }
 
 void TChunkFileWriter::SetFailed(const TError& error)
@@ -104,7 +105,7 @@ TFuture<void> TChunkFileWriter::Open()
 
     // NB: Races are possible between file creation and a call to flock.
     // Unfortunately in Linux we can't create'n'flock a file atomically.
-    return IOEngine_->Open({FileName_ + NFS::TempFileSuffix, FileMode})
+    return IOEngine_->Open({FileName_ + NFS::TempFileSuffix, FileMode}, EWorkloadCategory::UserInteractive, {}) // TODO what descriptor and sessionId can we pass here
         .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TIOEngineHandlePtr& file) {
             YT_VERIFY(State_.load() == EState::Opening);
 
@@ -113,7 +114,7 @@ TFuture<void> TChunkFileWriter::Open()
             auto promise = NewPromise<void>();
             TryLockDataFile(promise);
             return promise.ToFuture();
-        }).AsyncVia(IOEngine_->GetAuxPoolInvoker()))
+        }).AsyncVia(IOEngine_->GetAuxPoolInvoker(EWorkloadCategory::UserInteractive, {}))) // TODO what can we pass here
         .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TError& error) {
             YT_VERIFY(State_.load() == EState::Opening);
 
@@ -132,12 +133,28 @@ bool TChunkFileWriter::WriteBlock(
     const TWorkloadDescriptor& workloadDescriptor,
     const TBlock& block)
 {
-    return WriteBlocks(workloadDescriptor, {block});
+    return WriteBlockWithSession(workloadDescriptor, block, {});
 }
 
 bool TChunkFileWriter::WriteBlocks(
     const TWorkloadDescriptor& workloadDescriptor,
     const std::vector<TBlock>& blocks)
+{
+    return WriteBlocksWithSession(workloadDescriptor, blocks, {});
+}
+
+bool TChunkFileWriter::WriteBlockWithSession(
+    const TWorkloadDescriptor& workloadDescriptor,
+    const TBlock& block,
+    NYT::TGuid sessionId)
+{
+    return WriteBlocksWithSession(workloadDescriptor, {block}, sessionId);
+}
+
+bool TChunkFileWriter::WriteBlocksWithSession(
+    const TWorkloadDescriptor& workloadDescriptor,
+    const std::vector<TBlock>& blocks,
+    NYT::TGuid sessionId)
 {
     if (auto error = TryChangeState(EState::Ready, EState::WritingBlocks); !error.IsOK()) {
         ReadyEvent_ = MakeFuture<void>(std::move(error));
@@ -170,7 +187,8 @@ bool TChunkFileWriter::WriteBlocks(
             std::move(buffers),
             SyncOnClose_
         },
-        workloadDescriptor.Category)
+        workloadDescriptor,
+        sessionId)
         .Apply(BIND([=, this, this_ = MakeStrong(this), newDataSize = currentOffset] (const TError& error) {
             YT_VERIFY(State_.load() == EState::WritingBlocks);
 
@@ -202,12 +220,20 @@ TFuture<void> TChunkFileWriter::Close(
     const TWorkloadDescriptor& workloadDescriptor,
     const TDeferredChunkMetaPtr& chunkMeta)
 {
+    return CloseWithSession(workloadDescriptor, chunkMeta, {});
+}
+
+TFuture<void> TChunkFileWriter::CloseWithSession(
+    const TWorkloadDescriptor& workloadDescriptor,
+    const TDeferredChunkMetaPtr& chunkMeta,
+    NYT::TGuid sessionId)
+{
     if (auto error = TryChangeState(EState::Ready, EState::Closing); !error.IsOK()) {
         return MakeFuture<void>(std::move(error));
     }
 
     auto metaFileName = FileName_ + ChunkMetaSuffix;
-    return IOEngine_->Close({std::move(DataFile_), DataSize_, SyncOnClose_})
+    return IOEngine_->Close({std::move(DataFile_), DataSize_, SyncOnClose_}, workloadDescriptor, sessionId)
         .Apply(BIND([=, this, this_ = MakeStrong(this)] {
             YT_VERIFY(State_.load() == EState::Closing);
 
@@ -221,7 +247,7 @@ TFuture<void> TChunkFileWriter::Close(
             ChunkMeta_->CopyFrom(*chunkMeta);
             SetProtoExtension(ChunkMeta_->mutable_extensions(), BlocksExt_);
 
-            return IOEngine_->Open({metaFileName + NFS::TempFileSuffix, FileMode});
+            return IOEngine_->Open({metaFileName + NFS::TempFileSuffix, FileMode}, workloadDescriptor, sessionId);
         }))
         .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TIOEngineHandlePtr& chunkMetaFile) {
             YT_VERIFY(State_.load() == EState::Closing);
@@ -249,13 +275,15 @@ TFuture<void> TChunkFileWriter::Close(
                     {std::move(buffer)},
                     SyncOnClose_
                 },
-                workloadDescriptor.Category)
+                workloadDescriptor,
+                sessionId)
                 .Apply(BIND(&IIOEngine::Close, IOEngine_, IIOEngine::TCloseRequest{
                     std::move(chunkMetaFile),
                     MetaDataSize_,
                     SyncOnClose_
                 },
-                workloadDescriptor.Category));
+                workloadDescriptor,
+                sessionId));
         }))
         .Apply(BIND([=, this, this_ = MakeStrong(this)] {
             YT_VERIFY(State_.load() == EState::Closing);
@@ -267,8 +295,8 @@ TFuture<void> TChunkFileWriter::Close(
                 return VoidFuture;
             }
 
-            return IOEngine_->FlushDirectory({NFS::GetDirectoryName(FileName_)});
-        }).AsyncVia(IOEngine_->GetAuxPoolInvoker()))
+            return IOEngine_->FlushDirectory({NFS::GetDirectoryName(FileName_)}, workloadDescriptor, sessionId);
+        }).AsyncVia(IOEngine_->GetAuxPoolInvoker(workloadDescriptor, sessionId)))
         .Apply(BIND([this, _this = MakeStrong(this)] (const TError& error) {
             YT_VERIFY(State_.load() == EState::Closing);
 
@@ -318,7 +346,7 @@ TFuture<void> TChunkFileWriter::Cancel()
 
             State_.store(EState::Aborted);
         })
-        .AsyncVia(IOEngine_->GetAuxPoolInvoker())
+        .AsyncVia(IOEngine_->GetAuxPoolInvoker(EWorkloadCategory::UserInteractive, {})) // TODO what can we pass here
         .Run();
 }
 

--- a/yt/yt/server/lib/io/chunk_file_writer.h
+++ b/yt/yt/server/lib/io/chunk_file_writer.h
@@ -50,11 +50,26 @@ public:
         const TWorkloadDescriptor& workloadDescriptor,
         const std::vector<NChunkClient::TBlock>& blocks) override;
 
+    bool WriteBlockWithSession(
+        const TWorkloadDescriptor& workloadDescriptor,
+        const NChunkClient::TBlock& block,
+        NYT::TGuid sessionId);
+
+    bool WriteBlocksWithSession(
+        const TWorkloadDescriptor& workloadDescriptor,
+        const std::vector<NChunkClient::TBlock>& blocks,
+        NYT::TGuid sessionId);
+
     TFuture<void> GetReadyEvent() override;
 
     TFuture<void> Close(
         const TWorkloadDescriptor& workloadDescriptor,
         const NChunkClient::TDeferredChunkMetaPtr& chunkMeta) override;
+
+    TFuture<void> CloseWithSession(
+        const TWorkloadDescriptor& workloadDescriptor,
+        const NChunkClient::TDeferredChunkMetaPtr& chunkMeta,
+        NYT::TGuid sessionId);
 
     const NChunkClient::NProto::TChunkInfo& GetChunkInfo() const override;
     const NChunkClient::NProto::TDataStatistics& GetDataStatistics() const override;

--- a/yt/yt/server/lib/io/dynamic_io_engine.cpp
+++ b/yt/yt/server/lib/io/dynamic_io_engine.cpp
@@ -37,77 +37,84 @@ public:
 
     TFuture<TReadResponse> Read(
         std::vector<TReadRequest> requests,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TRefCountedTypeCookie tagCookie,
-        TSessionId sessionId,
+        const TSessionId& sessionId,
         bool useDedicatedAllocations) override
     {
-        return GetCurrentEngine()->Read(std::move(requests), category, tagCookie, sessionId, useDedicatedAllocations);
+        return GetCurrentEngine()->Read(std::move(requests), descriptor, tagCookie, sessionId, useDedicatedAllocations);
     }
 
     TFuture<void> Write(
         TWriteRequest request,
-        EWorkloadCategory category,
-        TSessionId sessionId) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->Write(std::move(request), category, sessionId);
+        return GetCurrentEngine()->Write(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushFile(
         TFlushFileRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->FlushFile(std::move(request), category);
+        return GetCurrentEngine()->FlushFile(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushFileRange(
         TFlushFileRangeRequest request,
-        EWorkloadCategory category,
-        TSessionId sessionId) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->FlushFileRange(std::move(request), category, sessionId);
+        return GetCurrentEngine()->FlushFileRange(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushDirectory(
         TFlushDirectoryRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->FlushDirectory(std::move(request), category);
+        return GetCurrentEngine()->FlushDirectory(std::move(request), descriptor, sessionId);
     }
 
     TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->Open(std::move(request), category);
+        return GetCurrentEngine()->Open(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Close(
         TCloseRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->Close(std::move(request), category);
+        return GetCurrentEngine()->Close(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Allocate(
         TAllocateRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->Allocate(std::move(request), category);
+        return GetCurrentEngine()->Allocate(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Lock(
         TLockRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->Lock(std::move(request), category);
+        return GetCurrentEngine()->Lock(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Resize(
         TResizeRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->Resize(std::move(request), category);
+        return GetCurrentEngine()->Resize(std::move(request), descriptor, sessionId);
     }
 
     bool IsSick() const override
@@ -157,9 +164,11 @@ public:
         GetCurrentEngine()->Reconfigure(dynamicIOConfig);
     }
 
-    const IInvokerPtr& GetAuxPoolInvoker() override
+    IInvokerPtr GetAuxPoolInvoker(
+        const TWorkloadDescriptor& descriptor,
+        const TSessionId& sessionId) override
     {
-        return GetCurrentEngine()->GetAuxPoolInvoker();
+        return GetCurrentEngine()->GetAuxPoolInvoker(descriptor, sessionId);
     }
 
     i64 GetTotalReadBytes() const override

--- a/yt/yt/server/lib/io/io_engine.h
+++ b/yt/yt/server/lib/io/io_engine.h
@@ -106,6 +106,10 @@ struct IIOEngine
         i64 Offset = -1;
         i64 Size = -1;
         bool Async = false;
+        bool UseSpecifiedFlags = false;
+        bool SyncFileRangeWaitBefore = false;
+        bool SyncFileRangeWrite = false;
+        bool SyncFileRangeWaitAfter = false;
     };
 
     struct TFlushDirectoryRequest
@@ -131,50 +135,59 @@ struct IIOEngine
 
     virtual TFuture<TReadResponse> Read(
         std::vector<TReadRequest> requests,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TRefCountedTypeCookie tagCookie,
-        TSessionId sessionId = {},
+        const TSessionId& sessionId = {},
         bool useDedicatedAllocations = false) = 0;
     virtual TFuture<void> Write(
         TWriteRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle,
-        TSessionId sessionId = {}) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual TFuture<void> FlushFile(
         TFlushFileRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
     virtual TFuture<void> FlushFileRange(
         TFlushFileRangeRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle,
-        TSessionId sessionId = {}) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
     virtual TFuture<void> FlushDirectory(
         TFlushDirectoryRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
     virtual TFuture<void> Close(
         TCloseRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual TFuture<void> Allocate(
         TAllocateRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual TFuture<void> Lock(
         TLockRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual TFuture<void> Resize(
         TResizeRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual bool IsSick() const = 0;
 
     virtual void Reconfigure(const NYTree::INodePtr& dynamicIOConfig) = 0;
 
-    virtual const IInvokerPtr& GetAuxPoolInvoker() = 0;
+    virtual IInvokerPtr GetAuxPoolInvoker(
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {}) = 0;
 
     virtual i64 GetTotalReadBytes() const = 0;
     virtual i64 GetTotalWrittenBytes() const = 0;
@@ -186,8 +199,8 @@ struct IIOEngine
     // Extension methods.
     TFuture<TSharedRef> ReadAll(
         const TString& path,
-        EWorkloadCategory category = EWorkloadCategory::Idle,
-        TSessionId sessionId = {});
+        const TWorkloadDescriptor& descriptor = {},
+        const TSessionId& sessionId = {});
 };
 
 DEFINE_REFCOUNTED_TYPE(IIOEngine)

--- a/yt/yt/server/lib/io/io_engine_base.cpp
+++ b/yt/yt/server/lib/io/io_engine_base.cpp
@@ -226,46 +226,46 @@ void TRequestCounterGuard::MoveFrom(TRequestCounterGuard&& other)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TFuture<TIOEngineHandlePtr> TIOEngineBase::Open(TOpenRequest request, EWorkloadCategory category)
+TFuture<TIOEngineHandlePtr> TIOEngineBase::Open(TOpenRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoOpen, MakeStrong(this), std::move(request))
-        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Close(TCloseRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::Close(TCloseRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& /*sessionId*/)
 {
     auto invoker = (request.Flush || request.Size) ? FsyncInvoker_ : AuxInvoker_;
     return BIND(&TIOEngineBase::DoClose, MakeStrong(this), std::move(request))
-        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(invoker, GetBasicPriority(category)))
+        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(invoker, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::FlushDirectory(TFlushDirectoryRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::FlushDirectory(TFlushDirectoryRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoFlushDirectory, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(FsyncInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(FsyncInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Allocate(TAllocateRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::Allocate(TAllocateRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoAllocate, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Lock(TLockRequest request, EWorkloadCategory category)
+ TFuture<void> TIOEngineBase::Lock(TLockRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoLock, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Resize(TResizeRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::Resize(TResizeRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoResize, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
@@ -274,7 +274,7 @@ bool TIOEngineBase::IsSick() const
     return Sick_;
 }
 
-const IInvokerPtr& TIOEngineBase::GetAuxPoolInvoker()
+IInvokerPtr TIOEngineBase::GetAuxPoolInvoker(const TWorkloadDescriptor& /*descriptor*/, const TSessionId& /*sessionId*/)
 {
     return AuxThreadPool_->GetInvoker();
 }

--- a/yt/yt/server/lib/io/io_engine_base.h
+++ b/yt/yt/server/lib/io/io_engine_base.h
@@ -160,21 +160,21 @@ class TIOEngineBase
     : public IIOEngine
 {
 public:
-    TFuture<TIOEngineHandlePtr> Open(TOpenRequest request, EWorkloadCategory category) override;
+    TFuture<TIOEngineHandlePtr> Open(TOpenRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
-    TFuture<void> Close(TCloseRequest request, EWorkloadCategory category) override;
+    TFuture<void> Close(TCloseRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
-    TFuture<void> FlushDirectory(TFlushDirectoryRequest request, EWorkloadCategory category) override;
+    TFuture<void> FlushDirectory(TFlushDirectoryRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
-    TFuture<void> Allocate(TAllocateRequest request, EWorkloadCategory category) override;
+    TFuture<void> Allocate(TAllocateRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
-    virtual TFuture<void> Lock(TLockRequest request, EWorkloadCategory category) override;
+    virtual TFuture<void> Lock(TLockRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
-    virtual TFuture<void> Resize(TResizeRequest request, EWorkloadCategory category) override;
+    virtual TFuture<void> Resize(TResizeRequest request, const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
     bool IsSick() const override;
 
-    const IInvokerPtr& GetAuxPoolInvoker() override;
+    IInvokerPtr GetAuxPoolInvoker(const TWorkloadDescriptor& descriptor, const TSessionId& sessionId) override;
 
     i64 GetTotalReadBytes() const override;
 

--- a/yt/yt/server/lib/io/io_engine_fair.cpp
+++ b/yt/yt/server/lib/io/io_engine_fair.cpp
@@ -1,13 +1,12 @@
 #include "io_engine.h"
 #include "io_engine_base.h"
 #include "io_engine_uring.h"
-#include "io_engine_fair.h"
 #include "io_request_slicer.h"
 #include "private.h"
 
 #include <yt/yt/core/concurrency/action_queue.h>
 #include <yt/yt/core/concurrency/two_level_fair_share_thread_pool.h>
-#include <yt/yt/core/concurrency/new_fair_share_thread_pool.h>
+#include <yt/yt/core/concurrency/new_new_fair_share_thread_pool.h>
 #include <yt/yt/core/concurrency/thread_pool.h>
 
 #include <yt/yt/core/threading/thread.h>
@@ -44,62 +43,17 @@ using TSessionId = TIOEngineBase::TSessionId;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TIOEngineHandle::TIOEngineHandle(const TString& fName, EOpenMode oMode) noexcept
-    : TFileHandle(fName, oMode)
-    , OpenForDirectIO_(oMode & DirectAligned)
-{ }
+DECLARE_REFCOUNTED_CLASS(TFairIOEngineConfig)
 
-bool TIOEngineHandle::IsOpenForDirectIO() const
-{
-    return OpenForDirectIO_;
-}
-
-void TIOEngineHandle::MarkOpenForDirectIO(EOpenMode* oMode)
-{
-    *oMode |= DirectAligned;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-TFuture<TSharedRef> IIOEngine::ReadAll(
-    const TString& path,
-    const TWorkloadDescriptor& descriptor,
-    const TSessionId& sessionId)
-{
-    return Open({path, OpenExisting | RdOnly | Seq | CloseOnExec}, descriptor, sessionId)
-        .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TIOEngineHandlePtr& handle) {
-            struct TReadAllBufferTag
-            { };
-            return Read(
-                {{handle, 0, handle->GetLength()}},
-                descriptor,
-                GetRefCountedTypeCookie<TReadAllBufferTag>(),
-                sessionId)
-                .Apply(BIND(
-                    [=, this, this_ = MakeStrong(this), handle = handle]
-                    (const TReadResponse& response)
-                {
-                    YT_VERIFY(response.OutputBuffers.size() == 1);
-                    return Close({.Handle = handle}, descriptor, sessionId)
-                        .Apply(BIND([buffers = response.OutputBuffers] {
-                            return buffers[0];
-                        }));
-                }));
-        }));
-}
-
-////////////////////////////////////////////////////////////////////////////////
-
-DECLARE_REFCOUNTED_CLASS(TThreadPoolIOEngineConfig)
-
-class TThreadPoolIOEngineConfig
+class TFairIOEngineConfig
     : public TIOEngineConfigBase
 {
 public:
-    int ReadThreadCount;
-    int WriteThreadCount;
+    // Request size in bytes.
+    int DesiredRequestSize;
+    int MinRequestSize;
 
-    bool EnablePwritev;
+    // always flush after write with specified flags
     bool AlwaysFlushAfterWrite;
     bool SyncFileRangeWaitBefore;
     bool SyncFileRangeWrite;
@@ -108,193 +62,278 @@ public:
     bool FlushAfterWrite;
     bool AsyncFlushAfterWrite;
 
-    // Request size in bytes.
-    i64 DesiredRequestSize;
-    i64 MinRequestSize;
+    int ReadWriteThreadCount;
 
-    // Fair-share thread pool settings.
-    double DefaultPoolWeight;
-    double UserInteractivePoolWeight;
+    // Fair IO engine tries to estimate disk load of a single operation by the number of bytes submitted to disk.
+    // This approximation is bad for HDDs because even small request can force HDD to rotate and take some time.
+    // AdditiveCostOfOperationInBytes increases estimation for all reqests by this amount of bytes.
+    // This applied only to read and write operations.
+    int AdditiveCostOfOperationInBytes;
 
-    REGISTER_YSON_STRUCT(TThreadPoolIOEngineConfig);
+    THashMap<TString, double> PoolWeights;
+    TDuration BucketTtl;
+
+    REGISTER_YSON_STRUCT(TFairIOEngineConfig);
 
     static void Register(TRegistrar registrar)
     {
-        registrar.Parameter("read_thread_count", &TThis::ReadThreadCount)
-            .GreaterThanOrEqual(1)
-            .Default(1);
-        registrar.Parameter("write_thread_count", &TThis::WriteThreadCount)
-            .GreaterThanOrEqual(1)
-            .Default(1);
+        registrar.Parameter("desired_request_size", &TThis::DesiredRequestSize)
+            .GreaterThanOrEqual(4_KB)
+            .Default(1_MB);
+        registrar.Parameter("min_request_size", &TThis::MinRequestSize)
+            .GreaterThanOrEqual(512)
+            .Default(32_KB);
 
-        registrar.Parameter("enable_pwritev", &TThis::EnablePwritev)
-            .Default(true);
         registrar.Parameter("always_flush_after_write", &TThis::AlwaysFlushAfterWrite)
-            .Default(false);
+            .Default(true);
         registrar.Parameter("sync_file_range_write_before", &TThis::SyncFileRangeWaitBefore)
-            .Default(false);
+            .Default(true);
         registrar.Parameter("sync_file_range_write", &TThis::SyncFileRangeWrite)
-            .Default(false);
+            .Default(true);
         registrar.Parameter("sync_file_range_write_after", &TThis::SyncFileRangeWaitAfter)
-            .Default(false);
+            .Default(true);
 
         registrar.Parameter("flush_after_write", &TThis::FlushAfterWrite)
             .Default(false);
         registrar.Parameter("async_flush_after_write", &TThis::AsyncFlushAfterWrite)
             .Default(false);
 
-        registrar.Parameter("desired_request_size", &TThis::DesiredRequestSize)
-            .GreaterThanOrEqual(4_KB)
-            .Default(128_KB);
-        registrar.Parameter("min_request_size", &TThis::MinRequestSize)
-            .GreaterThanOrEqual(512)
-            .Default(64_KB);
-
-        registrar.Parameter("default_pool_weight", &TThis::DefaultPoolWeight)
-            .GreaterThan(0)
-            .Default(1);
-        registrar.Parameter("user_interactive_pool_weight", &TThis::UserInteractivePoolWeight)
+        registrar.Parameter("readwrite_thread_count", &TThis::ReadWriteThreadCount)
             .GreaterThanOrEqual(1)
-            .Default(4);
+            .Default(8);
+
+        registrar.Parameter("additive_cost_of_operation_in_bytes", &TThis::AdditiveCostOfOperationInBytes)
+            .GreaterThanOrEqual(0)
+            .Default(0);
+
+        registrar.Parameter("pool_weights", &TThis::PoolWeights)
+            .Default();
+        registrar.Parameter("bucket_ttl", &TThis::BucketTtl)
+            .Default(TDuration::Minutes(5));
     }
 };
 
-DEFINE_REFCOUNTED_TYPE(TThreadPoolIOEngineConfig)
+DEFINE_REFCOUNTED_TYPE(TFairIOEngineConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-class TFixedPriorityExecutor
-{
-public:
-    TFixedPriorityExecutor(
-        const TThreadPoolIOEngineConfigPtr& config,
-        const TString& locationId,
-        NLogging::TLogger /* logger */)
-        : ReadThreadPool_(CreateThreadPool(config->ReadThreadCount, Format("IOR:%v", locationId)))
-        , WriteThreadPool_(CreateThreadPool(config->WriteThreadCount, Format("IOW:%v", locationId)))
-        , ReadInvoker_(CreatePrioritizedInvoker(ReadThreadPool_->GetInvoker(), NProfiling::TTagSet({{"invoker", "fixed_priority_executor_reader"}, {"location_id", locationId}})))
-        , WriteInvoker_(CreatePrioritizedInvoker(WriteThreadPool_->GetInvoker(), NProfiling::TTagSet({{"invoker", "fixed_priority_executor_writer"}, {"location_id", locationId}})))
-    { }
-
-    IInvokerPtr GetReadInvoker(const TWorkloadDescriptor& descriptor, TIOEngineBase::TSessionId)
-    {
-        return CreateFixedPriorityInvoker(ReadInvoker_, GetBasicPriority(descriptor.Category));
-    }
-
-    IInvokerPtr GetWriteInvoker(const TWorkloadDescriptor& descriptor, TIOEngineBase::TSessionId)
-    {
-        return CreateFixedPriorityInvoker(WriteInvoker_, GetBasicPriority(descriptor.Category));
-    }
-
-    void Reconfigure(const TThreadPoolIOEngineConfigPtr& config)
-    {
-        ReadThreadPool_->Configure(config->ReadThreadCount);
-        WriteThreadPool_->Configure(config->WriteThreadCount);
-    }
-
-private:
-    const IThreadPoolPtr ReadThreadPool_;
-    const IThreadPoolPtr WriteThreadPool_;
-    const IPrioritizedInvokerPtr ReadInvoker_;
-    const IPrioritizedInvokerPtr WriteInvoker_;
-};
-
-class TPoolWeightProvider
+class TTwoLevelPoolWeightProvider
     : public IPoolWeightProvider
 {
 public:
-    TPoolWeightProvider(double defaultPoolWeight, double userInteractivePoolWeight)
-        : DefaultPoolWeight_(defaultPoolWeight)
-        , UserInteractivePoolWeight_(userInteractivePoolWeight)
+    TTwoLevelPoolWeightProvider(THashMap<TString, double> poolWeights)
+        : PoolWeights_(std::move(poolWeights))
     { }
 
     double GetWeight(const TString& poolName) override {
-        if (poolName == "Default") {
-            return DefaultPoolWeight_;
-        } else if (poolName == "UserInteractive") {
-            return UserInteractivePoolWeight_;
+        if (auto it = PoolWeights_.find(poolName); it != PoolWeights_.end()) {
+            return it->second;
+        } else {
+            return 1.0;
+        }
+    }
+
+    void Configure(THashMap<TString, double> poolWeights) {
+        PoolWeights_ = std::move(poolWeights);
+    }
+
+private:
+    THashMap<TString, double> PoolWeights_;
+};
+
+struct TBucketCacheEntry final
+{
+    NProfiling::TCpuInstant LastAccessTime;
+    TString PoolName;
+    TString BucketName;
+    IInvokerWithExpectedBytesPtr InvokerPtr;
+};
+
+bool operator < (const TIntrusivePtr<TBucketCacheEntry>& lhs, const TIntrusivePtr<TBucketCacheEntry>& rhs) {
+    return std::tie(lhs->LastAccessTime, lhs->PoolName, lhs->BucketName) < std::tie(rhs->LastAccessTime, rhs->PoolName, rhs->BucketName);
+}
+
+// Caches pointers to buckets in order to prolong their live(and progress) between calls.
+class TBucketCache final
+{
+public:
+    TBucketCache(
+        TDuration bucketTtl,
+        NLogging::TLogger logger)
+        : EntryTtl_(bucketTtl)
+        , Logger_(logger)
+    { }
+
+    IInvokerWithExpectedBytesPtr Get(
+        const INewNewTwoLevelFairShareThreadPoolPtr threadPool,
+        const TString& poolName,
+        const TString& bucketTag,
+        const double bucketWeight)
+    {
+        auto guard = Guard(Lock_);
+        auto now = NProfiling::GetCpuInstant();
+        FlushByTtl(now);
+
+        auto entry = KeyToEntry_.find(std::make_pair(poolName, bucketTag));
+        if (entry != KeyToEntry_.end()) {
+            EntriesSet_.erase(entry->second);
+            entry->second->LastAccessTime = now;
+            EntriesSet_.insert(entry->second);
+            return entry->second->InvokerPtr;
+        } else {
+            auto newEntry = New<TBucketCacheEntry>();
+            newEntry->LastAccessTime = now;
+            newEntry->PoolName = poolName;
+            newEntry->BucketName = bucketTag;
+            newEntry->InvokerPtr = threadPool->GetInvokerWithExpectedBytes(poolName, bucketTag, bucketWeight);
+            KeyToEntry_[std::make_pair(poolName, bucketTag)] = newEntry;
+            EntriesSet_.insert(newEntry);
+            return newEntry->InvokerPtr;
+        }
+    }
+
+private:
+    // Should be called with Lock acquired.
+    void FlushByTtl(NProfiling::TCpuInstant now) {
+        while (!EntriesSet_.empty() && (*EntriesSet_.begin())->LastAccessTime + NProfiling::DurationToCpuDuration(EntryTtl_) < now) {
+            auto entry = *EntriesSet_.begin();
+            EntriesSet_.erase(EntriesSet_.begin());
+            KeyToEntry_.erase(std::make_pair(entry->PoolName, entry->BucketName));
+        }
+    }
+
+private:
+    const TDuration EntryTtl_;
+    const NLogging::TLogger Logger_;
+    YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, Lock_);
+    THashMap<std::pair<TString, TString>, TIntrusivePtr<TBucketCacheEntry>> KeyToEntry_;
+    TSet<TIntrusivePtr<TBucketCacheEntry>> EntriesSet_;
+};
+
+class TTwoLevelFairShareThreadPool
+{
+public:
+    TTwoLevelFairShareThreadPool(
+        TFairIOEngineConfigPtr config,
+        const TString& locationId,
+        NLogging::TLogger logger)
+        : PoolWeightProvider_(New<TTwoLevelPoolWeightProvider>(config->PoolWeights))
+        , MainThreadPool_(CreateNewNewTwoLevelFairShareThreadPool(
+            config->ReadWriteThreadCount,
+            Format("TLFLoc:%v", locationId),
+            {
+                PoolWeightProvider_,
+                false
+            }))
+        , Logger(logger)
+        , BucketCache_(New<TBucketCache>(config->BucketTtl, logger))
+    { }
+
+    IInvokerWithExpectedBytesPtr GetInvoker(const TWorkloadDescriptor& workloadDescriptor, const TSessionId& sessionId)
+    {
+        const auto& poolName = ToString(workloadDescriptor.Category);
+        const auto& bucketTag = GetBucketTag(workloadDescriptor, sessionId);
+        const auto bucketWeight = GetBucketWeight(workloadDescriptor);
+        return BucketCache_->Get(MainThreadPool_, poolName, bucketTag, bucketWeight);
+    }
+
+    void Reconfigure(const TFairIOEngineConfigPtr& config)
+    {
+        PoolWeightProvider_->Configure(config->PoolWeights);
+        MainThreadPool_->Configure(config->ReadWriteThreadCount);
+    }
+
+private:
+    TString GetBucketTag(const TWorkloadDescriptor& workloadDescriptor, const TSessionId& sessionId) {
+        if (workloadDescriptor.DiskFairShareBucketTag) {
+            return *workloadDescriptor.DiskFairShareBucketTag;
+        } else if (!sessionId.IsEmpty()) {
+            return ToString(sessionId);
+        } else {
+            // TODO a better solution than random bucket?
+            return "Random-" + ToString(TSessionId::Create());
+        }
+    }
+
+    double GetBucketWeight(const TWorkloadDescriptor& workloadDescriptor) {
+        if (workloadDescriptor.DiskFairShareBucketWeight && *workloadDescriptor.DiskFairShareBucketWeight > 0) {
+            return *workloadDescriptor.DiskFairShareBucketWeight;
         } else {
             return 1.0;
         }
     }
 
 private:
-    const double DefaultPoolWeight_;
-    const double UserInteractivePoolWeight_;
+    TIntrusivePtr<TTwoLevelPoolWeightProvider> PoolWeightProvider_;
+    const INewNewTwoLevelFairShareThreadPoolPtr MainThreadPool_;
+    const NLogging::TLogger Logger;
+    TIntrusivePtr<TBucketCache> BucketCache_;
 };
 
-class TFairShareThreadPool
+class TWrappedInvokerWithExpectedBytes
+    : public virtual IInvoker
 {
 public:
-    TFairShareThreadPool(
-        TThreadPoolIOEngineConfigPtr config,
-        const TString& locationId,
-        NLogging::TLogger logger)
-        : ReadThreadPool_(CreateNewTwoLevelFairShareThreadPool(
-            config->ReadThreadCount,
-            Format("FSH:%v", locationId),
-            {
-                New<TPoolWeightProvider>(config->DefaultPoolWeight, config->UserInteractivePoolWeight)
-            }))
-        , WriteThreadPool_(CreateThreadPool(config->WriteThreadCount, Format("IOW:%v", locationId)))
-        , WriteInvoker_(CreatePrioritizedInvoker(WriteThreadPool_->GetInvoker(), NProfiling::TTagSet({{"invoker", "io_fair_share_thread_pool_writer"}, {"location_id", locationId}})))
-        , Logger(logger)
-        , DefaultPool_{"Default", config->DefaultPoolWeight}
-        , UserInteractivePool_{"UserInteractive", config->UserInteractivePoolWeight}
-    { }
+    TWrappedInvokerWithExpectedBytes(IInvokerWithExpectedBytesPtr invoker, i64 expectedBytes)
+        : Underlying_(invoker)
+        , ExpectedBytes_(expectedBytes)
+    {}
 
-    IInvokerPtr GetReadInvoker(const TWorkloadDescriptor& descriptor, TIOEngineBase::TSessionId client)
-    {
-        const auto& pool = GetPoolByCategory(descriptor.Category);
-        return ReadThreadPool_->GetInvoker(pool.Name, ToString(client));
+    //! Schedules invocation of a given callback.
+    void Invoke(TClosure callback) override {
+        Underlying_->InvokeWithExpectedBytes(callback, ExpectedBytes_);
     }
 
-    IInvokerPtr GetWriteInvoker(const TWorkloadDescriptor& descriptor, TIOEngineBase::TSessionId)
-    {
-        return CreateFixedPriorityInvoker(WriteInvoker_, GetBasicPriority(descriptor.Category));
-    }
-
-    void Reconfigure(const TThreadPoolIOEngineConfigPtr& config)
-    {
-        ReadThreadPool_->Configure(config->ReadThreadCount);
-        WriteThreadPool_->Configure(config->WriteThreadCount);
-    }
-
-private:
-    struct TPoolDescriptor
-    {
-        TString Name;
-        double Weight = 1.0;
-    };
-
-    const TPoolDescriptor& GetPoolByCategory(EWorkloadCategory category)
-    {
-        if (category == EWorkloadCategory::UserInteractive) {
-            return UserInteractivePool_;
+    //! Schedules multiple callbacks.
+    void Invoke(TMutableRange<TClosure> callbacks) override {
+        std::vector<std::pair<TClosure, i64>> newCallbacks;
+        for (auto c : callbacks) {
+            newCallbacks.push_back({c, ExpectedBytes_});
         }
-        return DefaultPool_;
+        Underlying_->InvokeWithExpectedBytes(newCallbacks);
+    }
+
+    //! Returns the thread id this invoker is bound to.
+    //! For invokers not bound to any particular thread,
+    //! returns |InvalidThreadId|.
+    NThreading::TThreadId GetThreadId() const override {
+        return Underlying_->GetThreadId();
+    }
+
+    //! Returns true if this invoker is either equal to #invoker or wraps it,
+    //! in some sense.
+    bool CheckAffinity(const IInvokerPtr& invoker) const override {
+        return Underlying_->CheckAffinity(invoker);
+    }
+
+    //! Returns true if invoker is serialized, i.e. never executes
+    //! two callbacks concurrently.
+    bool IsSerialized() const override {
+        return Underlying_->IsSerialized();
+    }
+
+    using TWaitTimeObserver = std::function<void(TDuration)>;
+    void RegisterWaitTimeObserver(TWaitTimeObserver waitTimeObserver) override {
+        return Underlying_->RegisterWaitTimeObserver(waitTimeObserver);
     }
 
 private:
-    const ITwoLevelFairShareThreadPoolPtr ReadThreadPool_;
-    const IThreadPoolPtr WriteThreadPool_;
-    const IPrioritizedInvokerPtr WriteInvoker_;
-    const NLogging::TLogger Logger;
-
-    const TPoolDescriptor DefaultPool_;
-    const TPoolDescriptor UserInteractivePool_;
+    IInvokerWithExpectedBytesPtr Underlying_;
+    i64 ExpectedBytes_;
 };
 
-template <typename TThreadPool, typename TRequestSlicer>
-class TThreadPoolIOEngine
+DEFINE_REFCOUNTED_TYPE(TWrappedInvokerWithExpectedBytes)
+
+template <typename TRequestSlicer>
+class TFairIOEngine
     : public TIOEngineBase
 {
 public:
-    using TConfig = TThreadPoolIOEngineConfig;
+    using TConfig = TFairIOEngineConfig;
     using TConfigPtr = TIntrusivePtr<TConfig>;
 
-    TThreadPoolIOEngine(
-        TConfigPtr config,
+    TFairIOEngine(
+        TFairIOEngineConfigPtr config,
         TString locationId,
         TProfiler profiler,
         NLogging::TLogger logger)
@@ -304,7 +343,7 @@ public:
             std::move(profiler),
             std::move(logger))
         , StaticConfig_(std::move(config))
-        , MainThreadPool_(StaticConfig_, LocationId_, Logger)
+        , ThreadPool_(StaticConfig_, LocationId_, Logger)
         , Config_(StaticConfig_)
         , RequestSlicer_(StaticConfig_->DesiredRequestSize, StaticConfig_->MinRequestSize)
     { }
@@ -319,7 +358,7 @@ public:
         std::vector<TFuture<void>> futures;
         futures.reserve(requests.size());
 
-        auto invoker = MainThreadPool_.GetReadInvoker(descriptor, sessionId);
+        auto invoker = ThreadPool_.GetInvoker(descriptor, sessionId);
 
         i64 paddedBytes = 0;
         for (const auto& request : requests) {
@@ -329,18 +368,17 @@ public:
 
         for (int index = 0; index < std::ssize(requests); ++index) {
             for (auto& slice : RequestSlicer_.Slice(std::move(requests[index]), buffers[index])) {
-                auto future = BIND(
-                    &TThreadPoolIOEngine::DoRead,
-                    MakeStrong(this),
-                    std::move(slice.Request),
-                    std::move(slice.OutputBuffer),
-                    TWallTimer(),
-                    descriptor,
-                    sessionId,
-                    Passed(CreateInFlightRequestGuard(EIOEngineRequestType::Read)))
-                    .AsyncVia(invoker)
-                    .Run();
-                futures.push_back(std::move(future));
+                i64 expectedBytes = Config_.Acquire()->AdditiveCostOfOperationInBytes + slice.Request.Size;
+                futures.push_back(
+                    BIND(&TFairIOEngine::DoRead,
+                        MakeStrong(this),
+                        std::move(slice.Request),
+                        std::move(slice.OutputBuffer),
+                        TWallTimer(),
+                        descriptor,
+                        sessionId)
+                    .AsyncVia(New<TWrappedInvokerWithExpectedBytes>(invoker, expectedBytes))
+                    .Run());
             }
         }
 
@@ -364,17 +402,12 @@ public:
         YT_ASSERT(request.Handle);
         std::vector<TFuture<void>> futures;
         for (auto& slice : RequestSlicer_.Slice(std::move(request))) {
-            auto future = BIND(
-                &TThreadPoolIOEngine::DoWrite,
-                MakeStrong(this),
-                std::move(slice),
-                TWallTimer(),
-                Passed(CreateInFlightRequestGuard(EIOEngineRequestType::Write)))
-                .AsyncVia(MainThreadPool_.GetWriteInvoker(descriptor, sessionId))
-                .Run();
-            futures.push_back(std::move(future));
+            auto expectedBytes = Config_.Acquire()->AdditiveCostOfOperationInBytes + static_cast<i64>(GetByteSize(slice.Buffers));
+            futures.push_back(
+                BIND(&TFairIOEngine::DoWrite, MakeStrong(this), std::move(slice), TWallTimer())
+                .AsyncVia(New<TWrappedInvokerWithExpectedBytes>(ThreadPool_.GetInvoker(descriptor, sessionId), expectedBytes))
+                .Run());
         }
-
         return AllSucceeded(std::move(futures));
     }
 
@@ -383,8 +416,9 @@ public:
         const TWorkloadDescriptor& descriptor,
         const TSessionId& sessionId) override
     {
-        return BIND(&TThreadPoolIOEngine::DoFlushFile, MakeStrong(this), std::move(request))
-            .AsyncVia(MainThreadPool_.GetWriteInvoker(descriptor, sessionId))
+        auto expectedBytes = 0;
+        return BIND(&TFairIOEngine::DoFlushFile, MakeStrong(this), std::move(request))
+            .AsyncVia(New<TWrappedInvokerWithExpectedBytes>(ThreadPool_.GetInvoker(descriptor, sessionId), expectedBytes))
             .Run();
     }
 
@@ -393,22 +427,23 @@ public:
         const TWorkloadDescriptor& descriptor,
         const TSessionId& sessionId) override
     {
+        auto expectedBytes = 0;
         std::vector<TFuture<void>> futures;
         for (auto& slice : RequestSlicer_.Slice(std::move(request))) {
             futures.push_back(
-                BIND(&TThreadPoolIOEngine::DoFlushFileRange, MakeStrong(this), std::move(slice))
-                .AsyncVia(MainThreadPool_.GetWriteInvoker(descriptor, sessionId))
+                BIND(&TFairIOEngine::DoFlushFileRange, MakeStrong(this), std::move(slice))
+                .AsyncVia(New<TWrappedInvokerWithExpectedBytes>(ThreadPool_.GetInvoker(descriptor, sessionId), expectedBytes))
                 .Run());
         }
         return AllSucceeded(std::move(futures));
     }
 
 protected:
-    const TConfigPtr StaticConfig_;
-    TThreadPool MainThreadPool_;
+    const TFairIOEngineConfigPtr StaticConfig_;
+    TTwoLevelFairShareThreadPool ThreadPool_;
 
 private:
-    TAtomicIntrusivePtr<TConfig> Config_;
+    TAtomicIntrusivePtr<TFairIOEngineConfig> Config_;
     TRequestSlicer RequestSlicer_;
 
 
@@ -467,12 +502,10 @@ private:
         TMutableRef buffer,
         TWallTimer timer,
         const TWorkloadDescriptor& descriptor,
-        const TSessionId& sessionId,
-        TRequestCounterGuard requestCounterGuard)
+        const TSessionId& sessionId)
     {
+        Y_UNUSED(descriptor); // TODO fix
         YT_VERIFY(std::ssize(buffer) == request.Size);
-
-        Y_UNUSED(requestCounterGuard);
 
         const auto readWaitTime = timer.GetElapsedTime();
         AddReadWaitTimeSample(readWaitTime);
@@ -544,41 +577,6 @@ private:
     }
 
     void DoWrite(
-        const TWriteRequest& request,
-        TWallTimer timer,
-        TRequestCounterGuard requestCounterGuard)
-    {
-        auto guard = std::move(requestCounterGuard);
-        auto writtenBytes = DoWriteImpl(request, timer);
-
-        auto config = Config_.Acquire();
-        if (config->AlwaysFlushAfterWrite && writtenBytes) {
-            DoFlushFileRange(TFlushFileRangeRequest{
-                .Handle = request.Handle,
-                .Offset = request.Offset,
-                .Size = writtenBytes,
-                .UseSpecifiedFlags = true,
-                .SyncFileRangeWaitBefore = config->SyncFileRangeWaitBefore,
-                .SyncFileRangeWrite= config->SyncFileRangeWrite,
-                .SyncFileRangeWaitAfter = config->SyncFileRangeWaitAfter
-                });
-        } else if (config->FlushAfterWrite && request.Flush && writtenBytes) {
-            DoFlushFileRange(TFlushFileRangeRequest{
-                .Handle = request.Handle,
-                .Offset = request.Offset,
-                .Size = writtenBytes
-            });
-        } else if (config->AsyncFlushAfterWrite && writtenBytes) {
-            DoFlushFileRange(TFlushFileRangeRequest{
-                .Handle = request.Handle,
-                .Offset = request.Offset,
-                .Size = writtenBytes,
-                .Async = true
-            });
-        }
-    }
-
-    i64 DoWriteImpl(
         const TWriteRequest& request,
         TWallTimer timer)
     {
@@ -689,7 +687,7 @@ private:
                     }
                 };
 
-                if (config->EnablePwritev && isPwritevSupported()) {
+                if (isPwritevSupported()) {
                     pwritev();
                 } else {
                     pwrite();
@@ -697,7 +695,33 @@ private:
             }
         });
 
-        return fileOffset - request.Offset;
+        auto writtenBytes = fileOffset - request.Offset;
+
+        auto config = Config_.Acquire();
+        if (config->AlwaysFlushAfterWrite && writtenBytes) {
+            DoFlushFileRange(TFlushFileRangeRequest{
+                .Handle = request.Handle,
+                .Offset = request.Offset,
+                .Size = writtenBytes,
+                .UseSpecifiedFlags = true,
+                .SyncFileRangeWaitBefore = config->SyncFileRangeWaitBefore,
+                .SyncFileRangeWrite = config->SyncFileRangeWrite,
+                .SyncFileRangeWaitAfter = config->SyncFileRangeWaitAfter
+                });
+        } else if (config->FlushAfterWrite && request.Flush && writtenBytes) {
+            DoFlushFileRange(TFlushFileRangeRequest{
+                .Handle = request.Handle,
+                .Offset = request.Offset,
+                .Size = writtenBytes
+            });
+        } else if (config->AsyncFlushAfterWrite && writtenBytes) {
+            DoFlushFileRange(TFlushFileRangeRequest{
+                .Handle = request.Handle,
+                .Offset = request.Offset,
+                .Size = writtenBytes,
+                .Async = true
+            });
+        }
     }
 
     void DoFlushFile(const TFlushFileRequest& request)
@@ -786,78 +810,30 @@ private:
     {
         auto config = UpdateYsonStruct(StaticConfig_, node);
 
-        MainThreadPool_.Reconfigure(config);
+        ThreadPool_.Reconfigure(config);
         Config_.Store(config);
     }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IIOEnginePtr CreateIOEngine(
-    EIOEngineType engineType,
+IIOEnginePtr CreateIOEngineFair(
     NYTree::INodePtr ioConfig,
     TString locationId,
-    TProfiler profiler,
+    NProfiling::TProfiler profiler,
     NLogging::TLogger logger)
-{
-    using TClassicThreadPoolIOEngine = TThreadPoolIOEngine<TFixedPriorityExecutor, TDummyRequestSlicer>;
-    using TClassicThreadPoolSlicedIOEngine = TThreadPoolIOEngine<TFixedPriorityExecutor, TIORequestSlicer>;
-    using TFairShareThreadPoolIOEngine = TThreadPoolIOEngine<TFairShareThreadPool, TIORequestSlicer>;
 
-    switch (engineType) {
-        case EIOEngineType::ThreadPool:
-            return CreateIOEngine<TClassicThreadPoolIOEngine>(
-                std::move(ioConfig),
-                std::move(locationId),
-                std::move(profiler),
-                std::move(logger));
-        case EIOEngineType::ThreadPoolSliced:
-            return CreateIOEngine<TClassicThreadPoolSlicedIOEngine>(
-                std::move(ioConfig),
-                std::move(locationId),
-                std::move(profiler),
-                std::move(logger));
-#ifdef _linux_
-        case EIOEngineType::Uring:
-        case EIOEngineType::FairShareUring:
-            return CreateIOEngineUring(
-                engineType,
-                std::move(ioConfig),
-                std::move(locationId),
-                std::move(profiler),
-                std::move(logger));
-#endif
-        case EIOEngineType::FairShareThreadPool:
-            return CreateIOEngine<TFairShareThreadPoolIOEngine>(
-                std::move(ioConfig),
-                std::move(locationId),
-                std::move(profiler),
-                std::move(logger));
-#ifdef _linux_
-        case NYT::NIO::EIOEngineType::Fair:
-            return CreateIOEngineFair(
-                std::move(ioConfig),
-                std::move(locationId),
-                std::move(profiler),
-                std::move(logger)
-            );
-#endif
-        default:
-            THROW_ERROR_EXCEPTION("Unknown IO engine %Qlv",
-                engineType);
-    }
-}
-
-std::vector<EIOEngineType> GetSupportedIOEngineTypes()
 {
-    std::vector<EIOEngineType> result;
-    result.push_back(EIOEngineType::ThreadPool);
-    if (IsUringIOEngineSupported()) {
-        result.push_back(EIOEngineType::Uring);
-        result.push_back(EIOEngineType::FairShareUring);
-    }
-    result.push_back(EIOEngineType::FairShareThreadPool);
-    return result;
+#ifdef _linux_
+
+    return CreateIOEngine<TFairIOEngine<TIORequestSlicer>>(
+        std::move(ioConfig),
+        std::move(locationId),
+        std::move(profiler),
+        std::move(logger));
+
+#endif
+    return { };
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/io/io_engine_fair.h
+++ b/yt/yt/server/lib/io/io_engine_fair.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "public.h"
+
+#include <yt/yt/library/profiling/sensor.h>
+
+#include <yt/yt/core/ytree/public.h>
+
+#include <yt/yt/core/logging/log.h>
+
+namespace NYT::NIO {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IIOEnginePtr CreateIOEngineFair(
+    NYTree::INodePtr ioConfig,
+    TString locationId,
+    NProfiling::TProfiler profiler,
+    NLogging::TLogger logger);
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NIO

--- a/yt/yt/server/lib/io/public.h
+++ b/yt/yt/server/lib/io/public.h
@@ -11,6 +11,8 @@ DEFINE_ENUM(EIOEngineType,
     (Uring)
     (FairShareThreadPool)
     (FairShareUring)
+    (Fair)
+    (ThreadPoolSliced)
 );
 
 DEFINE_ENUM(EDirectIOPolicy,

--- a/yt/yt/server/lib/io/unittests/gentle_loader_ut.cpp
+++ b/yt/yt/server/lib/io/unittests/gentle_loader_ut.cpp
@@ -95,9 +95,9 @@ public:
 
     TFuture<TReadResponse> Read(
         std::vector<TReadRequest> /*requests*/,
-        EWorkloadCategory /*category*/,
+        const TWorkloadDescriptor& /*descriptor*/,
         TRefCountedTypeCookie /*tagCookie*/,
-        TSessionId /*sessionId*/,
+        const TSessionId& /*sessionId*/,
         bool /*useDedicatedAllocations*/) override
     {
         return RunRequest(Config_.ReadLatency, Config_.ReadFailingProbability)
@@ -108,37 +108,40 @@ public:
 
     TFuture<void> Write(
         TWriteRequest /*request*/,
-        EWorkloadCategory /*category*/,
-        TSessionId /*sessionId*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(Config_.WriteLatency, Config_.WriteFailingProbability);
     }
 
     TFuture<void> FlushFile(
         TFlushFileRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> FlushFileRange(
         TFlushFileRangeRequest /*request*/,
-        EWorkloadCategory /*category*/,
-        TSessionId /*sessionId*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> FlushDirectory(
         TFlushDirectoryRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(Config_.OpenLatency, Config_.OpenFailingProbability)
             .Apply(BIND([] {
@@ -148,28 +151,32 @@ public:
 
     TFuture<void> Close(
         TCloseRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> Allocate(
         TAllocateRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> Lock(
         TLockRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> Resize(
         TResizeRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
@@ -180,7 +187,9 @@ public:
         return false;
     }
 
-    const IInvokerPtr& GetAuxPoolInvoker() override
+    IInvokerPtr GetAuxPoolInvoker(
+        const TWorkloadDescriptor& /*descriptor*/,
+        const TSessionId& /*sessionId*/) override
     {
         YT_UNIMPLEMENTED();
     }

--- a/yt/yt/server/lib/io/ya.make
+++ b/yt/yt/server/lib/io/ya.make
@@ -20,6 +20,7 @@ SRCS(
     dynamic_io_engine.cpp
     io_engine_base.cpp
     io_engine_uring.cpp
+    io_engine_fair.cpp
 )
 
 PEERDIR(

--- a/yt/yt/server/node/data_node/blob_chunk.cpp
+++ b/yt/yt/server/node/data_node/blob_chunk.cpp
@@ -890,7 +890,7 @@ IIOEngine::TReadRequest TBlobChunkBase::MakeChunkFragmentReadRequest(
 
 void TBlobChunkBase::SyncRemove(bool force)
 {
-    VERIFY_INVOKER_AFFINITY(Location_->GetAuxPoolInvoker());
+    VERIFY_INVOKER_AFFINITY(Location_->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
     Context_->BlobReaderCache->EvictReader(this);
 
@@ -902,7 +902,7 @@ TFuture<void> TBlobChunkBase::AsyncRemove()
     VERIFY_THREAD_AFFINITY_ANY();
 
     return BIND(&TBlobChunkBase::SyncRemove, MakeStrong(this), false)
-        .AsyncVia(Location_->GetAuxPoolInvoker())
+        .AsyncVia(Location_->GetAuxPoolInvoker({}, {})) // TODO what to pass here
         .Run();
 }
 

--- a/yt/yt/server/node/data_node/chunk_store.cpp
+++ b/yt/yt/server/node/data_node/chunk_store.cpp
@@ -205,7 +205,7 @@ TFuture<void> TChunkStore::InitializeLocation(const TStoreLocationPtr& location)
 
             location->Start();
         })
-        .AsyncVia(location->GetAuxPoolInvoker()));
+        .AsyncVia(location->GetAuxPoolInvoker({}, {}))); // TODO what to pass here
 }
 
 void TChunkStore::RegisterNewChunk(
@@ -357,7 +357,7 @@ TChunkStore::TChunkEntry TChunkStore::DoEraseChunk(const IChunkPtr& chunk)
 
 void TChunkStore::DoRegisterExistingChunk(const IChunkPtr& chunk)
 {
-    VERIFY_INVOKER_AFFINITY(chunk->GetLocation()->GetAuxPoolInvoker());
+    VERIFY_INVOKER_AFFINITY(chunk->GetLocation()->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
     {
         auto lockedChunkGuard = chunk->GetLocation()->TryLockChunk(chunk->GetId());

--- a/yt/yt/server/node/data_node/data_node_service.cpp
+++ b/yt/yt/server/node/data_node/data_node_service.cpp
@@ -1285,7 +1285,7 @@ private:
                     { };
                     readFutures.push_back(ioEngine->Read(
                         std::move(locationRequests[index]),
-                        workloadDescriptor.Category,
+                        workloadDescriptor,
                         GetRefCountedTypeCookie<TChunkFragmentBuffer>(),
                         readSessionId));
                 }

--- a/yt/yt/server/node/data_node/local_chunk_reader.cpp
+++ b/yt/yt/server/node/data_node/local_chunk_reader.cpp
@@ -287,7 +287,7 @@ public:
         const auto& ioEngine = chunk->GetLocation()->GetIOEngine();
         return ioEngine->Read(
             std::move(readRequests),
-            options.WorkloadDescriptor.Category,
+            options.WorkloadDescriptor,
             GetRefCountedTypeCookie<TChunkFragmentBufferTag>(),
             options.ReadSessionId)
             .ApplyUnique(BIND([

--- a/yt/yt/server/node/data_node/location.h
+++ b/yt/yt/server/node/data_node/location.h
@@ -268,7 +268,9 @@ public:
     double GetIOWeight() const;
 
     //! Returns an invoker for various auxiliarly IO activities.
-    const IInvokerPtr& GetAuxPoolInvoker();
+    IInvokerPtr GetAuxPoolInvoker(
+        const TWorkloadDescriptor& descriptor,
+        const TGuid& sessionId);
 
     //! Scan the location directory removing orphaned files and returning the list of found chunks.
     /*!

--- a/yt/yt/server/node/data_node/session_detail.cpp
+++ b/yt/yt/server/node/data_node/session_detail.cpp
@@ -34,7 +34,7 @@ TSessionBase::TSessionBase(
     , Location_(location)
     , Lease_(std::move(lease))
     , MasterEpoch_(Bootstrap_->GetMasterEpoch())
-    , SessionInvoker_(CreateSerializedInvoker(Location_->GetAuxPoolInvoker()))
+    , SessionInvoker_(CreateSerializedInvoker(Location_->GetAuxPoolInvoker(options.WorkloadDescriptor, SessionId_.ChunkId)))
     , Logger(DataNodeLogger.WithTag("LocationId: %v, ChunkId: %v",
         Location_->GetId(),
         SessionId_))

--- a/yt/yt/server/node/exec_node/cache_location.cpp
+++ b/yt/yt/server/node/exec_node/cache_location.cpp
@@ -171,7 +171,7 @@ std::vector<TString> TCacheLocation::GetChunkPartNames(TChunkId chunkId) const
 
 TFuture<void> TCacheLocation::RemoveChunks()
 {
-    VERIFY_INVOKER_AFFINITY(GetAuxPoolInvoker());
+    VERIFY_INVOKER_AFFINITY(GetAuxPoolInvoker(EWorkloadCategory::Idle, {})); // TODO what to pass here
     YT_LOG_INFO("Location is disabled; unregistering all the chunks in it (LocationId: %v)",
         GetId());
 
@@ -206,7 +206,7 @@ bool TCacheLocation::ScheduleDisable(const TError& reason)
             WaitFor(RemoveChunks())
                 .ThrowOnError();
             WaitFor(BIND(&TCacheLocation::SynchronizeActions, MakeStrong(this))
-                .AsyncVia(GetAuxPoolInvoker())
+                .AsyncVia(GetAuxPoolInvoker(EWorkloadCategory::Idle, {})) // TODO what to pass here
                 .Run())
                 .ThrowOnError();
             ResetLocationStatistic();
@@ -222,7 +222,7 @@ bool TCacheLocation::ScheduleDisable(const TError& reason)
                 GetState());
         }
     })
-        .AsyncVia(GetAuxPoolInvoker())
+        .AsyncVia(GetAuxPoolInvoker(EWorkloadCategory::Idle, {})) // TODO what to pass here
         .Run());
 
     return true;

--- a/yt/yt/server/node/exec_node/chunk_cache.cpp
+++ b/yt/yt/server/node/exec_node/chunk_cache.cpp
@@ -327,7 +327,7 @@ public:
 
             futures.push_back(
                 BIND(&TImpl::InitializeLocation, MakeStrong(this))
-                    .AsyncVia(location->GetAuxPoolInvoker())
+                    .AsyncVia(location->GetAuxPoolInvoker({}, {})) // TODO what to pass here
                     .Run(location));
 
             Locations_.push_back(location);
@@ -504,7 +504,7 @@ private:
 
     void InitializeLocation(const TCacheLocationPtr& location)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         auto descriptors = location->Scan();
 
@@ -603,7 +603,7 @@ private:
 
         TSessionCounterGuard sessionCounterGuard(location);
 
-        auto invoker = CreateSerializedInvoker(location->GetAuxPoolInvoker());
+        auto invoker = CreateSerializedInvoker(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
         invoker->Invoke(BIND(
             downloader,
             MakeStrong(this),
@@ -640,7 +640,7 @@ private:
         }
 
         YT_LOG_INFO("Scheduling cached chunk validation");
-        location->GetAuxPoolInvoker()->Invoke(BIND(
+        location->GetAuxPoolInvoker({}, {})->Invoke(BIND( // TODO what to pass here
             &TImpl::DoValidateChunk,
             MakeStrong(this),
             Passed(std::move(cookie)),
@@ -664,7 +664,7 @@ private:
         auto chunkId = descriptor.Descriptor.Id;
         const auto& location = descriptor.Location;
 
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         try {
             YT_LOG_INFO("Chunk validation started");
@@ -746,7 +746,7 @@ private:
         location->UpdateChunkCount(-1);
         location->UpdateUsedSpace(-descriptor.DiskSpace);
 
-        location->GetAuxPoolInvoker()->Invoke(BIND(
+        location->GetAuxPoolInvoker({}, {})->Invoke(BIND( // TODO what to pass here
             &TCacheLocation::RemoveChunkFiles,
             location,
             descriptor.Id,
@@ -779,7 +779,7 @@ private:
         const TCacheLocationPtr& location,
         const TChunkDescriptor& descriptor)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         auto chunkId = descriptor.Id;
 
@@ -965,7 +965,7 @@ private:
         const TClientChunkReadOptions& chunkReadOptions,
         TInsertCookie cookie)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         const auto& chunkSpec = key.chunk_specs(0);
         auto seedReplicas = GetReplicasFromChunkSpec(chunkSpec);
@@ -1127,7 +1127,7 @@ private:
         const TClientChunkReadOptions& chunkReadOptions,
         TInsertCookie cookie)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         try {
             auto producer = MakeFileProducer(
@@ -1214,7 +1214,7 @@ private:
         const TClientChunkReadOptions& chunkReadOptions,
         TInsertCookie cookie)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         try {
             auto producer = MakeTableProducer(
@@ -1366,7 +1366,7 @@ private:
         TLockedChunkGuard lockedChunkGuard,
         const std::function<void(IOutputStream*)>& producer)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         YT_LOG_INFO("Producing artifact file (ChunkId: %v, Location: %v)",
             chunkId,
@@ -1449,7 +1449,7 @@ private:
         const TCacheLocationPtr& location,
         TChunkId chunkId)
     {
-        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker());
+        VERIFY_INVOKER_AFFINITY(location->GetAuxPoolInvoker({}, {})); // TODO what to pass here
 
         if (!IsArtifactChunkId(chunkId)) {
             return TArtifactKey(chunkId);

--- a/yt/yt/ytlib/chunk_client/chunk_fragment_reader.cpp
+++ b/yt/yt/ytlib/chunk_client/chunk_fragment_reader.cpp
@@ -764,9 +764,11 @@ private:
 
     static TClientChunkReadOptions MakeOptions()
     {
+        auto workloadDescriptor = TWorkloadDescriptor(EWorkloadCategory::UserBatch);
+        workloadDescriptor.DiskFairShareBucketTag = "TPeriodicProbingSession";
         return {
             // TODO(akozhikhov): Employ some system category.
-            .WorkloadDescriptor = TWorkloadDescriptor(EWorkloadCategory::UserBatch),
+            .WorkloadDescriptor = workloadDescriptor,
             .ReadSessionId = TReadSessionId::Create()
         };
     }

--- a/yt/yt_proto/yt/client/misc/proto/workload.proto
+++ b/yt/yt_proto/yt/client/misc/proto/workload.proto
@@ -10,6 +10,8 @@ message TWorkloadDescriptor
     required int32 band = 2;
     optional int64 instant = 3;
     repeated string annotations = 4;
+    optional string disk_fair_share_bucket_tag = 5;
+    optional double disk_fair_share_bucket_weight = 6;
 }
 
 message TWorkloadDescriptorExt


### PR DESCRIPTION
This PR contains Fair IO PoC.

It consists of 3 parts:
1. "Coloring" of load to data nodes
   - Most APIs contain `workloadDescriptor` which specifies category of the load (`SystemReplication`, `UserInteractive`, `UserBatch`, ...). This PR adds `diskFairShareBucketTag` and `diskFairShareBucketWeight` to `workloadDescriptor` to group IO load by tag with correct weight
   - By default, tag is equal to `sessionId` or `readSessionId`, and weight is equal to 1. If we can't find a good tag, we make a random one.
   - Jobs were modified so their tag is equal to job id and weight is equal to cpu limit.
   - Unfortunately, `workloadDescriptor` is often ignored in code, so this PR also makes it mandatory and tries to fix the code for it
2. Weighted Fair Queue and thread pool.
   - There is already a Two-level WFQ with thread pool, in the file `yt/yt/core/concurrency/new_fair_share_thread_pool.cpp`. But it measures time for every operation which is not good for IO. It was copied to `yt/yt/core/concurrency/new_new_fair_share_thread_pool.cpp` and modified to work with expected IO bytes as a cost of an operation
3. Fair IO engine (`fair`)
   - A new `IOEngine` was introduced that:
      1. Creates a two-level WFQ with thread pool. First level is `workloadCategory`, second level is an arbitrary string(tag), which acts as a workload tag. Weights for first level are configured in data node config
      2. Parses workloadDescriptor of IO load, extracts correct `workloadCategory`, tag and weight, and submits an IO operation for execution to WFQ

It is better to illustrate what Fair IO engine does looking at it's config:
```
        registrar.Parameter("desired_request_size", &TThis::DesiredRequestSize)
            .Default(1_MB); // IO Requests (read, write) are splitted in parts of 1MB

        registrar.Parameter("always_flush_after_write", &TThis::AlwaysFlushAfterWrite)
            .Default(true); // After every write we execute sync_file_range syscall to keep dirty pages low. Parameters below specify passed flags.
        registrar.Parameter("sync_file_range_write_before", &TThis::SyncFileRangeWaitBefore)
            .Default(true);
        registrar.Parameter("sync_file_range_write", &TThis::SyncFileRangeWrite)
            .Default(true);
        registrar.Parameter("sync_file_range_write_after", &TThis::SyncFileRangeWaitAfter)
            .Default(true);

        registrar.Parameter("readwrite_thread_count", &TThis::ReadWriteThreadCount)
            .Default(8); // Amount of threads in a threadPool that execute read and write IO requests. Each requests uses at most `desired_request_size` bytes, so it is possible to control simultaneous disk load(Useful for shared disks).

        registrar.Parameter("additive_cost_of_operation_in_bytes", &TThis::AdditiveCostOfOperationInBytes)
            .Default(0); // Amount of bytes that is added to every read/write operation. Acts like a "tax" for operations that use small amount of bytes but cause big disk load(seek in HDD)

        registrar.Parameter("pool_weights", &TThis::PoolWeights)
            .Default(); // Weights of a first level of WFQ. Specifies disk share for SystemReplication, UserInteractive, UserBatch, etc.
        registrar.Parameter("bucket_ttl", &TThis::BucketTtl)
            .Default(TDuration::Minutes(5)); // WFQ needs to know when a bucket (load under the same `tag`) will stop coming. We assume it is 5 minutes and delete the bucket afterwards.
```

Our config overrides for HDD:
```
"io_config" = {
   "additive_cost_of_operation_in_bytes" = 1048576;
   "readwrite_thread_count" = 2;
};
"io_engine_type" = "fair";
```

This PR should be safe to merge and deploy anywhere. Unless `fair` IO engine is explicitly chosen in configs overrides, it should have 0 effects on the system.