### PR TITLE
Import ydb/library/yql/public/result_format from Arcadia

### DIFF
--- a/yt/yql/agent/ya.make
+++ b/yt/yql/agent/ya.make
@@ -45,6 +45,8 @@ PEERDIR(
     yt/yt/library/query/row_comparer
 
     yt/yql/plugin/bridge
+
+    ydb/library/yql/public/result_format
 )
 
 END()


### PR DESCRIPTION
 For get rid of SKIFF in favor of yson in YQL-YT interop.

