### PR TITLE
Couple fixes for clangd language server

### DIFF
--- a/yt/yt/client/api/file_reader.h
+++ b/yt/yt/client/api/file_reader.h
@@ -6,6 +6,7 @@
 #include <yt/yt/client/object_client/public.h>
 
 #include <yt/yt/core/concurrency/public.h>
+#include <yt/yt/core/concurrency/async_stream.h>
 
 namespace NYT::NApi {
 

--- a/yt/yt/client/ya.make
+++ b/yt/yt/client/ya.make
@@ -198,6 +198,11 @@ SRCS(
     kafka/requests.cpp
 )
 
+CONFIGURE_FILE(
+    api/rpc_proxy/protocol_version_variables.h.in
+    api/rpc_proxy/protocol_version_variables.h
+)
+
 SRCS(
     ${YT_SRCS}
     yt/yt/client/api/rpc_proxy/protocol_version_variables.h.in


### PR DESCRIPTION
- yt/client: include async_stream.h in file_reader.h
  NApi::IFileReader needs NConcurrency::IAsyncZeroCopyInputStream.
  
- Declare yt/yt/client/api/rpc_proxy/protocol_version_variables.h using CONFIGURE_FILE
  Otherwise resulting file does not materialize after:
  ya make --build-all --force-build-depends --replace-result --add-result=.h yt/yt/client/
  
  Proper source file generation is required at least for making clangd happy.
  
