### PR TITLE
Fix error message

### DIFF
--- a/yt/yt/server/master/cell_server/tamed_cell_manager.cpp
+++ b/yt/yt/server/master/cell_server/tamed_cell_manager.cpp
@@ -1093,7 +1093,7 @@ public:
         if (!cellBundle) {
             THROW_ERROR_EXCEPTION(
                 NYTree::EErrorCode::ResolveError,
-                "No such %Qlv cell bundle %Qlv",
+                "No such %lv cell bundle %Qlv",
                 cellarType,
                 name);
         }


### PR DESCRIPTION
`No such "tablet" cell bundle "default"` -> `No such tablet cell bundle "default"`