### PR TITLE
Fix queries finishing

### DIFF
--- a/yt/yt/server/query_tracker/query_tracker.cpp
+++ b/yt/yt/server/query_tracker/query_tracker.cpp
@@ -339,9 +339,14 @@ private:
             leaseTransactionId,
             optionalRecord->State);
 
+        // If current query state is "running", switch it to "pending". Otherwise, keep the existing state of a query;
+        // in particular, it may be "failing" or "completing" if the previous incarnation succeeded in reaching pre-terminating state.
+        auto newState = optionalRecord->State == EQueryState::Running ? EQueryState::Pending : optionalRecord->State;
+
         auto rowBuffer = New<TRowBuffer>();
         TActiveQueryPartial newRecord{
             .Key = queryRecord.Key,
+            .State = newState,
             .Incarnation = newIncarnation,
             .LeaseTransactionId = leaseTransactionId,
             .AssignedTracker = SelfAddress_,

--- a/yt/yt/tests/integration/queries/test_mock.py
+++ b/yt/yt/tests/integration/queries/test_mock.py
@@ -291,7 +291,7 @@ class TestQueryTrackerQueryRestart(YTEnvSetup):
             query.track()
 
     @authors("mpereskokova")
-    def test_query_tracker_compliting_query(self, query_tracker):
+    def test_query_tracker_completing_query(self, query_tracker):
         guid = self._insert_query("completing")
 
         query = Query(guid)

--- a/yt/yt/tests/integration/queries/test_mock.py
+++ b/yt/yt/tests/integration/queries/test_mock.py
@@ -246,6 +246,59 @@ class TestQueryTrackerBan(YTEnvSetup):
         wait(lambda: query.get_state() == "running", ignore_exceptions=True)
 
 
+class TestQueryTrackerPreFinishedState(YTEnvSetup):
+    DELTA_DRIVER_CONFIG = {
+        "cluster_connection_dynamic_config_policy": "from_cluster_directory",
+    }
+
+    def _insert_query(self, state, error="", is_abort=False):
+        guid = generate_uuid()
+        query = {
+            "query_id": guid,
+            "engine": "mock",
+            "user": "root",
+            "query": "run_forever",
+            "incarnation": 0,
+            "start_time": 0,
+            "progress": {},
+            "annotations": {},
+            "state": state,
+            "settings": {}
+        }
+        if is_abort:
+            query["abort_request"] = {"attributes": {}, "code": 100, "message": error}
+        else:
+            query["error"] = {"attributes": {}, "code": 100, "message": error}
+
+        insert_rows("//sys/query_tracker/active_queries", [query])
+        return guid
+
+    @authors("mpereskokova")
+    def test_query_tracker_aborting_query(self, query_tracker):
+        error = "test_abort"
+        guid = self._insert_query("aborting", error, is_abort=True)
+
+        query = Query(guid)
+        with raises_yt_error("aborted"):
+            query.track()
+
+    @authors("mpereskokova")
+    def test_query_tracker_failing_query(self, query_tracker):
+        error = "test_error"
+        guid = self._insert_query("failing", error)
+
+        query = Query(guid)
+        with raises_yt_error(error):
+            query.track()
+
+    @authors("mpereskokova")
+    def test_query_tracker_compliting_query(self, query_tracker):
+        guid = self._insert_query("completing")
+
+        query = Query(guid)
+        query.track()
+
+
 class TestAccessControl(YTEnvSetup):
     NUM_TEST_PARTITIONS = 16
 

--- a/yt/yt/tests/integration/queries/test_mock.py
+++ b/yt/yt/tests/integration/queries/test_mock.py
@@ -246,24 +246,24 @@ class TestQueryTrackerBan(YTEnvSetup):
         wait(lambda: query.get_state() == "running", ignore_exceptions=True)
 
 
-class TestQueryTrackerPreFinishedState(YTEnvSetup):
+class TestQueryTrackerQueryRestart(YTEnvSetup):
     DELTA_DRIVER_CONFIG = {
         "cluster_connection_dynamic_config_policy": "from_cluster_directory",
     }
 
-    def _insert_query(self, state, error="", is_abort=False):
+    def _insert_query(self, state, query="run_forever", settings={}, error="", is_abort=False):
         guid = generate_uuid()
         query = {
             "query_id": guid,
             "engine": "mock",
             "user": "root",
-            "query": "run_forever",
+            "query": query,
             "incarnation": 0,
             "start_time": 0,
             "progress": {},
             "annotations": {},
             "state": state,
-            "settings": {}
+            "settings": settings
         }
         if is_abort:
             query["abort_request"] = {"attributes": {}, "code": 100, "message": error}
@@ -284,16 +284,29 @@ class TestQueryTrackerPreFinishedState(YTEnvSetup):
 
     @authors("mpereskokova")
     def test_query_tracker_failing_query(self, query_tracker):
-        error = "test_error"
-        guid = self._insert_query("failing", error)
+        guid = self._insert_query("failing")
 
         query = Query(guid)
-        with raises_yt_error(error):
+        with raises_yt_error("failed"):
             query.track()
 
     @authors("mpereskokova")
     def test_query_tracker_compliting_query(self, query_tracker):
         guid = self._insert_query("completing")
+
+        query = Query(guid)
+        query.track()
+
+    @authors("mpereskokova")
+    def test_query_tracker_running_query(self, query_tracker):
+        guid = self._insert_query("running", query="complete_after", settings={"duration": 100})
+
+        query = Query(guid)
+        query.track()
+
+    @authors("mpereskokova")
+    def test_query_tracker_pending_query(self, query_tracker):
+        guid = self._insert_query("pending", query="complete_after", settings={"duration": 100})
 
         query = Query(guid)
         query.track()


### PR DESCRIPTION
Now, if qt crashes before completing the query, the query will remain incomplete forever.

This error occurred after introducing strong previous state conditions in state changing.
https://github.com/ytsaurus/ytsaurus/blame/main/yt/yt/server/query_tracker/handler_base.cpp#L342

Fixing it here