### PR TITLE
Remove wrong link from python start.md

### DIFF
--- a/yt/docs/en/_includes/api/python/start.md
+++ b/yt/docs/en/_includes/api/python/start.md
@@ -126,7 +126,6 @@ python
 
 ### Examples { #examples }
 
-* [About compiling Python programs in Arcadia](../../../api/python/examples.md#arcadia)
 * [Basic level](../../../api/python/examples.md#base)
    - [Reading and writing tables](../../../api/python/examples.md#read_write)
    - [Table schemas](../../../api/python/examples.md#table_schema)


### PR DESCRIPTION
It seems that "About compiling Python programs in Arcadia" relevant only for yandex team

