### PR TITLE
[WIP]: Transfer as YTSaurus ingestion

### DIFF
--- a/yt/chyt/controller/cmd/chyt-controller/init_cluster.go
+++ b/yt/chyt/controller/cmd/chyt-controller/init_cluster.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 	"golang.org/x/exp/slices"
 
 	"go.ytsaurus.tech/yt/chyt/controller/internal/app"
@@ -33,6 +34,9 @@ func doInitCluster() error {
 	}
 	if slices.Contains(config.Families, "livy") {
 		familyToInitializerFactory["livy"] = livy.NewClusterInitializer
+	}
+	if slices.Contains(config.Families, "tryt") {
+		familyToInitializerFactory["tryt"] = tryt.NewClusterInitializer
 	}
 
 	clusterInitializer := app.NewClusterInitializer(&config, familyToInitializerFactory)

--- a/yt/chyt/controller/cmd/chyt-controller/init_cluster.go
+++ b/yt/chyt/controller/cmd/chyt-controller/init_cluster.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 	"golang.org/x/exp/slices"
 
 	"go.ytsaurus.tech/yt/chyt/controller/internal/app"
@@ -10,6 +9,7 @@ import (
 	"go.ytsaurus.tech/yt/chyt/controller/internal/jupyt"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/livy"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/strawberry"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 )
 
 var initClusterCmd = &cobra.Command{

--- a/yt/chyt/controller/cmd/chyt-controller/one_shot_run.go
+++ b/yt/chyt/controller/cmd/chyt-controller/one_shot_run.go
@@ -10,6 +10,7 @@ import (
 	"go.ytsaurus.tech/yt/chyt/controller/internal/chyt"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/jupyt"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/strawberry"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yson"
 	"go.ytsaurus.tech/yt/go/yt"
@@ -52,6 +53,8 @@ func doOneShotRun() error {
 		ctor = chyt.NewController
 	} else if flagFamily == "jupyt" {
 		ctor = jupyt.NewController
+	} else if flagFamily == "tryt" {
+		ctor = tryt.NewController
 	} else {
 		panic(fmt.Errorf("unknown strawberry family %v", flagFamily))
 	}

--- a/yt/chyt/controller/cmd/chyt-controller/run.go
+++ b/yt/chyt/controller/cmd/chyt-controller/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 
 	"go.ytsaurus.tech/yt/chyt/controller/internal/api"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/app"
@@ -10,6 +9,7 @@ import (
 	"go.ytsaurus.tech/yt/chyt/controller/internal/jupyt"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/livy"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/strawberry"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 )
 
 var runCmd = &cobra.Command{

--- a/yt/chyt/controller/cmd/chyt-controller/run.go
+++ b/yt/chyt/controller/cmd/chyt-controller/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/tryt"
 
 	"go.ytsaurus.tech/yt/chyt/controller/internal/api"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/app"
@@ -67,6 +68,16 @@ func doRun() error {
 			ExtraCommands: []api.CmdDescriptor{},
 		}
 		cfs["livy"] = livyFactory
+	}
+
+	// TRYR Transfer controller is optional
+
+	if trytConfig, ok := config.Controllers["tryt"]; ok {
+		cfs["tryt"] = strawberry.ControllerFactory{
+			Ctor:          tryt.NewController,
+			Config:        trytConfig,
+			ExtraCommands: tryt.AllCommands,
+		}
 	}
 
 	a := app.New(&config, &options, cfs)

--- a/yt/chyt/controller/internal/app/one_shot_run.go
+++ b/yt/chyt/controller/internal/app/one_shot_run.go
@@ -43,6 +43,8 @@ func NewOneShotRunner(config *OneShotRunnerConfig, options *Options, cf strawber
 		Token:  config.Token,
 		Proxy:  config.Proxy,
 		Logger: withName(runner.l, "yt"),
+
+		DisableProxyDiscovery: true,
 	})
 	if err != nil {
 		panic(err)

--- a/yt/chyt/controller/internal/tryt/cluster_initializer.go
+++ b/yt/chyt/controller/internal/tryt/cluster_initializer.go
@@ -1,0 +1,24 @@
+package tryt
+
+import (
+	"go.ytsaurus.tech/library/go/core/log"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/strawberry"
+	"go.ytsaurus.tech/yt/go/ypath"
+	"go.ytsaurus.tech/yt/go/yt"
+)
+
+type ClusterInitializer struct {
+	ytc yt.Client
+}
+
+func (i *ClusterInitializer) InitializeCluster() error {
+	return nil
+}
+
+func (i *ClusterInitializer) ACONamespace() string {
+	return "tryt"
+}
+
+func NewClusterInitializer(l log.Logger, ytc yt.Client, root ypath.Path) strawberry.ClusterInitializer {
+	return &ClusterInitializer{ytc: ytc}
+}

--- a/yt/chyt/controller/internal/tryt/commands.go
+++ b/yt/chyt/controller/internal/tryt/commands.go
@@ -1,0 +1,5 @@
+package tryt
+
+import "go.ytsaurus.tech/yt/chyt/controller/internal/api"
+
+var AllCommands = []api.CmdDescriptor{} // TODO: restart command

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -1,19 +1,20 @@
 package tryt
 
+import "fmt"
+
 type Config struct {
 	ExtraEnvVars map[string]string `yson:"extra_env_vars"`
 	Command      *string           `yson:"command"`
+	LogLevel     *string           `yson:"log_level"`
+	LogConfig    *string           `yson:"log_config"`
+	JobCount     *int              `yson:"job_count"`
 }
 
-const (
-	DefaultCommand = "/usr/local/bin/trcli replicate --transfer /usr/local/bin/transfer.yaml --log-level info --log-config minimal"
-)
-
-func (c *Config) CommandOrDefault(Speclet) string {
+func (c *Config) CommandOrDefault(spec Speclet) string {
 	if c.Command != nil {
 		return *c.Command
 	}
-	return DefaultCommand
+	return fmt.Sprintf("/usr/local/bin/trcli %s --transfer /usr/local/bin/transfer.yaml --log-level %s --log-config %s", spec.Command(), c.LogLevelOrDefault(), c.LogConfigOrDefault())
 }
 
 func (c *Config) EnvVars(speclet Speclet) map[string]string {
@@ -27,4 +28,25 @@ func (c *Config) EnvVars(speclet Speclet) map[string]string {
 		res[k] = v
 	}
 	return res
+}
+
+func (c *Config) LogLevelOrDefault() string {
+	if c.LogLevel != nil {
+		return *c.LogLevel
+	}
+	return "info"
+}
+
+func (c *Config) LogConfigOrDefault() string {
+	if c.LogConfig != nil {
+		return *c.LogConfig
+	}
+	return "console"
+}
+
+func (c *Config) JobCountOrDefault() int {
+	if c.JobCount != nil {
+		return *c.JobCount
+	}
+	return 1
 }

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -8,13 +8,18 @@ type Config struct {
 	LogLevel     *string           `yson:"log_level"`
 	LogConfig    *string           `yson:"log_config"`
 	JobCount     *int              `yson:"job_count"`
+	Binary       *string           `yson:"binary_path"`
 }
 
 func (c *Config) CommandOrDefault(spec Speclet) string {
 	if c.Command != nil {
 		return *c.Command
 	}
-	return fmt.Sprintf("/usr/local/bin/trcli %s --transfer transfer.yaml --log-level %s --log-config %s", spec.Command(), c.LogLevelOrDefault(), c.LogConfigOrDefault())
+	cliPath := "/usr/local/bin/trcli"
+	if c.Binary != nil {
+		cliPath = "trcli"
+	}
+	return fmt.Sprintf("%s %s --transfer transfer.yaml --log-level %s --log-config %s", cliPath, spec.Command(), c.LogLevelOrDefault(), c.LogConfigOrDefault())
 }
 
 func (c *Config) EnvVars(speclet Speclet) map[string]string {

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -1,36 +1,27 @@
 package tryt
 
 type Config struct {
-	YTAuthCookieName    *string           `yson:"yt_auth_cookie_name"`
-	YTProxy             *string           `yson:"yt_proxy"`
-	ExtraEnvVars        map[string]string `yson:"extra_env_vars"`
-	LastActivityURLPath *string           `yson:"last_activity_url_path"`
-	Command             *string           `yson:"command"`
+	ExtraEnvVars map[string]string `yson:"extra_env_vars"`
+	Command      *string           `yson:"command"`
 }
 
 const (
-	DefaultYTAuthCookieName    = ""
-	DefaultLastActivityURLPath = "api/status"
-	DefaultCommand             = "bash -x start.sh /opt/conda/bin/jupyter lab --ip '*' --port $YT_PORT_0 --LabApp.token='' --allow-root >&2"
+	DefaultCommand = "replicate --transfer /usr/local/bin/transfer.yaml --log-level info --log-config minimal"
 )
 
-func (c *Config) YTAuthCookieNameOrDefault() string {
-	if c.YTAuthCookieName != nil {
-		return *c.YTAuthCookieName
-	}
-	return DefaultYTAuthCookieName
-}
-
-func (c *Config) LastActivityURLPathOrDefault() string {
-	if c.LastActivityURLPath != nil {
-		return *c.LastActivityURLPath
-	}
-	return DefaultLastActivityURLPath
-}
-
-func (c *Config) CommandOrDefault() string {
+func (c *Config) CommandOrDefault(Speclet) string {
 	if c.Command != nil {
 		return *c.Command
 	}
 	return DefaultCommand
+}
+
+func (c *Config) EnvVars(speclet Speclet) map[string]string {
+	res := map[string]string{
+		"YT_BASE_LAYER": speclet.DockerImage,
+	}
+	for k, v := range c.ExtraEnvVars {
+		res[k] = v
+	}
+	return res
 }

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -6,7 +6,7 @@ type Config struct {
 }
 
 const (
-	DefaultCommand = "replicate --transfer /usr/local/bin/transfer.yaml --log-level info --log-config minimal"
+	DefaultCommand = "/usr/local/bin/trcli replicate --transfer /usr/local/bin/transfer.yaml --log-level info --log-config minimal"
 )
 
 func (c *Config) CommandOrDefault(Speclet) string {
@@ -18,6 +18,9 @@ func (c *Config) CommandOrDefault(Speclet) string {
 
 func (c *Config) EnvVars(speclet Speclet) map[string]string {
 	res := map[string]string{
+		"NB_GID":        "0",
+		"NB_UID":        "0",
+		"NB_USER":       "root",
 		"YT_BASE_LAYER": speclet.DockerImage,
 	}
 	for k, v := range c.ExtraEnvVars {

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	LogConfig    *string           `yson:"log_config"`
 	JobCount     *int              `yson:"job_count"`
 	Binary       *string           `yson:"binary_path"`
+	ExtraLayers  []string          `yson:"extra_layers"`
 }
 
 func (c *Config) CommandOrDefault(spec Speclet) string {
@@ -22,12 +23,12 @@ func (c *Config) CommandOrDefault(spec Speclet) string {
 	return fmt.Sprintf("%s %s --transfer transfer.yaml --log-level %s --log-config %s", cliPath, spec.Command(), c.LogLevelOrDefault(), c.LogConfigOrDefault())
 }
 
-func (c *Config) EnvVars(speclet Speclet) map[string]string {
+func (c *Config) EnvVars() map[string]string {
 	res := map[string]string{
 		"NB_GID":        "0",
 		"NB_UID":        "0",
 		"NB_USER":       "root",
-		"YT_BASE_LAYER": speclet.DockerImage,
+		"YT_BASE_LAYER": "auto",
 	}
 	for k, v := range c.ExtraEnvVars {
 		res[k] = v

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -1,0 +1,36 @@
+package tryt
+
+type Config struct {
+	YTAuthCookieName    *string           `yson:"yt_auth_cookie_name"`
+	YTProxy             *string           `yson:"yt_proxy"`
+	ExtraEnvVars        map[string]string `yson:"extra_env_vars"`
+	LastActivityURLPath *string           `yson:"last_activity_url_path"`
+	Command             *string           `yson:"command"`
+}
+
+const (
+	DefaultYTAuthCookieName    = ""
+	DefaultLastActivityURLPath = "api/status"
+	DefaultCommand             = "bash -x start.sh /opt/conda/bin/jupyter lab --ip '*' --port $YT_PORT_0 --LabApp.token='' --allow-root >&2"
+)
+
+func (c *Config) YTAuthCookieNameOrDefault() string {
+	if c.YTAuthCookieName != nil {
+		return *c.YTAuthCookieName
+	}
+	return DefaultYTAuthCookieName
+}
+
+func (c *Config) LastActivityURLPathOrDefault() string {
+	if c.LastActivityURLPath != nil {
+		return *c.LastActivityURLPath
+	}
+	return DefaultLastActivityURLPath
+}
+
+func (c *Config) CommandOrDefault() string {
+	if c.Command != nil {
+		return *c.Command
+	}
+	return DefaultCommand
+}

--- a/yt/chyt/controller/internal/tryt/config.go
+++ b/yt/chyt/controller/internal/tryt/config.go
@@ -14,7 +14,7 @@ func (c *Config) CommandOrDefault(spec Speclet) string {
 	if c.Command != nil {
 		return *c.Command
 	}
-	return fmt.Sprintf("/usr/local/bin/trcli %s --transfer /usr/local/bin/transfer.yaml --log-level %s --log-config %s", spec.Command(), c.LogLevelOrDefault(), c.LogConfigOrDefault())
+	return fmt.Sprintf("/usr/local/bin/trcli %s --transfer transfer.yaml --log-level %s --log-config %s", spec.Command(), c.LogLevelOrDefault(), c.LogConfigOrDefault())
 }
 
 func (c *Config) EnvVars(speclet Speclet) map[string]string {

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -41,7 +41,7 @@ func (c *Controller) Prepare(
 	var filePaths []ypath.Rich
 	configP := c.root.Child(alias).Child("config.yaml")
 	configRich := configP.Rich()
-	configRich.FileName = "/usr/local/bin/transfer.yaml"
+	configRich.FileName = "transfer.yaml"
 	filePaths = append(filePaths, *configRich)
 	_, err = c.ytc.CreateNode(ctx, configP, yt.NodeFile, nil)
 	if err != nil {

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -35,7 +35,35 @@ func (c *Controller) Prepare(
 	speclet := oplet.ControllerSpeclet().(Speclet)
 	alias := oplet.Alias()
 	var filePaths []ypath.Rich
+	filePaths = append(filePaths, *c.root.Child("config.yaml").Attr("file_name").Child("/usr/local/bin/transfer.yaml").Rich())
 
+	w, err := c.ytc.WriteFile(ctx, c.root.Child("config.yaml"), nil)
+	if err != nil {
+		return
+	}
+	_, err = w.Write([]byte(fmt.Sprintf(
+		`
+id: %s
+type: %s
+src:
+  type: %s
+  params: |
+    %s
+dst:
+  type: %s
+  params: |
+    %s
+`,
+		alias,
+		speclet.TransferType,
+		speclet.SourceType,
+		speclet.SourceParams,
+		speclet.DestinationType,
+		speclet.DestinationParams,
+	)))
+	if err != nil {
+		return
+	}
 	spec = map[string]any{
 		"tasks": map[string]any{
 			"tryt": map[string]any{

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -43,6 +43,14 @@ func (c *Controller) Prepare(
 	configRich := configP.Rich()
 	configRich.FileName = "transfer.yaml"
 	filePaths = append(filePaths, *configRich)
+	if c.config.Binary != nil {
+		binaryPath, err := ypath.Parse(*c.config.Binary)
+		if err != nil {
+			return
+		}
+		binaryPath.FileName = "trcli"
+		filePaths = append(filePaths, *binaryPath)
+	}
 	_, err = c.ytc.CreateNode(ctx, configP, yt.NodeFile, nil)
 	if err != nil {
 		return

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -1,0 +1,178 @@
+package tryt
+
+import (
+	"context"
+	"go.ytsaurus.tech/library/go/core/log"
+	"go.ytsaurus.tech/yt/chyt/controller/internal/strawberry"
+	"go.ytsaurus.tech/yt/go/ypath"
+	"go.ytsaurus.tech/yt/go/yson"
+	"go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yterrors"
+)
+
+var (
+	_ strawberry.Controller = (*Controller)(nil)
+)
+
+type Controller struct {
+	ytc     yt.Client
+	l       log.Logger
+	root    ypath.Path
+	cluster string
+	config  Config
+}
+
+func (c *Controller) Prepare(
+	ctx context.Context,
+	oplet *strawberry.Oplet,
+) (
+	spec map[string]any,
+	description map[string]any,
+	annotation map[string]any,
+	err error,
+) {
+	return
+}
+
+func (c *Controller) Family() string {
+	return "tryt"
+}
+
+func (c *Controller) Root() ypath.Path {
+	return c.root
+}
+
+func (c *Controller) ParseSpeclet(specletYson yson.RawValue) (parsedSpeclet any, err error) {
+	var speclet Speclet
+	err = yson.Unmarshal(specletYson, &speclet)
+	if err != nil {
+		return nil, yterrors.Err("failed to parse speclet", err)
+	}
+	return speclet, nil
+}
+
+func (c *Controller) UpdateState() (changed bool, err error) {
+	return false, nil
+}
+
+func (c *Controller) DescribeOptions(parsedSpeclet any) []strawberry.OptionGroupDescriptor {
+	speclet := parsedSpeclet.(Speclet)
+
+	return []strawberry.OptionGroupDescriptor{
+		{
+			Title: "Transfer params",
+			Options: []strawberry.OptionDescriptor{
+				{
+					Title:        "Docker image",
+					Name:         "jupyter_docker_image",
+					Type:         strawberry.TypeString,
+					CurrentValue: speclet.DockerImage,
+					Description:  "A docker image containing jupyt and required stuff.",
+				},
+				{
+					Title:        "Type of source",
+					Name:         "src_type",
+					Type:         strawberry.TypeString,
+					CurrentValue: speclet.SourceType,
+					DefaultValue: "pg",
+					Description:  "Type of source endpoint, for example: kafka, pg, mysql, mongo.",
+				},
+				{
+					Title:        "Source params",
+					Name:         "src_params",
+					Type:         strawberry.TypeString,
+					CurrentValue: speclet.SourceParams,
+					DefaultValue: "{}",
+					Description:  "JSON-formatted params for source config.",
+				},
+				{
+					Title:        "Type of destinations",
+					Name:         "dst_type",
+					Type:         strawberry.TypeString,
+					CurrentValue: speclet.DestinationType,
+					DefaultValue: "yt",
+					Description:  "Type of destination endpoint, for example: yt.",
+				},
+				{
+					Title:        "Destination params",
+					Name:         "dst_params",
+					Type:         strawberry.TypeString,
+					CurrentValue: speclet.DestinationParams,
+					DefaultValue: "{}",
+					Description:  "JSON-formatted params for source config.",
+				},
+				{
+					Title:        "Transfer type",
+					Name:         "transfer_type",
+					Type:         strawberry.TypeDuration,
+					CurrentValue: speclet.TransferType,
+					DefaultValue: "SNAPSHOT_AND_INCREMENT",
+					Description:  "Transfer type: one of: SNAPSHOT_ONLY, INCREMENT_ONLY, SNAPSHOT_AND_INCREMENT",
+				},
+			},
+		},
+		{
+			Title: "Resources",
+			Options: []strawberry.OptionDescriptor{
+				{
+					Title:        "CPU",
+					Name:         "cpu",
+					Type:         strawberry.TypeInt64,
+					CurrentValue: speclet.CPU,
+					DefaultValue: DefaultCPU,
+					MinValue:     1,
+					MaxValue:     100,
+					Description:  "Number of CPU cores.",
+				},
+				{
+					Title:        "Total memory",
+					Name:         "memory",
+					Type:         strawberry.TypeByteCount,
+					CurrentValue: speclet.Memory,
+					DefaultValue: DefaultMemory,
+					MinValue:     2 * gib,
+					MaxValue:     128 * gib,
+					Description:  "Amount of RAM in bytes.",
+				},
+			},
+		},
+	}
+}
+
+func (c *Controller) GetOpBriefAttributes(parsedSpeclet any) map[string]any {
+	speclet := parsedSpeclet.(Speclet)
+
+	return map[string]any{
+		"cpu":    speclet.CPUOrDefault(),
+		"memory": speclet.MemoryOrDefault(),
+
+		"transfer_type": speclet.TransferType,
+		"src":           speclet.SourceType,
+		"dst":           speclet.DestinationType,
+	}
+}
+
+func (c *Controller) GetScalerTarget(ctx context.Context, opletInfo strawberry.OpletInfoForScaler) (*strawberry.ScalerTarget, error) {
+	return nil, nil
+}
+
+func parseConfig(rawConfig yson.RawValue) Config {
+	var controllerConfig Config
+	if rawConfig != nil {
+		if err := yson.Unmarshal(rawConfig, &controllerConfig); err != nil {
+			panic(err)
+		}
+	}
+	return controllerConfig
+}
+
+func NewController(l log.Logger, ytc yt.Client, root ypath.Path, cluster string, rawConfig yson.RawValue) strawberry.Controller {
+	c := &Controller{
+		l:       l,
+		ytc:     ytc,
+		root:    root,
+		cluster: cluster,
+		config:  parseConfig(rawConfig),
+	}
+	return c
+}

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -79,7 +79,7 @@ dst:
 		"tasks": map[string]any{
 			"tryt": map[string]any{
 				"command":                       c.config.CommandOrDefault(speclet),
-				"job_count":                     1,
+				"job_count":                     c.config.JobCountOrDefault(),
 				"cpu_limit":                     speclet.CPUOrDefault(),
 				"memory_limit":                  speclet.MemoryOrDefault(),
 				"environment":                   c.config.EnvVars(speclet),

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -2,6 +2,7 @@ package tryt
 
 import (
 	"context"
+	"fmt"
 	"go.ytsaurus.tech/library/go/core/log"
 	"go.ytsaurus.tech/yt/chyt/controller/internal/strawberry"
 	"go.ytsaurus.tech/yt/go/ypath"
@@ -31,6 +32,32 @@ func (c *Controller) Prepare(
 	annotation map[string]any,
 	err error,
 ) {
+	speclet := oplet.ControllerSpeclet().(Speclet)
+	alias := oplet.Alias()
+	var filePaths []ypath.Rich
+
+	spec = map[string]any{
+		"tasks": map[string]any{
+			"tryt": map[string]any{
+				"command":                       "replicate --transfer /usr/local/bin/transfer.yaml --log-level info --log-config minimal",
+				"job_count":                     1,
+				"cpu_limit":                     speclet.CPUOrDefault(),
+				"memory_limit":                  speclet.MemoryOrDefault(),
+				"environment":                   map[string]string{"YT_BASE_LAYER": speclet.DockerImage},
+				"docker_image":                  speclet.DockerImage,
+				"file_paths":                    filePaths,
+				"restart_completed_jobs":        true,
+				"memory_reserve_factor":         1.0,
+				"enable_rpc_proxy_in_job_proxy": true,
+			},
+		},
+		"max_failed_job_count": 100,
+		"title":                fmt.Sprintf("Transfer %s -> %s: %s", speclet.SourceType, speclet.DestinationType, alias),
+	}
+	annotation = map[string]any{
+		"is_spark": true,
+	}
+
 	return
 }
 

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -67,11 +67,11 @@ dst:
 	spec = map[string]any{
 		"tasks": map[string]any{
 			"tryt": map[string]any{
-				"command":                       "replicate --transfer /usr/local/bin/transfer.yaml --log-level info --log-config minimal",
+				"command":                       c.config.CommandOrDefault(speclet),
 				"job_count":                     1,
 				"cpu_limit":                     speclet.CPUOrDefault(),
 				"memory_limit":                  speclet.MemoryOrDefault(),
-				"environment":                   map[string]string{"YT_BASE_LAYER": speclet.DockerImage},
+				"environment":                   c.config.EnvVars(speclet),
 				"docker_image":                  speclet.DockerImage,
 				"file_paths":                    filePaths,
 				"restart_completed_jobs":        true,

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -44,12 +44,17 @@ func (c *Controller) Prepare(
 	configRich.FileName = "transfer.yaml"
 	filePaths = append(filePaths, *configRich)
 	if c.config.Binary != nil {
-		binaryPath, err := ypath.Parse(*c.config.Binary)
+		var binaryPath *ypath.Rich
+		binaryPath, err = ypath.Parse(*c.config.Binary)
 		if err != nil {
 			return
 		}
 		binaryPath.FileName = "trcli"
 		filePaths = append(filePaths, *binaryPath)
+	}
+	for _, l := range c.config.ExtraLayers {
+		p, _ := ypath.Parse(l)
+		filePaths = append(filePaths, *p)
 	}
 	_, err = c.ytc.CreateNode(ctx, configP, yt.NodeFile, nil)
 	if err != nil {
@@ -92,7 +97,7 @@ dst:
 				"job_count":                     c.config.JobCountOrDefault(),
 				"cpu_limit":                     speclet.CPUOrDefault(),
 				"memory_limit":                  speclet.MemoryOrDefault(),
-				"environment":                   c.config.EnvVars(speclet),
+				"environment":                   c.config.EnvVars(),
 				"docker_image":                  speclet.DockerImage,
 				"file_paths":                    filePaths,
 				"restart_completed_jobs":        true,

--- a/yt/chyt/controller/internal/tryt/controller.go
+++ b/yt/chyt/controller/internal/tryt/controller.go
@@ -40,7 +40,9 @@ func (c *Controller) Prepare(
 	alias := oplet.Alias()
 	var filePaths []ypath.Rich
 	configP := c.root.Child(alias).Child("config.yaml")
-	filePaths = append(filePaths, *configP.Rich())
+	configRich := configP.Rich()
+	configRich.FileName = "/usr/local/bin/transfer.yaml"
+	filePaths = append(filePaths, *configRich)
 	_, err = c.ytc.CreateNode(ctx, configP, yt.NodeFile, nil)
 	if err != nil {
 		return

--- a/yt/chyt/controller/internal/tryt/speclet.go
+++ b/yt/chyt/controller/internal/tryt/speclet.go
@@ -1,7 +1,5 @@
 package tryt
 
-import "time"
-
 type Speclet struct {
 	CPU    *uint64 `yson:"cpu"`
 	Memory *uint64 `yson:"memory"`
@@ -16,11 +14,9 @@ type Speclet struct {
 }
 
 const (
-	gib                = 1024 * 1024 * 1024
-	DefaultCPU         = 2
-	DefaultMemory      = 8 * gib
-	DefaultGPU         = 0
-	DefaultIdleTimeout = 24 * time.Hour
+	gib           = 1024 * 1024 * 1024
+	DefaultCPU    = 2
+	DefaultMemory = 8 * gib
 )
 
 func (s *Speclet) CPUOrDefault() uint64 {

--- a/yt/chyt/controller/internal/tryt/speclet.go
+++ b/yt/chyt/controller/internal/tryt/speclet.go
@@ -1,25 +1,25 @@
 package tryt
 
 type Speclet struct {
-	CPU    *uint64 `yson:"cpu"`
-	Memory *uint64 `yson:"memory"`
+	CPU    *float64 `yson:"cpu"`
+	Memory *uint64  `yson:"memory"`
 
 	DockerImage string `yson:"docker_image"`
 
 	TransferType      string `yson:"transfer_type"`
 	SourceType        string `yson:"src_type"`
-	SourceParams      string `yson:"src_params"`
+	SourceParams      any    `yson:"src_params"`
 	DestinationType   string `yson:"dst_type"`
-	DestinationParams string `yson:"dst_params"`
+	DestinationParams any    `yson:"dst_params"`
 }
 
 const (
 	gib           = 1024 * 1024 * 1024
-	DefaultCPU    = 2
-	DefaultMemory = 8 * gib
+	DefaultCPU    = 0.1
+	DefaultMemory = 2 * gib
 )
 
-func (s *Speclet) CPUOrDefault() uint64 {
+func (s *Speclet) CPUOrDefault() float64 {
 	if s.CPU != nil {
 		return *s.CPU
 	}

--- a/yt/chyt/controller/internal/tryt/speclet.go
+++ b/yt/chyt/controller/internal/tryt/speclet.go
@@ -16,7 +16,7 @@ type Speclet struct {
 const (
 	gib           = 1024 * 1024 * 1024
 	DefaultCPU    = 0.1
-	DefaultMemory = 2 * gib
+	DefaultMemory = 0.5 * gib
 )
 
 func (s *Speclet) CPUOrDefault() float64 {

--- a/yt/chyt/controller/internal/tryt/speclet.go
+++ b/yt/chyt/controller/internal/tryt/speclet.go
@@ -32,3 +32,12 @@ func (s *Speclet) MemoryOrDefault() uint64 {
 	}
 	return DefaultMemory
 }
+
+func (s *Speclet) Command() string {
+	switch s.TransferType {
+	case "INCREMENT_ONLY", "SNAPSHOT_AND_INCREMENT":
+		return "replicate"
+	default:
+		return "activate"
+	}
+}

--- a/yt/chyt/controller/internal/tryt/speclet.go
+++ b/yt/chyt/controller/internal/tryt/speclet.go
@@ -1,0 +1,38 @@
+package tryt
+
+import "time"
+
+type Speclet struct {
+	CPU    *uint64 `yson:"cpu"`
+	Memory *uint64 `yson:"memory"`
+
+	DockerImage string `yson:"docker_image"`
+
+	TransferType      string `yson:"transfer_type"`
+	SourceType        string `yson:"src_type"`
+	SourceParams      string `yson:"src_params"`
+	DestinationType   string `yson:"dst_type"`
+	DestinationParams string `yson:"dst_params"`
+}
+
+const (
+	gib                = 1024 * 1024 * 1024
+	DefaultCPU         = 2
+	DefaultMemory      = 8 * gib
+	DefaultGPU         = 0
+	DefaultIdleTimeout = 24 * time.Hour
+)
+
+func (s *Speclet) CPUOrDefault() uint64 {
+	if s.CPU != nil {
+		return *s.CPU
+	}
+	return DefaultCPU
+}
+
+func (s *Speclet) MemoryOrDefault() uint64 {
+	if s.Memory != nil {
+		return *s.Memory
+	}
+	return DefaultMemory
+}

--- a/yt/chyt/controller/internal/tryt/ya.make
+++ b/yt/chyt/controller/internal/tryt/ya.make
@@ -1,0 +1,11 @@
+GO_LIBRARY()
+
+SRCS(
+    cluster_initializer.go
+    commands.go
+    config.go
+    controller.go
+    speclet.go
+)
+
+END()

--- a/yt/chyt/controller/internal/ya.make
+++ b/yt/chyt/controller/internal/ya.make
@@ -10,4 +10,5 @@ RECURSE(
     monitoring
     sleep
     strawberry
+    tryt
 )

--- a/yt/go/go.sum
+++ b/yt/go/go.sum
@@ -80,7 +80,6 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
-github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0/go.mod h1:ggCgvZ2r7uOoQjOyu2Y1NhHmEPPzzuhWgcza5M1Ji1I=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -284,7 +283,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
-google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yt/go/go.sum
+++ b/yt/go/go.sum
@@ -80,6 +80,7 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0/go.mod h1:ggCgvZ2r7uOoQjOyu2Y1NhHmEPPzzuhWgcza5M1Ji1I=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -283,6 +284,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.63.2 h1:MUeiw1B2maTVZthpU5xvASfTh3LDbxHd6IJ6QQVU+xM=
 google.golang.org/grpc v1.63.2/go.mod h1:WAX/8DgncnokcFUldAxq7GeB5DXHDbMF+lLvDomNkRA=
+google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -2414,6 +2414,16 @@ def add_jupyt_parser(root_subparsers):
     add_strawberry_ctl_parser(add_jupyter_subparser, "jupyt")
 
 
+def add_tryt_parser(root_subparsers):
+   parser = populate_argument_help(root_subparsers.add_parser(
+       "tryt", description="Transfer over YT commands"))
+
+   tryt_subparsers = parser.add_subparsers(metavar="transfer_command", **SUBPARSER_KWARGS)
+
+   add_tryt_subparser = add_subparser(tryt_subparsers, params_argument=False)
+   add_strawberry_ctl_parser(add_tryt_subparser, "tryt")
+
+
 @copy_docstring_from(yt.find_spark_cluster)
 def find_spark_cluster_handler(*args, **kwargs):
     spark_cluster = yt.find_spark_cluster(*args, **kwargs)


### PR DESCRIPTION
The transfer is an open-source ingestion engine that has first-class YT support, you can run it from outside scope to YT-cluster, as shown [here](https://github.com/doublecloud/transfer/tree/main/examples/pg2yt), but running it as controlled job is way better user experience.

The general idea is to make transfer accessible the same way as it made for CHYT or JUPYT:

Create an ingestion transfer. To create a transfer you should specify docker-image with the configuration and pool for the operation.

```bash
yt tryt ctl create \
  --speclet-options '{
    "docker_image"="ghcr.io/doublecloud/transfer:v0.0.0-rc9";
    "transfer_type"="SNAPSHOT_AND_INCREMENT";
    "src_type"="pg";
    "src_params"={
        "Hosts"=["localhost"];
        "User"="postgres";
        "Password"="password";
        "Database"="mydb";
        "Port"=5432;
    };
    "dst_type"="yt";
    "dst_params"={
        "path"="//home/tryt";
        "cluster"="yt-backend:80";
        "cellbundle"="default";
        "primarymedium"="default";
    };
}' \
  test-transfer

```

Launch the transfer.

```
yt tryt ctl start test-transfer
```

Once transfer is running - data start to stream into YT-table.