### PR TITLE
Rework authentication commands in CLI over getpass.

### DIFF
--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -1927,42 +1927,37 @@ def add_get_job_spec_parser(add_parser):
 
 
 def add_set_user_password_parser(add_parser):
-    parser = add_parser("set-user-password", yt.set_user_password)
+    parser = add_parser("set-user-password", cli_impl._set_user_password_interactive)
     parser.add_argument("user", help="user to set password")
-    parser.add_argument("--current-password", type=str, help="current user password")
-    parser.add_argument("--new-password", type=str, help="new user password")
 
 
-@copy_docstring_from(yt.issue_token)
+@copy_docstring_from(cli_impl._issue_token_interactive)
 def issue_token(**kwargs):
-    result = yt.issue_token(**kwargs)
+    result = cli_impl._issue_token_interactive(**kwargs)
     print_to_output(result)
 
 
 def add_issue_token_parser(add_parser):
     parser = add_parser("issue-token", issue_token)
     parser.add_argument("user", help="user to issue token")
-    parser.add_argument("--password", type=str, help="user password")
 
 
 def add_revoke_token_parser(add_parser):
-    parser = add_parser("revoke-token", yt.revoke_token)
+    parser = add_parser("revoke-token", cli_impl._revoke_token_interactive)
     parser.add_argument("user", help="user to revoke token")
-    parser.add_argument("--password", type=str, help="user password")
-    parser.add_argument("--token", type=str, help="token to revoke")
-    parser.add_argument("--token-sha256", type=str, help="sha256-encoded token to revoke")
+    parser.add_argument("--token-sha256", type=str, help="sha256-encoded token to revoke; if omitted, token value "
+                                                         "is requested interactively")
 
 
-@copy_docstring_from(yt.list_user_tokens)
+@copy_docstring_from(cli_impl._list_user_tokens_interactive)
 def list_user_tokens(**kwargs):
-    result = yt.list_user_tokens(**kwargs)
+    result = cli_impl._list_user_tokens_interactive(**kwargs)
     print_to_output(result)
 
 
 def add_list_user_tokens(add_parser):
     parser = add_parser("list-user-tokens", list_user_tokens)
     parser.add_argument("user", help="user to revoke token")
-    parser.add_argument("--password", type=str, help="user password")
 
 
 @copy_docstring_from(yt.get_supported_features)

--- a/yt/python/yt/wrapper/auth_commands.py
+++ b/yt/python/yt/wrapper/auth_commands.py
@@ -11,7 +11,7 @@ def set_user_password(user, new_password, current_password=None,
                       client=None):
     """Updates user password."""
     params = {"user": user, "new_password_sha256": encode_sha256(new_password)}
-    if current_password:
+    if current_password is not None:
         params["current_password_sha256"] = encode_sha256(current_password)
     return make_request(
         "set_user_password",
@@ -36,6 +36,8 @@ def revoke_token(user, password=None, token=None, token_sha256=None,
                  client=None):
     """Revokes user token."""
     params = {"user": user}
+    if not token_sha256 and not token:
+        raise ValueError("Either token or token_sha256 must be provided")
     if not token_sha256:
         token_sha256 = encode_sha256(token)
     params["token_sha256"] = token_sha256

--- a/yt/python/yt/wrapper/cli_impl.py
+++ b/yt/python/yt/wrapper/cli_impl.py
@@ -1,8 +1,10 @@
-import yt.wrapper as yt
-import yt.logger as logger
 from .http_helpers import get_user_name
 from .common import YtError
 from .auth_commands import encode_sha256
+
+import yt.wrapper as yt
+import yt.logger as logger
+
 from getpass import getpass
 
 

--- a/yt/python/yt/wrapper/cli_impl.py
+++ b/yt/python/yt/wrapper/cli_impl.py
@@ -1,5 +1,9 @@
 import yt.wrapper as yt
 import yt.logger as logger
+from .http_helpers import get_user_name
+from .common import YtError
+from .auth_commands import encode_sha256
+from getpass import getpass
 
 
 def _set_attribute(path, name, value, recursive, client=None):
@@ -50,3 +54,65 @@ def _remove_attribute(path, name, recursive, client=None):
                 logger.info("Attribute '%s' is removed on path '%s'", name, str(obj))
     else:
         yt.remove_attribute(path, name)
+
+
+def _validate_authentication_command_permissions(user, client=None):
+    """Checks if the authenticated user (represented by client) has permission to run authentication commands on user,
+    and whether typing a password is required.
+
+    :returns: "passwordless" if no password is required, "password" if password is required, raises YtError if the
+    authenticated user is not allowed to run authentication commands on user.
+    """
+    # Follows TClient::ValidateAuthenticationCommandPermissions from native client.
+    self_user = get_user_name(client=client)
+    if yt.check_permission(self_user, "administer", "//sys/users/" + user)["action"] == "allow":
+        logger.debug("Allowing user %s to run passwordless authentication command on %s by present "
+                     "administer permission", self_user, user)
+        return "passwordless"
+    if self_user == user:
+        logger.debug("Password authentication required for user %s to run authentication command on themselves",
+                     self_user)
+        return "password"
+    raise YtError('Action can be performed either by user "{}" themselves, or by a user having "administer" permission '
+                  'on user \"{}\"'.format(user, user))
+
+
+def _maybe_request_password(user, client=None):
+    """Requests password if needed."""
+    if _validate_authentication_command_permissions(user, client=client) == "passwordless":
+        return None
+    return getpass("Current password for {}: ".format(user))
+
+
+def _set_user_password_interactive(user, client=None):
+    """Updates user password, reading it and optionally a current password
+    interactively and securely from console."""
+
+    current_password = _maybe_request_password(user, client=client)
+    new_password = getpass("New password: ")
+    new_password_retyped = getpass("Retype new password: ")
+    if new_password != new_password_retyped:
+        raise YtError("Passwords do not match")
+    return yt.set_user_password(user, new_password, current_password=current_password,
+                                client=client)
+
+
+def _issue_token_interactive(user, client=None):
+    """Issues a new token for user, reading password interactively and securely from console."""
+    password = _maybe_request_password(user, client=client)
+    return yt.issue_token(user, password=password, client=client)
+
+
+def _revoke_token_interactive(user, token_sha256=None, client=None):
+    """Revokes user token, reading password and maybe token value interactively and securely from console."""
+    password = _maybe_request_password(user, client=client)
+    if not token_sha256:
+        token = getpass("Token: ")
+        token_sha256 = encode_sha256(token)
+    return yt.revoke_token(user, password=password, token_sha256=token_sha256, client=client)
+
+
+def _list_user_tokens_interactive(user, client=None):
+    """Lists sha256-encoded user tokens, reading password interactively and securely from console."""
+    password = _maybe_request_password(user, client=client)
+    return yt.list_user_tokens(user, password=password, client=client)


### PR DESCRIPTION
Currently, authentication commands in CLI accept current/new user
passwords as command-line arguments, which is commonly considered
as a bad practice (as password typically leak to the shell history,
are publicly visible during typing, and for other obvious reasons).

For each method among set_user_password, issue_token, revoke_token,
list_user_tokens we introduce a similar command with suffix
"_interactive", which we use in a handler of a corresponding CLI
method. The interactive version reads secrets (passwords, tokens)
via getpass() method. Also, it is aware of server-side logic which
allows omitting the current user's password, if the authenticated user
has administrative permissions over a target user.

Despite being a backwards-incompatible change, it is justified
considering the dangerous behavior of the current CLI implementation.