### PR TITLE
[24.1] Make wire protocol reader validation limits configurable

### DIFF
--- a/yt/yt/client/table_client/wire_protocol.h
+++ b/yt/yt/client/table_client/wire_protocol.h
@@ -277,13 +277,25 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TWireProtocolOptions
+{
+    i64 MaxStringValueLength = NTableClient::MaxStringValueLength;
+    i64 MaxAnyValueLength = NTableClient::MaxAnyValueLength;
+    i64 MaxCompositeValueLength = NTableClient::MaxCompositeValueLength;
+    i64 MaxTimestampCountPerRow = NTableClient::MaxTimestampCountPerRow;
+    i64 MaxVersionedRowDataWeight = NTableClient::MaxServerVersionedRowDataWeight;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 //! Creates wire protocol reader.
 /*!
  *  If #rowBuffer is null, a default one is created.
  */
 std::unique_ptr<IWireProtocolReader> CreateWireProtocolReader(
     TSharedRef data,
-    TRowBufferPtr rowBuffer = TRowBufferPtr());
+    TRowBufferPtr rowBuffer = TRowBufferPtr(),
+    TWireProtocolOptions options = {});
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -298,7 +310,8 @@ IWireProtocolRowsetReaderPtr CreateWireProtocolRowsetReader(
     NCompression::ECodec codecId,
     NTableClient::TTableSchemaPtr schema,
     bool schemaful,
-    const NLogging::TLogger& logger);
+    const NLogging::TLogger& logger,
+    TWireProtocolOptions options = {});
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Cherrypicking this commit to 24.1: https://github.com/ytsaurus/ytsaurus/commit/8145f11a025c35bee6805fbddb693c15f9d41d28