### PR TITLE
[24.2] Make wire protocol reader validation limits configurable

### DIFF
--- a/yt/yt/client/table_client/wire_protocol.cpp
+++ b/yt/yt/client/table_client/wire_protocol.cpp
@@ -537,8 +537,9 @@ class TWireProtocolReader
     : public IWireProtocolReader
 {
 public:
-    explicit TWireProtocolReader(TSharedRef data, TRowBufferPtr rowBuffer)
+    explicit TWireProtocolReader(TSharedRef data, TRowBufferPtr rowBuffer, TWireProtocolOptions options)
         : RowBuffer_(rowBuffer ? std::move(rowBuffer) : New<TRowBuffer>(TWireProtocolReaderTag(), ReaderBufferChunkSize))
+        , Options_(std::move(options))
         , Data_(std::move(data))
         , Current_(Data_.Begin())
     { }
@@ -782,9 +783,11 @@ public:
 
 private:
     const TRowBufferPtr RowBuffer_;
+    const TWireProtocolOptions Options_;
 
     TSharedRef Data_;
     TIterator Current_;
+
 
     void ValidateSizeAvailable(size_t size)
     {
@@ -858,15 +861,15 @@ private:
 
     void DoReadStringData(EValueType type, ui32 length, const char** result, bool captureValues)
     {
-        ui32 limit = 0;
+        i64 limit = 0;
         if (type == EValueType::String) {
-            limit = MaxStringValueLength;
+            limit = Options_.MaxStringValueLength;
         }
         if (type == EValueType::Any) {
-            limit = MaxAnyValueLength;
+            limit = Options_.MaxAnyValueLength;
         }
         if (type == EValueType::Composite) {
-            limit = MaxCompositeValueLength;
+            limit = Options_.MaxCompositeValueLength;
         }
         if (length > limit) {
             THROW_ERROR_EXCEPTION("Value of type %Qlv is too long: length %v, limit %v",
@@ -995,10 +998,10 @@ private:
 
     void ValidateVersionedRowTimestampCount(const TVersionedRowHeader& rowHeader)
     {
-        if (rowHeader.WriteTimestampCount > MaxTimestampCountPerRow) {
+        if (rowHeader.WriteTimestampCount > Options_.MaxTimestampCountPerRow) {
             THROW_ERROR_EXCEPTION("Too many write timestamps in a versioned row");
         }
-        if (rowHeader.DeleteTimestampCount > MaxTimestampCountPerRow) {
+        if (rowHeader.DeleteTimestampCount > Options_.MaxTimestampCountPerRow) {
             THROW_ERROR_EXCEPTION("Too many delete timestamps in a versioned row");
         }
     }
@@ -1006,10 +1009,10 @@ private:
     void ValidateVersionedRowDataWeight(TVersionedRow row)
     {
         auto dataWeight = GetDataWeight(row);
-        if (dataWeight > MaxServerVersionedRowDataWeight) {
+        if (static_cast<i64>(dataWeight) > Options_.MaxVersionedRowDataWeight) {
             THROW_ERROR_EXCEPTION("Versioned row data weight is too large: %v > %v",
                 dataWeight,
-                MaxServerVersionedRowDataWeight)
+                Options_.MaxVersionedRowDataWeight)
                 << TErrorAttribute("key", ToOwningKey(row));
         }
     }
@@ -1053,9 +1056,9 @@ auto IWireProtocolReader::GetSchemaData(const TTableSchema& schema) -> TSchemaDa
 
 ////////////////////////////////////////////////////////////////////////////////
 
-std::unique_ptr<IWireProtocolReader> CreateWireProtocolReader(TSharedRef data, TRowBufferPtr rowBuffer)
+std::unique_ptr<IWireProtocolReader> CreateWireProtocolReader(TSharedRef data, TRowBufferPtr rowBuffer, TWireProtocolOptions options)
 {
-    return std::make_unique<TWireProtocolReader>(std::move(data), std::move(rowBuffer));
+    return std::make_unique<TWireProtocolReader>(std::move(data), std::move(rowBuffer), std::move(options));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1069,12 +1072,14 @@ public:
         NCompression::ECodec codecId,
         TTableSchemaPtr schema,
         bool schemaful,
-        const NLogging::TLogger& logger)
+        const NLogging::TLogger& logger,
+        TWireProtocolOptions options)
         : CompressedBlocks_(compressedBlocks)
         , Codec_(NCompression::GetCodec(codecId))
         , Schema_(std::move(schema))
         , Schemaful_(schemaful)
         , Logger(logger.WithTag("ReaderId: %v", TGuid::Create()))
+        , Options_(std::move(options))
     {
         YT_LOG_DEBUG("Wire protocol rowset reader created (BlockCount: %v, TotalCompressedSize: %v)",
             CompressedBlocks_.size(),
@@ -1103,7 +1108,7 @@ public:
             uncompressedBlock.Size());
 
         auto rowBuffer = New<TRowBuffer>(TWireProtocolReaderTag(), ReaderBufferChunkSize);
-        WireReader_ = CreateWireProtocolReader(uncompressedBlock, std::move(rowBuffer));
+        WireReader_ = CreateWireProtocolReader(uncompressedBlock, std::move(rowBuffer), Options_);
 
         if (!SchemaChecked_) {
             auto actualSchema = WireReader_->ReadTableSchema();
@@ -1165,6 +1170,7 @@ private:
     const TTableSchemaPtr Schema_;
     bool Schemaful_;
     const NLogging::TLogger Logger;
+    const TWireProtocolOptions Options_;
 
     int BlockIndex_ = 0;
     std::unique_ptr<IWireProtocolReader> WireReader_;
@@ -1178,14 +1184,16 @@ IWireProtocolRowsetReaderPtr CreateWireProtocolRowsetReader(
     NCompression::ECodec codecId,
     TTableSchemaPtr schema,
     bool schemaful,
-    const NLogging::TLogger& logger)
+    const NLogging::TLogger& logger,
+    TWireProtocolOptions options)
 {
     return New<TWireProtocolRowsetReader>(
         compressedBlocks,
         codecId,
         std::move(schema),
         schemaful,
-        logger);
+        logger,
+        std::move(options));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/table_client/wire_protocol.h
+++ b/yt/yt/client/table_client/wire_protocol.h
@@ -281,13 +281,25 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TWireProtocolOptions
+{
+    i64 MaxStringValueLength = NTableClient::MaxStringValueLength;
+    i64 MaxAnyValueLength = NTableClient::MaxAnyValueLength;
+    i64 MaxCompositeValueLength = NTableClient::MaxCompositeValueLength;
+    i64 MaxTimestampCountPerRow = NTableClient::MaxTimestampCountPerRow;
+    i64 MaxVersionedRowDataWeight = NTableClient::MaxServerVersionedRowDataWeight;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 //! Creates wire protocol reader.
 /*!
  *  If #rowBuffer is null, a default one is created.
  */
 std::unique_ptr<IWireProtocolReader> CreateWireProtocolReader(
     TSharedRef data,
-    TRowBufferPtr rowBuffer = TRowBufferPtr());
+    TRowBufferPtr rowBuffer = TRowBufferPtr(),
+    TWireProtocolOptions options = {});
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -302,7 +314,8 @@ IWireProtocolRowsetReaderPtr CreateWireProtocolRowsetReader(
     NCompression::ECodec codecId,
     NTableClient::TTableSchemaPtr schema,
     bool schemaful,
-    const NLogging::TLogger& logger);
+    const NLogging::TLogger& logger,
+    TWireProtocolOptions options = {});
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Cherrypicking this commit to 24.2: https://github.com/ytsaurus/ytsaurus/commit/8145f11a025c35bee6805fbddb693c15f9d41d28