### PR TITLE
Fix enable_idle_suspension field name in describe_options

### DIFF
--- a/yt/chyt/controller/internal/jupyt/controller.go
+++ b/yt/chyt/controller/internal/jupyt/controller.go
@@ -171,7 +171,7 @@ func (c *Controller) DescribeOptions(parsedSpeclet any) []strawberry.OptionGroup
 				},
 				{
 					Title:        "Enable idle timeout suspension",
-					Name:         "enable_idle_timeout_suspension",
+					Name:         "enable_idle_suspension",
 					Type:         strawberry.TypeBool,
 					CurrentValue: speclet.EnableIdleSuspension,
 					DefaultValue: false,


### PR DESCRIPTION
It is `enable_idle_suspension` in speclet: https://github.com/ytsaurus/ytsaurus/blob/main/yt/chyt/controller/internal/jupyt/speclet.go#L16.
