### PR TITLE
[odin] Stop using transaction for singular insert in dynamic table commands check; add ability to configure driver logging for odin server

### DIFF
--- a/yt/odin/bin/yt_odin/__main__.py
+++ b/yt/odin/bin/yt_odin/__main__.py
@@ -203,6 +203,7 @@ def main(args):
                 juggler_responsibles=juggler_config.get("responsibles"),
                 yt_enable_proxy_discovery=cluster_config["yt_config"].get("enable_proxy_discovery", True),
                 yt_driver_address_resolver_config=cluster_config["yt_config"].get("driver_address_resolver_config", {}),
+                yt_driver_logging_config=cluster_config["yt_config"].get("driver_logging_config", {}),
                 secrets=secrets)
 
             process = BoundProcess(target=run_odin, args=(db_kwargs, odin_kwargs),

--- a/yt/odin/checks/bin/dynamic_table_commands/__main__.py
+++ b/yt/odin/checks/bin/dynamic_table_commands/__main__.py
@@ -30,7 +30,7 @@ def run_check(yt_client, logger, options, states):
     rpc_client.remove(table, force=True)
 
     try:
-        rpc_client.create("table", table, attributes={
+        table_id = rpc_client.create("table", table, attributes={
             "dynamic": True,
             "schema": [
                 {"name": "x", "type": "string"},
@@ -40,15 +40,14 @@ def run_check(yt_client, logger, options, states):
             "expiration_time": "{}".format(datetime.utcnow() +
                                            timedelta(minutes=TABLE_EXPIRATION_TIME_DELTA_MINUTES)),
         })
-        logger.info("Created table %s", table)
+        logger.info("Created table %s with id %s", table, table_id)
 
         correct_rows = [{"x": "hello", "y": "world"}]
         rpc_client.mount_table(table, sync=True)
         logger.info("Mounted table")
 
-        with rpc_client.Transaction(type="tablet"):
-            rpc_client.insert_rows(table, correct_rows)
-            logger.info("Inserted rows")
+        rpc_client.insert_rows(table, correct_rows)
+        logger.info("Inserted rows")
 
         result_rows = list(rpc_client.select_rows("x, y from [{}]".format(table)))
 

--- a/yt/odin/lib/yt_odin/odinserver/odin.py
+++ b/yt/odin/lib/yt_odin/odinserver/odin.py
@@ -35,7 +35,8 @@ class Odin(object):
                  yt_heavy_request_retry_timeout=15000, default_check_timeout=65,
                  check_log_messages_max_size=16384, juggler_client_host=None, juggler_client_scheme=None,
                  juggler_client_port=None, juggler_host=None, juggler_responsibles=None,
-                 secrets=None, yt_enable_proxy_discovery=True, yt_driver_address_resolver_config=None):
+                 secrets=None, yt_enable_proxy_discovery=True, yt_driver_address_resolver_config=None,
+                 yt_driver_logging_config=None):
         signal.signal(signal.SIGHUP, sighup_handler)
 
         self.db_client_factory = db_client_factory
@@ -101,6 +102,7 @@ class Odin(object):
                 "start_operation_retries": retries_policy,
                 "token": token,
                 "driver_address_resolver_config": yt_driver_address_resolver_config,
+                "driver_logging_config": yt_driver_logging_config,
             })
 
         self.secrets = secrets


### PR DESCRIPTION
This PR does multiple small things:
* Removes client transaction from the `insert_rows` invocation in the `dynamic_table_commands` check. This allows client retries to work. Transaction is still created by proxies, so nothing changes logically.
* Adds table_id to `dynamic_table_commands` check logs, so that it is easier to debug problems with tables that were already deleted.
* Makes `driver_logging_config` configurable for odin server.

