### PR TITLE
Build YQL python udfs by default

### DIFF
--- a/.github/workflows/build-jobs.yaml
+++ b/.github/workflows/build-jobs.yaml
@@ -292,6 +292,8 @@ jobs:
           SCRIPT_FLAGS=""
           if [ "${{ inputs.build-yql-python-udfs }}" == "true" ]; then
             SCRIPT_FLAGS="${SCRIPT_FLAGS} --build-python-udfs yes"
+          else
+            SCRIPT_FLAGS="${SCRIPT_FLAGS} --build-python-udfs no"
           fi
 
           ../ytsaurus/ytsaurus/yt/docker/ya-build/query-tracker/build_yql_agent.sh ${SCRIPT_FLAGS}

--- a/yt/docker/ya-build/query-tracker/build_yql_agent.sh
+++ b/yt/docker/ya-build/query-tracker/build_yql_agent.sh
@@ -11,7 +11,7 @@
 set -eux
 shopt -s expand_aliases
 
-build_python_udfs="no"
+build_python_udfs="yes"
 
 print_usage() {
     cat << EOF


### PR DESCRIPTION
[This commit](https://github.com/ytsaurus/ytsaurus/commit/e047f03f6468bd23d25540db358bb13d50f6b896) changed default behaviour of `build_yql_agent.sh` (building python udf -> not building python udf)

I think by default such scripts should build all released functionality

We used this script to build our own images, and then suddenly lost python udfs. It is possible that someone else did the same

Adjusting default value for building python udfs in this script and consumers who relied to it