### PR TITLE
Remove legacy variable from operation_commands.py

### DIFF
--- a/yt/python/yt/wrapper/operation_commands.py
+++ b/yt/python/yt/wrapper/operation_commands.py
@@ -26,8 +26,6 @@ from multiprocessing import TimeoutError
 
 from io import StringIO
 
-OPERATIONS_PATH = "//sys/operations"
-
 
 class OperationInfoRetrier(Retrier):
     def __init__(self, retry_config, command, params, format, timeout, client=None):


### PR DESCRIPTION
OPERATIONS_PATH seems to be unused. And in any case it points to the implementation detail of YT scheduler, which should not be accessed by SDKs since the introduction of list_operations/get_operation API.

