### PR TITLE
Introduce the higher level primitives for tracking queries in Python SDK and CLI.

### DIFF
--- a/yt/python/yt/common.py
+++ b/yt/python/yt/common.py
@@ -363,10 +363,6 @@ class YtError(Exception):
         """Probably lock conflict in Sequoia tables."""
         return self.contains_code(6002)
 
-    def is_query_not_found(self):
-        """Query not found."""
-        return self.contains_code(3901)
-
 
 class YtResponseError(YtError):
     """Represents an error in YT response."""

--- a/yt/python/yt/common.py
+++ b/yt/python/yt/common.py
@@ -363,6 +363,10 @@ class YtError(Exception):
         """Probably lock conflict in Sequoia tables."""
         return self.contains_code(6002)
 
+    def is_query_not_found(self):
+        """Query not found."""
+        return self.contains_code(3901)
+
 
 class YtResponseError(YtError):
     """Represents an error in YT response."""

--- a/yt/python/yt/test_helpers/cleanup.py
+++ b/yt/python/yt/test_helpers/cleanup.py
@@ -28,6 +28,12 @@ def abort_transactions(list_action, abort_action, exists_action, get_action):
             continue
         if "QueueAgent" in title:
             continue
+        if "Lock for changelog store" in title:
+            continue
+        if "Upload to //sys/hydra_persistence" in title:
+            continue
+        if "Prerequisite for cell" in title:
+            continue
 
         sequoia = False
         for cell_id in sequoia_tablet_cells:

--- a/yt/python/yt/testlib/test_environment.py
+++ b/yt/python/yt/testlib/test_environment.py
@@ -359,12 +359,32 @@ def test_method_teardown(remove_operations_archive=True):
     if yt.config["backend"] == "proxy":
         assert yt.config["proxy"]["url"].startswith("localhost")
 
+    # TODO(max42): this whole logic of ignoring part of the objects depending on the parameter of test_method_teardown
+    # looks extermely complicated and requires lots of boilerplate code around fixture definitions (how can I express
+    # a test which requires both an operation archive and a query tracker? Which yt_env_smth should register a
+    # finalizer for that?).
+    #
+    # It would be better to have flags in the YtTestEnvironment to control the omission of some objects.
+
     object_ids_to_ignore = set()
     if not remove_operations_archive:
         for table in yt.list("//sys/operations_archive"):
             for tablet in yt.get("//sys/operations_archive/{}/@tablets".format(table)):
                 object_ids_to_ignore.add(tablet["cell_id"])
         object_ids_to_ignore.add(yt.get("//sys/accounts/operations_archive/@id"))
+
+    # For simplicity, we never cleanup query tracker objects. Query tracker is enabled in the only test suite,
+    # and in that test suite tests are assuming that query tracker state is reused, so it is safe.
+    if yt.exists("//sys/users/query_tracker"):
+        object_ids_to_ignore.add(yt.get("//sys/users/query_tracker/@id"))
+    if yt.exists("//sys/query_tracker"):
+        # Never remove query tracker tablet cells.
+        cell_ids = set()
+        for object in yt.list("//sys/query_tracker", attributes=["type", "dynamic"]):
+            if object.attributes["type"] == "table" and object.attributes.get("dynamic", False):
+                for tablet in yt.get("//sys/query_tracker/{}/@tablets".format(object)):
+                    cell_ids.add(tablet["cell_id"])
+                    object_ids_to_ignore.add(tablet["cell_id"])
 
     _cleanup_transactions()
     _cleanup_operations(remove_operations_archive=remove_operations_archive)

--- a/yt/python/yt/wrapper/client_api.py
+++ b/yt/python/yt/wrapper/client_api.py
@@ -14,7 +14,7 @@ from .flow_commands import (  # noqa
 from .queue_commands import (  # noqa
     register_queue_consumer, unregister_queue_consumer, list_queue_consumer_registrations, pull_queue, pull_consumer, pull_queue_consumer,
     advance_consumer, advance_queue_consumer, create_queue_producer_session, remove_queue_producer_session, push_queue_producer)
-from .query_commands import start_query, abort_query, alter_query, read_query_result, get_query, get_query_result, list_queries  # noqa
+from .query_commands import start_query, run_query, abort_query, alter_query, read_query_result, get_query, get_query_result, list_queries  # noqa
 from .run_operation_commands import (  # noqa
     run_erase, run_merge, run_sort, run_map_reduce, run_map, run_reduce,
     run_join_reduce, run_remote_copy, run_operation)

--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -2513,11 +2513,13 @@ class YtClient(ClientState):
         :param files: a YSON list of files, each of which is represented by a map with keys "name", "content", "type". Field "type" is one of "raw_inline_data", "url"
         :type files: list or None
         :param stage: query tracker stage, defaults to "production"
-        :type stage: str
+        :type stage: str or None
         :param annotations: a dictionary of annotations
         :type annotations: dict or None
         :param access_control_objects: list access control object names
         :type access_control_objects: list or None
+        :param sync: if True, wait for query to finish, otherwise return immediately
+        :type sync: bool
 
         """
         return client_api.run_query(

--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -2496,6 +2496,36 @@ class YtClient(ClientState):
             client=self,
             sync=sync, run_operation_mutation_id=run_operation_mutation_id, enable_optimizations=enable_optimizations)
 
+    def run_query(
+            self,
+            engine, query,
+            settings=None, files=None, stage=None, annotations=None, access_control_objects=None,
+            sync=True):
+        """
+        Run query and track its progress (unless sync = false).
+
+        :param engine: one of "ql", "yql", "chyt", "spyt".
+        :type engine: str
+        :param query: text of a query
+        :type query: str
+        :param settings: a dictionary of settings
+        :type settings: dict or None
+        :param files: a YSON list of files, each of which is represented by a map with keys "name", "content", "type". Field "type" is one of "raw_inline_data", "url"
+        :type files: list or None
+        :param stage: query tracker stage, defaults to "production"
+        :type stage: str
+        :param annotations: a dictionary of annotations
+        :type annotations: dict or None
+        :param access_control_objects: list access control object names
+        :type access_control_objects: list or None
+
+        """
+        return client_api.run_query(
+            engine, query,
+            client=self,
+            settings=settings, files=files, stage=stage, annotations=annotations, access_control_objects=access_control_objects,
+            sync=sync)
+
     def run_reduce(
             self,
             binary, source_table,
@@ -2812,7 +2842,7 @@ class YtClient(ClientState):
         """
         Start query.
 
-        :param engine: one of "ql", "yql".
+        :param engine: one of "ql", "yql", "chyt", "spyt".
         :type engine: str
         :param query: text of a query
         :type query: str

--- a/yt/python/yt/wrapper/config_remote_patch.py
+++ b/yt/python/yt/wrapper/config_remote_patch.py
@@ -241,3 +241,16 @@ def _validate_operation_link_pattern(local_value, remote_value):
     except KeyError:
         raise RuntimeError("Wrong placeholder")
     return ret
+
+
+def _validate_query_link_pattern(local_value, remote_value):
+    ret = remote_value.replace("{query_id}", "{id}").replace("{cluster_ui_host}", "{proxy}")
+    try:
+        ret.format(
+            proxy="PROXY",
+            cluster_path="CLUSTER_PATH",
+            id="QUERY"
+        )
+    except KeyError:
+        raise RuntimeError("Wrong placeholder")
+    return ret

--- a/yt/python/yt/wrapper/default_config.py
+++ b/yt/python/yt/wrapper/default_config.py
@@ -3,7 +3,9 @@ from __future__ import print_function
 from typing import Optional, Tuple
 
 from . import common
-from .config_remote_patch import RemotePatchableValueBase, RemotePatchableString, RemotePatchableBoolean, RemotePatchableInteger, _validate_operation_link_pattern  # noqa
+from .config_remote_patch import (RemotePatchableValueBase, RemotePatchableString, RemotePatchableBoolean,
+                                  RemotePatchableInteger, _validate_operation_link_pattern,
+                                  _validate_query_link_pattern)
 from .constants import DEFAULT_HOST_SUFFIX, SKYNET_MANAGER_URL, PICKLING_DL_ENABLE_AUTO_COLLECTION
 from .errors import YtConfigError
 from .mappings import VerifiedDict
@@ -170,7 +172,12 @@ default_config = {
 
         # Link to operation in web interface.
         # NB: this option can be overridden with settings from cluster
+        # TODO(max42): this default is prehistorically obsolete and can be changed to something actual.
         "operation_link_pattern": RemotePatchableString("{proxy}/{cluster_path}?page=operation&mode=detail&id={id}&tab=details", "operation_link_template", _validate_operation_link_pattern),
+
+        # Link to query in web interface.
+        # NB: this option can be overridden with settings from cluster
+        "query_link_pattern": RemotePatchableString("{proxy}/queries/{id}", "query_link_template", _validate_query_link_pattern),
 
         # Sometimes proxy can return incorrect or incomplete response.
         # This option enables checking response format for light requests.
@@ -462,6 +469,17 @@ default_config = {
         "stderr_encoding": "utf-8",
         # Collect operation's stderr from all jobs (not just failed)
         "always_show_job_stderr": False,
+    },
+
+    "query_tracker": {
+        # Query state check interval.
+        "poll_period": 1000,
+        # Log level used for print stderr messages.
+        "stderr_logging_level": "INFO",
+        # Log level used for printing operation progress.
+        "progress_logging_level": "INFO",
+        # Abort operation when SIGINT is received while waiting for the operation to finish.
+        "abort_on_sigint": True,
     },
 
     "read_parallel": {

--- a/yt/python/yt/wrapper/errors.py
+++ b/yt/python/yt/wrapper/errors.py
@@ -34,6 +34,17 @@ class YtOperationFailedError(YtError):
         super(YtOperationFailedError, self).__init__(message, attributes=attributes, inner_errors=inner_errors)
 
 
+class YtQueryFailedError(YtError):
+    """Query failed."""
+    def __init__(self, id, state, inner_errors, url):
+        message = "Query {0} {1}".format(id, state)
+        attributes = {
+            "id": id,
+            "state": state,
+            "url": url}
+        super(YtQueryFailedError, self).__init__(message, attributes=attributes, inner_errors=inner_errors)
+
+
 # COMPAT
 YtHttpResponseError = yt.common.YtResponseError
 

--- a/yt/python/yt/wrapper/operation_commands.py
+++ b/yt/python/yt/wrapper/operation_commands.py
@@ -584,11 +584,7 @@ def process_operation_unsuccessful_finish_state(operation, error):
     raise error
 
 
-def get_operation_url(operation, client=None):
-    proxy_url = get_proxy_address_url(required=False, client=client)
-    if not proxy_url:
-        return None
-
+def get_proxy_and_cluster_path(client=None):
     local_mode_proxy_address = get_local_mode_proxy_address(client=client)
     if local_mode_proxy_address is None and not is_local_mode(client=client):
         cluster_path = ""
@@ -600,6 +596,15 @@ def get_operation_url(operation, client=None):
         else:
             cluster_path = "ui/"
             proxy = get_proxy_address_url(client=client)
+    return proxy, cluster_path
+
+
+def get_operation_url(operation, client=None):
+    proxy_url = get_proxy_address_url(required=False, client=client)
+    if not proxy_url:
+        return None
+
+    proxy, cluster_path = get_proxy_and_cluster_path(client=client)
 
     return get_config(client)["proxy"]["operation_link_pattern"].format(
         proxy=proxy,

--- a/yt/python/yt/wrapper/query_commands.py
+++ b/yt/python/yt/wrapper/query_commands.py
@@ -2,15 +2,24 @@ from .driver import make_request, make_formatted_request
 from .config import get_config
 from .batch_response import apply_function_to_result
 from .table_helpers import _prepare_command_format
-from .common import datetime_to_string, set_param, get_value
+from .common import datetime_to_string, date_string_to_datetime, set_param, get_value, YtError, utcnow
+from .http_helpers import get_proxy_address_url
+from .errors import YtQueryFailedError
+from .operation_commands import TimeWatcher, get_proxy_and_cluster_path, order_progress
+from .exceptions_catcher import ExceptionCatcher
 
+import yt.logger as logger
+
+from collections import defaultdict
 from datetime import datetime
+from time import time
+import logging
 
 
 def start_query(engine, query, settings=None, files=None, stage=None, annotations=None, access_control_object=None, access_control_objects=None, client=None):
     """Start query.
 
-    :param engine: one of "ql", "yql".
+    :param engine: one of "ql", "yql", "chyt", "spyt".
     :type engine: str
     :param query: text of a query
     :type query: str
@@ -195,3 +204,303 @@ def list_queries(user=None, engine=None, state=None, filter=None, from_time=None
         params=params,
         format=format,
         client=client)
+
+# Helpers
+
+
+def get_query_url(query_id, client=None):
+    proxy_url = get_proxy_address_url(required=False, client=client)
+    if not proxy_url:
+        return None
+
+    proxy, cluster_path = get_proxy_and_cluster_path(client=client)
+
+    return get_config(client)["proxy"]["query_link_pattern"].format(
+        proxy=proxy,
+        cluster_path=cluster_path,
+        id=query_id)
+
+
+class QueryState(object):
+    """State of the query (simple wrapper for the string name)."""
+    def __init__(self, name):
+        self.name = name
+
+    def is_finished(self):
+        return self.name in ("aborted", "completed", "failed", "draft")
+
+    def is_unsuccessfully_finished(self):
+        return self.name in ("aborted", "failed")
+
+    def is_running(self):
+        return self.name == "running"
+
+    def is_starting(self):
+        return self.name == "starting"
+
+    def __eq__(self, other):
+        return self.name == str(other)
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __repr__(self):
+        return self.name
+
+    def __str__(self):
+        return self.name
+
+
+def get_query_state_monitor(query_id, time_watcher, stage=None, client=None):
+    """
+    Yields state and sleeps. Waits for the state of query to become final.
+
+    :return: iterator over query states.
+    """
+    last_state = None
+    while True:
+        state = QueryState(get_query(query_id, stage=stage, client=client, attributes=["state"])["state"])
+        yield state
+        if state.is_finished():
+            break
+
+        if state != last_state:
+            time_watcher.reset()
+        last_state = state
+
+        time_watcher.wait()
+
+
+class QueryResult(object):
+    """Holds information about query result."""
+    def __init__(self, query_id, result_index, query_tracker_stage=None, client=None):
+        self.query_id = query_id
+        self.result_index = result_index
+        self.query_tracker_stage = query_tracker_stage
+        self.client = client
+
+    def get_attributes(self):
+        """Returns query result attributes."""
+        return get_query_result(self.query_id, self.result_index, stage=self.query_tracker_stage, client=self.client)
+
+    def get_error(self):
+        """Returns error of the query result."""
+        attributes = self.get_attributes()
+        if "error" in attributes:
+            return YtError.from_dict(attributes["error"])
+        return None
+
+    def is_truncated(self):
+        """Returns whether the result is truncated."""
+        return self.get_attributes().get("is_truncated", False)
+
+    def read_rows(self, validate_not_truncated=True, format=None, raw=None):
+        error = self.get_error()
+        if error:
+            raise error
+        if validate_not_truncated and self.is_truncated():
+            raise YtError("Query result is truncated, use get_rows(validate_not_truncated=False) to get the truncated "
+                          "result")
+        return read_query_result(self.query_id, self.result_index, stage=self.query_tracker_stage,
+                                 format=format, raw=raw, client=self.client)
+
+    def __iter__(self):
+        return self.read_rows()
+
+
+class GenericQueryInfoPrinter(object):
+    """Tracks query state and prints info on updates."""
+    def __init__(self, query, client=None):
+        self.query = query
+        self.state = None
+        self.progress_line = None
+        # TODO(max42): the corresponding code in operation_commands.py handles timezones incorrectly
+        # around the daylight saving time changes. That code should be fixed as well.
+
+        start_time_str = self.query.get_attributes(attributes=["start_time"])["start_time"]
+        self.start_time = date_string_to_datetime(start_time_str)
+        self.client = client
+        self.level = logging.getLevelName(get_config(self.client)["query_tracker"]["progress_logging_level"])
+
+    def __call__(self, new_state):
+        if new_state.is_running():
+            new_progress_line = self.get_running_progress_line()
+            if self.progress_line != new_progress_line:
+                self.log("query %s: %s", self.query.id, new_progress_line)
+            self.progress_line = new_progress_line
+        elif new_state != self.state:
+            self.log("query %s %s", self.query.id, new_state)
+        self.state = new_state
+
+    # This method is to be overridden in subclasses for concrete engines.
+    def get_running_progress_line(self):
+        """Return a line that is to be printed for a running operation. It is printed only
+        if it differs from its previous state"""
+        return "running"
+
+    def log(self, message, *args, **kwargs):
+        elapsed_seconds = (utcnow() - self.start_time).total_seconds()
+        message = "({0:2} min) ".format(int(elapsed_seconds) // 60) + message
+        logger.log(self.level, message, *args, **kwargs)
+
+
+class YqlQueryInfoPrinter(GenericQueryInfoPrinter):
+    def get_running_progress_line(self):
+        progress = self.query.get_progress()
+        yql_progress = progress.get("yql_progress", {})
+        # YQL node progress contains something similar to YT progress counter and also some additional
+        # fields like "finishedAt" or "stages". We want to aggregate numbers that are similar to YT progress
+        # and output them similar to how YT operation progress is printed.
+        key_whitelist = ["aborted", "completed", "failed", "lost", "pending", "running", "total"]
+        total_progress = defaultdict(int)
+        for node_id, node_progress in yql_progress.items():
+            for key, value in node_progress.items():
+                if key in key_whitelist:
+                    total_progress[key] += value
+        return " ".join("{0}={1:<5}".format(k, v) for k, v in order_progress(total_progress))
+
+
+class Query(object):
+    """Holds information about query."""
+    def __init__(self, id, engine, query_tracker_stage=None,
+                 abort_exceptions=(KeyboardInterrupt, TimeoutError), client=None):
+        self.id = id
+        self.engine = engine
+        self.abort_exceptions = abort_exceptions
+        self.client = client
+        self.url = get_query_url(id, client=client)
+        self.query_tracker_stage = query_tracker_stage
+
+        # TODO(max42): CHYT support was introduced quite recently, so we do not support it yet. QL does not
+        # provide means of tracking query progress, so we do not support it either. SPYT will also follow later.
+        printers = {
+            "yql": YqlQueryInfoPrinter,
+        }
+        self.printer = printers.get(self.engine, GenericQueryInfoPrinter)(self, client=client)
+
+    def abort(self, message=None):
+        """Aborts query."""
+        abort_query(self.id, message=message, stage=self.query_tracker_stage, client=self.client)
+
+    def get_state_monitor(self, time_watcher):
+        """Returns iterator over query progress states."""
+        return get_query_state_monitor(self.id, time_watcher, stage=self.query_tracker_stage,
+                                       client=self.client)
+
+    def get_attributes(self, attributes=None):
+        """Returns query attributes, possibly with given attribute filter."""
+        return get_query(self.id, attributes=attributes, stage=self.query_tracker_stage, client=self.client)
+
+    def get_progress(self):
+        """Returns dictionary that represents the query execution progress."""
+        return self.get_attributes(attributes=["progress"]).get("progress", {})
+
+    def get_state(self):
+        """Returns object that represents state of operation."""
+        return QueryState(self.get_attributes(attributes=["state"])["state"])
+
+    def get_result(self, result_index=0):
+        """Returns query result with the given index."""
+        return QueryResult(self.id, result_index, query_tracker_stage=self.query_tracker_stage, client=self.client)
+
+    def get_results(self):
+        """Returns list of query results."""
+        result_count = self.get_attributes(attributes=["result_count"])["result_count"]
+        return [self.get_result(i) for i in range(result_count)]
+
+    def __iter__(self):
+        if len(self.get_results()) != 1:
+            raise YtError("Query does not have exactly one result; use get_results() instead")
+        return iter(self.get_result(0))
+
+    def get_error(self, return_error_if_all_results_are_errors=True):
+        """If query has failed, or, if return_error_if_all_results_are_errors = True and
+        all subqueries within a query resulted in errors, returns YtQueryFailed. Subquery errors
+        are returned as inner errors. Otherwise, return None."""
+        state = self.get_state()
+
+        if not state.is_finished():
+            return None
+
+        if state.is_unsuccessfully_finished():
+            error = self.get_attributes(attributes=["error"])["error"]
+            return YtQueryFailedError(self.id, state, [error], self.url)
+
+        if return_error_if_all_results_are_errors:
+            result_errors = [result.get_error() for result in self.get_results()]
+            if len(result_errors) >= 1 and all(error is not None for error in result_errors):
+                # YtQueryError.
+                return YtQueryFailedError(
+                    "All subqueries within a query resulted in errors",
+                    QueryState("failed"),
+                    result_errors,
+                    self.url)
+
+        return None
+
+    def wait(self, print_progress=True, timeout=None, raise_if_all_results_are_errors=True):
+        """Synchronously tracks query, prints current progress and finalizes at the completion.
+
+        If query fails, raises :class:`YtOperationFailedError <yt.wrapper.errors.YtOperationFailedError>`.
+        If `KeyboardInterrupt` occurs, aborts query, finalizes and re-raises `KeyboardInterrupt`.
+
+        :param bool print_progress: print progress
+        :param float timeout: timeout of query in msec. If `None`, wait indefinitely.
+        :param bool raise_if_all_results_are_errors: if `True`, raise `YtQueryFailedError` if all results are errors
+        even for a completed query.
+        """
+
+        query_poll_period = get_config(self.client)["query_tracker"]["poll_period"] / 1000.0
+        time_watcher = TimeWatcher(min_interval=query_poll_period / 10.0,
+                                   max_interval=query_poll_period,
+                                   slowdown_coef=0.2)
+        print_info = self.printer if print_progress else lambda state: None
+
+        def abort():
+            self.abort(message="query aborted by client interruption")
+            for state in self.get_state_monitor(TimeWatcher(1.0, 1.0, 0.0)):
+                print_info(state)
+
+        abort_on_sigint = get_config(self.client)["query_tracker"]["abort_on_sigint"]
+
+        with ExceptionCatcher(self.abort_exceptions, abort, enable=abort_on_sigint):
+            start_time = time()
+            for state in self.get_state_monitor(time_watcher):
+                print_info(state)
+                if timeout is not None and time() - start_time > timeout / 1000.0:
+                    raise TimeoutError("Timed out while waiting for query to finish")
+
+        error = self.get_error(return_error_if_all_results_are_errors=raise_if_all_results_are_errors)
+        if error is not None:
+            raise error
+
+
+def run_query(engine, query, settings=None, files=None, stage=None, annotations=None, access_control_objects=None, sync=True, client=None):
+    """Run query and track its progress (unless sync = false).
+
+    :param engine: one of "ql", "yql", "chyt", "spyt".
+    :type engine: str
+    :param query: text of a query
+    :type query: str
+    :param settings: a dictionary of settings
+    :type settings: dict or None
+    :param files: a YSON list of files, each of which is represented by a map with keys "name", "content", "type". Field "type" is one of "raw_inline_data", "url"
+    :type files: list or None
+    :param stage: query tracker stage, defaults to "production"
+    :type stage: str
+    :param annotations: a dictionary of annotations
+    :type annotations: dict or None
+    :param access_control_objects: list access control object names
+    :type access_control_objects: list or None
+    """
+
+    query_id = start_query(engine, query, settings=settings, files=files, stage=stage,
+                           annotations=annotations, access_control_objects=access_control_objects, client=client)
+    query = Query(query_id, engine, query_tracker_stage=stage, client=client)
+    if query.url:
+        logger.info("Query started: %s", query.url)
+    else:
+        logger.info("Query started: %s", query.id)
+    if sync:
+        query.wait()
+    return query

--- a/yt/python/yt/wrapper/testlib/ya.make
+++ b/yt/python/yt/wrapper/testlib/ya.make
@@ -9,6 +9,7 @@ ELSE()
         yt/python/yt/wrapper
         yt/python/yt/testlib
         yt/python/yt/yson
+        yt/python/yt/environment/components/query_tracker
 
         library/python/resource
     )

--- a/yt/python/yt/wrapper/tests/test_query_commands.py
+++ b/yt/python/yt/wrapper/tests/test_query_commands.py
@@ -1,0 +1,120 @@
+from .conftest import authors
+
+import yt.wrapper as yt
+
+import pytest
+
+from yt.wrapper.testlib.helpers import wait
+
+
+# This testsuite is mostly following the similar cases from tests/integration/queries/test_mock.py.
+# By using the mock engine we can keep this suite fast and not depending on heavy engines like YQL or CHYT.
+
+@pytest.mark.usefixtures("yt_env", "yt_query_tracker")
+class TestQueryCommands(object):
+    ERROR = {"code": 42, "message": "Mock query execution error", "attributes": {"some_attr": "some_value"}}
+    ROWSET1 = {
+        "schema": [{"name": "foo", "type": "int64"}, {"name": "bar", "type": "string"}],
+        "rows": [{"foo": 42, "bar": "abc"}, {"foo": -17, "bar": "def"}, {"foo": 123, "bar": "ghi"}]
+    }
+    ROWSET2 = {
+        "schema": [{"name": "baz", "type": "any"}],
+        "rows": [{"baz": 42}, {"baz": "abc"}, {"baz": True}]
+    }
+    TRUNCATED_ROWSET = {
+        "schema": [{"name": "qux", "type": "int64"}],
+        "rows": [{"qux": 0}, {"qux": 1}, {"qux": 2}],
+        "is_truncated": True
+    }
+
+    @authors("max42")
+    def test_fail(self, yt_query_tracker):
+        with pytest.raises(yt.errors.YtQueryFailedError):
+            yt.run_query("mock", "fail")
+
+        with pytest.raises(yt.errors.YtQueryFailedError):
+            yt.run_query("mock", "fail_by_exception")
+
+        with pytest.raises(yt.errors.YtQueryFailedError):
+            yt.run_query("mock", "fail_after", settings={"duration": 3000})
+
+        with pytest.raises(yt.errors.YtQueryFailedError):
+            yt.run_query("mock", "complete_after", settings={
+                "duration": 500,
+                "results": [
+                    {"error": self.ERROR},
+                ]
+            })
+
+        q = yt.run_query("mock", "complete_after", sync=False, settings={
+            "duration": 500,
+            "results": [
+                {"error": self.ERROR},
+            ]
+        })
+        with pytest.raises(yt.errors.YtQueryFailedError):
+            q.wait()
+        assert q.get_state() == "completed"
+        assert q.get_error() is not None
+        assert q.get_error(return_error_if_all_results_are_errors=False) is None
+        assert q.get_result(0).get_error() is not None
+
+    @authors("max42")
+    def test_abort(self, yt_query_tracker):
+        q = yt.run_query("mock", "run_forever", sync=False)
+        wait(lambda: q.get_state() == "running")
+        q.abort()
+        with pytest.raises(yt.errors.YtQueryFailedError):
+            q.wait()
+        assert q.get_state() == "aborted"
+
+    @authors("max42")
+    def test_complete_single_result(self, yt_query_tracker):
+        q = yt.run_query("mock", "complete_after", settings={
+            "duration": 500,
+            "results": [
+                self.ROWSET1,
+            ]
+        })
+
+        assert list(q) == self.ROWSET1["rows"]
+        assert list(q.get_result(0)) == self.ROWSET1["rows"]
+        assert list(q.get_result(0).read_rows()) == self.ROWSET1["rows"]
+
+    @authors("max42")
+    def test_complete_multiple_results(self, yt_query_tracker):
+        q = yt.run_query("mock", "complete_after", settings={
+            "duration": 500,
+            "results": [
+                self.ROWSET1,
+                self.ROWSET2,
+            ]
+        })
+
+        with pytest.raises(yt.errors.YtError):
+            # For a query with a number of results different from one, using it as an iterator is not allowed.
+            list(q)
+
+        results = q.get_results()
+        assert len(results) == 2
+        assert list(results[0]) == self.ROWSET1["rows"]
+        assert list(results[1]) == self.ROWSET2["rows"]
+
+    @authors("max42")
+    def test_complete_truncated_result(self, yt_query_tracker):
+        q = yt.run_query("mock", "complete_after", settings={
+            "duration": 500,
+            "results": [
+                self.TRUNCATED_ROWSET,
+            ]
+        })
+
+        # For a query with a truncated result, using it as an iterator throws an error,
+        # unless user very specifically asks for the resulting rows.
+        with pytest.raises(yt.errors.YtError):
+            list(q)
+        with pytest.raises(yt.errors.YtError):
+            list(q.get_result(0))
+        with pytest.raises(yt.errors.YtError):
+            list(q.get_result(0).read_rows())
+        assert list(q.get_result(0).read_rows(validate_not_truncated=False)) == self.TRUNCATED_ROWSET["rows"]

--- a/yt/python/yt/wrapper/tests/test_query_commands.py
+++ b/yt/python/yt/wrapper/tests/test_query_commands.py
@@ -11,7 +11,7 @@ from yt.wrapper.testlib.helpers import wait
 # By using the mock engine we can keep this suite fast and not depending on heavy engines like YQL or CHYT.
 
 @pytest.mark.usefixtures("yt_env", "yt_query_tracker")
-class TestQueryCommands(object):
+class TestQueryCommands:
     ERROR = {"code": 42, "message": "Mock query execution error", "attributes": {"some_attr": "some_value"}}
     ROWSET1 = {
         "schema": [{"name": "foo", "type": "int64"}, {"name": "bar", "type": "string"}],

--- a/yt/python/yt/wrapper/tests/ya.make
+++ b/yt/python/yt/wrapper/tests/ya.make
@@ -43,6 +43,7 @@ PEERDIR(
     yt/python/yt/wrapper/testlib
     yt/python/yt/testlib
     yt/python/yt/yson
+
     yt/yt/python/yt_driver_bindings
     yt/yt/python/yt_driver_rpc_bindings
     yt/yt/python/yt_yson_bindings
@@ -179,6 +180,7 @@ TEST_SRCS(
     test_parse_ypath.py
     test_ping_failed_modes.py
     test_queue_commands.py
+    test_query_commands.py
     test_random_sample.py
     test_run_compression_benchmarks.py
     test_spark.py


### PR DESCRIPTION
This PR introduces:
* `run_query` client method, which behaves similarly to run_map, run_reduce, ...,
  performing necessary polling and fancy reporting of the query status.
* `yt query` command for invoking and tracking the query.

Internally, the Query object is introduced, which resembles the Operation object
in its interface.

When printing progress, output is structured similarly to the output of
PrintOperationInfo, but may be customized per query engine. Currently,
only YQL is printed in fancy manner, summing up all progress counters of all
nodes. See the output below for an example.

```
$ ./yt query yql "$(cat query.sql)" --structured >output.yson
2024-11-30 22:03:16,988	INFO	Query started: https://<...>/queries/a39bdc25-9d20b77f-258afe2a-621478e8/details
2024-11-30 22:03:17,101	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8 pending
2024-11-30 22:03:17,341	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=0     pending=0     failed=0     aborted=0     lost=0     total=0
2024-11-30 22:03:31,621	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=0     pending=1     failed=0     aborted=0     lost=0     total=1
2024-11-30 22:03:36,102	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=3     pending=0     failed=0     aborted=0     lost=0     total=3
2024-11-30 22:03:37,235	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=3     pending=1     failed=0     aborted=0     lost=0     total=4
2024-11-30 22:03:40,619	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=2     completed=6     pending=0     failed=0     aborted=0     lost=0     total=8
2024-11-30 22:03:44,013	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=8     pending=0     failed=0     aborted=0     lost=0     total=8
2024-11-30 22:03:46,260	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=3     completed=8     pending=0     failed=0     aborted=0     lost=0     total=11
2024-11-30 22:03:47,389	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=11    pending=1     failed=0     aborted=0     lost=0     total=12
2024-11-30 22:03:51,886	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=13    pending=0     failed=0     aborted=0     lost=0     total=13
2024-11-30 22:03:53,019	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=13    pending=1     failed=0     aborted=0     lost=0     total=14
2024-11-30 22:03:56,400	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=15    pending=0     failed=0     aborted=0     lost=0     total=15
2024-11-30 22:04:00,868	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=1     completed=16    pending=0     failed=0     aborted=0     lost=0     total=17
2024-11-30 22:04:02,005	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=2     completed=17    pending=0     failed=0     aborted=0     lost=0     total=19
2024-11-30 22:04:03,128	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8: running=0     completed=19    pending=0     failed=0     aborted=0     lost=0     total=19
2024-11-30 22:04:09,902	INFO	( 0 min) query a39bdc25-9d20b77f-258afe2a-621478e8 completed
```

The rest of the query engines may be supported similarly, utilizing the respective
engine's means of progress introspection.
