### PR TITLE
[23.2] Add `require_password_in_authentication_commands` driver flag to allow skipping password check in authentication commands.

### DIFF
--- a/yt/yt/client/driver/config.cpp
+++ b/yt/yt/client/driver/config.cpp
@@ -58,6 +58,9 @@ void TDriverConfig::Register(TRegistrar registrar)
     registrar.Parameter("expect_structured_input_in_structured_batch_commands", &TThis::ExpectStructuredInputInStructuredBatchCommands)
         .Default(true);
 
+    registrar.Parameter("require_password_in_authentication_commands", &TThis::RequirePasswordInAuthenticationCommands)
+        .Default(true);
+
     registrar.Preprocessor([] (TThis* config) {
         config->ClientCache->Capacity = 1024_KB;
         config->ProxyDiscoveryCache->RefreshTime = TDuration::Seconds(15);

--- a/yt/yt/client/driver/config.h
+++ b/yt/yt/client/driver/config.h
@@ -45,6 +45,9 @@ public:
 
     bool ExpectStructuredInputInStructuredBatchCommands;
 
+    //! Controls whether authentication commands (SetUserPassword, IssueToken, ListUserTokens, etc.) require a correct password to be used.
+    bool RequirePasswordInAuthenticationCommands;
+
     REGISTER_YSON_STRUCT(TDriverConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/client/driver/driver.cpp
+++ b/yt/yt/client/driver/driver.cpp
@@ -396,6 +396,7 @@ public:
             identity.User);
 
         auto options = TClientOptions::FromAuthenticationIdentity(identity);
+        options.RequirePasswordInAuthenticationCommands = Config_->RequirePasswordInAuthenticationCommands;
         options.Token = request.UserToken;
         options.ServiceTicketAuth = request.ServiceTicket
             ? std::make_optional(New<NAuth::TServiceTicketFixedAuth>(*request.ServiceTicket))

--- a/yt/yt/client/driver/etc_commands.cpp
+++ b/yt/yt/client/driver/etc_commands.cpp
@@ -96,6 +96,9 @@ void TGetSupportedFeaturesCommand::DoExecute(ICommandContextPtr context)
     for (auto staticFeature : StaticFeatures) {
         features->AddChild(TString(staticFeature.first), BuildYsonNodeFluently().Value(staticFeature.second));
     }
+    features->AddChild(
+        "require_password_in_authentication_commands",
+        BuildYsonNodeFluently().Value(context->GetConfig()->RequirePasswordInAuthenticationCommands));
     context->ProduceOutputValue(BuildYsonStringFluently()
         .BeginMap()
             .Item("features").Value(features)

--- a/yt/yt/library/auth/authentication_options.h
+++ b/yt/yt/library/auth/authentication_options.h
@@ -36,6 +36,9 @@ struct TAuthenticationOptions
     std::optional<TString> SessionId;
     std::optional<TString> SslSessionId;
     std::optional<IServiceTicketAuthPtr> ServiceTicketAuth;
+
+    //! Controls whether authentication commands (SetUserPassword, IssueToken, ListUserTokens, etc.) require a correct password to be used.
+    bool RequirePasswordInAuthenticationCommands;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/tests/integration/misc/test_get_supported_features.py
+++ b/yt/yt/tests/integration/misc/test_get_supported_features.py
@@ -11,13 +11,15 @@ import pytest
 ##################################################################
 
 
-class TestGetFeatures(YTEnvSetup):
+class TestGetFeaturesBase(YTEnvSetup):
     NUM_MASTERS = 1
     NUM_NODES = 3
     NUM_SCHEDULERS = 1
     NUM_CONTROLLER_AGENTS = 1
     SKIP_STATISTICS_DESCRIPTIONS = False
 
+
+class TestGetFeatures(TestGetFeaturesBase):
     @authors("levysotsky")
     def test_get_features(self):
         driver = get_driver(api_version=4)
@@ -117,9 +119,24 @@ class TestGetFeatures(YTEnvSetup):
             assert "unit" in description
 
     @authors("aleksandr.gaev")
-    def test_user_tokens_with_metadata_feature(self):
-        driver = get_driver(api_version=4)
-        features = get_supported_features(driver=driver)
+    def test_features(self):
+        features = get_supported_features()
 
         assert "user_tokens_metadata" in features
         assert features["user_tokens_metadata"] == yson.YsonBoolean(True)
+
+        assert "require_password_in_authentication_commands" in features
+        assert features["require_password_in_authentication_commands"] == yson.YsonBoolean(True)
+
+
+class TestGetFeaturesWithConfigs(TestGetFeaturesBase):
+    DELTA_DRIVER_CONFIG = {
+        "require_password_in_authentication_commands": False,
+    }
+
+    @authors("aleksandr.gaev")
+    def test_features(self):
+        features = get_supported_features()
+
+        assert "require_password_in_authentication_commands" in features
+        assert features["require_password_in_authentication_commands"] == yson.YsonBoolean(False)

--- a/yt/yt/tests/integration/proxies/test_cypress_token_auth.py
+++ b/yt/yt/tests/integration/proxies/test_cypress_token_auth.py
@@ -1,20 +1,44 @@
 from yt_env_setup import YTEnvSetup
 from yt_commands import (
-    authors, create_user, issue_token, revoke_token, wait, get,
+    authors, create_user, issue_token, revoke_token, wait, get, set_user_password
 )
 
 import requests
+import hashlib
 
 
 ##################################################################
 
-
-class TestCypressTokenAuth(YTEnvSetup):
+class TestCypressTokenAuthBase(YTEnvSetup):
     NUM_MASTERS = 1
 
     ENABLE_HTTP_PROXY = True
     NUM_HTTP_PROXIES = 1
 
+    def _get_proxy_address(self):
+        return "http://" + self.Env.get_proxy_address()
+
+    def _make_request(self, path, token=None):
+        headers = {}
+        if token:
+            headers = {"Authorization": "OAuth " + token}
+        return requests.get(
+            self._get_proxy_address() + path,
+            headers=headers)
+
+    def _check_allow(self, path="/api/v4/get?path=//@", token=None):
+        rsp = self._make_request(path, token)
+        rsp.raise_for_status()
+
+    def _check_deny(self, path="/api/v4/get?path=//@", token=None):
+        rsp = self._make_request(path, token)
+        return rsp.status_code == 401
+
+    def _compute_sha256(self, value):
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+class TestCypressTokenAuth(TestCypressTokenAuthBase):
     DELTA_PROXY_CONFIG = {
         "auth": {
             "enable_authentication": True,
@@ -28,44 +52,95 @@ class TestCypressTokenAuth(YTEnvSetup):
         },
     }
 
-    def _get_proxy_address(self):
-        return "http://" + self.Env.get_proxy_address()
-
-    def _make_request(self, token=None):
-        headers = {}
-        if token:
-            headers = {"Authorization": "OAuth " + token}
-        return requests.get(
-            self._get_proxy_address() + "/api/v4/get?path=//@",
-            headers=headers)
-
-    def _check_allow(self, token=None):
-        rsp = self._make_request(token)
-        rsp.raise_for_status()
-
-    def _check_deny(self, token=None):
-        rsp = self._make_request(token)
-        return rsp.status_code == 401
-
     @authors("gritukan")
     def test_simple(self):
         create_user("u")
         t, t_hash = issue_token("u")
         assert get("//sys/cypress_tokens/@count") == 1
 
-        self._check_allow(t)
+        self._check_allow(token=t)
         assert self._check_deny()
-        assert self._check_deny("xxx")
+        assert self._check_deny(token="xxx")
 
         revoke_token("u", t_hash)
         assert get("//sys/cypress_tokens/@count") == 0
 
-        wait(lambda: self._check_deny(t))
+        wait(lambda: self._check_deny(token=t))
 
     @authors("aleksandr.gaev")
     def test_revoke_token(self):
+        create_user("u2")
+        t, t_hash = issue_token("u2")
+        self._check_allow(token=t)  # Activate cache.
+        revoke_token("u2", t_hash)
+        wait(lambda: self._check_deny(token=t))
+
+
+class TestAuthenticationCommands(TestCypressTokenAuthBase):
+    DELTA_PROXY_CONFIG = {
+        "auth": {
+            "enable_authentication": True,
+        },
+    }
+
+    @authors("aleksandr.gaev")
+    def test_authentication_commands(self):
+        create_user("u3")
+        t, _ = issue_token("u3")
+        _, t2_sha256 = issue_token("u3")
+        p1_sha256 = self._compute_sha256("p1")
+        p2_sha256 = self._compute_sha256("p2")
+
+        # Passwordless user should not be able to change password
+        assert not self._make_request(f"/api/v4/set_user_password?user=u3&new_password_sha256={p2_sha256}", t).ok
+
+        set_user_password("u3", "p1")
+
+        # Test failure without providing password.
+        assert self._make_request(f"/api/v4/set_user_password?user=u3&new_password_sha256={p2_sha256}", t).json()["message"] == "User provided invalid password"
+        assert self._make_request("/api/v4/issue_token?user=u3", t).json()["message"] == "User provided invalid password"
+        assert self._make_request(f"/api/v4/revoke_token?user=u3&token_sha256={t2_sha256}", t).json()["message"] == "User provided invalid password"
+        assert self._make_request("/api/v4/list_user_tokens?user=u3", t).json()["message"] == "User provided invalid password"
+
+        # Test success with providing password.
+        self._make_request(f"/api/v4/set_user_password?user=u3&current_password_sha256={p1_sha256}&new_password_sha256={p2_sha256}", t).raise_for_status()
+        self._make_request(f"/api/v4/issue_token?user=u3&password_sha256={p2_sha256}", t).raise_for_status()
+        self._make_request(f"/api/v4/revoke_token?user=u3&token_sha256={t2_sha256}&password_sha256={p2_sha256}", t).raise_for_status()
+        self._make_request(f"/api/v4/list_user_tokens?user=u3&password_sha256={p2_sha256}", t).raise_for_status()
+
+
+class TestAuthenticationCommandsWithNoPassword(TestCypressTokenAuthBase):
+    DELTA_PROXY_CONFIG = {
+        "driver": {
+            "require_password_in_authentication_commands": False,
+        },
+        "auth": {
+            "enable_authentication": True,
+        },
+    }
+
+    @authors("aleksandr.gaev")
+    def test_authentication_commands_without_password(self):
         create_user("u")
-        t, t_hash = issue_token("u")
-        self._check_allow(t)  # Activate cache.
-        revoke_token("u", t_hash)
-        wait(lambda: self._check_deny(t))
+        t, _ = issue_token("u")
+        _, t2_sha256 = issue_token("u")
+        _, t3_sha256 = issue_token("u")
+        p1_sha256 = self._compute_sha256("p1")
+        p2_sha256 = self._compute_sha256("p2")
+
+        # Passwordless user should be able to change password
+        self._make_request(f"/api/v4/set_user_password?user=u&new_password_sha256={p2_sha256}", t).raise_for_status()
+
+        set_user_password("u", "p3")
+
+        # Test success without providing password.
+        self._make_request(f"/api/v4/set_user_password?user=u&new_password_sha256={p1_sha256}", t).raise_for_status()
+        self._make_request("/api/v4/issue_token?user=u", t).raise_for_status()
+        self._make_request(f"/api/v4/revoke_token?user=u&token_sha256={t2_sha256}", t).raise_for_status()
+        self._make_request("/api/v4/list_user_tokens?user=u", t).raise_for_status()
+
+        # Test success with providing password.
+        self._make_request(f"/api/v4/set_user_password?user=u&current_password_sha256={p1_sha256}&new_password_sha256={p2_sha256}", t).raise_for_status()
+        self._make_request(f"/api/v4/issue_token?user=u&password_sha256={p2_sha256}", t).raise_for_status()
+        self._make_request(f"/api/v4/revoke_token?user=u&token_sha256={t3_sha256}&password_sha256={p2_sha256}", t).raise_for_status()
+        self._make_request(f"/api/v4/list_user_tokens?user=u&password_sha256={p2_sha256}", t).raise_for_status()

--- a/yt/yt/ytlib/api/native/client_authentication_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_authentication_impl.cpp
@@ -268,28 +268,30 @@ void TClient::DoValidateAuthenticationCommandPermissions(
                 << TErrorAttribute("authenticated_user", Options_.User);
         }
 
-        TGetNodeOptions getOptions;
-        static_cast<TTimeoutOptions&>(getOptions) = options;
+        if (Options_.RequirePasswordInAuthenticationCommands) {
+            TGetNodeOptions getOptions;
+            static_cast<TTimeoutOptions&>(getOptions) = options;
 
-        getOptions.Attributes = std::vector<TString>({
-            TString{HashedPasswordAttribute},
-            TString{PasswordSaltAttribute},
-            TString{PasswordRevisionAttribute},
-        });
+            getOptions.Attributes = std::vector<TString>({
+                TString{HashedPasswordAttribute},
+                TString{PasswordSaltAttribute},
+                TString{PasswordRevisionAttribute},
+            });
 
-        auto path = Format("//sys/users/%v", ToYPathLiteral(user));
-        auto rsp = WaitFor(GetNode(path, getOptions))
-            .ValueOrThrow();
-        auto rspNode = ConvertToNode(rsp);
-        const auto& attributes = rspNode->Attributes();
+            auto path = Format("//sys/users/%v", ToYPathLiteral(user));
+            auto rsp = WaitFor(GetNode(path, getOptions))
+                .ValueOrThrow();
+            auto rspNode = ConvertToNode(rsp);
+            const auto& attributes = rspNode->Attributes();
 
-        auto hashedPassword = attributes.Get<TString>(HashedPasswordAttribute);
-        auto passwordSalt = attributes.Get<TString>(PasswordSaltAttribute);
-        auto passwordRevision = attributes.Get<ui64>(PasswordRevisionAttribute);
+            auto hashedPassword = attributes.Get<TString>(HashedPasswordAttribute);
+            auto passwordSalt = attributes.Get<TString>(PasswordSaltAttribute);
+            auto passwordRevision = attributes.Get<ui64>(PasswordRevisionAttribute);
 
-        if (HashPasswordSha256(passwordSha256, passwordSalt) != hashedPassword) {
-            THROW_ERROR_EXCEPTION("User provided invalid password")
-                << TErrorAttribute("password_revision", passwordRevision);
+            if (HashPasswordSha256(passwordSha256, passwordSalt) != hashedPassword) {
+                THROW_ERROR_EXCEPTION("User provided invalid password")
+                    << TErrorAttribute("password_revision", passwordRevision);
+            }
         }
     }
 }


### PR DESCRIPTION
Cherrypicking https://github.com/ytsaurus/ytsaurus/commit/723db18f80a3ceff00ed67d6a9cb5872b9c1ffda to 23.2