### PR TITLE
[23.2] Introduce Weighted Fair Share ThreadPool IO engine

### DIFF
--- a/yt/yt/client/misc/workload.cpp
+++ b/yt/yt/client/misc/workload.cpp
@@ -29,17 +29,21 @@ TWorkloadDescriptor::TWorkloadDescriptor(
     int band,
     TInstant instant,
     std::vector<TString> annotations,
-    std::optional<NConcurrency::TFairShareThreadPoolTag> compressionFairShareTag)
+    std::optional<NConcurrency::TFairShareThreadPoolTag> compressionFairShareTag,
+    std::optional<TString> diskFairShareBucketTag,
+    std::optional<double> diskFairShareBucketWeight)
     : Category(category)
     , Band(band)
     , Instant(instant)
     , Annotations(std::move(annotations))
     , CompressionFairShareTag(std::move(compressionFairShareTag))
+    , DiskFairShareBucketTag(std::move(diskFairShareBucketTag))
+    , DiskFairShareBucketWeight(diskFairShareBucketWeight)
 { }
 
 TWorkloadDescriptor TWorkloadDescriptor::SetCurrentInstant() const
 {
-    return TWorkloadDescriptor(Category, Band, TInstant::Now(), Annotations, CompressionFairShareTag);
+    return TWorkloadDescriptor(Category, Band, TInstant::Now(), Annotations, CompressionFairShareTag, DiskFairShareBucketTag, DiskFairShareBucketWeight);
 }
 
 i64 TWorkloadDescriptor::GetPriority() const
@@ -89,6 +93,11 @@ i64 GetBasicPriority(EWorkloadCategory category)
     }
 }
 
+double GetBasicWeight(EWorkloadCategory category)
+{
+    return std::max(GetBasicPriority(category) / CategoryPriorityFactor + 1.0, 1.0);
+}
+
 IInvokerPtr GetCompressionInvoker(const TWorkloadDescriptor& workloadDescriptor)
 {
     if (workloadDescriptor.CompressionFairShareTag) {
@@ -112,6 +121,10 @@ struct TSerializableWorkloadDescriptor
         registrar.BaseClassParameter("category", &TWorkloadDescriptor::Category);
         registrar.BaseClassParameter("band", &TWorkloadDescriptor::Band)
             .Default(0);
+        registrar.BaseClassParameter("disk_fair_share_bucket_tag", &TWorkloadDescriptor::DiskFairShareBucketTag)
+            .Optional();
+        registrar.BaseClassParameter("disk_fair_share_bucket_weight", &TWorkloadDescriptor::DiskFairShareBucketWeight)
+            .Optional();
         registrar.BaseClassParameter("annotations", &TWorkloadDescriptor::Annotations)
             .Default();
     }
@@ -144,6 +157,12 @@ void ToProto(NYT::NProto::TWorkloadDescriptor* protoDescriptor, const TWorkloadD
     protoDescriptor->set_band(descriptor.Band);
     protoDescriptor->set_instant(ToProto<i64>(descriptor.Instant));
     ToProto(protoDescriptor->mutable_annotations(), descriptor.Annotations);
+    if (descriptor.DiskFairShareBucketTag) {
+        protoDescriptor->set_disk_fair_share_bucket_tag(*descriptor.DiskFairShareBucketTag);
+    }
+    if (descriptor.DiskFairShareBucketWeight) {
+        protoDescriptor->set_disk_fair_share_bucket_weight(*descriptor.DiskFairShareBucketWeight);
+    }
 }
 
 void FromProto(TWorkloadDescriptor* descriptor, const NYT::NProto::TWorkloadDescriptor& protoDescriptor)
@@ -152,6 +171,12 @@ void FromProto(TWorkloadDescriptor* descriptor, const NYT::NProto::TWorkloadDesc
     descriptor->Band = protoDescriptor.band();
     descriptor->Instant = FromProto<TInstant>(protoDescriptor.instant());
     FromProto(&descriptor->Annotations, protoDescriptor.annotations());
+    if (protoDescriptor.Hasdisk_fair_share_bucket_tag()) {
+        descriptor->DiskFairShareBucketTag = protoDescriptor.disk_fair_share_bucket_tag();
+    }
+    if (protoDescriptor.Hasdisk_fair_share_bucket_weight()) {
+        descriptor->DiskFairShareBucketWeight = protoDescriptor.disk_fair_share_bucket_weight();
+    }
 }
 
 void FormatValue(
@@ -175,6 +200,12 @@ void FormatValue(
             }
         }
         builder->AppendChar('}');
+    }
+    if (descriptor.DiskFairShareBucketTag) {
+        builder->AppendFormat(":%v", *descriptor.DiskFairShareBucketTag);
+    }
+    if (descriptor.DiskFairShareBucketWeight) {
+        builder->AppendFormat(":%v", *descriptor.DiskFairShareBucketWeight);
     }
 }
 

--- a/yt/yt/client/misc/workload.h
+++ b/yt/yt/client/misc/workload.h
@@ -23,7 +23,9 @@ struct TWorkloadDescriptor
         int band = 0,
         TInstant instant = {},
         std::vector<TString> annotations = {},
-        std::optional<NConcurrency::TFairShareThreadPoolTag> compressionFairShareTag = {});
+        std::optional<NConcurrency::TFairShareThreadPoolTag> compressionFairShareTag = {},
+        std::optional<TString> diskFairShareBucketTag = {},
+        std::optional<double> diskFairShareBucketWeight = {});
 
     //! The type of the workload defining its basic priority.
     EWorkloadCategory Category;
@@ -43,6 +45,12 @@ struct TWorkloadDescriptor
     //! If present, invoker from fair share thread pool will be used for decompression.
     std::optional<NConcurrency::TFairShareThreadPoolTag> CompressionFairShareTag;
 
+    //! Bucket and weight of the workload for disks.
+    //! All the workload in the same DiskFairShareBucketTag gets fair share of disks according to DiskFairShareBucketWeight.
+    //! DiskFairShareBucketWeight should be positive. 1 is the default value. Larger is better.
+    std::optional<TString> DiskFairShareBucketTag;
+    std::optional<double> DiskFairShareBucketWeight;
+
     //! Updates the instant field with the current time.
     TWorkloadDescriptor SetCurrentInstant() const;
 
@@ -52,6 +60,7 @@ struct TWorkloadDescriptor
 };
 
 i64 GetBasicPriority(EWorkloadCategory category);
+double GetBasicWeight(EWorkloadCategory category);
 
 IInvokerPtr GetCompressionInvoker(const TWorkloadDescriptor& workloadDescriptor);
 

--- a/yt/yt/core/CMakeLists.txt
+++ b/yt/yt/core/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(yt-yt-core PRIVATE
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fair_share_invoker_queue.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fair_share_queue_scheduler_thread.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fair_share_thread_pool.cpp
+  ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fair_share_weighted_thread_pool.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fair_throttler.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fiber_scheduler_thread.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/core/concurrency/fiber.cpp

--- a/yt/yt/core/concurrency/fair_share_weighted_thread_pool.cpp
+++ b/yt/yt/core/concurrency/fair_share_weighted_thread_pool.cpp
@@ -1,0 +1,1358 @@
+#include "fair_share_weighted_thread_pool.h"
+#include "private.h"
+#include "notify_manager.h"
+#include "profiling_helpers.h"
+#include "scheduler_thread.h"
+#include "thread_pool_detail.h"
+
+#include <yt/yt/core/actions/current_invoker.h>
+
+#include <yt/yt/core/misc/finally.h>
+#include <yt/yt/core/misc/heap.h>
+#include <yt/yt/core/misc/ring_queue.h>
+#include <yt/yt/core/misc/mpsc_stack.h>
+#include <yt/yt/core/misc/range_formatters.h>
+
+#include <yt/yt/library/profiling/sensor.h>
+
+#include <library/cpp/yt/containers/intrusive_linked_list.h>
+
+#include <library/cpp/yt/memory/public.h>
+
+#include <util/system/spinlock.h>
+
+#include <util/generic/xrange.h>
+
+namespace NYT::NConcurrency::NFairShareWeightedThreadPool {
+
+using namespace NProfiling;
+
+inline const NLogging::TLogger Logger("FairShareWeightedThreadPool");
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+DECLARE_REFCOUNTED_CLASS(TBucketMapping)
+DECLARE_REFCOUNTED_CLASS(TTwoLevelFairShareQueue)
+DECLARE_REFCOUNTED_CLASS(TBucket)
+
+struct TExecutionPool;
+
+// High 16 bits is thread index and 48 bits for thread pool ptr.
+thread_local TPackedPtr ThreadCookie = 0;
+
+static constexpr auto LogDurationThreshold = TDuration::Seconds(1);
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class T>
+class THeapItem
+{
+public:
+    THeapItem(const THeapItem&) = delete;
+    THeapItem& operator=(const THeapItem&) = delete;
+
+    explicit THeapItem(T* ptr)
+        : Ptr_(std::move(ptr))
+    {
+        AdjustBackReference();
+    }
+
+    ~THeapItem()
+    {
+        if (Ptr_) {
+            YT_ASSERT(Ptr_->PositionInHeap_ == this);
+            Ptr_->PositionInHeap_ = nullptr;
+        }
+    }
+
+    T& operator* ()
+    {
+        return *Ptr_;
+    }
+
+    const T& operator*() const
+    {
+        return *Ptr_;
+    }
+
+    T* operator->()
+    {
+        return Ptr_;
+    }
+
+    const T* operator->() const
+    {
+        return Ptr_;
+    }
+
+    bool operator < (const THeapItem<T>& other) const
+    {
+        return *Ptr_ < *other;
+    }
+
+    THeapItem(THeapItem&& other) noexcept
+        : Ptr_(std::move(other.Ptr_))
+    {
+        other.Ptr_ = nullptr;
+        AdjustBackReference();
+    }
+
+    THeapItem& operator=(THeapItem&& other) noexcept
+    {
+        Ptr_ = std::move(other.Ptr_);
+        other.Ptr_ = nullptr;
+        AdjustBackReference();
+
+        return *this;
+    }
+
+private:
+    T* Ptr_;
+
+    void AdjustBackReference()
+    {
+        if (Ptr_) {
+            Ptr_->PositionInHeap_ = this;
+        }
+    }
+};
+
+template <class T>
+class THeapItemBase
+{
+public:
+    friend THeapItem<T>;
+
+    THeapItem<T>* GetPositionInHeap() const
+    {
+        return PositionInHeap_;
+    }
+
+    ~THeapItemBase()
+    {
+        YT_ASSERT(!PositionInHeap_);
+    }
+
+private:
+    THeapItem<T>* PositionInHeap_ = nullptr;
+};
+
+template <class T>
+class TPriorityQueue
+{
+public:
+    void Insert(T* object)
+    {
+        Items_.emplace_back(object);
+        SiftUp(Items_.begin(), Items_.end(), Items_.end() - 1);
+        YT_ASSERT(object->GetPositionInHeap());
+    }
+
+    void Extract(const T* object)
+    {
+        auto* positionInHeap = object->GetPositionInHeap();
+        YT_ASSERT(Items_.data() <= positionInHeap && positionInHeap < Items_.data() + Items_.size());
+
+        std::swap(*positionInHeap, Items_.back());
+        SiftDown(
+            Items_.data(),
+            Items_.data() + std::ssize(Items_) - 1,
+            positionInHeap);
+
+        YT_ASSERT(Items_.back()->GetPositionInHeap() == object->GetPositionInHeap());
+        Items_.pop_back();
+    }
+
+    void AdjustDown(const T* object)
+    {
+        auto* positionInHeap = object->GetPositionInHeap();
+        YT_ASSERT(Items_.data() <= positionInHeap && positionInHeap < Items_.data() + Items_.size());
+        SiftDown(
+            Items_.data(),
+            Items_.data() + std::ssize(Items_),
+            positionInHeap);
+    }
+
+    T* GetFront()
+    {
+        YT_ASSERT(!Empty());
+        return &*Items_.front();
+    }
+
+    bool Empty() const
+    {
+        return Items_.empty();
+    }
+
+    size_t GetSize() const
+    {
+        return Items_.size();
+    }
+
+    T& operator[] (size_t index)
+    {
+        return *Items_[index];
+    }
+
+    template <class F>
+    void ForEach(F&& functor)
+    {
+        for (auto& item : Items_) {
+            functor(&*item);
+        }
+    }
+
+    void Clear()
+    {
+        Items_.clear();
+    }
+
+private:
+    std::vector<THeapItem<T>> Items_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TAction
+{
+    TCpuInstant EnqueuedAt = 0;
+    TCpuInstant StartedAt = 0;
+    TCpuInstant ExpectedBytes = 0;
+
+    // Callback keeps raw ptr to bucket to minimize bucket ref count.
+    TClosure Callback;
+    TBucketPtr BucketHolder;
+
+    TPackedPtr EnqueuedThreadCookie = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TEnqueuedTime
+    : public THeapItemBase<TEnqueuedTime>
+{
+    TCpuInstant Value = 0;
+};
+
+bool operator < (const TEnqueuedTime& lhs, const TEnqueuedTime& rhs)
+{
+    return lhs.Value < rhs.Value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Data for scheduling on the first level.
+struct TExecutionPool final
+    : public THeapItemBase<TExecutionPool>
+{
+    const TString PoolName;
+
+    // Profiling sensors.
+    const NProfiling::TSummary BucketCounter;
+    const NProfiling::TSummary SizeCounter;
+    const NProfiling::TCounter DequeuedCounter;
+    const TEventTimer WaitTimeCounter;
+    const TEventTimer ExecTimeCounter;
+    const TEventTimer TotalTimeCounter;
+    const NProfiling::TTimeCounter CumulativeTimeCounter;
+
+    // Action count is used to decide whether to reset excess time or not.
+    size_t ActionCountInQueue = 0;
+
+    TCpuDuration NextUpdateWeightInstant = 0;
+    double InverseWeight = 1.0;
+    TCpuDuration ExcessTime = 0;
+
+    TPriorityQueue<TBucket> ActiveBucketsHeap;
+    TCpuDuration LastBucketExcessTime = 0;
+
+    TIntrusiveLinkedListNode<TExecutionPool> LinkedListNode;
+    // Execution pool is retained for some after last usage to flush profiling counters.
+    TCpuInstant LastUsageTime = 0;
+
+    TExecutionPool(TString poolName, const TProfiler& profiler)
+        : PoolName(std::move(poolName))
+        , BucketCounter(profiler.Summary("/buckets"))
+        , SizeCounter(profiler.Summary("/size"))
+        , DequeuedCounter(profiler.Counter("/dequeued"))
+        , WaitTimeCounter(profiler.Timer("/time/wait"))
+        , ExecTimeCounter(profiler.Timer("/time/exec"))
+        , TotalTimeCounter(profiler.Timer("/time/total"))
+        , CumulativeTimeCounter(profiler.TimeCounter("/time/cumulative"))
+    { }
+};
+
+bool operator < (const TExecutionPool& lhs, const TExecutionPool& rhs)
+{
+    return lhs.ExcessTime < rhs.ExcessTime;
+}
+
+using TExecutionPoolPtr = ::NYT::TIntrusivePtr<TExecutionPool>;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Data for scheduling on the second level.
+struct TBucketBase
+{
+    const TString BucketName;
+    const TString PoolName;
+
+    TRingQueue<TAction> ActionQueue;
+    TExecutionPoolPtr Pool = nullptr;
+
+    TCpuDuration ExcessTime = 0;
+    double InverseWeight = 1.0;
+
+    TEnqueuedTime EnqueuedTime;
+
+    TBucketBase(TString bucketName, TString poolName, double bucketWeight = 1.0)
+        : BucketName(std::move(bucketName))
+        , PoolName(std::move(poolName))
+        , InverseWeight(1.0 / bucketWeight)
+    { }
+};
+
+bool operator < (const TBucketBase& lhs, const TBucketBase& rhs)
+{
+    return std::tie(lhs.ExcessTime, lhs.EnqueuedTime) < std::tie(rhs.ExcessTime, rhs.EnqueuedTime);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TBucket
+    : public IInvokerWithExpectedBytes
+    , public THeapItemBase<TBucket>
+    , public TBucketBase
+{
+public:
+    TBucket(TString bucketName, TString poolName, TBucketMappingPtr parent, double bucketWeight)
+        : TBucketBase(std::move(bucketName), std::move(poolName), bucketWeight)
+        , Parent_(std::move(parent))
+    { }
+
+    ~TBucket();
+
+    void RunCallback(const TClosure& callback, TCpuInstant cpuInstant)
+    {
+        YT_LOG_TRACE("Executing callback (EnqueuedAt: %v)", cpuInstant);
+        TCurrentInvokerGuard currentInvokerGuard(this);
+        callback.Run();
+    }
+
+    bool IsSerialized() const override
+    {
+        return false;
+    }
+
+    void Invoke(TClosure callback) override;
+
+    void Invoke(TMutableRange<TClosure> callbacks) override
+    {
+        for (auto& callback : callbacks) {
+            Invoke(std::move(callback));
+        }
+    }
+
+    void InvokeWithExpectedBytes(TClosure callback, i64 expectedBytes) override;
+
+    void InvokeWithExpectedBytes(TMutableRange<std::pair<TClosure, i64>> callbacks) override
+    {
+        for (auto& callback : callbacks) {
+            InvokeWithExpectedBytes(std::move(callback.first), std::move(callback.second));
+        }
+    }
+
+    NThreading::TThreadId GetThreadId() const override
+    {
+        return NThreading::InvalidThreadId;
+    }
+
+    bool CheckAffinity(const IInvokerPtr& invoker) const override
+    {
+        return invoker.Get() == this;
+    }
+
+    void RegisterWaitTimeObserver(TWaitTimeObserver /*waitTimeObserver*/) override
+    { }
+
+private:
+    const TBucketMappingPtr Parent_;
+};
+
+DEFINE_REFCOUNTED_TYPE(TBucket)
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TBucketMapping
+    : public TRefCounted
+{
+public:
+    struct TExecutionPoolToListNode
+    {
+        auto operator() (TExecutionPool* pool) const
+        {
+            return &pool->LinkedListNode;
+        }
+    };
+
+    using TPoolQueue = TIntrusiveLinkedList<TExecutionPool, TExecutionPoolToListNode>;
+
+    explicit TBucketMapping(TDuration poolRetentionTime)
+        : PoolRetentionTime_(poolRetentionTime)
+    { }
+
+    ~TBucketMapping()
+    {
+        auto guard = Guard(MappingLock_);
+
+        while (RetainPoolQueue_.GetSize() > 0) {
+            auto* frontPool = RetainPoolQueue_.GetFront();
+
+            auto poolIt = PoolMapping_.find(frontPool->PoolName);
+            YT_ASSERT(poolIt != PoolMapping_.end() && poolIt->second == frontPool);
+            PoolMapping_.erase(poolIt);
+
+            RetainPoolQueue_.PopFront();
+            NYT::DestroyRefCounted(frontPool);
+        }
+    }
+
+    virtual TProfiler GetPoolProfiler(const TString& poolName) = 0;
+
+    virtual void Invoke(TClosure callback, i64 expectedBytes, TBucket* bucket) = 0;
+
+    // GetInvoker is protected by mapping lock (can be sharded).
+    IInvokerWithExpectedBytesPtr GetInvoker(const TString& poolName, const TString& bucketName, double bucketWeight)
+    {
+        // TODO(lukyan): Use reader guard and update it to writer if needed.
+        auto guard = Guard(MappingLock_);
+
+        auto [bucketIt, bucketInserted] = BucketMapping_.emplace(std::make_pair(poolName, bucketName), nullptr);
+
+        auto bucket = bucketIt->second ? DangerousGetPtr(bucketIt->second) : nullptr;
+        if (!bucket) {
+            bucket = New<TBucket>(bucketName, poolName, MakeStrong(this), bucketWeight);
+            bucketIt->second = bucket.Get();
+            bucket->Pool = GetOrRegisterPool(bucket->PoolName);
+        }
+
+        return bucket;
+    }
+
+    // GetInvoker is protected by mapping lock (can be sharded).
+    void RemoveBucket(TBucket* bucket)
+    {
+        auto guard = Guard(MappingLock_);
+        auto bucketIt = BucketMapping_.find(std::make_pair(bucket->PoolName, bucket->BucketName));
+
+        if (bucketIt != BucketMapping_.end() && bucketIt->second == bucket) {
+            BucketMapping_.erase(bucketIt);
+        }
+
+        // Detach under lock.
+        auto* poolDangerousPtr = bucket->Pool.Release();
+
+        // Do not want use NewWithDeleter and keep pointer to TTwoLevelFairShareQueue in each execution pool.
+        if (NYT::GetRefCounter(poolDangerousPtr)->Unref(1)) {
+            auto poolsToRemove = DetachPool(poolDangerousPtr);
+            guard.Release();
+
+            while (poolsToRemove.GetSize() > 0) {
+                auto* frontPool = poolsToRemove.GetFront();
+                poolsToRemove.PopFront();
+                NYT::DestroyRefCounted(frontPool);
+            }
+        }
+    }
+
+    TExecutionPoolPtr GetOrRegisterPool(TString poolName)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MappingLock_);
+
+        auto [mappingIt, inserted] = PoolMapping_.emplace(poolName, nullptr);
+        if (!inserted) {
+            YT_ASSERT(mappingIt->second->PoolName == poolName);
+
+            auto* pool = mappingIt->second;
+            // If RetainPoolQueue_ contains only one element its LinkedListNode will be null.
+            // Determine that pool is in RetainPoolQueue_ by checking its ref count.
+            if (NYT::GetRefCounter(pool)->GetRefCount() == 0) {
+                RetainPoolQueue_.Remove(pool);
+                pool->LinkedListNode = {};
+
+                YT_LOG_TRACE("Restoring pool (PoolName: %v)", pool->PoolName);
+            }
+
+            YT_LOG_TRACE("Reusing pool (PoolName: %v)", pool->PoolName);
+
+            return pool;
+        } else {
+            YT_LOG_TRACE("Creating pool (PoolName: %v)", poolName);
+            auto pool = New<TExecutionPool>(poolName, GetPoolProfiler(poolName));
+            mappingIt->second = pool.Get();
+
+            return pool;
+        }
+    }
+
+    TPoolQueue DetachPool(TExecutionPool* pool)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MappingLock_);
+
+        YT_LOG_TRACE("Removing pool (PoolName: %v)", pool->PoolName);
+
+        auto currentInstant = GetCpuInstant();
+        pool->LastUsageTime = currentInstant;
+
+        // Items in RetainPoolQueue_ are ordered by LastUsageTime.
+        // When pool is used again it is removed from RetainPoolQueue_.
+        RetainPoolQueue_.PushBack(pool);
+        return ProceedRetainQueue(currentInstant);
+    }
+
+    TPoolQueue ProceedRetainQueue(TCpuInstant currentInstant)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MappingLock_);
+
+        YT_LOG_TRACE("ProceedRetainQueue (Size: %v)", RetainPoolQueue_.GetSize());
+
+        TPoolQueue poolsToRemove;
+
+        while (RetainPoolQueue_.GetSize() > 0) {
+            auto* frontPool = RetainPoolQueue_.GetFront();
+
+            auto lastUsageTime = frontPool->LastUsageTime;
+            if (CpuDurationToDuration(currentInstant - lastUsageTime) < PoolRetentionTime_) {
+                break;
+            }
+
+            YT_LOG_TRACE("Destroing pool (PoolName: %v)", frontPool->PoolName);
+
+            auto poolIt = PoolMapping_.find(frontPool->PoolName);
+            YT_ASSERT(poolIt != PoolMapping_.end() && poolIt->second == frontPool);
+            PoolMapping_.erase(poolIt);
+
+            RetainPoolQueue_.PopFront();
+            poolsToRemove.PushBack(frontPool);
+        }
+
+        return poolsToRemove;
+    }
+
+    void MaybeProceedRetainQueue(TCpuInstant currentInstant)
+    {
+        if (!MappingLock_.TryAcquire()) {
+            return;
+        }
+
+        auto finally = Finally([&] {
+            MappingLock_.Release();
+        });
+
+        auto poolsToRemove = ProceedRetainQueue(currentInstant);
+        MappingLock_.Release();
+        finally.Release();
+
+        while (poolsToRemove.GetSize() > 0) {
+            auto* frontPool = poolsToRemove.GetFront();
+            poolsToRemove.PopFront();
+            NYT::DestroyRefCounted(frontPool);
+        }
+    }
+
+private:
+    const TDuration PoolRetentionTime_;
+
+    YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, MappingLock_);
+    THashMap<std::pair<TString, TString>, TBucket*> BucketMapping_;
+    THashMap<TString, TExecutionPool*> PoolMapping_;
+
+    TPoolQueue RetainPoolQueue_;
+};
+
+DEFINE_REFCOUNTED_TYPE(TBucketMapping)
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TBucket::Invoke(TClosure callback)
+{
+    Parent_->Invoke(std::move(callback), 0, this);
+}
+
+void TBucket::InvokeWithExpectedBytes(TClosure callback, i64 expectedBytes)
+{
+    Parent_->Invoke(std::move(callback), expectedBytes, this);
+}
+
+TBucket::~TBucket()
+{
+    Parent_->RemoveBucket(this);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_ENUM(ERequest,
+    (None)
+    (EndExecute)
+    (FetchNext)
+);
+
+class TTwoLevelFairShareQueue
+    : protected TNotifyManager
+    , public TBucketMapping
+{
+public:
+    using TWaitTimeObserver = IFairShareWeightedThreadPool::TWaitTimeObserver;
+
+    TTwoLevelFairShareQueue(
+        TIntrusivePtr<NThreading::TEventCount> callbackEventCount,
+        const TString& threadNamePrefix,
+        const TFairShareWeightedThreadPoolOptions& options)
+        : TNotifyManager(std::move(callbackEventCount), GetThreadTags(threadNamePrefix), options.PollingPeriod)
+        , TBucketMapping(options.PoolRetentionTime)
+        , ThreadNamePrefix_(threadNamePrefix)
+        , Profiler_(TProfiler{"/fair_share_queue"}
+            .WithHot())
+        , CumulativeSchedulingTimeCounter_(Profiler_
+            .WithTags(GetThreadTags(ThreadNamePrefix_))
+            .TimeCounter("/time/scheduling_cumulative"))
+        , PoolWeightProvider_(options.PoolWeightProvider)
+        , VerboseLogging_(options.VerboseLogging)
+    { }
+
+    ~TTwoLevelFairShareQueue()
+    {
+        Shutdown();
+    }
+
+    void Configure(int threadCount)
+    {
+        ThreadCount_.store(threadCount);
+    }
+
+    // Invoke is lock free.
+    void Invoke(TClosure callback, i64 expectedBytes, TBucket* bucket) override
+    {
+        if (Stopped_.load()) {
+            return;
+        }
+
+        auto cpuInstant = GetCpuInstant();
+
+        YT_LOG_TRACE("Invoking action (EnqueuedAt: %v, Invoker: %v)",
+            cpuInstant,
+            ThreadNamePrefix_);
+
+        TAction action;
+        action.EnqueuedAt = cpuInstant;
+        action.ExpectedBytes = expectedBytes;
+        // Callback keeps raw ptr to bucket to minimize bucket ref count.
+        action.Callback = BIND(&TBucket::RunCallback, Unretained(bucket), std::move(callback), cpuInstant);
+        action.BucketHolder = MakeStrong(bucket);
+        action.EnqueuedThreadCookie = ThreadCookie;
+
+        InvokeQueue_.Enqueue(std::move(action));
+
+        NotifyFromInvoke(cpuInstant, ActiveThreads_.load() == 0);
+    }
+
+    void StopPrologue()
+    {
+        GetEventCount()->NotifyAll();
+    }
+
+    TClosure OnExecute(int index, bool fetchNext, std::function<bool()> isStopping)
+    {
+        while (true) {
+            auto cookie = GetEventCount()->PrepareWait();
+
+            auto hasAction = ThreadStates_[index].Action.BucketHolder;
+            int activeThreadDelta = hasAction ? -1 : 0;
+
+            auto callback = DoOnExecute(index, fetchNext);
+
+            if (callback) {
+                activeThreadDelta += 1;
+            }
+
+            YT_VERIFY(activeThreadDelta >= -1 && activeThreadDelta <= 1);
+
+            if (activeThreadDelta != 0) {
+                auto activeThreads = ActiveThreads_.fetch_add(activeThreadDelta);
+                auto newActiveThreads = activeThreads + activeThreadDelta;
+                YT_VERIFY(newActiveThreads >= 0 && newActiveThreads <= TThreadPoolBase::MaxThreadCount);
+                activeThreadDelta = 0;
+            }
+
+            if (callback || isStopping()) {
+                CancelWait();
+                return callback;
+            }
+
+            YT_VERIFY(fetchNext);
+            Wait(cookie, isStopping);
+        }
+    }
+
+    void Shutdown()
+    {
+        Drain();
+    }
+
+    void Drain()
+    {
+        Stopped_.store(true);
+        auto guard = Guard(MainLock_);
+
+        WaitHeap_.Clear();
+
+        std::vector<TBucket*> buckets;
+        ActivePoolsHeap_.ForEach([&] (auto* pool) {
+            pool->ActiveBucketsHeap.ForEach([&] (auto* bucket) {
+                buckets.push_back(bucket);
+            });
+            pool->ActiveBucketsHeap.Clear();
+        });
+        ActivePoolsHeap_.Clear();
+
+        // Actions hold strong references to buckets.
+        // Buckets' ActionQueue must be cleared before destroying actions.
+        std::vector<TAction> actions;
+        for (auto* bucket : buckets) {
+            while (!bucket->ActionQueue.empty()) {
+                actions.push_back(std::move(bucket->ActionQueue.front()));
+                bucket->ActionQueue.pop();
+            }
+        }
+
+        actions.clear();
+
+        InvokeQueue_.DequeueAll();
+    }
+
+    void RegisterWaitTimeObserver(TWaitTimeObserver waitTimeObserver)
+    {
+        WaitTimeObserver_ = waitTimeObserver;
+        auto alreadyInitialized = IsWaitTimeObserverSet_.exchange(true);
+
+        // Multiple observers are forbidden.
+        YT_VERIFY(!alreadyInitialized);
+    }
+
+private:
+    struct TThreadState
+    {
+        std::atomic<ERequest> Request = ERequest::None;
+
+        TCpuInstant AccountedAt = 0;
+        TAction Action;
+
+        // Used to store bucket ref under lock to destroy it outside.
+        TBucketPtr BucketToUnref;
+        int LastActionsInQueue;
+        TDuration TimeFromStart;
+        TDuration TimeFromEnqueue;
+    };
+
+    static_assert(sizeof(TThreadState) >= CacheLineSize);
+
+    const TString ThreadNamePrefix_;
+    const TProfiler Profiler_;
+    const NProfiling::TTimeCounter CumulativeSchedulingTimeCounter_;
+    const IPoolWeightProviderPtr PoolWeightProvider_;
+    const bool VerboseLogging_;
+
+    std::atomic<bool> Stopped_ = false;
+    TMpscStack<TAction> InvokeQueue_;
+    char Padding0_[CacheLineSize - sizeof(TMpscStack<TAction>)];
+
+    // Use simple non adaptive spinlock without complex wait strategies.
+    ::TSpinLock MainLock_;
+    char Padding1_[CacheLineSize - sizeof(::TSpinLock)];
+
+    std::array<TThreadState, TThreadPoolBase::MaxThreadCount> ThreadStates_;
+
+    TPriorityQueue<TExecutionPool> ActivePoolsHeap_;
+    TCpuDuration LastPoolExcessTime_ = 0;
+    TPriorityQueue<TEnqueuedTime> WaitHeap_;
+
+    // Buffer to keep actions during distribution to threads.
+    std::array<TAction, TThreadPoolBase::MaxThreadCount> OtherActions_;
+    std::atomic<int> ThreadCount_ = 0;
+    std::atomic<int> ActiveThreads_ = 0;
+
+    std::atomic<bool> IsWaitTimeObserverSet_;
+    TWaitTimeObserver WaitTimeObserver_;
+
+    TProfiler GetPoolProfiler(const TString& poolName) override
+    {
+        return Profiler_.WithTags(GetBucketTags(ThreadNamePrefix_, poolName));
+    }
+
+    Y_NO_INLINE void ConsumeInvokeQueue()
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        Y_UNUSED(Padding0_);
+        Y_UNUSED(Padding1_);
+
+        InvokeQueue_.DequeueAll(true, [&] (auto& action) {
+            auto* bucket = action.BucketHolder.Get();
+
+            auto* pool = bucket->Pool.Get();
+
+            YT_VERIFY(!pool->LinkedListNode.Next && !pool->LinkedListNode.Prev);
+
+            if (!pool->GetPositionInHeap()) {
+                // ExcessTime can be greater than last pool excess time
+                // if the pool is "currently executed" and reschedules action.
+                if (pool->ExcessTime < LastPoolExcessTime_) {
+                    // Use last pool excess time to schedule new pool
+                    // after earlier scheduled pools (and not yet executed) in queue.
+
+                    YT_LOG_DEBUG_IF(VerboseLogging_, "Initial pool excess time (Name: %v, ExcessTime: %v -> %v)",
+                        pool->PoolName,
+                        pool->ExcessTime,
+                        LastPoolExcessTime_);
+
+                    pool->ExcessTime = LastPoolExcessTime_;
+                }
+
+                ActivePoolsHeap_.Insert(pool);
+            }
+
+            ++pool->ActionCountInQueue;
+
+            auto enqueuedAt = action.EnqueuedAt;
+
+            bool wasEmpty = bucket->ActionQueue.empty();
+            bucket->ActionQueue.push(std::move(action));
+
+            if (wasEmpty) {
+                bucket->EnqueuedTime.Value = enqueuedAt;
+            }
+
+            YT_ASSERT(wasEmpty == !bucket->GetPositionInHeap());
+
+            if (!bucket->GetPositionInHeap()) {
+                // ExcessTime can be greater than last bucket excess time
+                // if the bucket is "currently executed" and reschedules action.
+                if (bucket->ExcessTime < pool->LastBucketExcessTime) {
+                    // Use last bucket excess time to schedule new bucket
+                    // after earlier scheduled buckets (and not yet executed) in queue.
+
+                    YT_LOG_DEBUG_IF(VerboseLogging_, "Initial bucket excess time (Name: %v, ExcessTime: %v -> %v)",
+                        bucket->BucketName,
+                        bucket->ExcessTime,
+                        pool->LastBucketExcessTime);
+
+                    bucket->ExcessTime = pool->LastBucketExcessTime;
+                }
+
+                pool->ActiveBucketsHeap.Insert(bucket);
+                pool->BucketCounter.Record(pool->ActiveBucketsHeap.GetSize());
+                WaitHeap_.Insert(&bucket->EnqueuedTime);
+            }
+        });
+    }
+
+    void ServeBeginExecute(TThreadState* threadState, TCpuInstant currentInstant, TAction action)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        YT_ASSERT(!threadState->Action.Callback);
+        YT_ASSERT(!threadState->Action.BucketHolder);
+
+        action.StartedAt = currentInstant;
+
+        threadState->AccountedAt = currentInstant;
+        threadState->Action = std::move(action);
+    }
+
+    void ServeEndExecute(TThreadState* threadState, TCpuInstant /*cpuInstant*/)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        auto action = std::move(threadState->Action);
+        YT_ASSERT(!threadState->Action.Callback);
+        YT_ASSERT(!action.Callback);
+
+        if (!action.BucketHolder) {
+            // There was no action in begin execute.
+            return;
+        }
+
+        // Try not to change bucket ref count under lock.
+        auto bucket = std::move(action.BucketHolder);
+
+        auto& pool = *bucket->Pool;
+        YT_ASSERT(pool.PoolName == bucket->PoolName);
+
+        // LastActionsInQueue is used to update SizeCounter outside lock.
+        threadState->LastActionsInQueue = --pool.ActionCountInQueue;
+
+        // Do not destroy bucket pointer under lock. Move it in thread state in other place and
+        // destroy in corresponding thread after combiner.
+        threadState->BucketToUnref = std::move(bucket);
+    }
+
+    Y_NO_INLINE void UpdateExcessTime(TBucket* bucket, TCpuDuration duration, TCpuInstant currentInstant)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        auto* pool = bucket->Pool.Get();
+
+        if (PoolWeightProvider_ && pool->NextUpdateWeightInstant < currentInstant) {
+            pool->NextUpdateWeightInstant = currentInstant + DurationToCpuDuration(TDuration::Seconds(1));
+            pool->InverseWeight = 1.0 / PoolWeightProvider_->GetWeight(pool->PoolName);
+        }
+
+        YT_LOG_DEBUG_IF(VerboseLogging_, "Increment excess time (BucketName: %v, PoolName: %v, ExcessTime: %v -> %v, Duration: %v, InverseWeight: %v)",
+            bucket->BucketName,
+            bucket->PoolName,
+            bucket->ExcessTime,
+            bucket->ExcessTime + duration * bucket->InverseWeight,
+            duration,
+            bucket->InverseWeight);
+
+        pool->ExcessTime += duration * pool->InverseWeight;
+        bucket->ExcessTime += duration * bucket->InverseWeight;
+
+        if (auto* positionInHeap = pool->GetPositionInHeap()) {
+            ActivePoolsHeap_.AdjustDown(pool);
+        }
+
+        if (auto* positionInHeap = bucket->GetPositionInHeap()) {
+            pool->ActiveBucketsHeap.AdjustDown(bucket);
+        }
+
+        // No need to update wait heap.
+        YT_ASSERT(!bucket->EnqueuedTime.GetPositionInHeap() == !bucket->GetPositionInHeap());
+    }
+
+    Y_NO_INLINE bool GetStarvingBucket(TAction* action)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        YT_LOG_DEBUG_IF(VerboseLogging_, "Buckets: %v",
+            MakeFormattableView(
+                xrange(size_t(0), ActivePoolsHeap_.GetSize()),
+                [&] (auto* builder, auto index) {
+                    auto& pool = ActivePoolsHeap_[index];
+                    builder->AppendFormat("%v [", CpuDurationToDuration(pool.ExcessTime));
+
+                    for (size_t bucketIndex = 0; bucketIndex < pool.ActiveBucketsHeap.GetSize(); ++bucketIndex) {
+                        const auto& bucket = pool.ActiveBucketsHeap[bucketIndex];
+
+                        builder->AppendFormat("%Qv:%v/%v ",
+                            bucket.BucketName,
+                            CpuDurationToDuration(bucket.ExcessTime),
+                            bucket.ActionQueue.front().EnqueuedAt);
+                    }
+                    builder->AppendFormat("]");
+                }));
+
+        if (ActivePoolsHeap_.Empty()) {
+            return false;
+        }
+
+        auto* pool = ActivePoolsHeap_.GetFront();
+        LastPoolExcessTime_ = pool->ExcessTime;
+
+        auto* bucket = pool->ActiveBucketsHeap.GetFront();
+        pool->LastBucketExcessTime = bucket->ExcessTime;
+
+        YT_ASSERT(!bucket->ActionQueue.empty());
+        *action = std::move(bucket->ActionQueue.front());
+        bucket->ActionQueue.pop();
+
+        YT_ASSERT(bucket == action->BucketHolder);
+
+        if (bucket->ActionQueue.empty()) {
+            bucket->EnqueuedTime.Value = std::numeric_limits<TCpuInstant>::max();
+
+            WaitHeap_.Extract(&bucket->EnqueuedTime);
+
+            pool->ActiveBucketsHeap.Extract(bucket);
+            pool->BucketCounter.Record(pool->ActiveBucketsHeap.GetSize());
+
+            if (pool->ActiveBucketsHeap.Empty()) {
+                ActivePoolsHeap_.Extract(pool);
+            }
+        } else {
+            bucket->EnqueuedTime.Value = bucket->ActionQueue.front().EnqueuedAt;
+            WaitHeap_.AdjustDown(&bucket->EnqueuedTime);
+        }
+
+        return true;
+    }
+
+    Y_NO_INLINE std::tuple<int, int> ServeCombinedRequests(TCpuInstant currentInstant, int currentThreadIndex)
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        auto threadCount = ThreadCount_.load();
+        // Thread pool size can be reconfigures during serving requests.
+        threadCount = std::max(threadCount, currentThreadIndex + 1);
+
+        // Saved thread requests. They must be saved before consuming invoke queue.
+        std::array<bool, TThreadPoolBase::MaxThreadCount> threadRequests{false};
+        std::array<int, TThreadPoolBase::MaxThreadCount> threadIds;
+        int requestCount = 0;
+
+        YT_LOG_TRACE("Updating excess time");
+
+        // Recalculate excess time for all currently evaluating or evaluated recently (end execute) buckets
+        for (int threadIndex = 0; threadIndex < threadCount; ++threadIndex) {
+            auto& threadState = ThreadStates_[threadIndex];
+
+            // TODO(lukyan): Can skip (for threads without requests) or throttle UpdateExcessTime if it happens frequently.
+            // For each currently evaluating buckets recalculate excess time.
+            if (auto* bucket = threadState.Action.BucketHolder.Get()) {
+
+                // TODO(lukyan): Update last excess time for pool without active buckets.
+                auto bytesConsumed = threadState.Action.ExpectedBytes;
+                threadState.Action.ExpectedBytes = 0;
+                UpdateExcessTime(bucket, bytesConsumed, currentInstant);
+                threadState.AccountedAt = currentInstant;
+            }
+
+            auto request = threadState.Request.load(std::memory_order::acquire);
+            if (request != ERequest::None) {
+                ServeEndExecute(&threadState, currentInstant);
+
+                if (request == ERequest::FetchNext) {
+                    // Save requests before ConsumeInvokeQueue. Otherwise some thread can schedule action
+                    // but action can not be fetched (schedule and fetch happens after ConsumeInvokeQueue).
+                    threadRequests[threadIndex] = true;
+                    threadIds[requestCount++] = threadIndex;
+                } else {
+                    threadState.Request.store(ERequest::None, std::memory_order::release);
+                }
+            }
+        }
+
+        YT_LOG_TRACE("Consuming invoke queue");
+
+        ConsumeInvokeQueue();
+
+        int fetchedActions = 0;
+        int otherActionCount = 0;
+
+        // Schedule actions to desired threads.
+        while (fetchedActions < requestCount) {
+            TAction action;
+
+            if (!GetStarvingBucket(&action)) {
+                break;
+            }
+
+            ++fetchedActions;
+
+            int threadIndex = -1;
+
+            auto unpackedCookie = TTaggedPtr<TTwoLevelFairShareQueue>::Unpack(action.EnqueuedThreadCookie);
+            // TODO(lukyan): Check also wait time. If it is too high, no matter where to schedule.
+            if (unpackedCookie.Ptr == this) {
+                threadIndex = unpackedCookie.Tag;
+            }
+
+            if (threadIndex != -1 && threadRequests[threadIndex]) {
+                ServeBeginExecute(&ThreadStates_[threadIndex], currentInstant, std::move(action));
+                threadRequests[threadIndex] = false;
+                ThreadStates_[threadIndex].Request.store(ERequest::None, std::memory_order::release);
+            } else {
+                OtherActions_[otherActionCount++] = std::move(action);
+            }
+        }
+
+        // Schedule other actions.
+        for (int threadIndex : MakeRange(threadIds.data(), requestCount)) {
+            if (threadRequests[threadIndex]) {
+                if (otherActionCount > 0) {
+                    ServeBeginExecute(&ThreadStates_[threadIndex], currentInstant, std::move(OtherActions_[--otherActionCount]));
+                }
+
+                ThreadStates_[threadIndex].Request.store(ERequest::None, std::memory_order::release);
+            }
+        }
+
+        return {requestCount, fetchedActions};
+    }
+
+    TCpuInstant GetMinEnqueuedAt()
+    {
+        VERIFY_SPINLOCK_AFFINITY(MainLock_);
+
+        return WaitHeap_.Empty()
+            ? std::numeric_limits<TCpuInstant>::max()
+            : WaitHeap_.GetFront()->Value;
+    }
+
+    TClosure DoOnExecute(int index, bool fetchNext)
+    {
+        auto cpuInstant = GetCpuInstant();
+        auto& threadState = ThreadStates_[index];
+
+        const auto& oldAction = threadState.Action;
+        if (oldAction.BucketHolder) {
+            auto waitTime = CpuDurationToDuration(oldAction.StartedAt - oldAction.EnqueuedAt);
+            auto timeFromStart = CpuDurationToDuration(cpuInstant - oldAction.StartedAt);
+            auto timeFromEnqueue = CpuDurationToDuration(cpuInstant - oldAction.EnqueuedAt);
+
+            threadState.TimeFromStart = timeFromStart;
+            threadState.TimeFromEnqueue = timeFromEnqueue;
+
+            if (timeFromStart > LogDurationThreshold) {
+                YT_LOG_DEBUG("Callback execution took too long (Wait: %v, Execution: %v, Total: %v)",
+                    waitTime,
+                    timeFromStart,
+                    timeFromEnqueue);
+            }
+
+            if (waitTime > LogDurationThreshold) {
+                YT_LOG_DEBUG("Callback wait took too long (Wait: %v, Execution: %v, Total: %v)",
+                    waitTime,
+                    timeFromStart,
+                    timeFromEnqueue);
+            }
+        }
+
+        auto finally = Finally([&] {
+            auto bucketToUndef = std::move(threadState.BucketToUnref);
+            if (bucketToUndef) {
+                auto* pool = bucketToUndef->Pool.Get();
+                pool->SizeCounter.Record(threadState.LastActionsInQueue);
+                pool->DequeuedCounter.Increment(1);
+                pool->ExecTimeCounter.Record(threadState.TimeFromStart);
+                pool->TotalTimeCounter.Record(threadState.TimeFromEnqueue);
+                pool->CumulativeTimeCounter.Add(threadState.TimeFromStart);
+                bucketToUndef.Reset();
+            }
+
+            const auto& action = threadState.Action;
+            if (action.BucketHolder) {
+                auto waitTime = CpuDurationToDuration(action.StartedAt - action.EnqueuedAt);
+                action.BucketHolder->Pool->WaitTimeCounter.Record(waitTime);
+                ReportWaitTime(waitTime);
+            }
+
+            CumulativeSchedulingTimeCounter_.Add(CpuDurationToDuration(GetCpuInstant() - cpuInstant));
+
+            if (!fetchNext) {
+                MaybeProceedRetainQueue(cpuInstant);
+            }
+        });
+
+        auto& request = threadState.Request;
+        YT_VERIFY(request == ERequest::None);
+        request.store(fetchNext ? ERequest::FetchNext : ERequest::EndExecute);
+
+        if (MainLock_.IsLocked() || !MainLock_.TryAcquire()) {
+            // Locked here.
+            while (true) {
+                SpinLockPause();
+
+                if (request.load(std::memory_order::acquire) == ERequest::None) {
+                    return std::move(threadState.Action.Callback);
+                } else if (!MainLock_.IsLocked() && MainLock_.TryAcquire()) {
+                    break;
+                }
+            }
+        }
+
+        ResetMinEnqueuedAt();
+
+        YT_LOG_TRACE("Started serving requests");
+        auto [requests, fetchedActions] = ServeCombinedRequests(cpuInstant, index);
+
+        // Evaluate notify condition here, but call NotifyAfterFetch outside lock.
+        auto newMinEnqueuedAt = GetMinEnqueuedAt();
+        MainLock_.Release();
+
+        auto endInstant = GetCpuInstant();
+        YT_LOG_TRACE("Finished serving requests (Duration: %v, Requests: %v, FetchCount: %v, MinEnqueuedAt: %v)",
+            CpuDurationToDuration(endInstant - cpuInstant),
+            requests,
+            fetchedActions,
+            CpuInstantToInstant(newMinEnqueuedAt));
+
+        NotifyAfterFetch(endInstant, newMinEnqueuedAt);
+
+        return std::move(threadState.Action.Callback);
+    }
+
+    void ReportWaitTime(TDuration waitTime)
+    {
+        if (IsWaitTimeObserverSet_.load()) {
+            WaitTimeObserver_(waitTime);
+        }
+    }
+};
+
+DEFINE_REFCOUNTED_TYPE(TTwoLevelFairShareQueue)
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TFairShareThread
+    : public TSchedulerThread
+{
+public:
+    TFairShareThread(
+        TTwoLevelFairShareQueuePtr queue,
+        TIntrusivePtr<NThreading::TEventCount> callbackEventCount,
+        const TString& threadGroupName,
+        const TString& threadName,
+        int index)
+        : TSchedulerThread(
+            std::move(callbackEventCount),
+            threadGroupName,
+            threadName)
+        , Queue_(std::move(queue))
+        , Index_(index)
+    { }
+
+protected:
+    const TTwoLevelFairShareQueuePtr Queue_;
+    const int Index_;
+
+    void OnStart() override
+    {
+        ThreadCookie = TTaggedPtr(Queue_.Get(), static_cast<ui16>(Index_)).Pack();
+    }
+
+    void StopPrologue() override
+    {
+        Queue_->StopPrologue();
+    }
+
+    TClosure OnExecute() override
+    {
+        bool fetchNext = !TSchedulerThread::IsStopping() || TSchedulerThread::GracefulStop_;
+
+        return Queue_->OnExecute(Index_, fetchNext, [&] {
+            return TSchedulerThread::IsStopping();
+        });
+    }
+
+    TClosure BeginExecute() override
+    {
+        Y_UNREACHABLE();
+    }
+
+    void EndExecute() override
+    {
+        Y_UNREACHABLE();
+    }
+};
+
+DEFINE_REFCOUNTED_TYPE(TFairShareThread)
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TTwoLevelFairShareThreadPool
+    : public IFairShareWeightedThreadPool
+    , public TThreadPoolBase
+{
+public:
+    TTwoLevelFairShareThreadPool(
+        int threadCount,
+        const TString& threadNamePrefix,
+        const TFairShareWeightedThreadPoolOptions& options)
+        : TThreadPoolBase(threadNamePrefix)
+        , Queue_(New<TTwoLevelFairShareQueue>(
+            CallbackEventCount_,
+            ThreadNamePrefix_,
+            options))
+    {
+        Configure(threadCount);
+    }
+
+    ~TTwoLevelFairShareThreadPool()
+    {
+        Shutdown();
+    }
+
+    void Configure(int threadCount) override
+    {
+        TThreadPoolBase::Configure(threadCount);
+    }
+
+    IInvokerWithExpectedBytesPtr GetInvokerWithExpectedBytes(
+        const TString& poolName,
+        const TFairShareThreadPoolTag& bucketName,
+        double bucketWeight) override
+    {
+        EnsureStarted();
+        return Queue_->GetInvoker(poolName, bucketName, bucketWeight);
+    }
+
+    void Shutdown() override
+    {
+        TThreadPoolBase::Shutdown();
+    }
+
+    int GetThreadCount() override
+    {
+        return TThreadPoolBase::GetThreadCount();
+    }
+
+    void RegisterWaitTimeObserver(TWaitTimeObserver waitTimeObserver) override
+    {
+        Queue_->RegisterWaitTimeObserver(waitTimeObserver);
+    }
+
+private:
+    const TIntrusivePtr<NThreading::TEventCount> CallbackEventCount_ = New<NThreading::TEventCount>();
+    const TTwoLevelFairShareQueuePtr Queue_;
+
+    void DoShutdown() override
+    {
+        TThreadPoolBase::DoShutdown();
+    }
+
+    TClosure MakeFinalizerCallback() override
+    {
+        return BIND([queue = Queue_, callback = TThreadPoolBase::MakeFinalizerCallback()] {
+            callback();
+            queue->Drain();
+        });
+    }
+
+    void DoConfigure(int threadCount) override
+    {
+        Queue_->Configure(threadCount);
+        TThreadPoolBase::DoConfigure(threadCount);
+    }
+
+    TSchedulerThreadPtr SpawnThread(int index) override
+    {
+        return New<TFairShareThread>(
+            Queue_,
+            CallbackEventCount_,
+            ThreadNamePrefix_,
+            MakeThreadName(index),
+            index);
+    }
+};
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+IFairShareWeightedThreadPoolPtr CreateFairShareWeightedThreadPool(
+    int threadCount,
+    const TString& threadNamePrefix,
+    const TFairShareWeightedThreadPoolOptions& options)
+{
+    return New<TTwoLevelFairShareThreadPool>(
+        threadCount,
+        threadNamePrefix,
+        options);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NConcurrency::NFairShareWeightedThreadPool

--- a/yt/yt/core/concurrency/fair_share_weighted_thread_pool.h
+++ b/yt/yt/core/concurrency/fair_share_weighted_thread_pool.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "public.h"
+
+#include <yt/yt/core/actions/invoker.h>
+#include <yt/yt/core/actions/public.h>
+
+
+namespace NYT::NConcurrency::NFairShareWeightedThreadPool {
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IInvokerWithExpectedBytes
+    : public virtual IInvoker
+{
+    virtual void InvokeWithExpectedBytes(TClosure callback, i64 expectedBytes) = 0;
+    virtual void InvokeWithExpectedBytes(TMutableRange<std::pair<TClosure, i64>> callbacks) = 0;
+};
+
+DECLARE_REFCOUNTED_STRUCT(IInvokerWithExpectedBytes)
+DEFINE_REFCOUNTED_TYPE(IInvokerWithExpectedBytes)
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IPoolWeightProvider
+    : public virtual TRefCounted
+{
+    virtual double GetWeight(const TString& poolName) = 0;
+};
+
+DEFINE_REFCOUNTED_TYPE(IPoolWeightProvider)
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct IFairShareWeightedThreadPool
+    : public virtual TRefCounted
+{
+    virtual int GetThreadCount() = 0;
+    virtual void Configure(int threadCount) = 0;
+    virtual void Shutdown() = 0;
+
+    using TWaitTimeObserver = std::function<void(TDuration)>;
+    virtual void RegisterWaitTimeObserver(TWaitTimeObserver waitTimeObserver) = 0;
+
+    virtual IInvokerWithExpectedBytesPtr GetInvokerWithExpectedBytes(
+        const TString& poolName,
+        const TFairShareThreadPoolTag& tag,
+        double bucketWeight = 1.0) = 0;
+};
+
+DEFINE_REFCOUNTED_TYPE(IFairShareWeightedThreadPool)
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TFairShareWeightedThreadPoolOptions
+{
+    IPoolWeightProviderPtr PoolWeightProvider = nullptr;
+    bool VerboseLogging = false;
+    TDuration PollingPeriod = TDuration::MilliSeconds(10);
+    TDuration PoolRetentionTime = TDuration::Seconds(30);
+};
+
+IFairShareWeightedThreadPoolPtr CreateFairShareWeightedThreadPool(
+    int threadCount,
+    const TString& threadNamePrefix,
+    const TFairShareWeightedThreadPoolOptions& options = {});
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NConcurrency

--- a/yt/yt/core/concurrency/public.h
+++ b/yt/yt/core/concurrency/public.h
@@ -106,6 +106,11 @@ DECLARE_REFCOUNTED_STRUCT(IPoolWeightProvider)
 
 DECLARE_REFCOUNTED_STRUCT(ITwoLevelFairShareThreadPool)
 
+namespace NFairShareWeightedThreadPool {
+    DECLARE_REFCOUNTED_STRUCT(IPoolWeightProvider)
+    DECLARE_REFCOUNTED_STRUCT(IFairShareWeightedThreadPool)
+} // namespace NFairShareWeightedThreadPool
+
 DECLARE_REFCOUNTED_CLASS(TFiber)
 
 DECLARE_REFCOUNTED_STRUCT(TFairThrottlerConfig)

--- a/yt/yt/core/ya.make
+++ b/yt/yt/core/ya.make
@@ -56,6 +56,7 @@ SRCS(
     concurrency/fair_share_invoker_queue.cpp
     concurrency/fair_share_queue_scheduler_thread.cpp
     concurrency/fair_share_thread_pool.cpp
+    concurrency/fair_share_weighted_thread_pool.cpp
     concurrency/fair_throttler.cpp
     concurrency/fiber_scheduler_thread.cpp
     concurrency/fiber.cpp

--- a/yt/yt/server/job_proxy/job_proxy.cpp
+++ b/yt/yt/server/job_proxy/job_proxy.cpp
@@ -501,6 +501,8 @@ void TJobProxy::RetrieveJobSpec()
             descriptor->Annotations.end(),
             annotations.begin(),
             annotations.end());
+        descriptor->DiskFairShareBucketTag = ToString(JobId_);
+        descriptor->DiskFairShareBucketWeight = CpuGuarantee_;
     }
 
     {

--- a/yt/yt/server/lib/hydra_common/file_changelog_index.cpp
+++ b/yt/yt/server/lib/hydra_common/file_changelog_index.cpp
@@ -36,6 +36,7 @@ TFileChangelogIndex::TFileChangelogIndex(
     , FileName_(std::move(fileName))
     , Config_(std::move(config))
     , WorkloadCategory_(workloadCategory)
+    , WorkloadDescriptor_(workloadCategory, 0, {}, {}, {}, "TFileChangelogIndex", {})
     , Logger(HydraLogger.WithTag("Path: %v", FileName_))
     , MemoryUsageTrackerGuard_(TMemoryUsageTrackerGuard::Acquire(memoryUsageTracker, 0))
 { }
@@ -49,12 +50,12 @@ EFileChangelogIndexOpenResult TFileChangelogIndex::Open()
         return EFileChangelogIndexOpenResult::MissingCreated;
     }
 
-    auto handle = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr}))
+    auto handle = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr}, WorkloadDescriptor_, {}))
         .ValueOrThrow();
 
     auto recreate = [&] (EFileChangelogIndexOpenResult result) {
         if (handle) {
-            WaitFor(IOEngine_->Close({.Handle = handle}))
+            WaitFor(IOEngine_->Close({.Handle = handle}, WorkloadDescriptor_, {}))
                 .ThrowOnError();
         }
 
@@ -65,9 +66,9 @@ EFileChangelogIndexOpenResult TFileChangelogIndex::Open()
     auto buffer = WaitFor(
         IOEngine_->Read(
             {{.Handle = handle, .Offset = 0, .Size = handle->GetLength()}},
-            // TODO(babenko): better workload category?
-            EWorkloadCategory::UserBatch,
-            GetRefCountedTypeCookie<TFileChangelogIndexScratchTag>()))
+            WorkloadDescriptor_,
+            GetRefCountedTypeCookie<TFileChangelogIndexScratchTag>(),
+            {}))
         .ValueOrThrow()
         .OutputBuffers[0];
 
@@ -93,10 +94,10 @@ EFileChangelogIndexOpenResult TFileChangelogIndex::Open()
     auto truncate = [&] (EFileChangelogIndexOpenResult result) {
         IndexFilePosition_ = current - buffer.Begin();
 
-        WaitFor(IOEngine_->Resize({.Handle = handle, .Size = IndexFilePosition_}))
+        WaitFor(IOEngine_->Resize({.Handle = handle, .Size = IndexFilePosition_}, WorkloadDescriptor_, {}))
             .ThrowOnError();
 
-        WaitFor(IOEngine_->FlushFile({.Handle = handle, .Mode = EFlushFileMode::All}))
+        WaitFor(IOEngine_->FlushFile({.Handle = handle, .Mode = EFlushFileMode::All}, WorkloadDescriptor_, {}))
             .ThrowOnError();
 
         YT_LOG_DEBUG("Changelog index file truncated (RecordCount: %v, IndexFilePosition: %v, DataFileLength: %v)",
@@ -172,7 +173,7 @@ void TFileChangelogIndex::Create()
 {
     Clear();
 
-    auto handle = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | CreateAlways}))
+    auto handle = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | CreateAlways}, WorkloadDescriptor_, {}))
         .ValueOrThrow();
 
     auto buffer = TSharedMutableRef::Allocate<TFileChangelogIndexScratchTag>(sizeof(TChangelogIndexHeader), {.InitializeStorage = false});
@@ -185,7 +186,8 @@ void TFileChangelogIndex::Create()
             .Offset = 0,
             .Buffers = {std::move(buffer)}
         },
-        WorkloadCategory_))
+        WorkloadDescriptor_,
+        {}))
         .ThrowOnError();
 
     Handle_ = std::move(handle);
@@ -200,7 +202,7 @@ void TFileChangelogIndex::Close()
         .ThrowOnError();
 
     if (auto handle = std::exchange(Handle_, nullptr)) {
-        WaitFor(IOEngine_->Close({.Handle = handle, .Flush = true}))
+        WaitFor(IOEngine_->Close({.Handle = handle, .Flush = true}, WorkloadDescriptor_, {}))
             .ThrowOnError();
     }
 }
@@ -332,7 +334,8 @@ void TFileChangelogIndex::AsyncFlush()
             .Buffers = {std::move(buffer)},
             .Flush = true,
         },
-        WorkloadCategory_)
+        WorkloadDescriptor_,
+        {})
         .Apply(BIND([=, this, this_ = MakeStrong(this)] {
             YT_VERIFY(Flushing_.exchange(false));
             YT_LOG_DEBUG("Finished flushing changelog file index segment");

--- a/yt/yt/server/lib/hydra_common/file_changelog_index.h
+++ b/yt/yt/server/lib/hydra_common/file_changelog_index.h
@@ -113,6 +113,7 @@ private:
     const TString FileName_;
     const TFileChangelogConfigPtr Config_;
     EWorkloadCategory WorkloadCategory_;
+    TWorkloadDescriptor WorkloadDescriptor_;
 
     const NLogging::TLogger Logger;
 

--- a/yt/yt/server/lib/hydra_common/unbuffered_file_changelog.cpp
+++ b/yt/yt/server/lib/hydra_common/unbuffered_file_changelog.cpp
@@ -32,6 +32,16 @@ static constexpr auto LockBackoffTime = TDuration::MilliSeconds(100);
 static constexpr int MaxLockRetries = 100;
 static constexpr auto WipeBufferSize = 16_MB;
 
+// TODO(babenko, aleksandr.gaev): better workload category?
+static const TWorkloadDescriptor UnbufferedFileChangelogWorkloadDescriptor(
+    EWorkloadCategory::UserBatch,
+    0,
+    {},
+    {},
+    {},
+    "TUnbufferedFileChangelog",
+    {});
+
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TUnbufferedFileChangelogHeaderTag
@@ -86,7 +96,7 @@ public:
 
         try {
             NFS::WrapIOErrors([&] {
-                DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}))
+                DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                     .ValueOrThrow();
                 LockDataFile();
 
@@ -94,9 +104,9 @@ public:
                 auto headerBuffer = WaitFor(
                     IOEngine_->Read(
                         {{.Handle = DataFileHandle_, .Offset = 0, .Size = headerBufferSize}},
-                        // TODO(babenko): better workload category?
-                        EWorkloadCategory::UserBatch,
-                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                        UnbufferedFileChangelogWorkloadDescriptor,
+                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                        {}))
                     .ValueOrThrow()
                     .OutputBuffers[0];
 
@@ -134,9 +144,9 @@ public:
                 SerializedMeta_ = WaitFor(
                     IOEngine_->Read(
                         {{.Handle = DataFileHandle_, .Offset = FileHeaderSize_, .Size = header->MetaSize}},
-                        // TODO(babenko): better workload category?
-                        EWorkloadCategory::UserBatch,
-                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                        UnbufferedFileChangelogWorkloadDescriptor,
+                        GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                        {}))
                     .ValueOrThrow()
                     .OutputBuffers[0];
                 DeserializeProto(&Meta_, SerializedMeta_);
@@ -187,10 +197,10 @@ public:
                 }
 
                  if (currentDataOffset < dataFileLength) {
-                    WaitFor(IOEngine_->Resize({.Handle = DataFileHandle_, .Size = currentDataOffset}))
+                    WaitFor(IOEngine_->Resize({.Handle = DataFileHandle_, .Size = currentDataOffset}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                         .ThrowOnError();
 
-                    WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::All}))
+                    WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::All}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                         .ThrowOnError();
 
                     YT_LOG_DEBUG("Changelog data file truncated (RecordCount: %v, DataFileLength: %v)",
@@ -238,7 +248,7 @@ public:
 
         try {
             NFS::WrapIOErrors([&] {
-                WaitFor(IOEngine_->Close({.Handle = std::exchange(DataFileHandle_, nullptr), .Flush = true}))
+                WaitFor(IOEngine_->Close({.Handle = std::exchange(DataFileHandle_, nullptr), .Flush = true}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                     .ThrowOnError();
 
                 Index_->SetFlushedDataRecordCount(recordCount);
@@ -353,7 +363,7 @@ public:
             withIndex);
 
         try {
-            WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::Data}))
+            WaitFor(IOEngine_->FlushFile({.Handle = DataFileHandle_, .Mode = EFlushFileMode::Data}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                 .ThrowOnError();
 
             Index_->SetFlushedDataRecordCount(GetRecordCount());
@@ -586,7 +596,7 @@ private:
         while (true) {
             YT_LOG_DEBUG("Locking data file");
 
-            auto error = WaitFor(IOEngine_->Lock({.Handle = DataFileHandle_, .Mode = ELockFileMode::Exclusive, .Nonblocking = true}));
+            auto error = WaitFor(IOEngine_->Lock({.Handle = DataFileHandle_, .Mode = ELockFileMode::Exclusive, .Nonblocking = true}, UnbufferedFileChangelogWorkloadDescriptor, {}));
             if (error.IsOK()) {
                 break;
             }
@@ -640,7 +650,7 @@ private:
         NFS::WrapIOErrors([&] {
             auto tempFileName = FileName_ + NFS::TempFileSuffix;
 
-            auto dataFile = WaitFor(IOEngine_->Open({.Path = tempFileName, .Mode = WrOnly | CloseOnExec | CreateAlways}))
+            auto dataFile = WaitFor(IOEngine_->Open({.Path = tempFileName, .Mode = WrOnly | CloseOnExec | CreateAlways}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                 .ValueOrThrow();
 
             WaitFor(IOEngine_->Write({
@@ -648,16 +658,17 @@ private:
                     .Offset = 0,
                     .Buffers = {std::move(buffer)}
                 },
-                EWorkloadCategory::UserBatch))
+                UnbufferedFileChangelogWorkloadDescriptor,
+                {}))
                 .ThrowOnError();
 
-            WaitFor(IOEngine_->Close({.Handle = dataFile, .Flush = true}))
+            WaitFor(IOEngine_->Close({.Handle = dataFile, .Flush = true}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                 .ThrowOnError();
 
             // TODO(babenko): use IO engine
             NFS::Replace(tempFileName, FileName_);
 
-            DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}))
+            DataFileHandle_ = WaitFor(IOEngine_->Open({.Path = FileName_, .Mode = RdWr | Seq | CloseOnExec}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                 .ValueOrThrow();
         });
     }
@@ -745,7 +756,7 @@ private:
             // Preallocate file if needed.
             if (Config_->PreallocateSize && currentFileOffset > CurrentFileSize_) {
                 auto newFileSize = std::max(CurrentFileSize_ + *Config_->PreallocateSize, currentFileOffset);
-                WaitFor(IOEngine_->Allocate({.Handle = DataFileHandle_, .Size = newFileSize}))
+                WaitFor(IOEngine_->Allocate({.Handle = DataFileHandle_, .Size = newFileSize}, UnbufferedFileChangelogWorkloadDescriptor, {}))
                     .ThrowOnError();
                 CurrentFileSize_ = newFileSize;
             }
@@ -756,7 +767,8 @@ private:
                     .Offset = CurrentFileOffset_.load(),
                     .Buffers = std::move(buffers)
                 },
-                EWorkloadCategory::UserBatch))
+                UnbufferedFileChangelogWorkloadDescriptor,
+                {}))
                 .ThrowOnError();
 
             RecordCount_ += std::ssize(records);
@@ -887,9 +899,9 @@ private:
         auto buffer = WaitFor(
             IOEngine_->Read(
                 {{.Handle = DataFileHandle_, .Offset = offset, .Size = sizeof(TRecordHeader)}},
-                // TODO(babenko): better workload category?
-                EWorkloadCategory::UserBatch,
-                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                UnbufferedFileChangelogWorkloadDescriptor,
+                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                {}))
             .ValueOrThrow()
             .OutputBuffers[0];
 
@@ -936,9 +948,9 @@ private:
         auto buffer = WaitFor(
             IOEngine_->Read(
                 {{.Handle = DataFileHandle_, .Offset = range.first, .Size = range.second - range.first}},
-                // TODO(babenko): better workload category?
-                EWorkloadCategory::UserBatch,
-                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>()))
+                UnbufferedFileChangelogWorkloadDescriptor,
+                GetRefCountedTypeCookie<TUnbufferedFileChangelogHeaderTag>(),
+                {}))
             .ValueOrThrow()
             .OutputBuffers[0];
 
@@ -1085,7 +1097,8 @@ private:
                     .Offset = currentOffset,
                     .Buffers = {std::move(currentBuffer)}
                 },
-                EWorkloadCategory::UserBatch))
+                UnbufferedFileChangelogWorkloadDescriptor,
+                {}))
                 .ThrowOnError();
             currentOffset += currentSize;
         }

--- a/yt/yt/server/lib/io/CMakeLists.txt
+++ b/yt/yt/server/lib/io/CMakeLists.txt
@@ -39,5 +39,6 @@ target_sources(server-lib-io PRIVATE
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/read_request_combiner.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/dynamic_io_engine.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/io_engine_base.cpp
+  ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/io_engine_fair.cpp
   ${CMAKE_SOURCE_DIR}/yt/yt/server/lib/io/io_engine_uring.cpp
 )

--- a/yt/yt/server/lib/io/chunk_file_reader.h
+++ b/yt/yt/server/lib/io/chunk_file_reader.h
@@ -140,7 +140,9 @@ private:
         NChunkClient::TChunkReaderStatisticsPtr chunkReaderStatistics,
         const TSharedRef& data);
 
-    TFuture<TIOEngineHandlePtr> OpenDataFile(EDirectIOFlag useDirectIO);
+    TFuture<TIOEngineHandlePtr> OpenDataFile(
+        const NChunkClient::TClientChunkReadOptions& options,
+        EDirectIOFlag useDirectIO);
     TIOEngineHandlePtr OnDataFileOpened(EDirectIOFlag useDirectIO, const TIOEngineHandlePtr& file);
     EDirectIOFlag GetDirectIOFlag(bool useDirectIO);
 

--- a/yt/yt/server/lib/io/dynamic_io_engine.cpp
+++ b/yt/yt/server/lib/io/dynamic_io_engine.cpp
@@ -36,77 +36,84 @@ public:
 
     TFuture<TReadResponse> Read(
         std::vector<TReadRequest> requests,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TRefCountedTypeCookie tagCookie,
         TSessionId sessionId,
         bool useDedicatedAllocations) override
     {
-        return GetCurrentEngine()->Read(std::move(requests), category, tagCookie, sessionId, useDedicatedAllocations);
+        return GetCurrentEngine()->Read(std::move(requests), descriptor, tagCookie, sessionId, useDedicatedAllocations);
     }
 
     TFuture<void> Write(
         TWriteRequest request,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TSessionId sessionId) override
     {
-        return GetCurrentEngine()->Write(std::move(request), category, sessionId);
+        return GetCurrentEngine()->Write(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushFile(
         TFlushFileRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->FlushFile(std::move(request), category);
+        return GetCurrentEngine()->FlushFile(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushFileRange(
         TFlushFileRangeRequest request,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TSessionId sessionId) override
     {
-        return GetCurrentEngine()->FlushFileRange(std::move(request), category, sessionId);
+        return GetCurrentEngine()->FlushFileRange(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushDirectory(
         TFlushDirectoryRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->FlushDirectory(std::move(request), category);
+        return GetCurrentEngine()->FlushDirectory(std::move(request), descriptor, sessionId);
     }
 
     TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->Open(std::move(request), category);
+        return GetCurrentEngine()->Open(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Close(
         TCloseRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->Close(std::move(request), category);
+        return GetCurrentEngine()->Close(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Allocate(
         TAllocateRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->Allocate(std::move(request), category);
+        return GetCurrentEngine()->Allocate(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Lock(
         TLockRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->Lock(std::move(request), category);
+        return GetCurrentEngine()->Lock(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Resize(
         TResizeRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return GetCurrentEngine()->Resize(std::move(request), category);
+        return GetCurrentEngine()->Resize(std::move(request), descriptor, sessionId);
     }
 
     bool IsSick() const override

--- a/yt/yt/server/lib/io/gentle_loader.cpp
+++ b/yt/yt/server/lib/io/gentle_loader.cpp
@@ -25,6 +25,16 @@ using namespace NConcurrency;
 static constexpr int PageSize = 4_KB;
 static constexpr int IOScale = 100;
 
+// TODO(aleksandr.gaev): better workload category?
+static const TWorkloadDescriptor GentleLoaderWorkloadDescriptor(
+    EWorkloadCategory::UserBatch,
+    0,
+    {},
+    {},
+    {},
+    "TGentleLoader",
+    {});
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TRandomReader
@@ -58,7 +68,7 @@ public:
                 mode |= DirectAligned;
             }
 
-            auto future = IOEngine_->Open({file->Path, mode})
+            auto future = IOEngine_->Open({file->Path, mode}, GentleLoaderWorkloadDescriptor, {})
                 .Apply(BIND([file] (const TIOEngineHandlePtr& handle) {
                     return TReadFileInfo{
                         .Handle = handle,
@@ -133,11 +143,15 @@ private:
         struct TChunkFileReaderBufferTag
         { };
 
+        auto descriptor = GentleLoaderWorkloadDescriptor;
+        descriptor.Category = category;
+
         NProfiling::TWallTimer requestTimer;
         return IOEngine_->Read(
             {{fileInfo.Handle, offset, readSize}},
-            category,
-            GetRefCountedTypeCookie<TChunkFileReaderBufferTag>())
+            descriptor,
+            GetRefCountedTypeCookie<TChunkFileReaderBufferTag>(),
+            {})
             .AsVoid()
             .Apply(BIND([requestTimer] {
                 return requestTimer.GetElapsedTime();
@@ -296,7 +310,7 @@ private:
             mode |= DirectAligned;
         }
 
-        info.Handle = WaitFor(IOEngine_->Open({info.FilePath, mode}))
+        info.Handle = WaitFor(IOEngine_->Open({info.FilePath, mode}, GentleLoaderWorkloadDescriptor, {}))
             .ValueOrThrow();
 
         if (Config_->PreallocateWriteFiles) {
@@ -304,7 +318,7 @@ private:
                 info.WriterIndex,
                 Config_->MaxWriteFileSize);
 
-            WaitFor(IOEngine_->Allocate({.Handle = info.Handle, .Size = Config_->MaxWriteFileSize}))
+            WaitFor(IOEngine_->Allocate({.Handle = info.Handle, .Size = Config_->MaxWriteFileSize}, GentleLoaderWorkloadDescriptor, {}))
                 .ThrowOnError();
         }
     }
@@ -318,16 +332,20 @@ private:
         }
 
         auto handle = fileInfo.Handle;
+        auto descriptor = GentleLoaderWorkloadDescriptor;
+        descriptor.Category = category;
+
         NProfiling::TWallTimer requestTimer;
         auto future = IOEngine_->Write({
                 .Handle = handle,
                 .Offset = fileInfo.Offset,
                 .Buffers = {MakeRandomBuffer(packetSize)},
             },
-            category)
+            descriptor,
+            {})
             .Apply(BIND([&] () {
                 if (Config_->FlushAfterWrite) {
-                    return IOEngine_->FlushFile({handle, EFlushFileMode::Data});
+                    return IOEngine_->FlushFile({handle, EFlushFileMode::Data}, descriptor, {});
                 }
                 return VoidFuture;
             }));

--- a/yt/yt/server/lib/io/io_engine.h
+++ b/yt/yt/server/lib/io/io_engine.h
@@ -106,6 +106,10 @@ struct IIOEngine
         i64 Offset = -1;
         i64 Size = -1;
         bool Async = false;
+        bool UseSpecifiedFlags = false;
+        bool SyncFileRangeWaitBefore = false;
+        bool SyncFileRangeWrite = false;
+        bool SyncFileRangeWaitAfter = false;
     };
 
     struct TFlushDirectoryRequest
@@ -131,44 +135,51 @@ struct IIOEngine
 
     virtual TFuture<TReadResponse> Read(
         std::vector<TReadRequest> requests,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TRefCountedTypeCookie tagCookie,
-        TSessionId sessionId = {},
+        TSessionId sessionId,
         bool useDedicatedAllocations = false) = 0;
     virtual TFuture<void> Write(
         TWriteRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle,
-        TSessionId sessionId = {}) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
 
     virtual TFuture<void> FlushFile(
         TFlushFileRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
     virtual TFuture<void> FlushFileRange(
         TFlushFileRangeRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle,
-        TSessionId sessionId = {}) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
     virtual TFuture<void> FlushDirectory(
         TFlushDirectoryRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
 
     virtual TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
     virtual TFuture<void> Close(
         TCloseRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
 
     virtual TFuture<void> Allocate(
         TAllocateRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
 
     virtual TFuture<void> Lock(
         TLockRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
 
     virtual TFuture<void> Resize(
         TResizeRequest request,
-        EWorkloadCategory category = EWorkloadCategory::Idle) = 0;
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) = 0;
 
     virtual bool IsSick() const = 0;
 
@@ -183,8 +194,8 @@ struct IIOEngine
     // Extension methods.
     TFuture<TSharedRef> ReadAll(
         const TString& path,
-        EWorkloadCategory category = EWorkloadCategory::Idle,
-        TSessionId sessionId = {});
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId);
 };
 
 DEFINE_REFCOUNTED_TYPE(IIOEngine)

--- a/yt/yt/server/lib/io/io_engine_base.cpp
+++ b/yt/yt/server/lib/io/io_engine_base.cpp
@@ -149,46 +149,46 @@ TDuration TRequestStatsGuard::GetElapsedTime() const
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TFuture<TIOEngineHandlePtr> TIOEngineBase::Open(TOpenRequest request, EWorkloadCategory category)
+TFuture<TIOEngineHandlePtr> TIOEngineBase::Open(TOpenRequest request, const TWorkloadDescriptor& descriptor, TSessionId /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoOpen, MakeStrong(this), std::move(request))
-        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Close(TCloseRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::Close(TCloseRequest request, const TWorkloadDescriptor& descriptor, TSessionId /*sessionId*/)
 {
     auto invoker = (request.Flush || request.Size) ? FsyncInvoker_ : AuxInvoker_;
     return BIND(&TIOEngineBase::DoClose, MakeStrong(this), std::move(request))
-        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(invoker, GetBasicPriority(category)))
+        .AsyncVia(NConcurrency::CreateFixedPriorityInvoker(invoker, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::FlushDirectory(TFlushDirectoryRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::FlushDirectory(TFlushDirectoryRequest request, const TWorkloadDescriptor& descriptor, TSessionId /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoFlushDirectory, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(FsyncInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(FsyncInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Allocate(TAllocateRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::Allocate(TAllocateRequest request, const TWorkloadDescriptor& descriptor, TSessionId /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoAllocate, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
- TFuture<void> TIOEngineBase::Lock(TLockRequest request, EWorkloadCategory category)
+ TFuture<void> TIOEngineBase::Lock(TLockRequest request, const TWorkloadDescriptor& descriptor, TSessionId /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoLock, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 
-TFuture<void> TIOEngineBase::Resize(TResizeRequest request, EWorkloadCategory category)
+TFuture<void> TIOEngineBase::Resize(TResizeRequest request, const TWorkloadDescriptor& descriptor, TSessionId /*sessionId*/)
 {
     return BIND(&TIOEngineBase::DoResize, MakeStrong(this), std::move(request))
-        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(category)))
+        .AsyncVia(CreateFixedPriorityInvoker(AuxInvoker_, GetBasicPriority(descriptor.Category)))
         .Run();
 }
 

--- a/yt/yt/server/lib/io/io_engine_base.h
+++ b/yt/yt/server/lib/io/io_engine_base.h
@@ -146,17 +146,17 @@ class TIOEngineBase
     : public IIOEngine
 {
 public:
-    TFuture<TIOEngineHandlePtr> Open(TOpenRequest request, EWorkloadCategory category) override;
+    TFuture<TIOEngineHandlePtr> Open(TOpenRequest request, const TWorkloadDescriptor& descriptor, TSessionId sessionId) override;
 
-    TFuture<void> Close(TCloseRequest request, EWorkloadCategory category) override;
+    TFuture<void> Close(TCloseRequest request, const TWorkloadDescriptor& descriptor, TSessionId sessionId) override;
 
-    TFuture<void> FlushDirectory(TFlushDirectoryRequest request, EWorkloadCategory category) override;
+    TFuture<void> FlushDirectory(TFlushDirectoryRequest request, const TWorkloadDescriptor& descriptor, TSessionId sessionId) override;
 
-    TFuture<void> Allocate(TAllocateRequest request, EWorkloadCategory category) override;
+    TFuture<void> Allocate(TAllocateRequest request, const TWorkloadDescriptor& descriptor, TSessionId sessionId) override;
 
-    virtual TFuture<void> Lock(TLockRequest request, EWorkloadCategory category) override;
+    virtual TFuture<void> Lock(TLockRequest request, const TWorkloadDescriptor& descriptor, TSessionId sessionId) override;
 
-    virtual TFuture<void> Resize(TResizeRequest request, EWorkloadCategory category) override;
+    virtual TFuture<void> Resize(TResizeRequest request, const TWorkloadDescriptor& descriptor, TSessionId sessionId) override;
 
     bool IsSick() const override;
 

--- a/yt/yt/server/lib/io/io_engine_fair.h
+++ b/yt/yt/server/lib/io/io_engine_fair.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "public.h"
+
+#include <yt/yt/library/profiling/sensor.h>
+
+#include <yt/yt/core/ytree/public.h>
+
+#include <yt/yt/core/logging/log.h>
+
+namespace NYT::NIO {
+
+////////////////////////////////////////////////////////////////////////////////
+
+IIOEnginePtr CreateIOEngineFair(
+    NYTree::INodePtr ioConfig,
+    TString locationId,
+    NProfiling::TProfiler profiler,
+    NLogging::TLogger logger);
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NIO

--- a/yt/yt/server/lib/io/io_workload_model.cpp
+++ b/yt/yt/server/lib/io/io_workload_model.cpp
@@ -375,7 +375,7 @@ public:
 
     TFuture<TReadResponse> Read(
         std::vector<TReadRequest> requests,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TRefCountedTypeCookie tagCookie,
         TSessionId sessionId,
         bool useDedicatedAllocations) override
@@ -383,7 +383,7 @@ public:
         NProfiling::TWallTimer requestTimer;
         auto future = Underlying_->Read(
             requests,
-            category,
+            descriptor,
             tagCookie,
             sessionId,
             useDedicatedAllocations);
@@ -392,7 +392,7 @@ public:
         future.AsVoid().Subscribe(BIND([=, this, this_ = MakeStrong(this)] (const NYT::TError& /*error*/) {
             auto duration = requestTimer.GetElapsedTime();
             for (const auto& request : requests) {
-                ModelManager_->RegisterRead(request, category, duration);
+                ModelManager_->RegisterRead(request, descriptor.Category, duration);
             }
         }));
 
@@ -401,15 +401,15 @@ public:
 
     TFuture<void> Write(
         TWriteRequest request,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TSessionId sessionId) override
     {
         NProfiling::TWallTimer requestTimer;
 
-        auto future = Underlying_->Write(request, category, sessionId);
+        auto future = Underlying_->Write(request, descriptor, sessionId);
 
         future.Subscribe(BIND([=, this, this_ = MakeStrong(this)] (const NYT::TErrorOr<void>&) {
-            ModelManager_->RegisterWrite(request, category, requestTimer.GetElapsedTime());
+            ModelManager_->RegisterWrite(request, descriptor.Category, requestTimer.GetElapsedTime());
         }));
 
         return future;
@@ -417,59 +417,66 @@ public:
 
     TFuture<void> FlushFile(
         TFlushFileRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->FlushFile(std::move(request), category);
+        return Underlying_->FlushFile(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushFileRange(
         TFlushFileRangeRequest request,
-        EWorkloadCategory category,
+        const TWorkloadDescriptor& descriptor,
         TSessionId sessionId) override
     {
-        return Underlying_->FlushFileRange(std::move(request), category, sessionId);
+        return Underlying_->FlushFileRange(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> FlushDirectory(
         TFlushDirectoryRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->FlushDirectory(std::move(request), category);
+        return Underlying_->FlushDirectory(std::move(request), descriptor, sessionId);
     }
 
     TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->Open(std::move(request), category);
+        return Underlying_->Open(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Close(
         TCloseRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->Close(std::move(request), category);
+        return Underlying_->Close(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Allocate(
         TAllocateRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->Allocate(std::move(request), category);
+        return Underlying_->Allocate(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Lock(
         TLockRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->Lock(std::move(request), category);
+        return Underlying_->Lock(std::move(request), descriptor, sessionId);
     }
 
     TFuture<void> Resize(
         TResizeRequest request,
-        EWorkloadCategory category) override
+        const TWorkloadDescriptor& descriptor,
+        TSessionId sessionId) override
     {
-        return Underlying_->Resize(std::move(request), category);
+        return Underlying_->Resize(std::move(request), descriptor, sessionId);
     }
 
     bool IsSick() const override

--- a/yt/yt/server/lib/io/public.h
+++ b/yt/yt/server/lib/io/public.h
@@ -11,6 +11,7 @@ DEFINE_ENUM(EIOEngineType,
     (Uring)
     (FairShareThreadPool)
     (FairShareUring)
+    (WeightedFairShareThreadPool)
 );
 
 DEFINE_ENUM(EDirectIOPolicy,

--- a/yt/yt/server/lib/io/unittests/gentle_loader_ut.cpp
+++ b/yt/yt/server/lib/io/unittests/gentle_loader_ut.cpp
@@ -95,7 +95,7 @@ public:
 
     TFuture<TReadResponse> Read(
         std::vector<TReadRequest> /*requests*/,
-        EWorkloadCategory /*category*/,
+        const TWorkloadDescriptor& /*descriptor*/,
         TRefCountedTypeCookie /*tagCookie*/,
         TSessionId /*sessionId*/,
         bool /*useDedicatedAllocations*/) override
@@ -108,7 +108,7 @@ public:
 
     TFuture<void> Write(
         TWriteRequest /*request*/,
-        EWorkloadCategory /*category*/,
+        const TWorkloadDescriptor& /*descriptor*/,
         TSessionId /*sessionId*/) override
     {
         return RunRequest(Config_.WriteLatency, Config_.WriteFailingProbability);
@@ -116,14 +116,15 @@ public:
 
     TFuture<void> FlushFile(
         TFlushFileRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> FlushFileRange(
         TFlushFileRangeRequest /*request*/,
-        EWorkloadCategory /*category*/,
+        const TWorkloadDescriptor& /*descriptor*/,
         TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
@@ -131,14 +132,16 @@ public:
 
     TFuture<void> FlushDirectory(
         TFlushDirectoryRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<TIOEngineHandlePtr> Open(
         TOpenRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(Config_.OpenLatency, Config_.OpenFailingProbability)
             .Apply(BIND([] {
@@ -148,28 +151,32 @@ public:
 
     TFuture<void> Close(
         TCloseRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> Allocate(
         TAllocateRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> Lock(
         TLockRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }
 
     TFuture<void> Resize(
         TResizeRequest /*request*/,
-        EWorkloadCategory /*category*/) override
+        const TWorkloadDescriptor& /*descriptor*/,
+        TSessionId /*sessionId*/) override
     {
         return RunRequest(TDuration{});
     }

--- a/yt/yt/server/lib/io/ya.make
+++ b/yt/yt/server/lib/io/ya.make
@@ -19,6 +19,7 @@ SRCS(
     read_request_combiner.cpp
     dynamic_io_engine.cpp
     io_engine_base.cpp
+    io_engine_fair.cpp
     io_engine_uring.cpp
 )
 

--- a/yt/yt/server/node/data_node/data_node_service.cpp
+++ b/yt/yt/server/node/data_node/data_node_service.cpp
@@ -1230,7 +1230,7 @@ private:
                     { };
                     readFutures.push_back(ioEngine->Read(
                         std::move(locationRequests[index]),
-                        workloadDescriptor.Category,
+                        workloadDescriptor,
                         GetRefCountedTypeCookie<TChunkFragmentBuffer>(),
                         readSessionId));
                 }

--- a/yt/yt/server/node/data_node/job.cpp
+++ b/yt/yt/server/node/data_node/job.cpp
@@ -544,6 +544,7 @@ private:
         workloadDescriptor.Annotations.push_back(Format("Replication of chunk %v%v",
             ChunkId_,
             isPullReplicationJob ? " as a virtual pull" : ""));
+        workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
 
         auto chunk = GetLocalChunkOrThrow(ChunkId_, sourceMediumIndex);
 
@@ -926,6 +927,7 @@ private:
         workloadDescriptor.Annotations.push_back(Format("%v of chunk %v",
             decommission ? "Decommission via repair" : "Repair",
             ChunkId_));
+        workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
 
         auto trackSystemJobsMemory = Bootstrap_
             ->GetDataNodeBootstrap()
@@ -1089,6 +1091,7 @@ private:
         workloadDescriptor.Category = EWorkloadCategory::SystemTabletLogging;
         workloadDescriptor.Annotations.push_back(Format("Seal of chunk %v",
             ChunkId_));
+        workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
 
         auto updateGuard = TChunkUpdateGuard::Acquire(chunk);
 
@@ -1555,6 +1558,7 @@ private:
         TWorkloadDescriptor workloadDescriptor;
         workloadDescriptor.Category = EWorkloadCategory::SystemMerge;
         workloadDescriptor.Annotations.push_back(Format("Merge chunk %v", chunkId));
+        workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
 
         IChunkReader::TReadBlocksOptions options;
         options.ClientOptions.WorkloadDescriptor = workloadDescriptor;
@@ -2111,7 +2115,10 @@ private:
                 EWorkloadCategory::SystemReincarnation,
                 /*band*/ 0,
                 /*instant*/ {},
-                {Format("Reincarnate chunk %v", OldChunkId_)}),
+                {Format("Reincarnate chunk %v", OldChunkId_)},
+                /*compressionFairShareTag*/ {},
+                ToString(JobId_),
+                /*diskFairShareBucketWeight=*/ {}),
             .TrackMemoryAfterSessionCompletion = Bootstrap_
                 ->GetDataNodeBootstrap()
                 ->GetDynamicConfigManager()
@@ -2472,7 +2479,10 @@ private:
             auto partChunkId = EncodeChunkId(chunkIdWithIndex);
 
             auto req = proxy.GetChunkMeta();
-            SetRequestWorkloadDescriptor(req, TWorkloadDescriptor(EWorkloadCategory::SystemTabletRecovery));
+            TWorkloadDescriptor workloadDescriptor;
+            workloadDescriptor.Category = EWorkloadCategory::SystemTabletRecovery;
+            workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
+            SetRequestWorkloadDescriptor(req, workloadDescriptor);
             req->SetTimeout(DynamicConfig_->RpcTimeout);
             ToProto(req->mutable_chunk_id(), partChunkId);
             req->add_extension_tags(TProtoExtensionTag<TMiscExt>::Value);
@@ -2611,6 +2621,7 @@ private:
         auto& workloadDescriptor = readBlocksOptions.ClientOptions.WorkloadDescriptor;
         workloadDescriptor.Category = EWorkloadCategory::SystemTabletRecovery;
         workloadDescriptor.Annotations = {Format("Autotomy of chunk %v", BodyChunkId_)};
+        workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
 
         std::vector<TSharedRef> rows;
         rows.reserve(lastRowIndex - firstRowIndex);
@@ -2766,6 +2777,7 @@ private:
 
         TWorkloadDescriptor workloadDescriptor;
         workloadDescriptor.Category = EWorkloadCategory::SystemTabletRecovery;
+        workloadDescriptor.DiskFairShareBucketTag = ToString(JobId_);
 
         for (int index = 0; index < std::ssize(parts); ++index) {
             const auto& part = parts[index];

--- a/yt/yt/server/node/data_node/local_chunk_reader.cpp
+++ b/yt/yt/server/node/data_node/local_chunk_reader.cpp
@@ -287,7 +287,7 @@ public:
         const auto& ioEngine = chunk->GetLocation()->GetIOEngine();
         return ioEngine->Read(
             std::move(readRequests),
-            options.WorkloadDescriptor.Category,
+            options.WorkloadDescriptor,
             GetRefCountedTypeCookie<TChunkFragmentBufferTag>(),
             options.ReadSessionId)
             .ApplyUnique(BIND([

--- a/yt/yt_proto/yt/client/misc/proto/workload.proto
+++ b/yt/yt_proto/yt/client/misc/proto/workload.proto
@@ -10,6 +10,8 @@ message TWorkloadDescriptor
     required int32 band = 2;
     optional int64 instant = 3;
     repeated string annotations = 4;
+    optional string disk_fair_share_bucket_tag = 5;
+    optional double disk_fair_share_bucket_weight = 6;
 }
 
 message TWorkloadDescriptorExt


### PR DESCRIPTION
Introduce Weighted Fair Share ThreadPool IO engine

Previous PR to 24.1: https://github.com/ytsaurus/ytsaurus/pull/877 with some comments

This PR introduces a new IOEngine: `WeightedFairShareThreadPool`. Using this engine improves fairness of disk usage on our clusters

This PR consists of 3 main parts:
1. Load coloring
   - IOEngine methods now accept `workloadDescriptor` and `sessionId` that are used for fair io
   - Codebase was adjusted to pass these parameters. They are mandatory, so nothing was missed
2. Weighted fair queue and threadpool over it
   - Time-based WFQ already exists in `yt/yt/core/concurrency/new_fair_share_thread_pool.cpp`
   - It was copied to `yt/yt/core/concurrency/fair_share_weighted_thread_pool.cpp` with small adjustments
      - Now fairness is not time-based, but expected bytes-based
      - Now buckets can have weights
3. `WeightedFairShareThreadPool` IOEngine
   - Uses new `fair_share_weighted_thread_pool` to execute read and write operations and balances them on expected disk load measured in bytes

This PR is on stable/23.2 for testing purposes. After getting LGTM it will be rebased to main

* Changelog entry
Type: feature
Component: map-reduce

Introduce Weighted Fair Share ThreadPool IO engine