### PR TITLE
[24.1] Fix account profiling incumbency

### DIFF
--- a/yt/yt/server/master/security_server/security_manager.cpp
+++ b/yt/yt/server/master/security_server/security_manager.cpp
@@ -4067,48 +4067,54 @@ private:
     void OnIncumbencyStarted(int shardIndex) override
     {
         TShardedIncumbentBase::OnIncumbencyStarted(shardIndex);
-        StartAccountsProfiling();
+        MaybeToggleAccountsProfiling();
     }
 
     void OnIncumbencyFinished(int shardIndex) override
     {
         TShardedIncumbentBase::OnIncumbencyFinished(shardIndex);
-        StopAccountsProfiling();
+        MaybeToggleAccountsProfiling();
+    }
+
+    bool NeedsAccountProfiling() const
+    {
+        if (!Bootstrap_->IsPrimaryMaster()) {
+            return false;
+        }
+
+        if (!GetDynamicConfig()->EnableAccountsProfiling) {
+            return false;
+        }
+
+        return GetActiveShardCount() > 0;
+    }
+
+    void MaybeToggleAccountsProfiling()
+    {
+        if (NeedsAccountProfiling()) {
+            StartAccountsProfiling();
+        } else {
+            StopAccountsProfiling();
+        }
     }
 
     void StartAccountsProfiling()
     {
-        if (!Bootstrap_->IsPrimaryMaster()) {
-            return;
-        }
-
-        const auto& dynamicConfig = GetDynamicConfig();
-        if (!dynamicConfig->EnableAccountsProfiling) {
-            return;
-        }
-
-        if (AccountsProfilingExecutor_) {
-            // Already started.
-            return;
+        if (!AccountsProfilingExecutor_) {
+            AccountsProfilingExecutor_ = New<TPeriodicExecutor>(
+                Bootstrap_->GetHydraFacade()->GetAutomatonInvoker(NCellMaster::EAutomatonThreadQueue::Periodic),
+                BIND(&TSecurityManager::OnAccountsProfiling, MakeWeak(this)),
+                GetDynamicConfig()->AccountsProfilingPeriod);
+            AccountsProfilingExecutor_->Start();
         }
 
         for (const auto& producer : AccountProfilingProducers_) {
             producer->SetEnabled(true);
         }
-
-        AccountsProfilingExecutor_ = New<TPeriodicExecutor>(
-            Bootstrap_->GetHydraFacade()->GetEpochAutomatonInvoker(NCellMaster::EAutomatonThreadQueue::Periodic),
-            BIND(&TSecurityManager::OnAccountsProfiling, MakeWeak(this)),
-            dynamicConfig->AccountsProfilingPeriod);
-        AccountsProfilingExecutor_->Start();
     }
 
     void StopAccountsProfiling()
     {
-        if (!Bootstrap_->IsPrimaryMaster()) {
-            return;
-        }
-
         if (AccountsProfilingExecutor_) {
             YT_UNUSED_FUTURE(AccountsProfilingExecutor_->Stop());
             AccountsProfilingExecutor_.Reset();
@@ -4838,9 +4844,8 @@ private:
         return Bootstrap_->GetConfigManager()->GetConfig()->SecurityManager;
     }
 
-    void OnDynamicConfigChanged(TDynamicClusterConfigPtr oldClusterConfig)
+    void OnDynamicConfigChanged(TDynamicClusterConfigPtr /*oldClusterConfig*/)
     {
-        const auto& oldConfig = oldClusterConfig->SecurityManager;
         const auto& newConfig = GetDynamicConfig();
 
         if (AccountStatisticsGossipExecutor_) {
@@ -4855,16 +4860,10 @@ private:
             AccountMasterMemoryUsageUpdateExecutor_->SetPeriod(newConfig->AccountMasterMemoryUsageUpdatePeriod);
         }
 
-        if (newConfig->EnableAccountsProfiling) {
-            StartAccountsProfiling();
+        MaybeToggleAccountsProfiling();
 
-            if (newConfig->AccountsProfilingPeriod != oldConfig->AccountsProfilingPeriod &&
-                AccountsProfilingExecutor_)
-            {
-                AccountsProfilingExecutor_->SetPeriod(newConfig->AccountsProfilingPeriod);
-            }
-        } else {
-            StopAccountsProfiling();
+        if (AccountsProfilingExecutor_) {
+            AccountsProfilingExecutor_->SetPeriod(newConfig->AccountsProfilingPeriod);
         }
 
         if (HasMutationContext()) {


### PR DESCRIPTION
Current implementation is racy for two reasons.

Firstly, the following scenario is possible:
1) Peer is a leader and profiles metrics
2) Leader is switched, profiling invoker is destroyed 3) Dynamic config changes, StartAccountsProfiling is called and new (epoch) invoker in created 4) Peer becomes leader again, invoker is not recreated while it is still bound to the finished epoch

Secondly, invoker is always stopped when some incumbency finishes, while it is possible that only a part of incumbencies should be finished (i.e. during the change of number of alive followers).

This PR fixes these problems and also does some code cleanup.

---
Co-authored-by: Grigory Reznikov <gritukan@tracto.ai>
7dca0641dbbcf55beb2bdf44bc91678f49af33b5

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/701

--

* Changelog entry
   Type: fix
   Component: master

Fixed issues with accounts profiling disabling itself during maintenance/master leader switches.
