### PR TITLE
Make solomon scrape options externally configurable and add some new options for prometheus

### DIFF
--- a/yt/yt/library/profiling/solomon/config.h
+++ b/yt/yt/library/profiling/solomon/config.h
@@ -24,8 +24,86 @@ DEFINE_REFCOUNTED_TYPE(TShardConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TSolomonExporterConfig
+//! This class defines externally and statically configurable options for fetching metrics.
+//! You can see how to pass these options externally in integration tests. Keep in mind that the passed values are
+//! parsed as YSON, so you need to follow YSON escaping/parsing rules. Most parameters are boolean, which you can
+//! pass as just "true"/"false" strings. Be careful when passing strings and pass additional surrounding quotes if
+//! needed. Parsing errors can be retrieved from YT error headers (X-YT-Error).
+//! NB: This class is used both as a base for TSolomonExporterConfig as well as a parser for arbitrary GET parameters
+//! passed to metric fetch requests (scrapes). It is hacky, but it allows us to save option-copying boilerplate all
+//! over the place. This is class is ref-counted because it is used as a base for other ref-counted YSON structs.
+struct TScrapeOptions
     : public NYTree::TYsonStruct
+{
+    //! If true, counter values will be converted to rates per second based on the requested window of measurements and internal grid step.
+    //! NB: If you are not using windowed reads this will return the rate during the last internal collection interval, which is
+    //! 5 seconds by default. Typically that is not acceptable: if the scrape interval is larger than 5 seconds, you will miss some deltas.
+    bool ConvertCountersToRateGauge;
+    //! If true, the option above will be set to true for all reads requesting Solomon-formats: SPACK and JSON (for historical reasons).
+    //! NB: If this is true by default in your static config, but you want to disable conversions for a specific Solomon-format read, you need to
+    //! set this value to false, not just the value above.
+    bool ForceConvertCountersToRateGaugeForSolomon;
+
+    //! If true, counter values will be converted to deltas based on the requested window of measurements and internal grid step.
+    //! NB: If you are not using windowed reads this will return the delta during the last internal collection interval, which is
+    //! 5 seconds by default. Typically that is not acceptable: if the scrape interval is larger than 5 seconds, you will miss some deltas.
+    bool ConvertCountersToDeltaGauge;
+    //! If true, the option above will be set to true for all reads requesting Solomon-formats: SPACK and JSON (for historical reasons).
+    //! NB: If this is true by default in your static config, but you want to disable conversions for a specific Solomon-format read, you need to
+    //! set this value to false, not just the value above.
+    bool ForceConvertCountersToDeltaGaugeForSolomon;
+
+    //! If true, and sensor names will be suffixed with `rate` or `delta` in case the corresponding options above are enabled.
+    //! This options respects the `sensor_component_delimiter` option defined below, it will be used as the delimiter before
+    //! the suffix.
+    bool RenameConvertedCounters;
+
+    // TODO(eshcherbin, achulkov2, gritukan?): Find out what this option actually entails. For now, we have no idea,
+    // other than the fact that it is defaulted for Solomon pulls.
+    bool EnableAggregationWorkaround;
+    bool ForceEnableAggregationWorkaroundForSolomon;
+
+    //! If true, sensors that can be aggregated by host (i.e. not marked as global) will be marked with the yt_aggr="1" label.
+    bool MarkAggregates;
+
+    //! If true, sensor names are stripped of everything leading up to and including the last `/` character.
+    //! Note that a suffix may still be appended if `rename_converted_counters` and any of the conversion options are set to true.
+    bool StripSensorsNamePrefix;
+
+    //! List of allowed special characters in delimiters between sensor name components.
+    //! We can expand this list if needed, but let's keep it short for now.
+    //! Prometheus only allows [a-zA-Z_:][a-zA-Z0-9_:]* for metric names and : are reserved for recording rules.
+    //! For Solomon we use . as a delimiter.
+    static constexpr auto SensorComponentDelimiterSpecialCharacterWhitelist = ".-_:";
+    //! This string will be used as a delimiter between sensor name components, e.g. between "yt", "resource_tracker" and "total_cpu".
+    //! Please keep in mind that Prometheus encoder will change all non-alphanumeric characters to underscores.
+    std::string SensorComponentDelimiter;
+    //! If true, all sensor name components (strings separated by `/`, e.g. "yt", "resource_tracker", "total_cpu") will
+    //! be converted to camel case, assuming they are in underscore case initially.
+    bool ConvertSensorComponentNamesToCamelCase;
+
+    //! If true, a label `metric_type` will be added to all sensors equal to the monlib monitoring type of the sensor.
+    //! This means that the type for counters will be `RATE`, not `COUNTER`.
+    //! This is useful for Prometheus to distinguish between counters and gauges, because we
+    //! typically cannot use the `convert_counters_to_rate_gauge` option.
+    bool AddMetricTypeLabel;
+
+    //! This config is simultaneously used for yson-configuration and parsed from parameters in GET requests.
+    //! To avoid conflicts, we forbid parameters that are already used as GET parameters with another meaning.
+    constexpr static const char* ForbiddenParameterNames[] = {"period", "now"};
+
+    REGISTER_YSON_STRUCT(TScrapeOptions);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TScrapeOptions)
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Inheriting from TScrapeOptions allows specifying default scrape options across the whole exporter.
+struct TSolomonExporterConfig
+    : public TScrapeOptions
 {
     TDuration GridStep;
 
@@ -38,17 +116,10 @@ struct TSolomonExporterConfig
     TDuration ThreadPoolPollingPeriod;
     TDuration EncodingThreadPoolPollingPeriod;
 
-    bool ConvertCountersToRateForSolomon;
-    bool RenameConvertedCounters;
-    bool ConvertCountersToDeltaGauge;
-
+    //! The options below control how summaries are exported by default.
     bool ExportSummary;
     bool ExportSummaryAsMax;
     bool ExportSummaryAsAvg;
-
-    bool MarkAggregates;
-
-    bool StripSensorsNamePrefix;
 
     bool EnableCoreProfilingCompatibility;
 

--- a/yt/yt/library/profiling/solomon/cube.h
+++ b/yt/yt/library/profiling/solomon/cube.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "public.h"
 #include "private.h"
 #include "tag_registry.h"
 
@@ -23,18 +24,15 @@ struct TReadOptions
 
     std::function<bool(const std::string&)> SensorFilter;
 
-    bool ConvertCountersToRateGauge = false;
-    bool ConvertCountersToDeltaGauge = false;
-    bool RenameConvertedCounters = true;
+    // NB: Be careful when modifying this field, as you might be modifying
+    // a shared object. If you need to modify it, make a deep copy first.
+    // TODO(achulkov2): Ideally, it should be a lite YSON struct, but I do
+    // not know how to use such structs as bases for ref-counted YSON structs.
+    TScrapeOptionsPtr ScrapeOptions;
+
     double RateDenominator = 1.0;
+
     bool EnableHistogramCompat = false;
-
-    bool EnableSolomonAggregationWorkaround = false;
-
-    // Direct summary export is not supported by solomon, yet.
-    ESummaryPolicy SummaryPolicy = ESummaryPolicy::Default;
-
-    bool MarkAggregates = false;
 
     std::optional<std::string> Host;
 
@@ -45,6 +43,8 @@ struct TReadOptions
     bool DisableSensorsRename = false;
     bool DisableDefault = false;
 
+    ESummaryPolicy SummaryPolicy = ESummaryPolicy::Default;
+
     int LingerWindowSize = 0;
 
     // Used only in ReadRecentSensorValue.
@@ -52,9 +52,6 @@ struct TReadOptions
 
     // Only makes sense with ExportSummaryAsMax and ReadAllProjections.
     bool SummaryAsMaxForAllTime = false;
-
-    // Drop all prefix before last '/'.
-    bool StripSensorsNamePrefix = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/library/profiling/solomon/exporter.h
+++ b/yt/yt/library/profiling/solomon/exporter.h
@@ -18,6 +18,8 @@
 
 #include <library/cpp/monlib/encode/format.h>
 
+#include <library/cpp/cgiparam/cgiparam.h>
+
 namespace NYT::NProfiling {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -131,6 +133,10 @@ private:
         const NHttp::IRequestPtr& req,
         const NHttp::IResponseWriterPtr& rsp);
 
+    static TScrapeOptionsPtr ParseScrapeOptions(
+        const TScrapeOptionsPtr& staticScrapeOptions,
+        const TCgiParameters& parameters,
+        bool isSolomonPull);
     void ValidatePeriodAndGrid(std::optional<TDuration> period, std::optional<TDuration> readGridStep, TDuration gridStep);
 
     TErrorOr<TReadWindow> SelectReadWindow(TInstant now, TDuration period, std::optional<TDuration> readGridStep, TDuration gridStep);

--- a/yt/yt/library/profiling/solomon/helpers.cpp
+++ b/yt/yt/library/profiling/solomon/helpers.cpp
@@ -35,15 +35,6 @@ TOutputEncodingContext CreateOutputEncodingContextFromHeaders(const THeadersPtr&
         }
     }
 
-    if (auto isSolomonPull = headers->Find(IsSolomonPullHeaderName)) {
-        if (!TryFromString<bool>(*isSolomonPull, context.IsSolomonPull)) {
-            THROW_ERROR_EXCEPTION("Invalid value of %Qv header", IsSolomonPullHeaderName)
-                << TErrorAttribute("value", *isSolomonPull);
-        }
-    } else {
-        context.IsSolomonPull = context.Format == ::NMonitoring::EFormat::JSON || context.Format == ::NMonitoring::EFormat::SPACK;
-    }
-
     context.EncoderBuffer = std::make_shared<TStringStream>();
 
     switch (context.Format) {
@@ -68,6 +59,15 @@ TOutputEncodingContext CreateOutputEncodingContextFromHeaders(const THeadersPtr&
 
         default:
             THROW_ERROR_EXCEPTION("Unsupported format %Qv", ::NMonitoring::ContentTypeByFormat(context.Format));
+    }
+
+    if (auto isSolomonPull = headers->Find(IsSolomonPullHeaderName)) {
+        if (!TryFromString<bool>(*isSolomonPull, context.IsSolomonPull)) {
+            THROW_ERROR_EXCEPTION("Invalid value of %Qv header", IsSolomonPullHeaderName)
+                << TErrorAttribute("value", *isSolomonPull);
+        }
+    } else {
+        context.IsSolomonPull = (context.Format == ::NMonitoring::EFormat::JSON || context.Format == ::NMonitoring::EFormat::SPACK);
     }
 
     return context;

--- a/yt/yt/library/profiling/solomon/proxy.h
+++ b/yt/yt/library/profiling/solomon/proxy.h
@@ -107,6 +107,7 @@ private:
     //! For safety we only proxy whitelisted headers.
     static NHttp::THeadersPtr PreparePullHeaders(const NHttp::THeadersPtr& reqHeaders, const TOutputEncodingContext& outputContext);
     //! For safety we only proxy whitelisted parameters.
+    static bool IsWhitelistedParameter(const TString& name);
     static TCgiParameters PreparePullParameters(const TCgiParameters& parameters);
 };
 

--- a/yt/yt/library/profiling/solomon/public.h
+++ b/yt/yt/library/profiling/solomon/public.h
@@ -7,6 +7,7 @@ namespace NYT::NProfiling {
 ////////////////////////////////////////////////////////////////////////////////
 
 DECLARE_REFCOUNTED_STRUCT(TShardConfig)
+DECLARE_REFCOUNTED_STRUCT(TScrapeOptions)
 DECLARE_REFCOUNTED_STRUCT(TSolomonExporterConfig)
 DECLARE_REFCOUNTED_STRUCT(TSolomonProxyConfig)
 

--- a/yt/yt/library/profiling/unittests/exporter_ut.cpp
+++ b/yt/yt/library/profiling/unittests/exporter_ut.cpp
@@ -219,7 +219,8 @@ TEST(TSolomonExporterTest, ReadSensorsStripSensorsOption)
 
     // With Strip option
     TReadOptions options;
-    options.StripSensorsNamePrefix = true;
+    options.ScrapeOptions = New<TScrapeOptions>();
+    options.ScrapeOptions->StripSensorsNamePrefix = true;
     out = exporter->ReadJson(options, "/uptime/");
     ASSERT_TRUE(out);
 

--- a/yt/yt/library/profiling/unittests/solomon_ut.cpp
+++ b/yt/yt/library/profiling/unittests/solomon_ut.cpp
@@ -5,6 +5,7 @@
 #include <yt/yt/library/profiling/impl.h>
 #include <yt/yt/library/profiling/producer.h>
 
+#include <yt/yt/library/profiling/solomon/config.h>
 #include <yt/yt/library/profiling/solomon/registry.h>
 #include <yt/yt/library/profiling/solomon/remote.h>
 
@@ -150,7 +151,9 @@ TTestMetricConsumer CollectSensors(TSolomonRegistryPtr impl, int subsample = 1, 
     TTestMetricConsumer testConsumer;
 
     TReadOptions options;
-    options.EnableSolomonAggregationWorkaround = enableHack;
+    options.ScrapeOptions = New<TScrapeOptions>();
+    options.ScrapeOptions->EnableAggregationWorkaround = enableHack;
+    options.ScrapeOptions->MarkAggregates = false;
     options.Times = {{{}, TInstant::Now()}};
     for (int j = subsample - 1; j >= 0; --j) {
         options.Times[0].first.push_back(impl->IndexOf(i - j));
@@ -170,6 +173,8 @@ TTestMetricConsumer ReadSensors(TSolomonRegistryPtr impl)
 
     TReadOptions options;
     options.Times = {{{impl->IndexOf(i - 1)}, TInstant::Now()}};
+    options.ScrapeOptions = New<TScrapeOptions>();
+    options.ScrapeOptions->MarkAggregates = false;
 
     impl->ReadSensors(options, &testConsumer);
     Cerr << "-------------------------------------" << Endl;

--- a/yt/yt/tests/integration/misc/test_profiling.py
+++ b/yt/yt/tests/integration/misc/test_profiling.py
@@ -1,0 +1,277 @@
+from yt_env_setup import YTEnvSetup
+
+from yt_commands import (authors, get, raises_yt_error)
+
+from yt.common import YtResponseError
+
+import pytest
+import requests
+import simplejson
+import json
+
+##################################################################
+
+
+def try_parse_yt_error_headers(rsp):
+    if "X-YT-Error" in rsp.headers:
+        assert "X-YT-Framing" not in rsp.headers
+        raise YtResponseError(json.loads(rsp.headers.get("X-YT-Error")))
+    rsp.raise_for_status()
+
+
+##################################################################
+
+
+class Sensor:
+    def __init__(self, name, value, timestamp, kind=None, labels=None):
+        self.name = name
+        self.value = value
+        self.timestamp = timestamp
+        self.kind = kind
+        self.labels = labels or {}
+
+    def from_json(json):
+        try:
+            return Sensor(
+                json["labels"]["sensor"],
+                float(json["value"]) if "value" in json else json["hist"],
+                json["ts"],
+                json["kind"],
+                json["labels"],
+            )
+        except KeyError as e:
+            raise ValueError(f"Invalid sensor JSON: {json}") from e
+
+    # This might not work for histograms or some other types, but we don't check them (for now).
+    def from_prometheus_line(line, kind):
+        # yt_http_connections_accepted{yt_aggr="1", another_label="5"} 1 1733941661000
+        # yt_tablet_server_tablet_cell_decommissioner_check_orphans_max 0.000003 1733943237000
+        try:
+            labels = {}
+            if "{" in line:
+                name, rem = line.split("{")
+                labels_raw, rem = rem.split("} ")
+                labels = {key: value.strip("\"") for key, value in [label.split("=") for label in labels_raw.split(", ") if label]}
+                value, timestamp = rem.split(" ")
+                value = float(value)
+            else:
+                name, value, timestamp = line.split(" ")
+            return Sensor(name, value, timestamp, kind=kind, labels=labels)
+        except ValueError as e:
+            raise ValueError(f"Invalid Prometheus sensor line: {line}") from e
+
+    @classmethod
+    def is_prometheus_type_line(cls, line):
+        return line.startswith("# TYPE")
+
+    @classmethod
+    def infer_prometheus_type(cls, line):
+        assert line.startswith("# TYPE")
+        prometheus_type = line.split(" ")[3]
+
+        if prometheus_type == "gauge":
+            return "GAUGE"
+        elif prometheus_type == "counter":
+            return "RATE"
+        elif prometheus_type == "histogram":
+            return "HIST"
+
+        # TODO(achulkov2): Maybe replace with dummy type and dummy sensor.
+        raise ValueError(f"Unsupported Prometheus type: {prometheus_type}")
+
+    def __str__(self):
+        return f"Sensor(name={self.name}, labels={self.labels}, kind={self.kind}, value={self.value}, ts={self.timestamp})"
+
+    def __repr__(self):
+        return str(self)
+
+
+class SensorSet:
+    def __init__(self, sensors):
+        self.sensors = sensors
+
+    def match_singular(self, **kwargs):
+        matches = self.match(**kwargs)
+        assert len(matches) == 1
+        return matches[0]
+
+    def match(self, full_name=None, ordered_name_substrings=None, labels={}):
+        def match_function(sensor):
+            substring_criteria = True
+            substring_positions = [sensor.name.lower().find(substring.lower()) for substring in (ordered_name_substrings or [])]
+            for i, position in enumerate(substring_positions):
+                if position == -1:
+                    substring_criteria = False
+                    break
+                if i > 0 and position <= substring_positions[i - 1]:
+                    substring_criteria = False
+                    break
+
+            return all((
+                full_name is None or sensor.name == full_name,
+                ordered_name_substrings is None or substring_criteria,
+                all((sensor.labels.get(key, "") == value for key, value in labels.items())),
+            ))
+
+        return [sensor for sensor in self.sensors if match_function(sensor)]
+
+    def check_condition(self, condition, **kwargs):
+        matches = self.match(**kwargs)
+        for match in matches:
+            assert condition(match), f"Condition failed for sensor: {match}"
+
+
+# There are two suites of test for profiling: unit tests in library/profiling/unittests
+# and the integration tests in this file. The intent of these test is to at least check
+# the ability to override scraping options via scrape parameters, but they are also used
+# to check some of the newer functionality. The integration tests are not exhaustive and
+# some older functionality is only tested in unit tests. In general, it is up to your
+# personal preference where to add new tests.
+class TestProfiling(YTEnvSetup):
+    NUM_MASTERS = 1
+    NUM_NODES = 0
+
+    ENABLE_RESOURCE_TRACKING = True
+
+    DELTA_MASTER_CONFIG = {
+        "solomon_exporter": {
+            "force_convert_counters_to_rate_gauge_for_solomon": False,
+            "force_convert_counters_to_delta_gauge_for_solomon": False,
+            "force_enable_aggregation_workaround_for_solomon": False,
+        }
+    }
+
+    def _get_endpoint(self):
+        monitoring_port = self.Env.configs["master"][0]["monitoring_port"]
+        return f"http://localhost:{monitoring_port}/solomon/all"
+
+    def get_sensors_raw(self, **kwargs):
+        rsp = requests.get(self._get_endpoint(), **kwargs)
+        try_parse_yt_error_headers(rsp)
+        return rsp
+
+    def _get_build_version(self):
+        master_address = self.Env.configs["master"][0]["primary_master"]["addresses"][0]
+        return get(f"//sys/primary_masters/{master_address}/orchid/build_info/binary_version")
+
+    def get_sensors(self, format="json", params=None):
+        assert format in ("json", "prometheus")
+        # JSON is the default format.
+        headers = {"Accept": "text/plain"} if format == "prometheus" else {}
+
+        raw_sensors = self.get_sensors_raw(headers=headers, params=params)
+        try_parse_yt_error_headers(raw_sensors)
+        parsed_sensors = []
+
+        if format == "json":
+            try:
+                for sensor in raw_sensors.json()["sensors"]:
+                    parsed_sensors.append(Sensor.from_json(sensor))
+            except simplejson.JSONDecodeError as e:
+                raise ValueError(f"Invalid sensor JSON: {raw_sensors.text}") from e
+        elif format == "prometheus":
+            type = "GAUGE"
+            for line in raw_sensors.text.split("\n"):
+                if Sensor.is_prometheus_type_line(line):
+                    type = Sensor.infer_prometheus_type(line)
+                    continue
+                if line:
+                    parsed_sensors.append(Sensor.from_prometheus_line(line, type))
+
+        return SensorSet(parsed_sensors)
+
+    @authors("achulkov2")
+    @pytest.mark.parametrize("format", ["json", "prometheus"])
+    def test_basic(self, format):
+        build_version = self._get_build_version()
+
+        build_version_sensor = self.get_sensors(format=format).match_singular(ordered_name_substrings=["yt", "build", "version"])
+        assert build_version_sensor.value == 1.0
+        assert build_version_sensor.kind == "GAUGE"
+        assert build_version_sensor.labels["version"] == build_version
+        assert build_version_sensor.labels["yt_aggr"] == "1"
+
+    @authors("achulkov2")
+    def test_sensor_name_configuration(self):
+        sensors = self.get_sensors(params={
+            "convert_sensor_component_names_to_camel_case": r"%true",
+            # We need to add quotes, otherwise YSON parser tries to parse an integer due to leading minus sign.
+            "sensor_component_delimiter": "\"-_-\""})
+        build_version_sensor = sensors.match_singular(
+            ordered_name_substrings=["yt", "resource", "tracker", "total", "cpu"],
+            labels={"thread": "Automaton"})
+        assert build_version_sensor.name == "Yt-_-ResourceTracker-_-TotalCpu"
+
+    @authors("achulkov2")
+    @pytest.mark.parametrize("conversion_type", ["rate", "delta"])
+    @pytest.mark.parametrize("rename_converted_counters", [True, False])
+    def test_counter_to_rate_conversions(self, conversion_type, rename_converted_counters):
+        def is_converted_gauge(sensor):
+            return sensor.kind == "GAUGE" and not (rename_converted_counters ^ sensor.name.endswith(conversion_type))
+
+        def is_rate(sensor):
+            return sensor.kind == "RATE" and not sensor.name.endswith(conversion_type)
+
+        sensors = self.get_sensors(params={
+            f"convert_counters_to_{conversion_type}_gauge": "true",
+            "rename_converted_counters": "true" if rename_converted_counters else "false",
+            "add_metric_type_label": "true"})
+
+        sensors.check_condition(is_converted_gauge, ordered_name_substrings=["yt", "hydra", "mutation", "count"])
+
+        # JSON is considered a Solomon format due to historical reasons.
+        sensors = self.get_sensors(params={
+            f"convert_counters_to_{conversion_type}_gauge": "false",
+            f"force_convert_counters_to_{conversion_type}_gauge_for_solomon": "true",
+            "rename_converted_counters": "true" if rename_converted_counters else "false",
+            "add_metric_type_label": "true"})
+
+        sensors.check_condition(is_converted_gauge, ordered_name_substrings=["yt", "hydra", "mutation", "count"])
+
+        # But you can turn these conversions off even for Solomon formats.
+        sensors = self.get_sensors(params={
+            f"convert_counters_to_{conversion_type}_gauge": "false",
+            f"force_convert_counters_to_{conversion_type}_gauge_for_solomon": "false",
+            "rename_converted_counters": "true" if rename_converted_counters else "false",
+            "add_metric_type_label": "true"})
+
+        sensors.check_condition(is_rate, ordered_name_substrings=["yt", "hydra", "mutation", "count"])
+
+        # Prometheus is not a Solomon format.
+        sensors = self.get_sensors(format="prometheus", params={
+            f"convert_counters_to_{conversion_type}_gauge": "false",
+            f"force_convert_counters_to_{conversion_type}_gauge_for_solomon": "true",
+            "rename_converted_counters": "true" if rename_converted_counters else "false",
+            "add_metric_type_label": "true"})
+
+        sensors.check_condition(is_rate, ordered_name_substrings=["yt", "hydra", "mutation", "count"])
+
+        # But you can get the conversion for Prometheus if you want.
+        sensors = self.get_sensors(format="prometheus", params={
+            f"convert_counters_to_{conversion_type}_gauge": "true",
+            "rename_converted_counters": "true" if rename_converted_counters else "false",
+            "add_metric_type_label": "true"})
+
+        sensors.check_condition(is_converted_gauge, ordered_name_substrings=["yt", "hydra", "mutation", "count"])
+
+    @authors("achulkov2")
+    def test_yson_parameter_parsing(self):
+        with raises_yt_error("Cannot parse string"):
+            self.get_sensors(params={
+                "convert_sensor_component_names_to_camel_case": r"%true",
+                "sensor_component_delimiter": "-_-"})
+
+        with raises_yt_error("Character \"!\" is not allowed in \"sensor_component_delimiter\""):
+            self.get_sensors(params={"sensor_component_delimiter": "\"!\""})
+
+        with raises_yt_error("both set"):
+            self.get_sensors(params={
+                "convert_counters_to_rate_gauge": "true",
+                "convert_counters_to_delta_gauge": "true"})
+
+        # Booleans can be parsed without %.
+        sensors = self.get_sensors(params={
+            "convert_sensor_component_names_to_camel_case": r"true"
+        })
+        build_version_sensor = sensors.match_singular(ordered_name_substrings=["yt", "build", "version"])
+        assert build_version_sensor.name == "Yt.Build.Version"

--- a/yt/yt/tests/integration/misc/ya.make
+++ b/yt/yt/tests/integration/misc/ya.make
@@ -13,6 +13,7 @@ TEST_SRCS(
     test_io_tracking.py
     test_logging.py
     test_orchid.py
+    test_profiling.py
     test_schema.py
     test_schema_unified.py
     test_security_tags.py

--- a/yt/yt/tests/integration/proxies/test_http_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_http_proxy.py
@@ -602,6 +602,14 @@ class TestSolomonProxy(HttpProxyTestBase):
         with raises_yt_error("Could not pull sensors from any endpoint"):
             self.get_sensors(params={"period": "5s"})
 
+    @authors("achulkov2")
+    def test_parameter_forwarding(self):
+        # Scrape parameters should be forwarded to individual endpoints.
+        sensors = self.get_sensors(params={"convert_sensor_component_names_to_camel_case": "true"})
+        build_version_sensors = self.filter_sensors(sensors, sensor_name="Build.Version")
+        # Sensors for schedulers are not returned, since they are declared public.
+        assert len(build_version_sensors) == 3
+
 
 class HttpProxyAccessCheckerTestBase(HttpProxyTestBase):
     DELTA_PROXY_CONFIG = {


### PR DESCRIPTION
This PR adds some new behavior for handling metric scraps and makes them more externally configurable.

Some new options are added:
* `sensor_component_delimiter`: allows specifying the delimiter, which should replace the `/` symbol used to separate metric "categories" used within the codebase. E.g. the sensor `yt/resource_tracker/total_cpu` turns into `yt.resource_tracker.total_cpu` by default (existing behavior) and into `yt-resource_tracker-total_cpu` if `sensor_component_delimiter`=`"-"` (new feature).
* `convert_sensor_component_names_to_camel_case`: if true, sensor component names like `resource_tracker` and `total_cpu` are converted from underscore case to camel case.
* `add_metric_type_label`: if true, sensors are instrumented with an additional `metric_type` label, which contains the type of the time series from the perspective of our internal monitoring library (e.g. `GAUGE`, `RATE`, `COUNTER`, `HIST`, etc).

Additionally, most scraping options can now be provided as GET parameters when fetching metrics, e.g. `GET .../solomon/all?convert_counters_to_rate_gauge=true`. These parameters are parsed as YSON and shared with the static solomon exporter configuration (but have precedence over it). 

Also added some comments here and there across eporter.cpp/cube.cpp for better understanding of the implementation, and documented all scrape options in detail.

* Changelog entry
Type: feature
Component: misc-server

Configurable scrape options for solomon exporter. New scrape options to allow configuration of delimiters between components in sensor names and potential conversion of component names to CamelCase. New scrape option to instrument RATE time series.
