### PR TITLE
Add `pragma DqEngine = 'force';` to dq liveness odin check

### DIFF
--- a/yt/odin/checks/bin/query_tracker_dq_liveness/__main__.py
+++ b/yt/odin/checks/bin/query_tracker_dq_liveness/__main__.py
@@ -29,7 +29,7 @@ def run_check(yt_client, logger, options, states):
         states,
         soft_timeout,
         "yql",
-        "select x + 1 as result from `{table}`;",
+        "pragma DqEngine = 'force'; select x + 1 as result from `{table}`;",
         Data(SCHEMA, SOURCE_DATA, RESULT_DATA),
         progress_check=progress_check,
     )


### PR DESCRIPTION
DQ liveness check should fail when DQ is not working. Now it fallbacks to mapreduce and stays green