### PR TITLE
Introduce temporary tokens for operations

### DIFF
--- a/yt/yt/client/api/security_client.h
+++ b/yt/yt/client/api/security_client.h
@@ -89,6 +89,9 @@ struct TIssueTemporaryTokenOptions
 struct TIssueTokenResult
 {
     TString Token;
+    //! Cypress node corresponding to issued token.
+    //! Deleting this node will revoke the token.
+    NCypressClient::TNodeId TokenNodeId;
 };
 
 struct TRefreshTemporaryTokenOptions

--- a/yt/yt/client/api/security_client.h
+++ b/yt/yt/client/api/security_client.h
@@ -91,7 +91,7 @@ struct TIssueTokenResult
     TString Token;
     //! Cypress node corresponding to issued token.
     //! Deleting this node will revoke the token.
-    NCypressClient::TNodeId TokenNodeId;
+    NCypressClient::TNodeId NodeId;
 };
 
 struct TRefreshTemporaryTokenOptions

--- a/yt/yt/server/lib/scheduler/config.cpp
+++ b/yt/yt/server/lib/scheduler/config.cpp
@@ -839,6 +839,8 @@ void TTestingOptions::Register(TRegistrar registrar)
         .Default();
     registrar.Parameter("node_heartbeat_processing_delay", &TThis::NodeHeartbeatProcessingDelay)
         .Default();
+    registrar.Parameter("operation_node_creation_delay", &TThis::OperationNodeCreationDelay)
+        .Default();
     registrar.Parameter("secure_vault_creation_delay", &TThis::SecureVaultCreationDelay)
         .Default();
 }
@@ -1281,6 +1283,9 @@ void TSchedulerConfig::Register(TRegistrar registrar)
 
     registrar.Parameter("operation_spec_tree_size_limit", &TThis::OperationSpecTreeSizeLimit)
         .Default(std::numeric_limits<int>::max());
+
+    registrar.Parameter("temporary_operation_token_expiration_timeout", &TThis::TemporaryOperationTokenExpirationTimeout)
+        .Default(TDuration::Days(7));
 
     registrar.Preprocessor([&] (TThis* config) {
         config->OperationServiceResponseKeeper->EnableWarmup = false;

--- a/yt/yt/server/lib/scheduler/config.h
+++ b/yt/yt/server/lib/scheduler/config.h
@@ -620,6 +620,9 @@ public:
     // Testing option that enables sleeping after node state checking.
     TDelayConfigPtr NodeHeartbeatProcessingDelay;
 
+    // Testing option that enables sleeping right before creation of operation node.
+    TDelayConfigPtr OperationNodeCreationDelay;
+
     // Testing option that enables sleeping after creation of operation node, but before creation of secure vault node.
     TDelayConfigPtr SecureVaultCreationDelay;
 
@@ -1030,6 +1033,13 @@ public:
     NRpc::TServerDynamicConfigPtr RpcServer;
 
     int OperationSpecTreeSizeLimit;
+
+    //! Configures the default expiration timeout used when creating temporary
+    //! tokens for operations. In a regular scenario the expiration timeout
+    //! is removed right after creating the operation node in Cypress. However,
+    //! if a scheduler does disconnect after the token is issued but before the
+    //! operation node is created, this will ensure it is cleaned up eventually.
+    TDuration TemporaryOperationTokenExpirationTimeout;
 
     REGISTER_YSON_STRUCT(TSchedulerConfig);
 

--- a/yt/yt/server/scheduler/master_connector.cpp
+++ b/yt/yt/server/scheduler/master_connector.cpp
@@ -194,6 +194,36 @@ public:
         return NYson::ConvertToYsonStringNestingLimited(value, GetYsonNestingLevelLimit());
     }
 
+    TFuture<TIssueTokenResult> DoIssueTemporaryOperationToken(TOperationPtr operation)
+    {
+        VERIFY_THREAD_AFFINITY(ControlThread);
+        YT_VERIFY(State_ != EMasterConnectorState::Disconnected);
+
+        YT_LOG_DEBUG(
+            "Issuing temporary operation token (OperationId: %v, User: %v)",
+            operation->GetId(),
+            operation->GetAuthenticatedUser());
+
+        auto attributes = CreateEphemeralAttributes();
+        attributes->Set("operation_id", operation->GetId());
+        attributes->Set("responsible", "scheduler");
+
+        TIssueTemporaryTokenOptions options;
+        options.ExpirationTimeout = Config_->TemporaryOperationTokenExpirationTimeout;
+        options.Description = Format("Temporary token for operation %v", operation->GetId());
+
+        return Bootstrap_->GetClient()->IssueTemporaryToken(operation->GetAuthenticatedUser(), std::move(attributes), options);
+    }
+
+    TFuture<void> ClearTokenExpirationTimeout(TNodeId tokenNodeId)
+    {
+        VERIFY_THREAD_AFFINITY(ControlThread);
+
+        // Force is not necessary when removing attributes.
+        TRemoveNodeOptions options;
+        return Bootstrap_->GetClient()->RemoveNode(Format("%v/@expiration_timeout", FromObjectId(tokenNodeId)), options);
+    }
+
     void DoCreateOperationNode(TOperationPtr operation)
     {
         YT_ASSERT_THREAD_AFFINITY(ControlThread);
@@ -205,7 +235,13 @@ public:
             YT_LOG_INFO("Creating operation node (OperationId: %v)",
                 operationId);
 
+            if (operation->Spec()->IssueTemporaryToken) {
+                YT_VERIFY(operation->GetTemporaryTokenNodeId() != NullObjectId);
+            }
+
             {
+                MaybeDelay(Config_->TestingOptions->OperationNodeCreationDelay);
+
                 auto batchReq = StartObjectBatchRequest();
                 bool enableHeavyRuntimeParameters = Config_->EnableHeavyRuntimeParameters;
 
@@ -222,6 +258,8 @@ public:
                         })
                         .Item("acl").Value(MakeOperationArtifactAcl(operation->BaseAcl()))
                         .Item("has_secure_vault").Value(static_cast<bool>(operation->GetSecureVault()))
+                        .Item("temporary_token_node_id").Value(operation->GetTemporaryTokenNodeId())
+                        .Item("need_to_clear_temporary_token_expiration_timeout").Value(operation->Spec()->IssueTemporaryToken)
                     .EndAttributes()
                     .BeginMap().EndMap();
                 ValidateYson(operationYson, GetYsonNestingLevelLimit());
@@ -261,6 +299,32 @@ public:
 
                 GetCumulativeError(batchRspOrError)
                     .ThrowOnError();
+            }
+
+            if (operation->Spec()->IssueTemporaryToken) {
+                YT_LOG_DEBUG(
+                    "Removing expiration timeout from issued operation token (TokenNodeId: %v, User: %v, OperationId: %v)",
+                    operation->GetTemporaryTokenNodeId(),
+                    operation->GetAuthenticatedUser(),
+                    operationId);
+
+                WaitFor(ClearTokenExpirationTimeout(operation->GetTemporaryTokenNodeId()))
+                    .ThrowOnError();
+
+                YT_LOG_DEBUG(
+                    "Persisting temporary token expiration timeout removal in operation node (OperationId: %v, User: %v)",
+                    operationId,
+                    operation->GetAuthenticatedUser());
+
+                WaitFor(Bootstrap_->GetClient()->SetNode(
+                    Format("%v/@need_to_clear_temporary_token_expiration_timeout", GetOperationPath(operationId)),
+                    ConvertToYsonString(false)))
+                    .ThrowOnError();
+
+                YT_LOG_INFO("Finalized temporary operation token (OperationId: %v, TokenNodeId: %v, User: %v)",
+                    operationId,
+                    operation->GetTemporaryTokenNodeId(),
+                    operation->GetAuthenticatedUser());
             }
         } catch (const std::exception& ex) {
             auto error = TError("Error creating operation node %v", operationId)
@@ -331,6 +395,16 @@ public:
                 operationId);
         }
         return error.IsOK();
+    }
+
+    TFuture<TIssueTokenResult> IssueTemporaryOperationToken(const TOperationPtr& operation)
+    {
+        VERIFY_THREAD_AFFINITY(ControlThread);
+        YT_VERIFY(State_ != EMasterConnectorState::Disconnected);
+
+        return BIND(&TImpl::DoIssueTemporaryOperationToken, MakeStrong(this), operation)
+            .AsyncVia(GetCancelableControlInvoker(EControlQueue::MasterConnector))
+            .Run();
     }
 
     TFuture<void> CreateOperationNode(TOperationPtr operation)
@@ -1003,7 +1077,7 @@ private:
         struct TProcessedOperationsBatch final
         {
             std::vector<TOperationPtr> Operations;
-            std::vector<TOperationId> IncompleteOperationIds;
+            std::vector<TRemoveOperationRequest> IncompleteOperationRemoveRequests;
         };
 
         TProcessedOperationsBatch ProcessOperationsBatch(
@@ -1018,6 +1092,12 @@ private:
 
             for (const auto& rspValues : rspValuesChunk) {
                 auto attributesNode = ConvertToAttributes(rspValues.AttributesYson);
+
+                // We need to collect these nodes from attributes manually, because we might fail operations before re-creating the actual operation object.
+                std::vector<TNodeId> dependentNodeIds;
+                if (auto temporaryTokenNodeId = attributesNode->Get<TNodeId>("temporary_token_node_id", NullObjectId); temporaryTokenNodeId != NullObjectId) {
+                    dependentNodeIds.push_back(temporaryTokenNodeId);
+                }
 
                 IMapNodePtr secureVault;
 
@@ -1036,7 +1116,20 @@ private:
                     }
                 } else if (attributesNode->Get<bool>("has_secure_vault", false)) {
                     YT_LOG_INFO("Operation secure vault is missing; operation skipped (OperationId: %v)", rspValues.OperationId);
-                    result.IncompleteOperationIds.push_back(rspValues.OperationId);
+                    result.IncompleteOperationRemoveRequests.push_back(TRemoveOperationRequest{
+                        .Id = rspValues.OperationId,
+                        .DependentNodeIds = std::move(dependentNodeIds),
+                    });
+                    continue;
+                }
+
+                if (attributesNode->Get<bool>("need_to_clear_temporary_token_expiration_timeout", false)) {
+                    YT_LOG_INFO("Operation temporary token has non-null expiration timeout; operation skipped (OperationId: %v)",
+                        rspValues.OperationId);
+                    result.IncompleteOperationRemoveRequests.push_back(TRemoveOperationRequest{
+                        .Id = rspValues.OperationId,
+                        .DependentNodeIds = std::move(dependentNodeIds),
+                    });
                     continue;
                 }
 
@@ -1093,10 +1186,12 @@ private:
                 "alerts",
                 "provided_spec",
                 "has_secure_vault",
+                "temporary_token_node_id",
+                "need_to_clear_temporary_token_expiration_timeout",
             };
             const int operationsCount = std::ssize(OperationIds_);
 
-            std::vector<TOperationId> operationIdsToRemove;
+            std::vector<TRemoveOperationRequest> operationRemovalRequests;
 
             YT_LOG_INFO("Fetching attributes and secure vaults for unfinished operations (UnfinishedOperationCount: %v)",
                 operationsCount);
@@ -1203,8 +1298,8 @@ private:
                     for (auto& operation : processedBatch.Operations) {
                         Result_.Operations.push_back(std::move(operation));
                     }
-                    for (auto operationId : processedBatch.IncompleteOperationIds) {
-                        operationIdsToRemove.push_back(operationId);
+                    for (auto operationId : processedBatch.IncompleteOperationRemoveRequests) {
+                        operationRemovalRequests.push_back(operationId);
                     }
                 }
             }
@@ -1230,7 +1325,7 @@ private:
                 });
 
             auto operationsCleaner = Owner_->Bootstrap_->GetScheduler()->GetOperationsCleaner();
-            operationsCleaner->SubmitForRemoval(std::move(operationIdsToRemove));
+            operationsCleaner->SubmitForRemoval(std::move(operationRemovalRequests));
 
             YT_LOG_INFO("Operation objects created from attributes");
         }
@@ -1287,6 +1382,7 @@ private:
                 std::move(preprocessedSpec.TrimmedAnnotations),
                 std::move(preprocessedSpec.BriefVanillaTaskSpecs),
                 secureVault,
+                attributes.Get<TNodeId>("temporary_token_node_id", NullObjectId),
                 runtimeParameters,
                 std::move(baseAcl),
                 user,
@@ -2136,6 +2232,11 @@ void TMasterConnector::RegisterOperation(const TOperationPtr& operation)
 void TMasterConnector::UnregisterOperation(const TOperationPtr& operation)
 {
     Impl_->UnregisterOperation(operation);
+}
+
+TFuture<TIssueTokenResult> TMasterConnector::IssueTemporaryOperationToken(const TOperationPtr& operation)
+{
+    return Impl_->IssueTemporaryOperationToken(operation);
 }
 
 TFuture<void> TMasterConnector::CreateOperationNode(const TOperationPtr& operation)

--- a/yt/yt/server/scheduler/master_connector.h
+++ b/yt/yt/server/scheduler/master_connector.h
@@ -9,6 +9,7 @@
 #include <yt/yt/ytlib/object_client/object_service_proxy.h>
 
 #include <yt/yt/client/api/public.h>
+#include <yt/yt/client/api/security_client.h>
 
 #include <yt/yt/core/actions/signal.h>
 
@@ -79,6 +80,8 @@ public:
 
     void RegisterOperation(const TOperationPtr& operation);
     void UnregisterOperation(const TOperationPtr& operation);
+
+    TFuture<NApi::TIssueTokenResult> IssueTemporaryOperationToken(const TOperationPtr& operation);
 
     TFuture<void> CreateOperationNode(const TOperationPtr& operation);
     TFuture<void> UpdateInitializedOperationNode(const TOperationPtr& operation);

--- a/yt/yt/server/scheduler/operation.cpp
+++ b/yt/yt/server/scheduler/operation.cpp
@@ -621,12 +621,14 @@ bool TOperation::AddSecureVaultEntry(const TString& key, const INodePtr& value)
     return SecureVault_->AddChild(key, value);
 }
 
-void TOperation::SetTemporaryToken(const TString& token)
+void TOperation::SetTemporaryToken(const TString& token, const TNodeId& nodeId)
 {
     YT_VERIFY(State_ == EOperationState::Starting);
     YT_VERIFY(Spec_->IssueTemporaryToken);
     // We check that the key is not already present in the secure vault before calling this method.
     YT_VERIFY(AddSecureVaultEntry(Spec_->TemporaryTokenEnvironmentVariableName, ConvertToNode(token)));
+
+    TemporaryTokenNodeId_ = nodeId;
 }
 
 std::vector<TNodeId> TOperation::GetDependentNodeIds() const

--- a/yt/yt/server/scheduler/operation.cpp
+++ b/yt/yt/server/scheduler/operation.cpp
@@ -96,7 +96,7 @@ TOperation::TOperation(
     TYsonString trimmedAnnotations,
     std::optional<TBriefVanillaTaskSpecMap> briefVanillaTaskSpecs,
     IMapNodePtr secureVault,
-    TNodeId temporaryTokenNodeId,
+    std::optional<TNodeId> temporaryTokenNodeId,
     TOperationRuntimeParametersPtr runtimeParameters,
     NSecurityClient::TSerializableAccessControlList baseAcl,
     const std::string& authenticatedUser,
@@ -631,8 +631,8 @@ void TOperation::SetTemporaryToken(const TString& token)
 
 std::vector<TNodeId> TOperation::GetDependentNodeIds() const
 {
-    if (TemporaryTokenNodeId_ != NullObjectId) {
-        return {TemporaryTokenNodeId_};
+    if (TemporaryTokenNodeId_) {
+        return {*TemporaryTokenNodeId_};
     }
 
     return {};

--- a/yt/yt/server/scheduler/operation.cpp
+++ b/yt/yt/server/scheduler/operation.cpp
@@ -23,6 +23,7 @@
 namespace NYT::NScheduler {
 
 using namespace NApi;
+using namespace NCypressClient;
 using namespace NTransactionClient;
 using namespace NObjectClient;
 using namespace NSecurityClient;
@@ -95,6 +96,7 @@ TOperation::TOperation(
     TYsonString trimmedAnnotations,
     std::optional<TBriefVanillaTaskSpecMap> briefVanillaTaskSpecs,
     IMapNodePtr secureVault,
+    TNodeId temporaryTokenNodeId,
     TOperationRuntimeParametersPtr runtimeParameters,
     NSecurityClient::TSerializableAccessControlList baseAcl,
     const std::string& authenticatedUser,
@@ -113,6 +115,7 @@ TOperation::TOperation(
     , Suspended_(suspended)
     , UserTransactionId_(userTransactionId)
     , SecureVault_(std::move(secureVault))
+    , TemporaryTokenNodeId_(temporaryTokenNodeId)
     , Events_(events)
     , Spec_(std::move(spec))
     , ProvidedSpecString_(std::move(providedSpecString))
@@ -603,6 +606,36 @@ TFuture<void> TOperation::AbortCommonTransactions()
             .PropagateCancelationToInput = false,
             .CancelInputOnShortcut = false,
         });
+}
+
+bool TOperation::AddSecureVaultEntry(const TString& key, const INodePtr& value)
+{
+    YT_VERIFY(State_ == EOperationState::Starting);
+
+    if (!SecureVault_) {
+        YT_LOG_DEBUG("Creating empty secure vault due to scheduler request (OperationId: %v)", Id_);
+        SecureVault_ = GetEphemeralNodeFactory()->CreateMap();
+    }
+
+    YT_LOG_DEBUG("Adding secure vault entry (OperationId: %v, Key: %v)", Id_, key);
+    return SecureVault_->AddChild(key, value);
+}
+
+void TOperation::SetTemporaryToken(const TString& token)
+{
+    YT_VERIFY(State_ == EOperationState::Starting);
+    YT_VERIFY(Spec_->IssueTemporaryToken);
+    // We check that the key is not already present in the secure vault before calling this method.
+    YT_VERIFY(AddSecureVaultEntry(Spec_->TemporaryTokenEnvironmentVariableName, ConvertToNode(token)));
+}
+
+std::vector<TNodeId> TOperation::GetDependentNodeIds() const
+{
+    if (TemporaryTokenNodeId_ != NullObjectId) {
+        return {TemporaryTokenNodeId_};
+    }
+
+    return {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/scheduler/operation.h
+++ b/yt/yt/server/scheduler/operation.h
@@ -236,7 +236,7 @@ public:
 
     //! Stores the id of the Cypress node corresponding to the temporary
     //! token issued for the operation, if any.
-    DEFINE_BYVAL_RW_PROPERTY(NCypressClient::TNodeId, TemporaryTokenNodeId, NCypressClient::NullObjectId);
+    DEFINE_BYVAL_RW_PROPERTY(std::optional<NCypressClient::TNodeId>, TemporaryTokenNodeId);
 
     DEFINE_BYVAL_RW_PROPERTY_FORCE_FLUSH(std::optional<TInstant>, FinishTime);
 
@@ -437,7 +437,7 @@ public:
         NYson::TYsonString trimmedAnnotations,
         std::optional<TBriefVanillaTaskSpecMap> briefVanillaTaskSpecs,
         NYTree::IMapNodePtr secureVault,
-        NCypressClient::TNodeId temporaryTokenNodeId,
+        std::optional<NCypressClient::TNodeId> temporaryTokenNodeId,
         TOperationRuntimeParametersPtr runtimeParameters,
         NSecurityClient::TSerializableAccessControlList baseAcl,
         const std::string& authenticatedUser,

--- a/yt/yt/server/scheduler/operation.h
+++ b/yt/yt/server/scheduler/operation.h
@@ -421,7 +421,7 @@ public:
     //! Adds token to secure vault according to the operation spec.
     //! Requires that the operation is in `Starting` state, token issuance is request in spec,
     //! and that the secure vault does not contain the key specified in the operation spec.
-    void SetTemporaryToken(const TString& token);
+    void SetTemporaryToken(const TString& token, const NCypressClient::TNodeId& nodeId);
 
     //! Returns a list of Cypress nodes which must be deleted alongside the operation node.
     std::vector<NCypressClient::TNodeId> GetDependentNodeIds() const;

--- a/yt/yt/server/scheduler/operations_cleaner.cpp
+++ b/yt/yt/server/scheduler/operations_cleaner.cpp
@@ -692,7 +692,7 @@ public:
 
         GetCancelableInvoker()->Invoke(BIND([this, this_ = MakeStrong(this), requests = std::move(requests)] {
             for (auto request : requests) {
-                EnqueueForRemoval(request);
+                EnqueueForRemoval(std::move(request));
             }
         }));
     }
@@ -840,7 +840,7 @@ public:
         result.ControllerFeatures = attributes.FindYson("controller_features");
 
         if (auto temporaryTokenNodeId = attributes.Find<TNodeId>("temporary_token_node_id")) {
-            result.DependentNodeIds = std::vector{*temporaryTokenNodeId};
+            result.DependentNodeIds = {*temporaryTokenNodeId};
         }
 
         return result;
@@ -1202,7 +1202,7 @@ private:
 
         YT_LOG_DEBUG("Operation enqueued for removal (OperationId: %v, DependentNodeIds: %v)", request.Id, request.DependentNodeIds);
         RemovePending_++;
-        RemoveBatcher_->Enqueue(request);
+        RemoveBatcher_->Enqueue(std::move(request));
     }
 
     void EnqueueForArchivation(TOperationId operationId)
@@ -1510,7 +1510,7 @@ private:
                         }
                     }
 
-                    auto removeOperationRequest = requests[index];
+                    auto& removeOperationRequest = requests[index];
                     if (isLocked) {
                         LockedOperationQueue_.emplace_back(std::move(removeOperationRequest), now);
                         ++lockedOperationCount;

--- a/yt/yt/server/scheduler/operations_cleaner.h
+++ b/yt/yt/server/scheduler/operations_cleaner.h
@@ -11,9 +11,18 @@ namespace NYT::NScheduler {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TArchiveOperationRequest
+struct TRemoveOperationRequest
 {
     TOperationId Id;
+    //! It is guaranteed that all dependent nodes will be successfully
+    //! removed before the operation node is removed itself.
+    std::vector<NCypressClient::TNodeId> DependentNodeIds;
+};
+
+struct TArchiveOperationRequest
+    : public TRemoveOperationRequest
+{
+    // Id is present in TRemoveOperationRequest.
     TInstant StartTime;
     TInstant FinishTime;
     EOperationState State;
@@ -79,7 +88,7 @@ public:
     void SubmitForArchivation(TArchiveOperationRequest request);
     void SubmitForArchivation(std::vector<TOperationId> operations);
 
-    void SubmitForRemoval(std::vector<TOperationId> operations);
+    void SubmitForRemoval(std::vector<TRemoveOperationRequest> requests);
 
     void UpdateConfig(const TOperationsCleanerConfigPtr& config);
 
@@ -102,7 +111,6 @@ public:
 
     TArchiveOperationRequest InitializeRequestFromOperation(const TOperationPtr& operation);
     TArchiveOperationRequest InitializeRequestFromAttributes(const NYTree::IAttributeDictionary& attributes);
-
 private:
     class TImpl;
     const TIntrusivePtr<TImpl> Impl_;

--- a/yt/yt/server/scheduler/scheduler.cpp
+++ b/yt/yt/server/scheduler/scheduler.cpp
@@ -674,7 +674,7 @@ public:
             std::move(preprocessedSpec.TrimmedAnnotations),
             std::move(preprocessedSpec.BriefVanillaTaskSpecs),
             secureVault,
-            /*temporaryTokenNodeId*/ NullObjectId,
+            /*temporaryTokenNodeId*/ std::nullopt,
             runtimeParameters,
             std::move(baseAcl),
             user,
@@ -2665,14 +2665,16 @@ private:
                 // We check this first, so that we don't create a token in vain.
                 auto secureVault = operation->GetSecureVault();
                 if (secureVault && secureVault->FindChild(operation->Spec()->TemporaryTokenEnvironmentVariableName)) {
-                    THROW_ERROR_EXCEPTION("Temporary token environment variable %Qv already exists in secure vault", operation->Spec()->TemporaryTokenEnvironmentVariableName);
+                    THROW_ERROR_EXCEPTION(
+                        "Temporary token environment variable %Qv already exists in secure vault",
+                        operation->Spec()->TemporaryTokenEnvironmentVariableName);
                 }
 
                 auto temporaryToken = WaitFor(MasterConnector_->IssueTemporaryOperationToken(operation))
                     .ValueOrThrow();
                 // NB: This modifies secure vault contents.
                 operation->SetTemporaryToken(temporaryToken.Token);
-                operation->SetTemporaryTokenNodeId(temporaryToken.TokenNodeId);
+                operation->SetTemporaryTokenNodeId(temporaryToken.NodeId);
             } catch (const std::exception& ex) {
                 auto wrappedError = TError("Failed to issue temporary token for operation %v",
                     operation->GetId())

--- a/yt/yt/server/scheduler/scheduler.cpp
+++ b/yt/yt/server/scheduler/scheduler.cpp
@@ -2662,19 +2662,10 @@ private:
 
         if (operation->Spec()->IssueTemporaryToken) {
             try {
-                // We check this first, so that we don't create a token in vain.
-                auto secureVault = operation->GetSecureVault();
-                if (secureVault && secureVault->FindChild(operation->Spec()->TemporaryTokenEnvironmentVariableName)) {
-                    THROW_ERROR_EXCEPTION(
-                        "Temporary token environment variable %Qv already exists in secure vault",
-                        operation->Spec()->TemporaryTokenEnvironmentVariableName);
-                }
-
                 auto temporaryToken = WaitFor(MasterConnector_->IssueTemporaryOperationToken(operation))
                     .ValueOrThrow();
                 // NB: This modifies secure vault contents.
-                operation->SetTemporaryToken(temporaryToken.Token);
-                operation->SetTemporaryTokenNodeId(temporaryToken.NodeId);
+                operation->SetTemporaryToken(temporaryToken.Token, temporaryToken.NodeId);
             } catch (const std::exception& ex) {
                 auto wrappedError = TError("Failed to issue temporary token for operation %v",
                     operation->GetId())

--- a/yt/yt/tests/integration/node/test_user_job.py
+++ b/yt/yt/tests/integration/node/test_user_job.py
@@ -2248,7 +2248,8 @@ class TestTemporaryTokens(YTEnvSetup):
             "type": "async",
         })
 
-        expiration_timeout = 5000
+        # This should be enough time for the remainder of the test.
+        expiration_timeout = 20000
         update_scheduler_config("temporary_operation_token_expiration_timeout", expiration_timeout)
 
         create_user("alice")

--- a/yt/yt/tests/integration/node/test_user_job.py
+++ b/yt/yt/tests/integration/node/test_user_job.py
@@ -12,11 +12,11 @@ from yt_commands import (
     wait_breakpoint, release_breakpoint, with_breakpoint,
     events_on_fs, create, create_pool, create_table,
     ls, get, set, remove, link, exists, create_network_project, create_tmpdir,
-    create_user, make_ace, start_transaction, lock,
+    create_user, make_ace, start_transaction, lock, list_user_tokens,
     write_file, read_table, remote_copy, get_driver,
     write_table, map, abort_op, sort,
     vanilla, run_test_vanilla, abort_job, get_job_spec,
-    list_jobs, get_job, get_job_stderr, get_operation,
+    list_jobs, get_job, get_job_stderr, get_operation, get_operation_cypress_path,
     sync_create_cells, get_singular_chunk_id,
     update_nodes_dynamic_config, set_node_banned, check_all_stderrs,
     assert_statistics, assert_statistics_v2, extract_statistic_v2,
@@ -2083,6 +2083,199 @@ class TestSecureVault(YTEnvSetup):
         assert op.id != op_id
 
         op.track()
+
+
+##################################################################
+
+class TestTemporaryTokens(YTEnvSetup):
+    NUM_MASTERS = 1
+    NUM_NODES = 3
+    NUM_SCHEDULERS = 1
+
+    ENABLE_HTTP_PROXY = True
+    NUM_HTTP_PROXIES = 1
+
+    USE_DYNAMIC_TABLES = True
+
+    DELTA_PROXY_CONFIG = {
+        "auth": {
+            "enable_authentication": True,
+        },
+    }
+
+    DELTA_SCHEDULER_CONFIG = {
+        "scheduler": {
+            "operations_cleaner": {
+                "enable": True,
+                "hard_retained_operation_count": 0,
+                "clean_delay": 0,
+                "analysis_period": 100,
+                "min_archivation_retry_sleep_delay": 100,
+                "max_archivation_retry_sleep_delay": 110,
+                "max_removal_sleep_delay": 100,
+            },
+        }
+    }
+
+    def setup_method(self, method):
+        super(TestTemporaryTokens, self).setup_method(method)
+        sync_create_cells(1)
+        init_operations_archive.create_tables_latest_version(
+            self.Env.create_native_client(),
+            override_tablet_cell_bundle="default",
+        )
+
+    @authors("achulkov2")
+    def test_basic(self):
+        create_user("alice")
+        assert not list_user_tokens("alice")
+
+        command = with_breakpoint(f"""
+            export YT_PROXY={self.Env.get_proxy_address()};
+            curl -X POST \"http://$YT_PROXY/api/v3/create?path=//tmp/created_from_operation&type=map_node\" \\
+                -H \"Accept: application/json\" -H \"Authorization: OAuth $YT_SECURE_VAULT_YT_TOKEN\" \\
+                >&2;
+            BREAKPOINT;
+        """)
+
+        op = run_test_vanilla(spec={"max_failed_job_count": 1, "issue_temporary_token": True}, command=command, authenticated_user="alice")
+        op_path = get_operation_cypress_path(op.id)
+
+        wait_breakpoint()
+
+        token_node_id = get(op_path + "/@temporary_token_node_id")
+        token_hash = get(f"#{token_node_id}/@key")
+
+        alice_tokens = list_user_tokens("alice", with_metadata=True)
+        assert len(alice_tokens) == 1
+
+        assert token_hash in alice_tokens
+        assert op.id in alice_tokens[token_hash]["description"]
+        assert alice_tokens[token_hash]["effective_expiration"] == {"time": yson.YsonEntity(), "timeout": yson.YsonEntity()}
+
+        assert get("//tmp/created_from_operation/@owner") == "alice"
+
+        release_breakpoint()
+
+        op.track()
+
+        wait(lambda: not exists(op_path))
+
+        assert not list_user_tokens("alice")
+
+    @authors("achulkov2")
+    def test_secure_vault_keys(self):
+        create_user("alice")
+        assert not list_user_tokens("alice")
+
+        command = f"""
+            export YT_PROXY={self.Env.get_proxy_address()};
+            curl -X POST \"http://$YT_PROXY/api/v3/create?path=//tmp/created_from_operation_$YT_SECURE_VAULT_NODE_SUFFIX&type=map_node\" \\
+                -H \"Accept: application/json\" -H \"Authorization: OAuth $YT_SECURE_VAULT_ANOTHER_YT_TOKEN\" \\
+                >&2;
+        """
+
+        op = run_test_vanilla(
+            spec={
+                "max_failed_job_count": 1,
+                "issue_temporary_token": True,
+                "temporary_token_environment_variable_name": "ANOTHER_YT_TOKEN",
+                "secure_vault": {"NODE_SUFFIX": "first"},
+            },
+            command=command,
+            authenticated_user="alice")
+        op.track()
+        assert get("//tmp/created_from_operation_first/@owner") == "alice"
+
+        with raises_yt_error("already exists"):
+            run_test_vanilla(
+                spec={
+                    "max_failed_job_count": 1,
+                    "issue_temporary_token": True,
+                    "temporary_token_environment_variable_name": "ANOTHER_YT_TOKEN",
+                    "secure_vault": {"NODE_SUFFIX": "second", "ANOTHER_YT_TOKEN": "i-am-not-a-token"},
+                },
+                command=command,
+                authenticated_user="alice")
+
+        assert not exists("//tmp/created_from_operation_second")
+
+        wait(lambda: not list_user_tokens("alice"))
+
+    @authors("achulkov2")
+    def test_revive(self):
+        create_user("alice")
+        assert not list_user_tokens("alice")
+
+        command = with_breakpoint(f"""
+            BREAKPOINT;
+            export YT_PROXY={self.Env.get_proxy_address()};
+            curl -X POST \"http://$YT_PROXY/api/v3/create?path=//tmp/created_from_operation&type=map_node\" \\
+                -H \"Accept: application/json\" -H \"Authorization: OAuth $YT_SECURE_VAULT_YT_TOKEN\" \\
+                >&2;
+        """, breakpoint_name="first_breakpoint")
+        command += with_breakpoint("BREAKPOINT;", breakpoint_name="second_breakpoint")
+
+        op = run_test_vanilla(spec={"max_failed_job_count": 1, "issue_temporary_token": True}, command=command, authenticated_user="alice")
+
+        wait_breakpoint("first_breakpoint")
+
+        assert len(list_user_tokens("alice")) == 1
+
+        with Restarter(self.Env, SCHEDULERS_SERVICE):
+            time.sleep(2)
+
+        release_breakpoint("first_breakpoint")
+        wait_breakpoint("second_breakpoint")
+
+        # No new token should be created, value should still be in secure vault.
+        assert len(list_user_tokens("alice")) == 1
+        assert get("//tmp/created_from_operation/@owner") == "alice"
+
+        release_breakpoint("second_breakpoint")
+
+        op.track()
+
+        wait(lambda: not exists(get_operation_cypress_path(op.id)))
+
+        # Token should still be removed, token node id is persisted through revival
+        assert not list_user_tokens("alice")
+
+    @authors("achulkov2")
+    def test_token_expiration_timeout(self):
+        update_scheduler_config("testing_options/operation_node_creation_delay", {
+            "duration": 3000,
+            "type": "async",
+        })
+
+        expiration_timeout = 5000
+        update_scheduler_config("temporary_operation_token_expiration_timeout", expiration_timeout)
+
+        create_user("alice")
+        assert not list_user_tokens("alice")
+
+        op_response = run_test_vanilla(
+            spec={"max_failed_job_count": 1, "issue_temporary_token": True},
+            command="sleep 5",
+            return_response=True,
+            authenticated_user="alice")
+
+        # Give enough time for the token to be issued.
+        time.sleep(1)
+
+        assert len(list_user_tokens("alice")) == 1
+
+        with Restarter(self.Env, SCHEDULERS_SERVICE):
+            pass
+
+        op_response.wait()
+        assert not op_response.is_ok()
+
+        alice_tokens = list_user_tokens("alice", with_metadata=True)
+        assert len(alice_tokens) == 1
+        list(alice_tokens.values())[0]["effective_expiration"]["timeout"] == expiration_timeout
+
+        wait(lambda: not list_user_tokens("alice"))
 
 
 ##################################################################

--- a/yt/yt/ytlib/api/native/client_authentication_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_authentication_impl.cpp
@@ -176,6 +176,7 @@ TIssueTokenResult TClient::DoIssueTokenImpl(
 
     return TIssueTokenResult{
         .Token = token,
+        .TokenNodeId = rspOrError.Value(),
     };
 }
 

--- a/yt/yt/ytlib/api/native/client_authentication_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_authentication_impl.cpp
@@ -176,7 +176,7 @@ TIssueTokenResult TClient::DoIssueTokenImpl(
 
     return TIssueTokenResult{
         .Token = token,
-        .TokenNodeId = rspOrError.Value(),
+        .NodeId = rspOrError.Value(),
     };
 }
 

--- a/yt/yt/ytlib/scheduler/config.cpp
+++ b/yt/yt/ytlib/scheduler/config.cpp
@@ -908,6 +908,16 @@ void TOperationSpecBase::Register(TRegistrar registrar)
             }
         }
 
+        if (spec->IssueTemporaryToken) {
+            NControllerAgent::ValidateEnvironmentVariableName(spec->TemporaryTokenEnvironmentVariableName);
+
+            if (spec->SecureVault && spec->SecureVault->FindChild(spec->TemporaryTokenEnvironmentVariableName)) {
+                THROW_ERROR_EXCEPTION(
+                    "Temporary token environment variable %Qv already exists in secure vault",
+                    spec->TemporaryTokenEnvironmentVariableName);
+            }
+        }
+
         if (spec->Alias && !spec->Alias->StartsWith(OperationAliasPrefix)) {
             THROW_ERROR_EXCEPTION("Operation alias should start with %Qv", OperationAliasPrefix)
                 << TErrorAttribute("operation_alias", spec->Alias);

--- a/yt/yt/ytlib/scheduler/config.cpp
+++ b/yt/yt/ytlib/scheduler/config.cpp
@@ -711,6 +711,12 @@ void TOperationSpecBase::Register(TRegistrar registrar)
     registrar.Parameter("enable_secure_vault_variables_in_job_shell", &TThis::EnableSecureVaultVariablesInJobShell)
         .Default(true);
 
+    registrar.Parameter("issue_temporary_token", &TThis::IssueTemporaryToken)
+        .Default(false);
+
+    registrar.Parameter("temporary_token_environment_variable_name", &TThis::TemporaryTokenEnvironmentVariableName)
+        .Default("YT_TOKEN");
+
     registrar.Parameter("suspend_operation_if_account_limit_exceeded", &TThis::SuspendOperationIfAccountLimitExceeded)
         .Default(false);
 

--- a/yt/yt/ytlib/scheduler/config.h
+++ b/yt/yt/ytlib/scheduler/config.h
@@ -1033,6 +1033,14 @@ public:
     //! This flag enables secure vault variables in job shell.
     bool EnableSecureVaultVariablesInJobShell;
 
+    //! If true, scheduler will issue a temporary token for the authenticated user which allows
+    //! accessing the host cluster. This token will be removed after the operation is finished.
+    //! The value of the token will be added to the operation's secure vault with the key defined
+    //! in the option below.
+    bool IssueTemporaryToken;
+    //! Key to be used for adding temporary token to the secure vault. Defaults to YT_TOKEN.
+    TString TemporaryTokenEnvironmentVariableName;
+
     //! Suspend operation in case of jobs failed due to account limit exceeded.
     bool SuspendOperationIfAccountLimitExceeded;
 


### PR DESCRIPTION
This PR adds two new spec options available for all operations. If `issue_temporary_token` is set to true, the scheduler will issue a token for the authenticated user of the operation via the Cypress tokens mechanism. The token will be placed into the operation's secure vault with `temporary_token_environment_variable_name` used as key. 

The token is removed by operations cleaner. In order for that to work, we persist the Cypress node id of the issued token in the `temporary_token_node_id` operation node attribute. Such dependent nodes are removed strictly before removing the operation node.

To improve performance, instead of issuing a token transactionally with creating the operation node, we issue it with an expiration timeout first, and then remove the expiration timeout after the operation node is created. If scheduler fails after token is issued but before the operation node is actually created, the expiration timeout will ensure that the token is eventually deleted.

I chose this approach over more typical lease extension mechanisms mainly because I feel that the proposed solution is simpler than introducing new periodic logic to scheduler/CA. There is also the concern of tokens expiring during job revival, which is unlikely if the lease timeout is large enough, but still makes me like the other solution a bit less.

* Changelog entry
Type: feature
Component: scheduler

Add the ability to issue temporary tokens valid during the lifetime of an operation and place them into the operation's secure vault.
