### PR TITLE
Parse docker image with digest

### DIFF
--- a/yt/yt/server/controller_agent/controllers/helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/helpers.cpp
@@ -296,22 +296,30 @@ void SafeUpdateAggregatedJobStatistics(
 
 TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config)
 {
+    TStringBuf imageRef;
     TStringBuf imageTag;
 
-    // Format: [REGISTRY/]IMAGE[:TAG], where REGISTRY is FQDN[:PORT].
+    // Format: [REGISTRY/]IMAGE[:TAG][@DIGEST], where REGISTRY is FQDN[:PORT].
     // Registry FQDN must has at least one "." or PORT.
-    if (!StringSplitter(dockerImage).Split('/').Limit(2).TryCollectInto(&Registry, &imageTag) ||
+    if (!StringSplitter(dockerImage).Split('/').Limit(2).TryCollectInto(&Registry, &imageRef) ||
         Registry.find_first_of(".:") == TString::npos)
     {
         Registry = "";
-        imageTag = dockerImage;
+        imageRef = dockerImage;
     } else if (Registry == config->InternalRegistryAddress) {
         Registry = "";
     }
 
+    if (!StringSplitter(imageRef).Split('@').Limit(2).TryCollectInto(&imageTag, &Digest)) {
+        imageTag = imageRef;
+        Digest = "";
+    }
+
     if (!StringSplitter(imageTag).Split(':').Limit(2).TryCollectInto(&Image, &Tag)) {
         Image = imageTag;
-        Tag = "latest";
+        if (Digest == "") {
+            Tag = "latest";
+        }
     }
 }
 

--- a/yt/yt/server/controller_agent/controllers/helpers.h
+++ b/yt/yt/server/controller_agent/controllers/helpers.h
@@ -88,6 +88,7 @@ struct TDockerImageSpec
     TString Registry;
     TString Image;
     TString Tag;
+    TString Digest;
 
     TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config);
 

--- a/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
+++ b/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
@@ -16,13 +16,41 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
 
     internalConfig->InternalRegistryAddress = "internal.registry";
 
-    // Format: [REGISTRY[:PORT]/]IMAGE[:TAG]
+    // Format: [REGISTRY[:PORT]/]IMAGE[:TAG][@DIGEST]
 
     {
         TDockerImageSpec image("image", defaultConfig);
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("image:tag", defaultConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("image@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "");
+        EXPECT_EQ(image.Digest, "hash:digest");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("image:tag@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "hash:digest");
         EXPECT_EQ(image.IsInternal(), true);
     }
 
@@ -31,6 +59,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "home/user/image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), true);
     }
 
@@ -39,6 +68,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "home/user/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), true);
     }
 
@@ -47,6 +77,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -55,6 +86,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -63,6 +95,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -71,6 +104,25 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "");
+        EXPECT_EQ(image.Digest, "hash:digest");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image:tag@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "hash:digest");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -79,6 +131,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -87,6 +140,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -95,6 +149,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry:8888");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -103,6 +158,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry:8888");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -111,6 +167,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "internal.registry");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -119,6 +176,16 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("external.registry/project/image:tag@hash:digest", internalConfig);
+        EXPECT_EQ(image.Registry, "external.registry");
+        EXPECT_EQ(image.Image, "project/image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "hash:digest");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -127,6 +194,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), true);
     }
 }


### PR DESCRIPTION
Full scheme is [REGISTRY/]IMAGE[:TAG][@DIGEST]

Digest refers to image manifest of image index and have higher priority
than tag. Unlike to tag image referenced by digest never changes because
of its nature.

Parsing in controller-agent will be used later for linking docker image
from external registry with artifacts stored within cluster.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
Link: https://github.com/distribution/reference/blob/main/reference.go
Link: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#definitions
Link: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests