### PR TITLE
Revive operations_snapshots check

### DIFF
--- a/yt/odin/checks/bin/operations_snapshots/__main__.py
+++ b/yt/odin/checks/bin/operations_snapshots/__main__.py
@@ -1,18 +1,9 @@
-from yt_odin_checks.lib.check_runner import main
+from datetime import datetime
 
 from yt.common import date_string_to_datetime, YT_DATETIME_FORMAT_STRING
 import yt.wrapper as yt
 
-from datetime import datetime
-
-
-def process_response(rsp):
-    if rsp.is_ok():
-        return rsp.get_result()
-
-    error = yt.YtResponseError(rsp.get_error())
-    if not error.is_resolve_error():
-        raise error
+from yt_odin_checks.lib.check_runner import main
 
 
 def run_check(yt_client, logger, options, states):
@@ -23,22 +14,37 @@ def run_check(yt_client, logger, options, states):
     batch_client = yt.create_batch_client(client=yt_client, max_batch_size=100)
 
     for operation in operations:
-        # TODO(asaitgalin): Migrate to new operations storage scheme.
-        op_path = "//sys/operations/" + operation
-        responses[(operation, "events")] = batch_client.get(op_path + "/@events")
-        responses[(operation, "last_successful_snapshot_time")] = \
-            batch_client.get(op_path + "/@progress/last_successful_snapshot_time")
+        args = {"attributes": ["events", "progress"]}
+        if operation.startswith("*"):
+            args["operation_alias"] = operation
+            args["include_scheduler"] = True
+        else:
+            args["operation_id"] = operation
+
+        responses[operation] = batch_client.get_operation(**args)
 
     batch_client.commit_batch()
 
     operations_without_snapshots = []
 
     for operation in operations:
-        events = process_response(responses[(operation, "events")])
-        last_successful_snapshot_time = process_response(
-            responses[(operation, "last_successful_snapshot_time")])
+        op_resp = responses[operation]
 
-        if events is None or last_successful_snapshot_time is None:
+        if not op_resp.is_ok():
+            error = yt.YtResponseError(op_resp.get_error())
+            if not error.is_resolve_error():
+                raise error
+            else:
+                logger.warning("Got error resolving %s: %s", operation, error)
+                continue
+
+        assert op_resp.is_ok()
+        result = op_resp.get_result()
+        try:
+            events = result["events"]
+            last_successful_snapshot_time = result["progress"]["last_successful_snapshot_time"]
+        except KeyError as e:
+            logger.warning("Failed to get operation info for %s: %s", operation, e)
             continue
 
         last_successful_snapshot_time = date_string_to_datetime(last_successful_snapshot_time)
@@ -61,11 +67,9 @@ def run_check(yt_client, logger, options, states):
 
     logger.info("Number of long running operations without built snapshots: %d", len(operations_without_snapshots))
     if operations_without_snapshots:
+        print(operations_without_snapshots)
         for operation, last_successful_snapshot_time in operations_without_snapshots[:10]:
-            dt = datetime \
-                .utcfromtimestamp(last_successful_snapshot_time) \
-                .strftime(YT_DATETIME_FORMAT_STRING)
-
+            dt = last_successful_snapshot_time.strftime(YT_DATETIME_FORMAT_STRING)
             logger.info("  Operation %s had its last snapshot built at %s", operation, dt)
 
         return states.UNAVAILABLE_STATE

--- a/yt/odin/checks/tests/test_operations_snapshots.py
+++ b/yt/odin/checks/tests/test_operations_snapshots.py
@@ -1,0 +1,16 @@
+from yt_odin.logserver import FULLY_AVAILABLE_STATE
+from yt_odin.test_helpers import make_check_dir, configure_and_run_checks
+
+
+CHECK_OPTIONS = {
+    "critical_time_without_snapshot_threshold": 3600,
+}
+
+CHECK_NAME = "operations_snapshots"
+
+
+def test_operations_snapshots(yt_env):
+    proxy_url = yt_env.yt_client.config["proxy"]["url"]
+    checks_path = make_check_dir(CHECK_NAME, CHECK_OPTIONS)
+    storage = configure_and_run_checks(proxy_url, checks_path)
+    assert abs(storage.get_service_states(CHECK_NAME)[-1] - FULLY_AVAILABLE_STATE) <= 0.001

--- a/yt/odin/checks/tests/ya.make
+++ b/yt/odin/checks/tests/ya.make
@@ -15,6 +15,7 @@ TEST_SRCS(
     test_master_alerts.py
     test_master_chunk_management.py
     test_oauth_health.py
+    test_operations_snapshots.py
     test_quorum_health.py
     test_register_watcher.py
     test_scheduler_uptime.py
@@ -54,6 +55,7 @@ DEPENDS(
     yt/odin/checks/bin/master_alerts
     yt/odin/checks/bin/master_chunk_management
     yt/odin/checks/bin/oauth_health
+    yt/odin/checks/bin/operations_snapshots
     yt/odin/checks/bin/quorum_health
     yt/odin/checks/bin/register_watcher
     yt/odin/checks/bin/scheduler_uptime


### PR DESCRIPTION
- It didn't work with operation aliases (trying to access cypress path with `*`, which is forbidden: https://github.com/ytsaurus/ytsaurus/blob/e7eea1ed49fb49d12d64639161e33943a4e06fa4/yt/yt/core/ytree/node_detail.cpp#L264)
- And it couldn't work at all since operations in `//sys/operations` are stored in dirs with prefixes

* Changelog entry
Type: fix
Component: odin

<!-- Here you can write a message for release notes -->
Odin check `operations_snapshots` was brought back to life.  