### PR TITLE
Allow sending/reading values larger than 16MB to RPC proxy via wire protocol to/from methods dealing with static tables.

### DIFF
--- a/yt/yt/client/api/rpc_proxy/row_batch_reader.cpp
+++ b/yt/yt/client/api/rpc_proxy/row_batch_reader.cpp
@@ -18,7 +18,11 @@ TRowBatchReader::TRowBatchReader(
     IAsyncZeroCopyInputStreamPtr underlying,
     bool isStreamWithStatistics)
     : Underlying_(std::move(underlying))
-    , Decoder_(CreateWireRowStreamDecoder(NameTable_))
+    , Decoder_(CreateWireRowStreamDecoder(NameTable_, TWireProtocolOptions {
+        .MaxStringValueLength = std::numeric_limits<i64>::max(),
+        .MaxAnyValueLength = std::numeric_limits<i64>::max(),
+        .MaxCompositeValueLength = std::numeric_limits<i64>::max(),
+    }))
     , IsStreamWithStatistics_(isStreamWithStatistics)
 {
     YT_VERIFY(Underlying_);

--- a/yt/yt/client/api/rpc_proxy/row_batch_reader.cpp
+++ b/yt/yt/client/api/rpc_proxy/row_batch_reader.cpp
@@ -18,11 +18,7 @@ TRowBatchReader::TRowBatchReader(
     IAsyncZeroCopyInputStreamPtr underlying,
     bool isStreamWithStatistics)
     : Underlying_(std::move(underlying))
-    , Decoder_(CreateWireRowStreamDecoder(NameTable_, TWireProtocolOptions {
-        .MaxStringValueLength = std::numeric_limits<i64>::max(),
-        .MaxAnyValueLength = std::numeric_limits<i64>::max(),
-        .MaxCompositeValueLength = std::numeric_limits<i64>::max(),
-    }))
+    , Decoder_(CreateWireRowStreamDecoder(NameTable_, CreateUnlimitedWireProtocolOptions()))
     , IsStreamWithStatistics_(isStreamWithStatistics)
 {
     YT_VERIFY(Underlying_);

--- a/yt/yt/client/api/rpc_proxy/wire_row_stream.h
+++ b/yt/yt/client/api/rpc_proxy/wire_row_stream.h
@@ -3,13 +3,16 @@
 #include "public.h"
 
 #include <yt/yt/client/table_client/public.h>
+#include <yt/yt/client/table_client/wire_protocol.h>
 
 namespace NYT::NApi::NRpcProxy {
 
 ////////////////////////////////////////////////////////////////////////////////
 
 IRowStreamEncoderPtr CreateWireRowStreamEncoder(NTableClient::TNameTablePtr nameTable);
-IRowStreamDecoderPtr CreateWireRowStreamDecoder(NTableClient::TNameTablePtr nameTable);
+IRowStreamDecoderPtr CreateWireRowStreamDecoder(
+    NTableClient::TNameTablePtr nameTable,
+    NTableClient::TWireProtocolOptions wireProtocolOptions = {});
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/client/table_client/wire_protocol.cpp
+++ b/yt/yt/client/table_client/wire_protocol.cpp
@@ -1055,6 +1055,16 @@ auto IWireProtocolReader::GetSchemaData(const TTableSchema& schema) -> TSchemaDa
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TWireProtocolOptions CreateUnlimitedWireProtocolOptions() {
+    return {
+        .MaxStringValueLength = std::numeric_limits<i64>::max(),
+        .MaxAnyValueLength = std::numeric_limits<i64>::max(),
+        .MaxCompositeValueLength = std::numeric_limits<i64>::max(),
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 std::unique_ptr<IWireProtocolReader> CreateWireProtocolReader(TSharedRef data, TRowBufferPtr rowBuffer, TWireProtocolOptions options)
 {
     return std::make_unique<TWireProtocolReader>(std::move(data), std::move(rowBuffer), std::move(options));

--- a/yt/yt/client/table_client/wire_protocol.cpp
+++ b/yt/yt/client/table_client/wire_protocol.cpp
@@ -1055,7 +1055,8 @@ auto IWireProtocolReader::GetSchemaData(const TTableSchema& schema) -> TSchemaDa
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TWireProtocolOptions CreateUnlimitedWireProtocolOptions() {
+TWireProtocolOptions CreateUnlimitedWireProtocolOptions()
+{
     return {
         .MaxStringValueLength = std::numeric_limits<i64>::max(),
         .MaxAnyValueLength = std::numeric_limits<i64>::max(),

--- a/yt/yt/client/table_client/wire_protocol.h
+++ b/yt/yt/client/table_client/wire_protocol.h
@@ -288,6 +288,8 @@ struct TWireProtocolOptions
     i64 MaxVersionedRowDataWeight = NTableClient::MaxServerVersionedRowDataWeight;
 };
 
+TWireProtocolOptions CreateUnlimitedWireProtocolOptions();
+
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Creates wire protocol reader.

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -329,7 +329,13 @@ IRowStreamDecoderPtr CreateRowStreamDecoder(
 {
     switch (rowsetFormat) {
         case NApi::NRpcProxy::NProto::RF_YT_WIRE:
-            return CreateWireRowStreamDecoder(std::move(nameTable));
+        {
+            TWireProtocolOptions wireProtocolOptions;
+            wireProtocolOptions.MaxStringValueLength = std::numeric_limits<i64>::max();
+            wireProtocolOptions.MaxAnyValueLength = std::numeric_limits<i64>::max();
+            wireProtocolOptions.MaxCompositeValueLength = std::numeric_limits<i64>::max();
+            return CreateWireRowStreamDecoder(std::move(nameTable), wireProtocolOptions);
+        }
 
         case NApi::NRpcProxy::NProto::RF_ARROW:
             return CreateArrowRowStreamDecoder(std::move(schema), std::move(nameTable));

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -329,13 +329,7 @@ IRowStreamDecoderPtr CreateRowStreamDecoder(
 {
     switch (rowsetFormat) {
         case NApi::NRpcProxy::NProto::RF_YT_WIRE:
-        {
-            TWireProtocolOptions wireProtocolOptions;
-            wireProtocolOptions.MaxStringValueLength = std::numeric_limits<i64>::max();
-            wireProtocolOptions.MaxAnyValueLength = std::numeric_limits<i64>::max();
-            wireProtocolOptions.MaxCompositeValueLength = std::numeric_limits<i64>::max();
-            return CreateWireRowStreamDecoder(std::move(nameTable), wireProtocolOptions);
-        }
+            return CreateWireRowStreamDecoder(std::move(nameTable), CreateUnlimitedWireProtocolOptions());
 
         case NApi::NRpcProxy::NProto::RF_ARROW:
             return CreateArrowRowStreamDecoder(std::move(schema), std::move(nameTable));

--- a/yt/yt/tests/integration/proxies/test_rpc_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_rpc_proxy.py
@@ -901,31 +901,34 @@ class TestOperationsRpcProxy(TestRpcProxyBase):
 
     @authors("faucct")
     def test_writing_large_rows(self):
-        data = [{"index": 0, "str": "F" * (17 << 20)}]
+        MB = 1 << 20
+        data = [{"index": 0, "str": "F" * (17 * MB)}]
         create("table", "//tmp/table", attributes={"dynamic": False, "schema": self._schema})
-        write_table("//tmp/table", data, table_writer={"max_row_weight": 20 << 20})
+        write_table("//tmp/table", data, table_writer={"max_row_weight": 20 * MB})
         assert read_table("//tmp/table") == data
 
     @authors("faucct")
     def test_writing_large_rows_129(self):
-        data = [{"index": 0, "str": "F" * (129 << 20)}]
+        MB = 1 << 20
+        data = [{"index": 0, "str": "F" * (129 * MB)}]
         create("table", "//tmp/table", attributes={"dynamic": False, "schema": self._schema})
-        with raises_yt_error(f'Expected <= {128 << 20}, found {130 << 20}'):
-            write_table("//tmp/table", data, table_writer={"max_row_weight": 130 << 20})
+        with raises_yt_error(f'Expected <= {128 * MB}, found {130 * MB}'):
+            write_table("//tmp/table", data, table_writer={"max_row_weight": 130 * MB})
         with raises_yt_error() as e:
-            write_table("//tmp/table", data, table_writer={"max_row_weight": 128 << 20})
+            write_table("//tmp/table", data, table_writer={"max_row_weight": 128 * MB})
         assert 'Memory limit exceeded while parsing YSON stream: ' in str(e[0]) or 'Row weight is too large' in str(e[0])
         assert read_table("//tmp/table") == []
 
     @authors("faucct")
     @pytest.mark.parametrize("atomicity", ["none", "full"])
     def test_writing_large_dynamic_rows(self, atomicity):
-        data = [{"index": 0, "str": "F" * (17 << 20)}]
+        MB = 1 << 20
+        data = [{"index": 0, "str": "F" * (17 * MB)}]
         create("table", "//tmp/dynamic", attributes={"dynamic": True, "schema": self._schema, "atomicity": atomicity})
         sync_create_cells(1)
         sync_mount_table("//tmp/dynamic")
-        with raises_yt_error(f'Value of type "string" is too long: length {17 << 20}, limit {16 << 20}'):
-            insert_rows("//tmp/dynamic", data, table_writer={"max_row_weight": 20 << 20})
+        with raises_yt_error(f'Value of type "string" is too long: length {17 * MB}, limit {16 * MB}'):
+            insert_rows("//tmp/dynamic", data, table_writer={"max_row_weight": 20 * MB})
         sync_unmount_table("//tmp/dynamic")
         assert read_table("//tmp/dynamic") == []
 

--- a/yt/yt/tests/integration/proxies/test_rpc_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_rpc_proxy.py
@@ -907,18 +907,25 @@ class TestOperationsRpcProxy(TestRpcProxyBase):
         assert read_table("//tmp/table") == data
 
     @authors("faucct")
+    def test_writing_large_rows_129(self):
+        data = [{"index": 0, "str": "F" * (129 << 20)}]
+        create("table", "//tmp/table", attributes={"dynamic": False, "schema": self._schema})
+        with raises_yt_error(f'Expected <= {128 << 20}, found {130 << 20}'):
+            write_table("//tmp/table", data, table_writer={"max_row_weight": 130 << 20})
+        with raises_yt_error() as e:
+            write_table("//tmp/table", data, table_writer={"max_row_weight": 128 << 20})
+        assert 'Memory limit exceeded while parsing YSON stream: ' in str(e[0]) or 'Row weight is too large' in str(e[0])
+        assert read_table("//tmp/table") == []
+
+    @authors("faucct")
     @pytest.mark.parametrize("atomicity", ["none", "full"])
     def test_writing_large_dynamic_rows(self, atomicity):
         data = [{"index": 0, "str": "F" * (17 << 20)}]
         create("table", "//tmp/dynamic", attributes={"dynamic": True, "schema": self._schema, "atomicity": atomicity})
         sync_create_cells(1)
         sync_mount_table("//tmp/dynamic")
-        try:
+        with raises_yt_error(f'Value of type "string" is too long: length {17 << 20}, limit {16 << 20}'):
             insert_rows("//tmp/dynamic", data, table_writer={"max_row_weight": 20 << 20})
-        except YtResponseError as err:
-            assert f'Value of type "string" is too long: length {17 << 20}, limit {16 << 20}' in str(err)
-        else:
-            assert False, "Failed to catch response error"
         sync_unmount_table("//tmp/dynamic")
         assert read_table("//tmp/dynamic") == []
 

--- a/yt/yt/tests/integration/proxies/test_rpc_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_rpc_proxy.py
@@ -901,7 +901,7 @@ class TestOperationsRpcProxy(TestRpcProxyBase):
 
     @authors("faucct")
     def test_writing_large_rows(self):
-        MB = 1 << 20
+        MB = 1024 ** 2
         data = [{"index": 0, "str": "F" * (17 * MB)}]
         create("table", "//tmp/table", attributes={"dynamic": False, "schema": self._schema})
         write_table("//tmp/table", data, table_writer={"max_row_weight": 20 * MB})
@@ -909,7 +909,7 @@ class TestOperationsRpcProxy(TestRpcProxyBase):
 
     @authors("faucct")
     def test_writing_large_rows_129(self):
-        MB = 1 << 20
+        MB = 1024 ** 2
         data = [{"index": 0, "str": "F" * (129 * MB)}]
         create("table", "//tmp/table", attributes={"dynamic": False, "schema": self._schema})
         with raises_yt_error(f'Expected <= {128 * MB}, found {130 * MB}'):
@@ -922,7 +922,7 @@ class TestOperationsRpcProxy(TestRpcProxyBase):
     @authors("faucct")
     @pytest.mark.parametrize("atomicity", ["none", "full"])
     def test_writing_large_dynamic_rows(self, atomicity):
-        MB = 1 << 20
+        MB = 1024 ** 2
         data = [{"index": 0, "str": "F" * (17 * MB)}]
         create("table", "//tmp/dynamic", attributes={"dynamic": True, "schema": self._schema, "atomicity": atomicity})
         sync_create_cells(1)

--- a/yt/yt/tests/integration/proxies/test_rpc_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_rpc_proxy.py
@@ -899,6 +899,13 @@ class TestOperationsRpcProxy(TestRpcProxyBase):
 
         assert select_rows("* from [//tmp/t_out] LIMIT " + str(2 * size)) == original_table
 
+    @authors("faucct")
+    def test_writing_large_rows(self):
+        data = [{"index": 0, "str": "F" * 17 * (1 << 20)}]
+        create("table", "//tmp/table", attributes={"dynamic": False, "schema": self._schema})
+        write_table("//tmp/table", data, table_writer={"max_row_weight": 20 * (1 << 20)})
+        assert read_table("//tmp/table") == data
+
     @authors("kiselyovp")
     def test_abort_operation(self):
         op = self._start_simple_operation_with_breakpoint()


### PR DESCRIPTION
Historically, it data written through RPC proxies had pass dynamic table row validation standards, like max 16MB value size. This is inconvenient for static tables.
SPYT needs to write large values – https://github.com/ytsaurus/ytsaurus-spyt/issues/43. 
Disable wire input Max*ValueLength validation on RPC proxies.
The methods affected by this change are `WriteTable` and `ReadShuffleData` in rpc proxy server and TTableReader in rpc proxy client.

* Changelog entry
Type: feature
Component: proxy

Allow sending/reading values larger than 16MB to RPC proxy via wire protocol to/from methods dealing with static tables.