### PR TITLE
Handle job setup commands for CRI job environment

### DIFF
--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1104,6 +1104,78 @@ public:
             ImageCache_);
     }
 
+    TFuture<std::vector<TShellCommandOutput>> RunSetupCommands(
+        int slotIndex,
+        ESlotType slotType,
+        TJobId jobId,
+        const std::vector<TShellCommandConfigPtr>& commands,
+        const TRootFS& rootFS,
+        const std::string& /*user*/,
+        const std::optional<std::vector<TDevice>>& /*devices*/,
+        int startIndex) override
+    {
+        YT_ASSERT_THREAD_AFFINITY(JobThread);
+
+        YT_VERIFY(slotType == ESlotType::Common);
+
+        auto spec = New<NCri::TCriContainerSpec>();
+
+        // Run setup using default docker image for job workspace.
+        spec->Image.Image = ConcreteConfig_->JobProxyImage;
+
+        spec->Labels[YTJobIdLabel] = ToString(jobId);
+
+        // NB: If nvidia container runtime is used, empty list of devices
+        // should be set explicitly to avoid binding all devices to job container.
+        if (Bootstrap_->GetGpuManager()->HasGpuDevices()) {
+            spec->Environment["NVIDIA_VISIBLE_DEVICES"] = "";
+        }
+
+        // Add bind mounts required for user job.
+        for (const auto& bind : rootFS.Binds) {
+            spec->BindMounts.push_back(NCri::TCriBindMount{
+                .ContainerPath = bind.TargetPath,
+                .HostPath = bind.SourcePath,
+                .ReadOnly = bind.ReadOnly,
+            });
+        }
+
+        const auto& cpusetCpu = SlotCpusetCpus_[slotIndex];
+        if (cpusetCpu != EmptyCpuSet) {
+            spec->Resources.CpusetCpus = cpusetCpu;
+        }
+
+        std::vector<TFuture<void>> results;
+        results.reserve(std::ssize(commands));
+        for (int index = 0; index < std::ssize(commands); ++index) {
+            spec->Name = Format("setup-command-%v", startIndex + index);
+
+            const auto& command = commands[index];
+            auto process = Executor_->CreateProcess(
+                command->Path,
+                spec,
+                PodDescriptors_[slotIndex],
+                PodSpecs_[slotIndex]);
+            process->AddArguments(command->Args);
+            process->SetWorkingDirectory("/slot/home");
+
+            results.push_back(
+                BIND([=] {
+                    return process->Spawn();
+                })
+                .AsyncVia(ActionQueue_->GetInvoker())
+                .Run());
+        }
+
+        return AllSucceeded(std::move(results))
+            .Apply(BIND([this, this_ = MakeStrong(this), slotIndex](const TError& error) {
+                Executor_->CleanPodSandbox(PodDescriptors_[slotIndex]);
+                error.ThrowOnError();
+                return std::vector<TShellCommandOutput>{};
+            })
+            .AsyncVia(ActionQueue_->GetInvoker()));
+    }
+
 private:
     static constexpr TStringBuf SlotPodPrefix = "yt_slot_";
     static constexpr TStringBuf LocalBinDir = "/usr/local/bin";

--- a/yt/yt/tests/integration/node/test_user_job.py
+++ b/yt/yt/tests/integration/node/test_user_job.py
@@ -4353,3 +4353,53 @@ class TestJobStatistics(YTEnvSetup):
 @pytest.mark.skipif(not is_uring_supported() or is_uring_disabled(), reason="io_uring is not available on this host")
 class TestJobStatisticsUring(TestJobStatistics):
     NODE_IO_ENGINE_TYPE = "uring"
+
+
+##################################################################
+
+
+@authors("khlebnikov")
+class TestJobSetupCommandCri(YTEnvSetup):
+    JOB_ENVIRONMENT_TYPE = "cri"
+
+    NUM_MASTERS = 1
+    NUM_SCHEDULERS = 1
+    NUM_NODES = 1
+
+    def test_success(self):
+        update_nodes_dynamic_config({
+            "exec_node": {
+                "job_controller": {
+                    "job_common": {
+                        "job_setup_command": {
+                            "path": "/bin/bash",
+                            "args": [ "-c", "echo success >setup.txt", ],
+                        },
+                    },
+                },
+            },
+        })
+
+        op = run_test_vanilla("cat ../home/setup.txt >&2", track=True)
+        check_all_stderrs(op, b"success\n", 1)
+
+    def test_failure(self):
+        update_nodes_dynamic_config({
+            "exec_node": {
+                "job_controller": {
+                    "job_common": {
+                        "job_setup_command": {
+                            "path": "/bin/false",
+                            "args": [],
+                        },
+                    },
+                },
+            },
+        })
+
+        op = run_test_vanilla("true")
+        op.track(raise_on_failed=False)
+        assert op.get_state() == "failed"
+        err = op.get_error()
+        assert err.contains_code(10000)
+        assert err.find_matching_error(10000).attributes.get("exit_code") == 1


### PR DESCRIPTION
Basic support for job setup commands, without elevated capabilities.
Unlike to porto we don't have rootfs, so setup commadns are run in separate
container but have access to same bind mounts and slot directories.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: feature
Component: misc-server
Handle job setup commands for CRI job environment