### PR TITLE
[stable/24.2] cherry-pick docker image patches

### DIFF
--- a/yt/yt/server/controller_agent/controllers/helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/helpers.cpp
@@ -295,22 +295,30 @@ void SafeUpdateAggregatedJobStatistics(
 
 TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config)
 {
+    TStringBuf imageRef;
     TStringBuf imageTag;
 
-    // Format: [REGISTRY/]IMAGE[:TAG], where REGISTRY is FQDN[:PORT].
+    // Format: [REGISTRY/]IMAGE[:TAG][@DIGEST], where REGISTRY is FQDN[:PORT].
     // Registry FQDN must has at least one "." or PORT.
-    if (!StringSplitter(dockerImage).Split('/').Limit(2).TryCollectInto(&Registry, &imageTag) ||
+    if (!StringSplitter(dockerImage).Split('/').Limit(2).TryCollectInto(&Registry, &imageRef) ||
         Registry.find_first_of(".:") == TString::npos)
     {
         Registry = "";
-        imageTag = dockerImage;
+        imageRef = dockerImage;
     } else if (Registry == config->InternalRegistryAddress) {
         Registry = "";
     }
 
+    if (!StringSplitter(imageRef).Split('@').Limit(2).TryCollectInto(&imageTag, &Digest)) {
+        imageTag = imageRef;
+        Digest = "";
+    }
+
     if (!StringSplitter(imageTag).Split(':').Limit(2).TryCollectInto(&Image, &Tag)) {
         Image = imageTag;
-        Tag = "latest";
+        if (Digest == "") {
+            Tag = "latest";
+        }
     }
 }
 

--- a/yt/yt/server/controller_agent/controllers/helpers.h
+++ b/yt/yt/server/controller_agent/controllers/helpers.h
@@ -88,6 +88,7 @@ struct TDockerImageSpec
     TString Registry;
     TString Image;
     TString Tag;
+    TString Digest;
 
     TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config);
 

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -10032,6 +10032,10 @@ void TOperationControllerBase::InitUserJobSpecTemplate(
         jobSpec->add_environment(Format("YT_DISCOVERY_ADDRESSES=%v", addresses));
     }
 
+    if (jobSpecConfig->DockerImage) {
+        jobSpec->add_environment(Format("YT_JOB_DOCKER_IMAGE=%v", *jobSpecConfig->DockerImage));
+    }
+
     BuildFileSpecs(jobSpec, files, jobSpecConfig, Config->EnableBypassArtifactCache);
 
     if (jobSpecConfig->Monitoring->Enable) {

--- a/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
+++ b/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
@@ -16,13 +16,41 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
 
     internalConfig->InternalRegistryAddress = "internal.registry";
 
-    // Format: [REGISTRY[:PORT]/]IMAGE[:TAG]
+    // Format: [REGISTRY[:PORT]/]IMAGE[:TAG][@DIGEST]
 
     {
         TDockerImageSpec image("image", defaultConfig);
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("image:tag", defaultConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("image@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "");
+        EXPECT_EQ(image.Digest, "hash:digest");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("image:tag@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "hash:digest");
         EXPECT_EQ(image.IsInternal(), true);
     }
 
@@ -31,6 +59,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "home/user/image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), true);
     }
 
@@ -39,6 +68,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "home/user/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), true);
     }
 
@@ -47,6 +77,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -55,6 +86,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -63,6 +95,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -71,6 +104,25 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "localhost:5000");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "");
+        EXPECT_EQ(image.Digest, "hash:digest");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("localhost:5000/image:tag@hash:digest", defaultConfig);
+        EXPECT_EQ(image.Registry, "localhost:5000");
+        EXPECT_EQ(image.Image, "image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "hash:digest");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -79,6 +131,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -87,6 +140,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -95,6 +149,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry:8888");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -103,6 +158,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry:8888");
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -111,6 +167,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "internal.registry");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -119,6 +176,16 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "external.registry");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), false);
+    }
+
+    {
+        TDockerImageSpec image("external.registry/project/image:tag@hash:digest", internalConfig);
+        EXPECT_EQ(image.Registry, "external.registry");
+        EXPECT_EQ(image.Image, "project/image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "hash:digest");
         EXPECT_EQ(image.IsInternal(), false);
     }
 
@@ -127,6 +194,7 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
         EXPECT_EQ(image.IsInternal(), true);
     }
 }

--- a/yt/yt/server/node/exec_node/job_workspace_builder.cpp
+++ b/yt/yt/server/node/exec_node/job_workspace_builder.cpp
@@ -628,12 +628,18 @@ private:
             YT_LOG_INFO("Preparing root volume (Image: %v)", imageDescriptor);
 
             return ImageCache_->PullImage(imageDescriptor, Context_.DockerAuth)
-                .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TErrorOr<TCriImageCacheEntryPtr>& imageOrError) {
+                .Apply(BIND([
+                    =,
+                    this,
+                    this_ = MakeStrong(this),
+                    authenticated = bool(Context_.DockerAuth)
+                ] (const TErrorOr<TCriImageCacheEntryPtr>& imageOrError) {
                     if (!imageOrError.IsOK()) {
                         YT_LOG_WARNING(imageOrError, "Failed to prepare root volume (Image: %v)", imageDescriptor);
 
                         THROW_ERROR_EXCEPTION(EErrorCode::DockerImagePullingFailed, "Failed to pull docker image")
                             << TErrorAttribute("docker_image", *dockerImage)
+                            << TErrorAttribute("authenticated", authenticated)
                             << imageOrError;
                     }
 

--- a/yt/yt/tests/integration/node/test_layers.py
+++ b/yt/yt/tests/integration/node/test_layers.py
@@ -680,12 +680,14 @@ class TestCriDockerImage(TestLayersBase):
     @authors("khlebnikov")
     @pytest.mark.timeout(180)
     def test_environment_variables(self):
+        docker_image = self.Env.yt_config.default_docker_image
         self.create_tables()
         map(
             in_=self.INPUT_TABLE,
             out=self.OUTPUT_TABLE,
             spec={
                 "mapper": {
+                    "docker_image": docker_image,
                     "command": 'printenv | sed -E \'s#"#\\\\"#g;s#([^=]*)=(.*)#{name="\\1"; value="\\2";};#\'',
                     "environment": {
                         "MY_VARIABLE_A": "MY_VALUE_A",
@@ -726,6 +728,7 @@ class TestCriDockerImage(TestLayersBase):
             "YT_JOB_INDEX": lambda x: x == "0",
             "YT_TASK_JOB_INDEX": lambda x: x == "0",
             "YT_JOB_COOKIE": lambda x: x == "0",
+            "YT_JOB_DOCKER_IMAGE": lambda x: x == docker_image,
             # set by operation spec
             "MY_VARIABLE_A": lambda x: x == "MY_VALUE_A",
             "MY_VARIABLE_B": lambda x: x == "MY_VALUE_B",


### PR DESCRIPTION
- Add docker pull error attribute about docker_auth presence
  This makes missing docker_auth much more obvious.
  
  ---
  8418dd55af0fa876df5fbd24429f0da9ee3a5e6c
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/829
  
  (cherry picked from commit 7dc53c40bd103ef01256fe9e7bf878bf39dd4d85)
- Set YT_JOB_DOCKER_IMAGE in job environment
  Issue: https://github.com/ytsaurus/ytsaurus/issues/828
  
  ---
  2328325be3e76d2698cbe760a6d542a33c50487e
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/830
  
  (cherry picked from commit ad828e81fcdd251662ddaaaa99b7d30ca8c15fb4)
- Parse docker image with digest
  Full scheme is [REGISTRY/]IMAGE[:TAG][@DIGEST]
  
  Digest refers to image manifest of image index and have higher priority
  than tag. Unlike to tag image referenced by digest never changes because
  of its nature.
  
  Parsing in controller-agent will be used later for linking docker image
  from external registry with artifacts stored within cluster.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  Link: https://github.com/distribution/reference/blob/main/reference.go
  Link: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#definitions
  Link: https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
  
  ---
  
  Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1007
  commit_hash:4285eb0f5ec3a13dab23d358d8c916a3cdeb3eb4
  
  (cherry picked from commit f5d012c993a198428f1e00eda323c647fa0c5860)

---
Changelog entry
Type: feature
Component: misc-server
Set YT_JOB_DOCKER_IMAGE in job environment