### PR TITLE
[stable/24.1] Do not retry execve in process spawn action

### DIFF
--- a/yt/yt/library/process/process.h
+++ b/yt/yt/library/process/process.h
@@ -41,7 +41,9 @@ public:
     virtual NNet::IConnectionReaderPtr GetStdOutReader() = 0;
     virtual NNet::IConnectionReaderPtr GetStdErrReader() = 0;
 
+    //! Returns process completion future, which ends with EErrorCode::OK or EProcessErrorCode.
     TFuture<void> Spawn();
+
     virtual void Kill(int signal) = 0;
 
     TString GetPath() const;


### PR DESCRIPTION
Parent is blocked on vfork() - sleeping here for 5 seconds is a bad idea.

It's better to fail with error EProcessErrorCode::CannotStartProcess and
let initiator decide what to do: retry or abort operation.

---
96370a274ae9a14327913b303d7d5f9e197df47b

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/634

(cherry picked from commit fbc4e2cc6a322011a4077427c8f1eff37a6dfd55)