### PR TITLE
[stable/24.1] Add per-band options for rpc bus connection parallelism

### DIFF
--- a/yt/yt/core/bus/public.h
+++ b/yt/yt/core/bus/public.h
@@ -19,6 +19,9 @@ using TTosLevel = int;
 constexpr int DefaultTosLevel = 0;
 constexpr int BlackHoleTosLevel = -1;
 
+constexpr int DefaultMinMultiplexingParallelism = 1;
+constexpr int DefaultMaxMultiplexingParallelism = 1'000;
+
 constexpr size_t MaxMessagePartCount = 1 << 28;
 constexpr size_t MaxMessagePartSize = 1_GB;
 

--- a/yt/yt/core/bus/tcp/config.cpp
+++ b/yt/yt/core/bus/tcp/config.cpp
@@ -15,6 +15,20 @@ void TMultiplexingBandConfig::Register(TRegistrar registrar)
 
     registrar.Parameter("network_to_tos_level", &TThis::NetworkToTosLevel)
         .Default();
+
+    registrar.Parameter("min_multiplexing_parallelism", &TThis::MinMultiplexingParallelism)
+        .GreaterThanOrEqual(1)
+        .Default(DefaultMinMultiplexingParallelism);
+
+    registrar.Parameter("max_multiplexing_parallelism", &TThis::MaxMultiplexingParallelism)
+        .GreaterThanOrEqual(1)
+        .Default(DefaultMaxMultiplexingParallelism);
+
+    registrar.Postprocessor([] (TThis* config) {
+        THROW_ERROR_EXCEPTION_UNLESS(
+            config->MinMultiplexingParallelism <= config->MaxMultiplexingParallelism,
+            "\"min_multiplexing_parallelism\" exceeds \"max_multiplexing_parallelism\"");
+    });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/bus/tcp/config.h
+++ b/yt/yt/core/bus/tcp/config.h
@@ -20,6 +20,9 @@ public:
     int TosLevel;
     THashMap<TString, int> NetworkToTosLevel;
 
+    int MinMultiplexingParallelism;
+    int MaxMultiplexingParallelism;
+
     REGISTER_YSON_STRUCT(TMultiplexingBandConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/core/bus/tcp/dispatcher.cpp
+++ b/yt/yt/core/bus/tcp/dispatcher.cpp
@@ -53,6 +53,11 @@ TTosLevel TTcpDispatcher::GetTosLevelForBand(EMultiplexingBand band)
     return Impl_->GetTosLevelForBand(band);
 }
 
+int TTcpDispatcher::GetMultiplexingParallelism(EMultiplexingBand band, int multiplexingParallelism)
+{
+    return Impl_->GetMultiplexingParallelism(band, multiplexingParallelism);
+}
+
 NYTree::IYPathServicePtr TTcpDispatcher::GetOrchidService()
 {
     return Impl_->GetOrchidService();

--- a/yt/yt/core/bus/tcp/dispatcher.h
+++ b/yt/yt/core/bus/tcp/dispatcher.h
@@ -61,6 +61,9 @@ public:
     //! Returns the TOS level configured for a band.
     TTosLevel GetTosLevelForBand(EMultiplexingBand band);
 
+    //! Returns adjusted multiplexing parallelism for a band.
+    int GetMultiplexingParallelism(EMultiplexingBand band, int multiplexingParallelism);
+
     //! Provides diagnostics for the whole TCP bus subsystem.
     NYTree::IYPathServicePtr GetOrchidService();
 

--- a/yt/yt/core/bus/tcp/dispatcher_impl.cpp
+++ b/yt/yt/core/bus/tcp/dispatcher_impl.cpp
@@ -144,6 +144,21 @@ TTosLevel TTcpDispatcher::TImpl::GetTosLevelForBand(EMultiplexingBand band)
     return bandDescriptor.TosLevel.load(std::memory_order::relaxed);
 }
 
+int TTcpDispatcher::TImpl::GetMultiplexingParallelism(EMultiplexingBand band, int multiplexingParallelism)
+{
+    if (band < TEnumTraits<EMultiplexingBand>::GetMinValue() || band > TEnumTraits<EMultiplexingBand>::GetMaxValue()) {
+        return std::clamp<int>(
+            multiplexingParallelism,
+            DefaultMinMultiplexingParallelism,
+            DefaultMaxMultiplexingParallelism);
+    }
+    const auto& bandDescriptor = BandToDescriptor_[band];
+    return std::clamp<int>(
+        multiplexingParallelism,
+        bandDescriptor.MinMultiplexingParallelism.load(std::memory_order::relaxed),
+        bandDescriptor.MaxMultiplexingParallelism.load(std::memory_order::relaxed));
+}
+
 IPollerPtr TTcpDispatcher::TImpl::GetAcceptorPoller()
 {
     static const TString ThreadNamePrefix("BusAcpt");
@@ -189,6 +204,8 @@ void TTcpDispatcher::TImpl::Configure(const TTcpDispatcherConfigPtr& config)
         const auto& bandConfig = config->MultiplexingBands[band];
         auto& bandDescriptor = BandToDescriptor_[band];
         bandDescriptor.TosLevel.store(bandConfig ? bandConfig->TosLevel : DefaultTosLevel);
+        bandDescriptor.MinMultiplexingParallelism.store(bandConfig ? bandConfig->MinMultiplexingParallelism : DefaultMinMultiplexingParallelism);
+        bandDescriptor.MaxMultiplexingParallelism.store(bandConfig ? bandConfig->MaxMultiplexingParallelism : DefaultMaxMultiplexingParallelism);
     }
 }
 

--- a/yt/yt/core/bus/tcp/dispatcher_impl.h
+++ b/yt/yt/core/bus/tcp/dispatcher_impl.h
@@ -42,6 +42,8 @@ public:
 
     TTosLevel GetTosLevelForBand(EMultiplexingBand band);
 
+    int GetMultiplexingParallelism(EMultiplexingBand band, int multiplexingParallelism);
+
     NConcurrency::IPollerPtr GetAcceptorPoller();
     NConcurrency::IPollerPtr GetXferPoller();
 
@@ -99,6 +101,8 @@ private:
     struct TBandDescriptor
     {
         std::atomic<TTosLevel> TosLevel = DefaultTosLevel;
+        std::atomic<int> MinMultiplexingParallelism = DefaultMinMultiplexingParallelism;
+        std::atomic<int> MaxMultiplexingParallelism = DefaultMaxMultiplexingParallelism;
     };
 
     TEnumIndexedArray<EMultiplexingBand, TBandDescriptor> BandToDescriptor_;

--- a/yt/yt/core/rpc/channel.h
+++ b/yt/yt/core/rpc/channel.h
@@ -78,6 +78,7 @@ struct TSendOptions
     bool GenerateAttachmentChecksums = true;
     bool RequestHeavy = false;
     EMultiplexingBand MultiplexingBand = EMultiplexingBand::Default;
+    // Parallelism is adjusted by per-band configuration.
     int MultiplexingParallelism = 1;
     // For testing purposes only.
     std::optional<TDuration> SendDelay;

--- a/yt/yt/ytlib/chunk_client/replication_reader.cpp
+++ b/yt/yt/ytlib/chunk_client/replication_reader.cpp
@@ -2604,6 +2604,7 @@ private:
         auto req = proxy.GetBlockRange();
         req->SetResponseHeavy(true);
         req->SetMultiplexingBand(SessionOptions_.MultiplexingBand);
+        req->SetMultiplexingParallelism(SessionOptions_.MultiplexingParallelism);
         SetRequestWorkloadDescriptor(req, WorkloadDescriptor_);
         ToProto(req->mutable_chunk_id(), ChunkId_);
         req->set_first_block_index(FirstBlockIndex_);
@@ -2877,6 +2878,7 @@ private:
         auto req = proxy.GetChunkMeta();
         req->SetResponseHeavy(true);
         req->SetMultiplexingBand(SessionOptions_.MultiplexingBand);
+        req->SetMultiplexingParallelism(SessionOptions_.MultiplexingParallelism);
         SetRequestWorkloadDescriptor(req, WorkloadDescriptor_);
         req->set_enable_throttling(true);
         ToProto(req->mutable_chunk_id(), ChunkId_);


### PR DESCRIPTION
- Set requst multiplexing parallelism in chunk client

- Add for RPC bus band config options for range of multiplexing parallelism

Motivation: required connection parallelism more depends on cluster topology.
It's easier to provide configuration on this level than fixing all possible initiators.

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/895
commit_hash:85eab5883734974d688c8e1a0143f7d005eccde8

(cherry picked from commit 2b19df010a54f442f490c8e88d1f6fc97950808d)