### PR TITLE
Fix multiprocessing spawn inside jobs

### DIFF
--- a/yt/python/yt/wrapper/_py_runner.py
+++ b/yt/python/yt/wrapper/_py_runner.py
@@ -154,7 +154,7 @@ def main():
                                           __main_filename,
                                           ('', 'rb', imp.__dict__[__main_module_type]))
         else:  # python3
-            import importlib
+            import importlib.util
             spec = importlib.util.spec_from_file_location(__main_module_name, __main_filename)
             main_module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(main_module)

--- a/yt/python/yt/wrapper/tests/test_operations.py
+++ b/yt/python/yt/wrapper/tests/test_operations.py
@@ -806,7 +806,7 @@ print(op.id)
         # We have to disable pickling for system modules
         # because it incorrectly pickles multiprocessing.
         # We also have to disable local mode because
-        #
+        # attached files are not appearing at the /slot/sandbox directory inside the job (we can only absolute paths only).
         with set_config_option("pickling/ignore_system_modules", True), set_config_option("is_local_mode", False):
             yt.run_operation(operation_spec)
 


### PR DESCRIPTION
Fixing a crash in the wrapper when running multiprocessing `spawn` inside a job. Key points to consider:
1. Local mode hasn't been fixed because attached files are not included in /slot/sandbox -> they are not in PYTHONPATH and only accessible via absolute paths.
2. I am not using ./modules/tmpfs. I can switch to it, but there are two arguments against doing so:
  1. It complicates the code and, in my implementation, relies on the enable_tmpfs_archive flag (which is not intuitive). Introducing a new flag would make the logic even more confusing.
  2. Currently, _main_module is uploading to /slot/sandbox (non-tmpfs by default), and conceptually, nothing fundamentally changes.
  3. `_main_module` should not be more than a couple of kilobytes even with the most weird cases.

---

* Changelog entry
Type: fix
Component: python-sdk

Fix running new processes inside a job by multiprocessing spawn.

