### PR TITLE
Add "addresses" to job description. Use it in get-job-stderr and get-job-spec

### DIFF
--- a/yt/go/proto/client/api/rpc_proxy/ya.make
+++ b/yt/go/proto/client/api/rpc_proxy/ya.make
@@ -8,6 +8,7 @@ PEERDIR(
     yt/go/proto/client/chaos_client
     yt/go/proto/client/chunk_client
     yt/go/proto/client/hive
+    yt/go/proto/client/node_tracker_client
     yt/go/proto/client/scheduler
     yt/go/proto/client/table_client
     yt/go/proto/client/tablet_client

--- a/yt/go/proto/client/node_tracker_client/ya.make
+++ b/yt/go/proto/client/node_tracker_client/ya.make
@@ -1,0 +1,20 @@
+PROTO_LIBRARY()
+
+ONLY_TAGS(GO_PROTO)
+
+PEERDIR(
+    yt/go/proto/core/misc
+)
+
+PROTO_ADDINCL(
+    GLOBAL
+    yt
+)
+
+SRCS(
+    # TODO(aleksandr.gaev): Adding this file produces an error `node_directory.pb.go:188:2: undefined: file_yt_proto_yt_client_node_tracker_client_proto_node_proto_init`.
+    # ${ARCADIA_ROOT}/yt/yt_proto/yt/client/node_tracker_client/proto/node_directory.proto
+    ${ARCADIA_ROOT}/yt/yt_proto/yt/client/node_tracker_client/proto/node.proto
+)
+
+END()

--- a/yt/go/proto/client/ya.make
+++ b/yt/go/proto/client/ya.make
@@ -4,6 +4,7 @@ RECURSE(
     chunk_client
     discovery_client
     hive
+    node_tracker_client
     scheduler
     table_client
     tablet_client

--- a/yt/python/yt/environment/init_operations_archive.py
+++ b/yt/python/yt/environment/init_operations_archive.py
@@ -688,7 +688,6 @@ TRANSFORMS[55] = [
             })),
 ]
 
-
 TRANSFORMS[56] = [
     Conversion(
         "jobs",
@@ -744,6 +743,64 @@ TRANSFORMS[56] = [
                 "account": OPERATIONS_ARCHIVE_ACCOUNT_NAME,
             })),
 ]
+
+TRANSFORMS[57] = [
+    Conversion(
+        "jobs",
+        table_info=TableInfo(
+            [
+                ("job_id_partition_hash", "uint64", "farm_hash(job_id_hi, job_id_lo) % {}".format(JOB_TABLE_PARTITION_COUNT)),
+                ("operation_id_hash", "uint64", "farm_hash(operation_id_hi, operation_id_lo)"),
+                ("operation_id_hi", "uint64"),
+                ("operation_id_lo", "uint64"),
+                ("job_id_hi", "uint64"),
+                ("job_id_lo", "uint64")
+            ], [
+                ("type", "string"),
+                ("state", "string"),
+                ("start_time", "int64"),
+                ("finish_time", "int64"),
+                ("address", "string"),
+                ("error", "any"),
+                ("interruption_info", "any"),
+                ("statistics", "any"),
+                ("stderr_size", "uint64"),
+                ("spec", "string"),
+                ("spec_version", "int64"),
+                ("has_spec", "boolean"),
+                ("has_fail_context", "boolean"),
+                ("fail_context_size", "uint64"),
+                ("events", "any"),
+                ("transient_state", "string"),
+                ("update_time", "int64"),
+                ("core_infos", "any"),
+                ("job_competition_id", "string"),
+                ("has_competitors", "boolean"),
+                ("exec_attributes", "any"),
+                ("task_name", "string"),
+                ("statistics_lz4", "string"),
+                ("brief_statistics", "any"),
+                ("pool_tree", "string"),
+                ("monitoring_descriptor", "string"),
+                ("probing_job_competition_id", "string"),
+                ("has_probing_competitors", "boolean"),
+                ("job_cookie", "int64"),
+                ("controller_state", "string"),
+                ("archive_features", "any"),
+                ("$ttl", "uint64"),
+                ("operation_incarnation", "string"),
+                ("allocation_id_hi", "uint64"),
+                ("allocation_id_lo", "uint64"),
+                ("addresses", "any"),
+            ],
+            default_lock="operations_cleaner",
+            attributes={
+                "atomicity": "none",
+                "tablet_cell_bundle": SYS_BUNDLE_NAME,
+                "account": OPERATIONS_ARCHIVE_ACCOUNT_NAME,
+            })),
+]
+
 
 # NB(renadeen): don't forget to update min_required_archive_version at yt/yt/server/lib/scheduler/config.cpp
 

--- a/yt/python/yt/operations_archive/clear_operations.py
+++ b/yt/python/yt/operations_archive/clear_operations.py
@@ -125,6 +125,7 @@ class OperationsArchiver(object):
         "job_type",
         "state",
         "address",
+        "addresses",
         "uncompressed_data_size",
         "error",
         "size",
@@ -235,6 +236,7 @@ class OperationsArchiver(object):
             row["type" if self.version >= 6 else "job_type"] = attributes["job_type"]
             row["state"] = attributes["state"]
             row["address"] = attributes["address"]
+            row["addresses"] = attributes["addresses"]
             row["start_time"] = date_string_to_timestamp_mcs(attributes["start_time"])
             row["finish_time"] = date_string_to_timestamp_mcs(attributes["finish_time"])
 

--- a/yt/yt/client/api/operation_client.cpp
+++ b/yt/yt/client/api/operation_client.cpp
@@ -285,6 +285,7 @@ void Serialize(const TJob& job, NYson::IYsonConsumer* consumer, TStringBuf idKey
             .OptionalItem("controller_state", job.ControllerState)
             .OptionalItem("archive_state", job.ArchiveState)
             .OptionalItem("address", job.Address)
+            .OptionalItem("addresses", job.Addresses)
             .OptionalItem("start_time", job.StartTime)
             .OptionalItem("finish_time", job.FinishTime)
             .OptionalItem("has_spec", job.HasSpec)

--- a/yt/yt/client/api/operation_client.h
+++ b/yt/yt/client/api/operation_client.h
@@ -3,8 +3,9 @@
 #include "client_common.h"
 
 #include <yt/yt/client/scheduler/operation_id_or_alias.h>
-
 #include <yt/yt/client/scheduler/public.h>
+
+#include <yt/yt/client/node_tracker_client/public.h>
 
 namespace NYT::NApi {
 
@@ -368,6 +369,7 @@ struct TJob
     std::optional<TInstant> StartTime;
     std::optional<TInstant> FinishTime;
     std::optional<TString> Address;
+    std::optional<NNodeTrackerClient::TAddressMap> Addresses;
     std::optional<double> Progress;
     std::optional<ui64> StderrSize;
     std::optional<ui64> FailContextSize;

--- a/yt/yt/client/api/rpc_proxy/helpers.cpp
+++ b/yt/yt/client/api/rpc_proxy/helpers.cpp
@@ -840,6 +840,7 @@ void ToProto(NProto::TJob* protoJob, const NApi::TJob& job)
     YT_OPTIONAL_SET_PROTO(protoJob, finish_time, job.FinishTime);
 
     YT_OPTIONAL_TO_PROTO(protoJob, address, job.Address);
+    YT_OPTIONAL_TO_PROTO(protoJob, addresses, job.Addresses);
     if (job.Progress) {
         protoJob->set_progress(*job.Progress);
     }
@@ -905,6 +906,11 @@ void FromProto(NApi::TJob* job, const NProto::TJob& protoJob)
     job->StartTime = YT_OPTIONAL_FROM_PROTO(protoJob, start_time, TInstant);
     job->FinishTime = YT_OPTIONAL_FROM_PROTO(protoJob, finish_time, TInstant);
     job->Address = YT_OPTIONAL_FROM_PROTO(protoJob, address);
+    if (protoJob.has_addresses()) {
+        job->Addresses = FromProto<NNodeTrackerClient::TAddressMap>(protoJob.addresses());
+    } else {
+        job->Addresses = {};
+    }
     job->Progress = YT_OPTIONAL_FROM_PROTO(protoJob, progress);
     job->StderrSize = YT_OPTIONAL_FROM_PROTO(protoJob, stderr_size);
     job->FailContextSize = YT_OPTIONAL_FROM_PROTO(protoJob, fail_context_size);

--- a/yt/yt/server/controller_agent/controllers/job_info.cpp
+++ b/yt/yt/server/controller_agent/controllers/job_info.cpp
@@ -26,6 +26,7 @@ using namespace NYTree;
 TJobNodeDescriptor::TJobNodeDescriptor(const TExecNodeDescriptorPtr& other)
     : Id(other->Id)
     , Address(other->Address)
+    , Addresses(other->Addresses)
     , IOWeight(other->IOWeight)
 { }
 
@@ -36,6 +37,10 @@ void TJobNodeDescriptor::Persist(const TPersistenceContext& context)
     Persist(context, Id);
     Persist(context, Address);
     Persist(context, IOWeight);
+
+    if (context.GetVersion() >= ESnapshotVersion::AddAddressesToJob) {
+        Persist(context, Addresses);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/controller_agent/controllers/job_info.h
+++ b/yt/yt/server/controller_agent/controllers/job_info.h
@@ -32,6 +32,7 @@ struct TJobNodeDescriptor
 
     NNodeTrackerClient::TNodeId Id = NNodeTrackerClient::InvalidNodeId;
     std::string Address;
+    NNodeTrackerClient::TAddressMap Addresses;
     double IOWeight = 0.0;
 
     void Persist(const TPersistenceContext& context);

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -3962,6 +3962,7 @@ void TOperationControllerBase::BuildJobAttributes(
         .Item("job_type").Value(joblet->JobType)
         .Item("state").Value(state)
         .Item("address").Value(joblet->NodeDescriptor.Address)
+        .Item("addresses").Value(joblet->NodeDescriptor.Addresses)
         .Item("start_time").Value(joblet->StartTime)
         .Item("account").Value(joblet->DebugArtifactsAccount)
         .Item("progress").Value(joblet->Progress)
@@ -11225,6 +11226,7 @@ void TOperationControllerBase::HandleJobReport(const TJobletPtr& joblet, TContro
             .OperationId(OperationId)
             .JobId(joblet->JobId)
             .Address(joblet->NodeDescriptor.Address)
+            .Addresses(joblet->NodeDescriptor.Addresses)
             .Ttl(joblet->ArchiveTtl)
             .AllocationId(AllocationIdFromJobId(joblet->JobId)));
 }

--- a/yt/yt/server/lib/controller_agent/job_report.cpp
+++ b/yt/yt/server/lib/controller_agent/job_report.cpp
@@ -45,6 +45,12 @@ TControllerJobReport TControllerJobReport::Address(std::optional<std::string> ad
     return std::move(*this);
 }
 
+TControllerJobReport TControllerJobReport::Addresses(std::optional<NNodeTrackerClient::TAddressMap> addresses)
+{
+    Addresses_ = addresses;
+    return std::move(*this);
+}
+
 TControllerJobReport TControllerJobReport::ControllerState(EJobState controllerState)
 {
     ControllerState_ = FormatEnum(controllerState);

--- a/yt/yt/server/lib/controller_agent/job_report.h
+++ b/yt/yt/server/lib/controller_agent/job_report.h
@@ -15,6 +15,7 @@ public:
     TControllerJobReport HasCompetitors(bool hasCompetitors, EJobCompetitionType competitionType);
     TControllerJobReport JobCookie(ui64 jobCookie);
     TControllerJobReport Address(std::optional<std::string> address);
+    TControllerJobReport Addresses(std::optional<NNodeTrackerClient::TAddressMap> addresses);
     TControllerJobReport ControllerState(EJobState controllerState);
     TControllerJobReport Ttl(std::optional<TDuration> ttl);
     TControllerJobReport OperationIncarnation(std::string operationIncarnation);

--- a/yt/yt/server/lib/exec_node/job_report.cpp
+++ b/yt/yt/server/lib/exec_node/job_report.cpp
@@ -142,6 +142,12 @@ TNodeJobReport TNodeJobReport::Address(std::optional<std::string> address)
     return std::move(*this);
 }
 
+TNodeJobReport TNodeJobReport::Addresses(std::optional<NNodeTrackerClient::TAddressMap> addresses)
+{
+    Addresses_ = addresses;
+    return std::move(*this);
+}
+
 void TNodeJobReport::SetStatistics(const TYsonString& statistics)
 {
     Statistics_ = StripAttributes(statistics).ToString();

--- a/yt/yt/server/lib/exec_node/job_report.h
+++ b/yt/yt/server/lib/exec_node/job_report.h
@@ -33,6 +33,7 @@ public:
     TNodeJobReport TreeId(TString treeId);
     TNodeJobReport MonitoringDescriptor(TString monitoringDescriptor);
     TNodeJobReport Address(std::optional<std::string> address);
+    TNodeJobReport Addresses(std::optional<NNodeTrackerClient::TAddressMap> addresses);
     TNodeJobReport ArchiveFeatures(const NYson::TYsonString& archiveFeatures);
 
     void SetStatistics(const NYson::TYsonString& statistics);

--- a/yt/yt/server/lib/misc/estimate_size_helpers-inl.h
+++ b/yt/yt/server/lib/misc/estimate_size_helpers-inl.h
@@ -28,6 +28,12 @@ size_t EstimateSize(const std::optional<T>& v)
     return v ? EstimateSize(*v) : 0;
 }
 
+template <typename T1, typename T2>
+size_t EstimateSize(const std::pair<T1, T2>& v)
+{
+    return EstimateSize(v.first) + EstimateSize(v.second);
+}
+
 template <typename C>
     requires std::ranges::range<C>
 size_t EstimateSize(const C& value)

--- a/yt/yt/server/lib/misc/job_report.h
+++ b/yt/yt/server/lib/misc/job_report.h
@@ -107,6 +107,7 @@ public:
     DEFINE_BYREF_RO_PROPERTY(std::optional<TString>, MonitoringDescriptor);
     DEFINE_BYREF_RO_PROPERTY(std::optional<ui64>, JobCookie);
     DEFINE_BYREF_RO_PROPERTY(std::optional<std::string>, Address);
+    DEFINE_BYREF_RO_PROPERTY(std::optional<NNodeTrackerClient::TAddressMap>, Addresses);
     DEFINE_BYREF_RO_PROPERTY(std::optional<TString>, ControllerState);
     DEFINE_BYREF_RO_PROPERTY(std::optional<TString>, ArchiveFeatures);
     DEFINE_BYREF_RO_PROPERTY(std::optional<TDuration>, Ttl);

--- a/yt/yt/server/lib/misc/job_reporter.cpp
+++ b/yt/yt/server/lib/misc/job_reporter.cpp
@@ -83,6 +83,7 @@ public:
             Report_.FinishTime(),
             /*updateTime*/ TInstant::Now().MicroSeconds(),
             Report_.Address(),
+            Report_.Addresses(),
             Report_.StderrSize(),
             Report_.HasCompetitors(),
             Report_.HasProbingCompetitors(),
@@ -188,6 +189,7 @@ public:
         if (archiveVersion >= 53 && Report_.Ttl()) {
             record.Ttl = Report_.Ttl()->MilliSeconds();
         }
+
         // COMPAT(eshcherbin)
         if (archiveVersion >= 55 && Report_.OperationIncarnation()) {
             record.OperationIncarnation = Report_.OperationIncarnation();
@@ -197,6 +199,11 @@ public:
             auto allocationIdAsGuid = Report_.AllocationId().Underlying();
             record.AllocationIdHi = allocationIdAsGuid.Parts64[0];
             record.AllocationIdLo = allocationIdAsGuid.Parts64[1];
+        }
+
+        // COMPAT(aleksandr.gaev)
+        if (archiveVersion >= 57 && Report_.Addresses()) {
+            record.Addresses = ConvertToYsonString(*Report_.Addresses());
         }
 
         return FromRecord(record);

--- a/yt/yt/server/lib/scheduler/config.cpp
+++ b/yt/yt/server/lib/scheduler/config.cpp
@@ -1264,7 +1264,7 @@ void TSchedulerConfig::Register(TRegistrar registrar)
         .Default(true);
 
     registrar.Parameter("min_required_archive_version", &TThis::MinRequiredArchiveVersion)
-        .Default(56);
+        .Default(57);
 
     registrar.Parameter("rpc_server", &TThis::RpcServer)
         .DefaultNew();

--- a/yt/yt/server/lib/scheduler/exec_node_descriptor.h
+++ b/yt/yt/server/lib/scheduler/exec_node_descriptor.h
@@ -27,6 +27,7 @@ struct TExecNodeDescriptor
     TExecNodeDescriptor(
         NNodeTrackerClient::TNodeId id,
         const std::string& address,
+        const NNodeTrackerClient::TAddressMap& addresses,
         const std::optional<std::string>& dataCenter,
         double ioWeight,
         bool online,
@@ -41,6 +42,7 @@ struct TExecNodeDescriptor
 
     NNodeTrackerClient::TNodeId Id = NNodeTrackerClient::InvalidNodeId;
     std::string Address;
+    NNodeTrackerClient::TAddressMap Addresses;
     std::optional<std::string> DataCenter;
     double IOWeight = 0.0;
     bool Online = false;

--- a/yt/yt/server/lib/scheduler/proto/controller_agent_tracker_service.proto
+++ b/yt/yt/server/lib/scheduler/proto/controller_agent_tracker_service.proto
@@ -18,6 +18,7 @@ message TExecNodeDescriptor
     required TJobResources resource_limits = 4;
     required NNodeTrackerClient.NProto.TDiskResources disk_resources = 7;
     repeated string tags = 5;
+    optional NNodeTrackerClient.NProto.TAddressMap addresses = 8;
 }
 
 message TExecNodeDescriptorList

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -1638,7 +1638,8 @@ void TJob::HandleJobReport(TNodeJobReport&& jobReport)
         jobReport
             .OperationId(GetOperationId())
             .JobId(GetId())
-            .Address(Bootstrap_->GetLocalDescriptor().GetDefaultAddress()));
+            .Address(Bootstrap_->GetLocalDescriptor().GetDefaultAddress())
+            .Addresses(Bootstrap_->GetLocalDescriptor().Addresses()));
 }
 
 void TJob::ReportSpec()

--- a/yt/yt/server/scheduler/exec_node.cpp
+++ b/yt/yt/server/scheduler/exec_node.cpp
@@ -29,6 +29,11 @@ const std::string& TExecNode::GetDefaultAddress() const
     return NodeDescriptor_.GetDefaultAddress();
 }
 
+const TAddressMap& TExecNode::GetAddresses() const
+{
+    return NodeDescriptor_.Addresses();
+}
+
 bool TExecNode::CanSchedule(const TSchedulingTagFilter& filter) const
 {
     return filter.IsEmpty() || filter.CanSchedule(Tags_);
@@ -39,6 +44,7 @@ TExecNodeDescriptorPtr TExecNode::BuildExecDescriptor() const
     return New<TExecNodeDescriptor>(
         Id_,
         GetDefaultAddress(),
+        GetAddresses(),
         NodeDescriptor_.GetDataCenter(),
         IOWeight_,
         MasterState_ == NNodeTrackerClient::ENodeState::Online && SchedulerState_ == ENodeState::Online,

--- a/yt/yt/server/scheduler/exec_node.h
+++ b/yt/yt/server/scheduler/exec_node.h
@@ -143,6 +143,7 @@ public:
         ENodeState state);
 
     const std::string& GetDefaultAddress() const;
+    const NNodeTrackerClient::TAddressMap& GetAddresses() const;
 
     //! Checks if the node can handle jobs demanding a certain #tag.
     bool CanSchedule(const TSchedulingTagFilter& filter) const;

--- a/yt/yt/tests/integration/scheduler/test_get_job.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job.py
@@ -519,6 +519,28 @@ class TestGetJob(_TestGetJobCommon):
 
         get_job(op.id, job_id)
 
+    @authors("aleksandr.gaev")
+    def test_job_addresses(self):
+        op = run_test_vanilla(
+            with_breakpoint("BREAKPOINT"),
+        )
+        (job_id,) = wait_breakpoint()
+
+        def check_addresses(job_info):
+            return "address" in job_info and "addresses" in job_info
+
+        wait(lambda: check_addresses(get_job(op.id, job_id)))
+
+        release_breakpoint()
+
+        op.track()
+
+        job_info = get_job(op.id, job_id)
+        assert check_addresses(job_info)
+        assert len(job_info.get("address")) > 0
+        assert len(job_info.get("addresses")) > 0
+        assert job_info.get("addresses")["default"] == job_info.get("address")
+
 
 @pytest.mark.enabled_multidaemon
 class TestGetJobStatisticsLz4(_TestGetJobCommon):

--- a/yt/yt/tests/integration/scheduler/test_list_jobs.py
+++ b/yt/yt/tests/integration/scheduler/test_list_jobs.py
@@ -1151,6 +1151,27 @@ class TestListJobs(TestListJobsCommon):
         wait(lambda: len(list_jobs(op1.id, with_interruption_info=True)["jobs"]) == 2)
         wait(lambda: len(list_jobs(op1.id, with_interruption_info=False)["jobs"]) == 3)
 
+    @authors("aleksandr.gaev")
+    def test_job_addresses(self):
+        op = run_test_vanilla(
+            with_breakpoint("BREAKPOINT"),
+        )
+        (job_id,) = wait_breakpoint()
+
+        def check_addresses(list_jobs_response):
+            return len(list_jobs_response) == 1 and "address" in list_jobs_response[0] and "addresses" in list_jobs_response[0]
+
+        wait(lambda: check_addresses(list_jobs(op.id, verbose=False)["jobs"]))
+
+        release_breakpoint()
+
+        op.track()
+
+        jobs = list_jobs(op.id, verbose=False)["jobs"]
+        assert check_addresses(jobs)
+        assert len(jobs[0].get("address")) > 0
+        assert len(jobs[0].get("addresses")) > 0
+        assert jobs[0].get("addresses")["default"] == jobs[0].get("address")
 
 class TestListJobsAllocation(TestListJobsBase):
     NUM_NODES = 1

--- a/yt/yt/ytlib/controller_agent/serialize.h
+++ b/yt/yt/ytlib/controller_agent/serialize.h
@@ -50,6 +50,7 @@ DEFINE_ENUM(ESnapshotVersion,
     ((IsolateManiacsInSlicing)               (301710))
     ((MaxCompressedDataSizePerJob)           (301711))
     ((DynamicVanillaJobCount)                (301712))
+    ((AddAddressesToJob)                     (301713))
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/scheduler/records/job.yaml
+++ b/yt/yt/ytlib/scheduler/records/job.yaml
@@ -62,6 +62,11 @@ types:
         column_name: address
         column_type: String
 
+      - cpp_name: Addresses
+        cpp_type: NYson::TYsonString
+        column_name: addresses
+        column_type: Any
+
       - cpp_name: Error
         cpp_type: NYson::TYsonString
         column_name: error

--- a/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
+++ b/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
@@ -14,6 +14,7 @@ import "yt_proto/yt/core/ytree/proto/request_complexity_limits.proto";
 import "yt_proto/yt/client/chunk_client/proto/data_statistics.proto";
 import "yt_proto/yt/client/chaos_client/proto/replication_card.proto";
 import "yt_proto/yt/client/hive/proto/timestamp_map.proto";
+import "yt_proto/yt/client/node_tracker_client/proto/node.proto";
 import "yt_proto/yt/client/scheduler/proto/spec_patch.proto";
 import "yt_proto/yt/client/table_client/proto/versioned_io_options.proto";
 import "yt_proto/yt/client/tablet_client/proto/lock_mask.proto";
@@ -3211,6 +3212,7 @@ message TJob
     optional string monitoring_descriptor = 30;
     optional string operation_incarnation = 31;
     optional NYT.NProto.TGuid allocation_id = 32;
+    optional NNodeTrackerClient.NProto.TAddressMap addresses = 33;
 }
 
 message TListJobsStatistics

--- a/yt/yt_proto/yt/client/node_tracker_client/proto/node.proto
+++ b/yt/yt_proto/yt/client/node_tracker_client/proto/node.proto
@@ -3,6 +3,8 @@ package NYT.NNodeTrackerClient.NProto;
 import "yt_proto/yt/core/misc/proto/guid.proto";
 import "yt_proto/yt/core/misc/proto/error.proto";
 
+option go_package = "go.ytsaurus.tech/yt/go/proto/client/node_tracker_client";
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // TODO(gritukan): Move it to TReqFullChunkHeartbeat after switching to new heartbeats.


### PR DESCRIPTION
Issue: #1044

Added "addresses" field to job description. It has consequences on operations archive, `get-job`, etc

Main motivation behind it is to make `get-job-stderr` and `get-job-spec` work for jobs that run on exec nodes with non-default preferred address (remote exec nodes)

Version in this PR is tested locally. Publishing it early to run tests and get early feedback

TODO:
- Add tests for remote exec nodes
- Adjust go code (affects rpc proxy)

---

* Changelog entry
Type: fix
Component: map-reduce

Added "addresses" field to job description. Fixed get-job-stderr and get-job-spec for exec nodes with non-default preferred addresses

