### PR TITLE
Don't require controller agent to be local to exec node

### DIFF
--- a/yt/yt/server/node/cluster_node/bootstrap.cpp
+++ b/yt/yt/server/node/cluster_node/bootstrap.cpp
@@ -493,6 +493,11 @@ public:
         return Connection_->GetNodeDirectory();
     }
 
+    TNetworkPreferenceList GetNetworks() const override
+    {
+        return Connection_->GetNetworks();
+    }
+
     TNetworkPreferenceList GetLocalNetworks() const override
     {
         return Config_->Addresses.empty()
@@ -1879,6 +1884,11 @@ TMasterEpoch TBootstrapBase::GetMasterEpoch() const
 const TNodeDirectoryPtr& TBootstrapBase::GetNodeDirectory() const
 {
     return Bootstrap_->GetNodeDirectory();
+}
+
+TNetworkPreferenceList TBootstrapBase::GetNetworks() const
+{
+    return Bootstrap_->GetNetworks();
 }
 
 TNetworkPreferenceList TBootstrapBase::GetLocalNetworks() const

--- a/yt/yt/server/node/cluster_node/bootstrap.h
+++ b/yt/yt/server/node/cluster_node/bootstrap.h
@@ -126,6 +126,7 @@ struct IBootstrapBase
     virtual const NNodeTrackerClient::TNodeDirectoryPtr& GetNodeDirectory() const = 0;
 
     // Network stuff.
+    virtual NNodeTrackerClient::TNetworkPreferenceList GetNetworks() const = 0;
     virtual NNodeTrackerClient::TNetworkPreferenceList GetLocalNetworks() const = 0;
 
     // Servers.
@@ -285,6 +286,7 @@ public:
 
     const NNodeTrackerClient::TNodeDirectoryPtr& GetNodeDirectory() const override;
 
+    NNodeTrackerClient::TNetworkPreferenceList GetNetworks() const override;
     NNodeTrackerClient::TNetworkPreferenceList GetLocalNetworks() const override;
 
     const NHttp::IServerPtr& GetHttpServer() const override;

--- a/yt/yt/server/node/exec_node/helpers.cpp
+++ b/yt/yt/server/node/exec_node/helpers.cpp
@@ -215,14 +215,14 @@ namespace {
 
 TErrorOr<std::string> TryParseControllerAgentAddress(
     const NNodeTrackerClient::NProto::TAddressMap& proto,
-    const NNodeTrackerClient::TNetworkPreferenceList& localNetworks)
+    const NNodeTrackerClient::TNetworkPreferenceList& networks)
 {
     YT_ASSERT_THREAD_AFFINITY_ANY();
 
     auto addresses = FromProto<NNodeTrackerClient::TAddressMap>(proto);
 
     try {
-        return GetAddressOrThrow(addresses, localNetworks);
+        return GetAddressOrThrow(addresses, networks);
     } catch (const std::exception& ex) {
         return TError(
             "No suitable controller agent address exists from %v",
@@ -255,7 +255,7 @@ void FormatValue(
 
 TErrorOr<TControllerAgentDescriptor> TryParseControllerAgentDescriptor(
     const NControllerAgent::NProto::TControllerAgentDescriptor& proto,
-    const NNodeTrackerClient::TNetworkPreferenceList& localNetworks)
+    const NNodeTrackerClient::TNetworkPreferenceList& networks)
 {
     YT_ASSERT_THREAD_AFFINITY_ANY();
 
@@ -266,7 +266,7 @@ TErrorOr<TControllerAgentDescriptor> TryParseControllerAgentDescriptor(
             << TErrorAttribute("incarnation_id", incarnationId);
     }
 
-    auto addressOrError = TryParseControllerAgentAddress(proto.addresses(), localNetworks);
+    auto addressOrError = TryParseControllerAgentAddress(proto.addresses(), networks);
     if (!addressOrError.IsOK()) {
         return TError{std::move(addressOrError)}
             << TErrorAttribute("incarnation_id", incarnationId);

--- a/yt/yt/server/node/exec_node/job_controller.cpp
+++ b/yt/yt/server/node/exec_node/job_controller.cpp
@@ -1387,7 +1387,7 @@ private:
             for (const auto& protoAgentDescriptor : response->registered_controller_agents()) {
                 auto descriptorOrError = TryParseControllerAgentDescriptor(
                     protoAgentDescriptor,
-                    Bootstrap_->GetLocalNetworks());
+                    Bootstrap_->GetNetworks());
                 YT_LOG_FATAL_IF(
                     !descriptorOrError.IsOK(),
                     descriptorOrError,


### PR DESCRIPTION
Currently, exec node requires controller agent to be in the "local" network (1st network in addesses list for exec node)

It is not clear where this requirement comes from, so this PR removes it.

It allows the following exec node config to work:
```
  ytserver-exec-node.yson: |
    {
      "addresses" = [
        ["local-network";"end-0-address"];
      ];
      cluster_connection = {
        networks = [ "local-network"; "default" ];
      };
    }
```
Without this PR, exec node fails to execute jobs