### PR TITLE
Separate exec nodes from data and tablet in tests

### DIFF
--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -1703,6 +1703,7 @@ def _build_cluster_connection_config(yt_config,
             "is_client_mode_active" : True,
         },
         "upload_transaction_timeout": 5000,
+        #"networks": ["exec-nodes-network", "default"],
     }
 
     if len(cypress_proxy_rpc_ports) > 0:

--- a/yt/python/yt/test_helpers/set_timeouts.py
+++ b/yt/python/yt/test_helpers/set_timeouts.py
@@ -11,7 +11,7 @@ def get_timeout_mark(item):
 def pytest_collection_modifyitems(items, config):
     for item in items:
         if get_timeout_mark(item) is None:
-            item.add_marker(pytest.mark.timeout(90))
+            item.add_marker(pytest.mark.timeout(180))
         # By default plugin limits execution time not only of test function body but
         # including fixtures (setup_method/teardown_method/setup_class/teardown_class).
         # No problem if it is per test method fixtures (setup_method and teardown_method).

--- a/yt/yt/server/node/cluster_node/bootstrap.cpp
+++ b/yt/yt/server/node/cluster_node/bootstrap.cpp
@@ -493,6 +493,11 @@ public:
         return Connection_->GetNodeDirectory();
     }
 
+    TNetworkPreferenceList GetNetworks() const override
+    {
+        return Connection_->GetNetworks();
+    }
+
     TNetworkPreferenceList GetLocalNetworks() const override
     {
         return Config_->Addresses.empty()
@@ -1879,6 +1884,11 @@ TMasterEpoch TBootstrapBase::GetMasterEpoch() const
 const TNodeDirectoryPtr& TBootstrapBase::GetNodeDirectory() const
 {
     return Bootstrap_->GetNodeDirectory();
+}
+
+TNetworkPreferenceList TBootstrapBase::GetNetworks() const
+{
+    return Bootstrap_->GetNetworks();
 }
 
 TNetworkPreferenceList TBootstrapBase::GetLocalNetworks() const

--- a/yt/yt/server/node/cluster_node/bootstrap.h
+++ b/yt/yt/server/node/cluster_node/bootstrap.h
@@ -126,6 +126,7 @@ struct IBootstrapBase
     virtual const NNodeTrackerClient::TNodeDirectoryPtr& GetNodeDirectory() const = 0;
 
     // Network stuff.
+    virtual NNodeTrackerClient::TNetworkPreferenceList GetNetworks() const = 0;
     virtual NNodeTrackerClient::TNetworkPreferenceList GetLocalNetworks() const = 0;
 
     // Servers.
@@ -285,6 +286,7 @@ public:
 
     const NNodeTrackerClient::TNodeDirectoryPtr& GetNodeDirectory() const override;
 
+    NNodeTrackerClient::TNetworkPreferenceList GetNetworks() const override;
     NNodeTrackerClient::TNetworkPreferenceList GetLocalNetworks() const override;
 
     const NHttp::IServerPtr& GetHttpServer() const override;

--- a/yt/yt/server/node/exec_node/helpers.cpp
+++ b/yt/yt/server/node/exec_node/helpers.cpp
@@ -215,14 +215,14 @@ namespace {
 
 TErrorOr<std::string> TryParseControllerAgentAddress(
     const NNodeTrackerClient::NProto::TAddressMap& proto,
-    const NNodeTrackerClient::TNetworkPreferenceList& localNetworks)
+    const NNodeTrackerClient::TNetworkPreferenceList& networks)
 {
     YT_ASSERT_THREAD_AFFINITY_ANY();
 
     auto addresses = FromProto<NNodeTrackerClient::TAddressMap>(proto);
 
     try {
-        return GetAddressOrThrow(addresses, localNetworks);
+        return GetAddressOrThrow(addresses, networks);
     } catch (const std::exception& ex) {
         return TError(
             "No suitable controller agent address exists from %v",
@@ -255,7 +255,7 @@ void FormatValue(
 
 TErrorOr<TControllerAgentDescriptor> TryParseControllerAgentDescriptor(
     const NControllerAgent::NProto::TControllerAgentDescriptor& proto,
-    const NNodeTrackerClient::TNetworkPreferenceList& localNetworks)
+    const NNodeTrackerClient::TNetworkPreferenceList& networks)
 {
     YT_ASSERT_THREAD_AFFINITY_ANY();
 
@@ -266,7 +266,7 @@ TErrorOr<TControllerAgentDescriptor> TryParseControllerAgentDescriptor(
             << TErrorAttribute("incarnation_id", incarnationId);
     }
 
-    auto addressOrError = TryParseControllerAgentAddress(proto.addresses(), localNetworks);
+    auto addressOrError = TryParseControllerAgentAddress(proto.addresses(), networks);
     if (!addressOrError.IsOK()) {
         return TError{std::move(addressOrError)}
             << TErrorAttribute("incarnation_id", incarnationId);

--- a/yt/yt/server/node/exec_node/job_controller.cpp
+++ b/yt/yt/server/node/exec_node/job_controller.cpp
@@ -1387,7 +1387,7 @@ private:
             for (const auto& protoAgentDescriptor : response->registered_controller_agents()) {
                 auto descriptorOrError = TryParseControllerAgentDescriptor(
                     protoAgentDescriptor,
-                    Bootstrap_->GetLocalNetworks());
+                    Bootstrap_->GetNetworks());
                 YT_LOG_FATAL_IF(
                     !descriptorOrError.IsOK(),
                     descriptorOrError,


### PR DESCRIPTION
THIS IS A PR TO RUN TESTS

An attempt to separate exec nodes from data and tablet ones in tests, to estimate failed tests impact