### PR TITLE
Handle both docker image and layer artifacts in job spec simultaneously

### DIFF
--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1093,7 +1093,7 @@ public:
         YT_ASSERT_THREAD_AFFINITY(JobThread);
 
         // Inject default docker image for job workspace.
-        if (!context.DockerImage) {
+        if (!context.DockerImage && context.LayerArtifactKeys.empty()) {
             context.DockerImage = ConcreteConfig_->JobProxyImage;
         }
 


### PR DESCRIPTION
Exec node should choose method for building job workspace using either
docker image or layer tarball artifacts.

"Simple" job environment must report failure if any image/layer is specified.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type:
Component:

<Your description.>

