### PR TITLE
yt/error: optimize constructing TError from TErrorException

### DIFF
--- a/library/cpp/yt/error/error-inl.h
+++ b/library/cpp/yt/error/error-inl.h
@@ -313,6 +313,11 @@ TErrorOr<T>::TErrorOr(TErrorOr<U>&& other) noexcept
 }
 
 template <class T>
+TErrorOr<T>::TErrorOr(const TErrorException& errorEx) noexcept
+    : TError(errorEx)
+{ }
+
+template <class T>
 TErrorOr<T>::TErrorOr(const std::exception& ex)
     : TError(ex)
 { }

--- a/library/cpp/yt/error/error.cpp
+++ b/library/cpp/yt/error/error.cpp
@@ -242,6 +242,12 @@ TError::TErrorOr(TError&& other) noexcept
     : Impl_(std::move(other.Impl_))
 { }
 
+TError::TErrorOr(const TErrorException& errorEx) noexcept
+{
+    *this = errorEx.Error();
+    // NB: TErrorException verifies that error not IsOK at throwing end.
+}
+
 TError::TErrorOr(const std::exception& ex)
 {
     if (auto simpleException = dynamic_cast<const TSimpleException*>(&ex)) {

--- a/library/cpp/yt/error/error.h
+++ b/library/cpp/yt/error/error.h
@@ -56,6 +56,9 @@ void FormatValue(TStringBuilderBase* builder, TErrorCode code, TStringBuf spec);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Forward declaration.
+class TErrorException;
+
 template <class TValue>
 concept CErrorNestable = requires (TError& error, TValue&& operand)
 {
@@ -71,6 +74,8 @@ public:
 
     TErrorOr(const TError& other);
     TErrorOr(TError&& other) noexcept;
+
+    TErrorOr(const TErrorException& errorEx) noexcept;
 
     TErrorOr(const std::exception& ex);
 
@@ -364,6 +369,8 @@ public:
 
     TErrorOr(const TError& other);
     TErrorOr(TError&& other) noexcept;
+
+    TErrorOr(const TErrorException& errorEx) noexcept;
 
     TErrorOr(const std::exception& ex);
 


### PR DESCRIPTION
Here we can avoid dynamic cast and exception hazard.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.
