### PR TITLE
Extend OAuth login transformations with to_lower and to_upper

### DIFF
--- a/yt/yt/library/auth_server/config.cpp
+++ b/yt/yt/library/auth_server/config.cpp
@@ -148,12 +148,22 @@ void TOAuthCookieAuthenticatorConfig::Register(TRegistrar /*registrar*/)
 
 void TStringReplacementConfig::Register(TRegistrar registrar)
 {
-    registrar.Parameter("match_pattern", &TThis::MatchPattern);
-    registrar.Parameter("replacement", &TThis::Replacement);
+    registrar.Parameter("match_pattern", &TThis::MatchPattern)
+        .Default();
+    registrar.Parameter("replacement", &TThis::Replacement)
+        .Default();
+
+    registrar.Parameter("to_lower", &TThis::ToLower)
+        .Default(false);
+
+    registrar.Parameter("to_upper", &TThis::ToUpper)
+        .Default(false);
 
     registrar.Postprocessor([] (TThis* config) {
-        if (!config->MatchPattern) {
-            THROW_ERROR_EXCEPTION("Value of \"match_pattern\" cannot be null");
+        auto optionCount = static_cast<bool>(config->MatchPattern) + config->ToLower + config->ToUpper;
+
+        if (optionCount != 1) {
+            THROW_ERROR_EXCEPTION("Exactly one of the options \"match_pattern\", \"to_lower\" or \"to_upper\" must be set");
         }
     });
 }

--- a/yt/yt/library/auth_server/config.h
+++ b/yt/yt/library/auth_server/config.h
@@ -233,12 +233,22 @@ DEFINE_REFCOUNTED_TYPE(TOAuthCookieAuthenticatorConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// TODO(achulkov2): Replace with polymorphic YSON struct in 24.2+.
 class TStringReplacementConfig
     : public NYTree::TYsonStruct
 {
 public:
+    //! NB: The three transformations options below are mutually exclusive.
+
+    //! If set, replaces all non-overlapping matches of this pattern with the replacement string.
     NRe2::TRe2Ptr MatchPattern;
     TString Replacement;
+
+    //! If set, uppercase characters are replaced with lowercase.
+    bool ToLower;
+
+    //! If true, lowercase characters are replaced with uppercase.
+    bool ToUpper;
 
     REGISTER_YSON_STRUCT(TStringReplacementConfig);
 

--- a/yt/yt/library/auth_server/helpers.h
+++ b/yt/yt/library/auth_server/helpers.h
@@ -71,6 +71,11 @@ TError CheckCsrfToken(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Applies transformation described in the config to produce the output string.
+TString ApplyStringReplacement(const TString& input, const TStringReplacementConfigPtr& replacement, const NLogging::TLogger& logger = {});
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NAuth
 
 #define HELPERS_INL_H_

--- a/yt/yt/library/auth_server/oauth_service.cpp
+++ b/yt/yt/library/auth_server/oauth_service.cpp
@@ -4,8 +4,6 @@
 #include "private.h"
 #include "helpers.h"
 
-#include <yt/yt/library/re2/re2.h>
-
 #include <yt/yt/core/http/client.h>
 #include <yt/yt/core/http/helpers.h>
 #include <yt/yt/core/http/http.h>
@@ -127,18 +125,7 @@ private:
         const auto& formattedResponse = jsonResponseChecker->GetFormattedResponse()->AsMap();
         auto login = formattedResponse->GetChildValueOrThrow<TString>(Config_->UserInfoLoginField);
         for (const auto& transformation : Config_->LoginTransformations) {
-            auto loginBeforeTransformation = login;
-            auto replacementCount = RE2::GlobalReplace(
-                &login,
-                *transformation->MatchPattern,
-                transformation->Replacement);
-            YT_LOG_DEBUG(
-                "Login transformation for OAuth user info applied (Login: %v -> %v, MatchPattern: %v, Replacement: %v, ReplacementCount: %v)",
-                loginBeforeTransformation,
-                login,
-                transformation->MatchPattern->pattern(),
-                transformation->Replacement,
-                replacementCount);
+            login = ApplyStringReplacement(login, transformation, Logger());
         }
         auto userInfo = TOAuthUserInfoResult{
             .Login = std::move(login),

--- a/yt/yt/tests/integration/proxies/test_oauth.py
+++ b/yt/yt/tests/integration/proxies/test_oauth.py
@@ -23,15 +23,21 @@ def auth_config(port):
             "login_transformations": [
                 {
                     "match_pattern": r"(.*)@one-company\.(.*)",
-                    "replacement": r"\1"
+                    "replacement": r"\1",
                 },
                 {
-                    "match_pattern": r"(.*)@second-company\.(.*)",
-                    "replacement": r"\2-nosokhvost-\1"
+                    "to_upper": True,
+                },
+                {
+                    "match_pattern": r"(.*)@SECOND-COMPANY\.(.*)",
+                    "replacement": r"\2-nosokhvost-\1",
                 },
                 {
                     "match_pattern": r"(.*)@@(.*)\.(.*)",
                     "replacement": r"\2-\1"
+                },
+                {
+                    "to_lower": True,
                 },
             ],
         },
@@ -212,9 +218,9 @@ class TestOAuth(TestOAuthBase):
             assert data["login"] == expected_login
             assert data["realm"] == "oauth:token"
 
-        check_user("achulkov2@one-company.de", "achulkov2")
+        check_user("achulKOv2@one-company.de", "achulkov2")
         check_user("max42@second-company.be", "be-nosokhvost-max42")
-        check_user("john@@third-company.fr", "third-company-john")
+        check_user("jOHn@@third-company.fr", "third-company-john")
         check_user("fourth@fourth-company.com", "fourth@fourth-company.com")
         check_user("fifth", "fifth")
 


### PR DESCRIPTION
Added `to_lower` and `to_upper` as part of `TStringReplacementConfig`. It is applied after regexp replacement (but before the next transformation). Now you don't have to specify `match_pattern` if one of `to_lower`/`to_upper` is specified.

* Changelog entry
Type: feature
Component: proxy

Add to_lower and to_upper option to OAuth login_transformations.

