### PR TITLE
Add impersonation support in go sdk

### DIFF
--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -84,6 +84,14 @@ type Config struct {
 	// If Credentials are not set, OAuth token is used.
 	Credentials Credentials
 
+	// ImpersonationUser allows the client to impersonate another user.
+	//
+	// This behaviour is only allowed for superusers that are not banned.
+	// If not set, no impersonation is performed.
+	//
+	// Only relevant for HTTP client.
+	ImpersonationUser string
+
 	// TVMFn is used to issue service tickets for YT API requests.
 	//
 	// TVM is a preferred way of service authentication.

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -228,6 +228,10 @@ func (c *httpClient) newHTTPRequest(ctx context.Context, call *internal.Call, bo
 		credentials.Set(req)
 	}
 
+	if c.config.ImpersonationUser != "" {
+		req.Header.Add("X-YT-User-Name", c.config.ImpersonationUser)
+	}
+
 	c.logRequest(ctx, req)
 	return
 }


### PR DESCRIPTION
Sibling of #1054. Go SDK part, tested using existing behaviour for `yql_agent`, since OS tests are based on `ytsaurus:local` image. More tests to be added after main PR is merged and new `ytsaurus:local` is available.

**Can be merged in any order with the main PR.**

* Changelog entry
Type: feature
Component: go-sdk

Add support for setting ImpersonationUser.

