### PR TITLE
Add impersonation support in yt wrapper

### DIFF
--- a/yt/python/yt/wrapper/default_config.py
+++ b/yt/python/yt/wrapper/default_config.py
@@ -227,6 +227,13 @@ default_config = {
     # Set to yt.wrapper.tvm.ServiceTicketAuth(tvm_client) or yt.wrapper.tvm.UserTicketFixedAuth()
     "tvm_auth": None,
 
+    # This option allows the client to impersonate another user.
+    # Setting this option is only allowed for superusers that are not banned,
+    # all other attempts at impersonation will result in an authorization error.
+    # For now only the HTTP driver supports option, in the RPC driver it is ignored.
+    # If you are using the native driver, use the `driver_user_name` option below instead.
+    "impersonation_user": None,
+
     # Force using this version of api.
     "api_version": None,
 

--- a/yt/python/yt/wrapper/http_driver.py
+++ b/yt/python/yt/wrapper/http_driver.py
@@ -284,6 +284,10 @@ def make_request(command_name,
         if content_encoding != "identity" and not is_data_compressed:
             data = get_compressor(content_encoding)(data)
 
+    impersonation_user = get_config(client).get("impersonation_user")
+    if impersonation_user is not None:
+        headers["X-YT-User-Name"] = impersonation_user
+
     stream = use_framing or (command.output_type in ["binary", "tabular"])
     response = make_request_with_retries(
         command.http_method(),

--- a/yt/python/yt/wrapper/http_helpers.py
+++ b/yt/python/yt/wrapper/http_helpers.py
@@ -718,9 +718,9 @@ def get_user_name(token=None, headers=None, client=None):
 
     version = get_http_api_version(client=client)
 
+    headers = headers or {}
+
     if version in ("v3", "v4"):
-        if headers is None:
-            headers = {}
         if token is not None:
             headers["Authorization"] = "OAuth " + token.strip()
         data = None
@@ -730,6 +730,10 @@ def get_user_name(token=None, headers=None, client=None):
             return None
         data = "token=" + token.strip()
         verb = "login"
+
+    impersonation_user = get_config(client).get("impersonation_user")
+    if impersonation_user is not None:
+        headers["X-YT-User-Name"] = impersonation_user
 
     response = make_request_with_retries(
         "post",

--- a/yt/python/yt/wrapper/tests/test_authentication.py
+++ b/yt/python/yt/wrapper/tests/test_authentication.py
@@ -1,10 +1,14 @@
 from .helpers import get_tests_sandbox
 from .conftest import YtTestEnvironment, authors
+from .helpers import TEST_DIR, wait
 
 import mock
+import pytest
 
 import yt.wrapper as yt
 import yt.wrapper.tvm as tvm
+
+from yt.common import update
 
 
 @authors("ignat")
@@ -55,3 +59,45 @@ def test_tvm_user_ticket():
         except Exception:
             pass
         assert m.call_args.kwargs["headers"]["X-Ya-User-Ticket"] == "3:user:b64BODY:b64SIGN"
+
+
+@pytest.mark.usefixtures("yt_env_with_authentication")
+class TestImpresonation(object):
+    @authors("achulkov2")
+    def test_impersonation(self):
+        yt.create("user", attributes={"name": "alice"})
+        yt.set("//sys/tokens/bob", "alice")
+
+        yt.set(f"{TEST_DIR}/@acl/end", {"action": "allow", "subjects": ["alice"], "permissions": ["read", "write"]})
+
+        root_client_with_impersonation = yt.YtClient(config=update(yt.config.config, {"impersonation_user": "alice"}))
+
+        assert root_client_with_impersonation.get_user_name() == "alice"
+        node = TEST_DIR + "/node"
+        root_client_with_impersonation.create("map_node", node, attributes={"account": "tmp"})
+        assert root_client_with_impersonation.get(node + "/@owner") == "alice"
+
+        alice_client_with_impersonation = yt.YtClient(config=update(yt.config.config, {"token": "bob", "impersonation_user": "root"}))
+        # Oh my, Alice, what are you doing, you are not a superuser!
+        with pytest.raises(yt.YtError):
+            alice_client_with_impersonation.exists("/")
+
+        yt.add_member("alice", "superusers")
+
+        # Now it is OK, once caches are updated.
+        wait(lambda: alice_client_with_impersonation.exists("/"), ignore_exceptions=True)
+
+        yt.set("//sys/users/alice/@banned", True)
+
+        def wait_for_error(callback):
+            def check():
+                try:
+                    callback()
+                    return False
+                except yt.YtError:
+                    return True
+
+            wait(check)
+
+        # Alice is banned, she can't do anything.
+        wait_for_error(lambda: alice_client_with_impersonation.exists("/"))


### PR DESCRIPTION
Sibling of #1054. Separated for easier cherry-picking. Contains more extensive tests, since this is mostly wrapper-intended functionality.

**Needs to be merged after main PR for tests to work.**

* Changelog entry
Type: feature
Component: python-sdk

Add support for setting impersonation_user.

