### PR TITLE
Remove unused bus_client from YQL agent config, accidental copy paste

### DIFF
--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -331,8 +331,6 @@ void TYqlAgentConfig::Register(TRegistrar registrar)
         .Default(TDuration::Minutes(10));
     registrar.Parameter("issue_token_attempts", &TThis::IssueTokenAttempts)
         .Default(10);
-    registrar.Parameter("bus_client", &TThis::BusClient)
-        .DefaultNew();
     registrar.Parameter("yql_thread_count", &TThis::YqlThreadCount)
         .Default(256);
 }

--- a/yt/yql/agent/config.h
+++ b/yt/yql/agent/config.h
@@ -157,9 +157,6 @@ public:
     TDuration RefreshTokenPeriod;
     int IssueTokenAttempts;
 
-    //! Used to create channels to other queue agents.
-    NBus::TBusConfigPtr BusClient;
-
     int YqlThreadCount;
 
     REGISTER_YSON_STRUCT(TYqlAgentConfig);


### PR DESCRIPTION
YQL agents don't talk to each other:
<img width="1189" alt="Screenshot 2025-02-14 at 00 23 13" src="https://github.com/user-attachments/assets/32bc6951-097e-41ea-b28e-4c1f84fec1a5" />
