### PR TITLE
Use python3 for YT integration tests

### DIFF
--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -59,7 +59,7 @@ class LocalYtConfig(object):
             "log_writer_name": "debug",
         },
     })
-    default_docker_image = "docker.io/library/python:2.7-slim"
+    default_docker_image = "docker.io/library/python:3.8-slim"
 
     """Feature flags"""
     enable_master_cache = attr.ib(False)

--- a/yt/yt/tests/integration/controller/test_auto_merge.py
+++ b/yt/yt/tests/integration/controller/test_auto_merge.py
@@ -1008,7 +1008,7 @@ else:
         op = map(
             in_="//tmp/t_in",
             out=["//tmp/t_out"],
-            command="python mapper.py",
+            command="python3 mapper.py",
             file="//tmp/mapper.py",
             spec={
                 "auto_merge": {

--- a/yt/yt/tests/integration/controller/test_map_operation.py
+++ b/yt/yt/tests/integration/controller/test_map_operation.py
@@ -554,11 +554,11 @@ cat > /dev/null; echo {hello=world}
 import sys
 table_index = sys.stdin.readline().strip()
 row = sys.stdin.readline().strip()
-print row + table_index
+print(row + table_index)
 
 table_index = sys.stdin.readline().strip()
 row = sys.stdin.readline().strip()
-print row + table_index
+print(row + table_index)
 """
 
         create("file", "//tmp/mapper.py")
@@ -567,7 +567,7 @@ print row + table_index
         map(
             in_=["//tmp/t1", "//tmp/t2"],
             out="//tmp/out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             file="//tmp/mapper.py",
             spec={"mapper": {"format": yson.loads(b"<enable_table_index=true>yamr")}},
         )
@@ -1390,7 +1390,7 @@ print row + table_index
 
         update_inplace(spec, spec_patch)
 
-        mapper = b"""
+        mapper = b"""#!/usr/bin/env python3
 import json
 import os
 import sys
@@ -2624,7 +2624,7 @@ class TestInputOutputFormats(YTEnvSetup):
 import sys
 input = sys.stdin.readline().strip('\\n').split('\\t')
 assert input == ['tskv', 'foo=bar']
-print '{hello=world}'
+print('{hello=world}')
 
 """
         create("file", "//tmp/mapper.py")
@@ -2634,7 +2634,7 @@ print '{hello=world}'
         map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             file="//tmp/mapper.py",
             spec={"mapper": {"input_format": yson.loads(b"<line_prefix=tskv>dsv")}},
         )
@@ -2653,7 +2653,7 @@ input = sys.stdin.readline().strip('\\n')
 assert input == '<"table_index"=0;>#;'
 input = sys.stdin.readline().strip('\\n')
 assert input == '{"foo"="bar";};'
-print "tskv" + "\\t" + "hello=world"
+print("tskv" + "\\t" + "hello=world")
 """
         create("file", "//tmp/mapper.py")
         write_file("//tmp/mapper.py", mapper)
@@ -2662,7 +2662,7 @@ print "tskv" + "\\t" + "hello=world"
         map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             file="//tmp/mapper.py",
             spec={
                 "mapper": {
@@ -2685,7 +2685,7 @@ print "tskv" + "\\t" + "hello=world"
 import sys
 input = sys.stdin.readline().strip('\\n')
 assert input == '{"foo"="bar";};'
-print "key\\tsubkey\\tvalue"
+print("key\\tsubkey\\tvalue")
 
 """
         create("file", "//tmp/mapper.py")
@@ -2695,7 +2695,7 @@ print "key\\tsubkey\\tvalue"
         map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             file="//tmp/mapper.py",
             spec={
                 "mapper": {
@@ -2720,7 +2720,7 @@ print "key\\tsubkey\\tvalue"
 import sys
 input = sys.stdin.readline().strip('\\n').split('\\t')
 assert input == ['key', 'subkey', 'value']
-print '{hello=world}'
+print('{hello=world}')
 
 """
         create("file", "//tmp/mapper.py")
@@ -2730,7 +2730,7 @@ print '{hello=world}'
         map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             file="//tmp/mapper.py",
             spec={"mapper": {"input_format": yson.loads(b"<has_subkey=true>yamr")}},
         )
@@ -2817,10 +2817,10 @@ print '{hello=world}'
 
         script = b"\n".join(
             [
-                b"#!/usr/bin/python",
+                b"#!/usr/bin/env python3",
                 b"import sys",
                 b"import base64",
-                b"print '{out=\"' + base64.standard_b64encode(sys.stdin.read()) + '\"}'",
+                b"print('{out=\"' + base64.standard_b64encode(sys.stdin.buffer.read()).decode() + '\"}')",
             ]
         )
 

--- a/yt/yt/tests/integration/controller/test_map_reduce_operation.py
+++ b/yt/yt/tests/integration/controller/test_map_reduce_operation.py
@@ -220,7 +220,7 @@ def read_table():
 
 for key, rows in groupby(read_table(), lambda row: row["word"]):
     count = sum(int(row["count"]) for row in rows)
-    print "word=%s\\tcount=%s" % (key, count)
+    print("word=%s\\tcount=%s" % (key, count))
 """
 
         tx = start_transaction(timeout=60000)
@@ -245,7 +245,7 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
             map(
                 in_="//tmp/t_in",
                 out="//tmp/t_map_out",
-                command="python mapper.py",
+                command="python3 mapper.py",
                 file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
                 spec={"mapper": {"format": "dsv"}},
                 tx=tx,
@@ -257,7 +257,7 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_reduce_in",
                 out="//tmp/t_out",
                 reduce_by="word",
-                command="python reducer.py",
+                command="python3 reducer.py",
                 file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 spec={"reducer": {"format": "dsv"}},
                 tx=tx,
@@ -267,11 +267,11 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_in",
                 out="//tmp/t_out",
                 sort_by="word",
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 mapper_file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
-                reduce_combiner_command="python reducer.py",
+                reduce_combiner_command="python3 reducer.py",
                 reduce_combiner_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 reducer_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 spec={
                     "partition_count": 2,
@@ -288,9 +288,9 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_in",
                 out="//tmp/t_out",
                 sort_by="word",
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 mapper_file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 reducer_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 spec={
                     "partition_count": 1,
@@ -304,10 +304,10 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_in",
                 out="//tmp/t_out",
                 sort_by="word",
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 mapper_file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
                 reduce_combiner_command="cat >/dev/null",
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 reducer_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 spec={
                     "partition_count": 2,
@@ -324,9 +324,9 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_in",
                 out="//tmp/t_out",
                 sort_by="word",
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 mapper_file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
-                reduce_combiner_command="python reducer.py",
+                reduce_combiner_command="python3 reducer.py",
                 reduce_combiner_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 reducer_command="cat",
                 spec={
@@ -344,11 +344,11 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_in",
                 out="//tmp/t_out",
                 sort_by="word",
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 mapper_file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
-                reduce_combiner_command="python reducer.py",
+                reduce_combiner_command="python3 reducer.py",
                 reduce_combiner_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 reducer_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 spec={
                     "partition_count": 2,
@@ -366,11 +366,11 @@ for key, rows in groupby(read_table(), lambda row: row["word"]):
                 in_="//tmp/t_in",
                 out="//tmp/t_out",
                 sort_by="word",
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 mapper_file=["//tmp/mapper.py", "//tmp/yt_streaming.py"],
-                reduce_combiner_command="python reducer.py",
+                reduce_combiner_command="python3 reducer.py",
                 reduce_combiner_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 reducer_file=["//tmp/reducer.py", "//tmp/yt_streaming.py"],
                 spec={
                     "partition_count": 7,
@@ -484,8 +484,8 @@ for l in sys.stdin:
   d = dict([(a[0], int(a[1])) for a in pairs])
   x = d['x']
   y = d['y']
-  print l
-print "x={0}\ty={1}".format(x, y)
+  print(l)
+print("x={0}\ty={1}".format(x, y))
 """
 
         create("file", "//tmp/reducer.py")
@@ -499,7 +499,7 @@ print "x={0}\ty={1}".format(x, y)
             reduce_by="x",
             sort_by=sort_by,
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             spec={"partition_count": 2, "reducer": {"format": "dsv"}},
         )
 
@@ -1620,7 +1620,7 @@ for l in sys.stdin:
             in_="//tmp/t1",
             out="//tmp/t2",
             mapper_file=["//tmp/mapper.py"],
-            mapper_command="python mapper.py",
+            mapper_command="python3 mapper.py",
             reducer_command="cat",
             reduce_combiner_command="cat",
             sort_by=[{"name": "a", "sort_order": sort_order}],
@@ -1680,7 +1680,7 @@ for l in sys.stdin:
             in_="//tmp/input",
             out=["//tmp/mapper_output", "//tmp/reducer_output"],
             mapper_file=["//tmp/mapper.py"],
-            mapper_command="python mapper.py",
+            mapper_command="python3 mapper.py",
             reducer_command="cat",
             reduce_by=["a"],
             spec={
@@ -1765,7 +1765,7 @@ for l in sys.stdin:
             in_=["//tmp/in"],
             out="//tmp/out",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=[{"name": "a", "sort_order": "ascending"}],
             spec={
                 "partition_count": 1,
@@ -1872,7 +1872,7 @@ for l in sys.stdin:
             in_=["//tmp/in1", "//tmp/in2"],
             out="//tmp/out",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=[{"name": "a", "sort_order": sort_order}],
             spec=spec,
         )
@@ -1976,7 +1976,7 @@ for l in sys.stdin:
             in_=input_paths,
             out="//tmp/out",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=[
                 {"name": "a", "sort_order": sort_order},
                 {"name": "b", "sort_order": sort_order},
@@ -2061,10 +2061,10 @@ for l in sys.stdin:
     a, b = row["a"], row["b"]
     if a % 2 == 0:
         out_row = {"a": a // 2, "struct": row}
-        os.write(1, json.dumps(out_row) + "\\n")
+        os.write(1, json.dumps(out_row).encode() + b"\\n")
     else:
         out_row = {"a": a // 2, "struct1": {"a1": a - 1}}
-        os.write(4, json.dumps(out_row) + "\\n")
+        os.write(4, json.dumps(out_row).encode() + b"\\n")
 """
         create("file", "//tmp/mapper.py")
         write_file("//tmp/mapper.py", mapper)
@@ -2077,9 +2077,9 @@ for l in sys.stdin:
                 in_="//tmp/t1",
                 out="//tmp/t2",
                 mapper_file=["//tmp/mapper.py"],
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 reducer_file=["//tmp/reducer.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 sort_by=[{"name": "a", "sort_order": sort_order}],
                 spec={
                     "mapper": {
@@ -2099,9 +2099,9 @@ for l in sys.stdin:
                 in_="//tmp/t1",
                 out="//tmp/t2",
                 mapper_file=["//tmp/mapper.py"],
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 reducer_file=["//tmp/reducer.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 sort_by=[{"name": "a", "sort_order": sort_order}],
                 spec={
                     "partition_count": 1,
@@ -2122,9 +2122,9 @@ for l in sys.stdin:
                 in_="//tmp/t1",
                 out="//tmp/t2",
                 mapper_file=["//tmp/mapper.py"],
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 reducer_file=["//tmp/reducer.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 sort_by=[{"name": "a", "sort_order": sort_order}],
                 spec={
                     "partition_count": 2,
@@ -2148,9 +2148,9 @@ for l in sys.stdin:
                 in_="//tmp/t1",
                 out="//tmp/t2",
                 mapper_file=["//tmp/mapper.py"],
-                mapper_command="python mapper.py",
+                mapper_command="python3 mapper.py",
                 reducer_file=["//tmp/reducer.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 sort_by=[{"name": "a", "sort_order": sort_order}],
                 spec={
                     "partition_count": 7,
@@ -2233,10 +2233,10 @@ for l in sys.stdin:
     a, b = row["a"], row["b"]
     if a % 2 == 0:
         out_row = {"a": a // 2, "struct": row}
-        os.write(1, json.dumps(out_row) + "\\n")
+        os.write(1, json.dumps(out_row).encode() + b"\\n")
     else:
         out_row = {"a": a // 2, "struct1": {"a1": a - 1}}
-        os.write(4, json.dumps(out_row) + "\\n")
+        os.write(4, json.dumps(out_row).encode() + b"\\n")
 """
         create("file", "//tmp/mapper.py")
         write_file("//tmp/mapper.py", mapper)
@@ -2255,7 +2255,7 @@ for l in sys.stdin:
     else:
         assert table_index == 1
         row["struct1"]["a1"] += 100
-    os.write(table_index * 3 + 1, json.dumps(row))
+    os.write(table_index * 3 + 1, json.dumps(row).encode())
 """
         create("file", "//tmp/reduce_combiner.py")
         write_file("//tmp/reduce_combiner.py", reduce_combiner)
@@ -2267,11 +2267,11 @@ for l in sys.stdin:
             in_="//tmp/t1",
             out="//tmp/t2",
             mapper_file=["//tmp/mapper.py"],
-            mapper_command="python mapper.py",
+            mapper_command="python3 mapper.py",
             reduce_combiner_file=["//tmp/reduce_combiner.py"],
-            reduce_combiner_command="cat" if cat_combiner else "python reduce_combiner.py",
+            reduce_combiner_command="cat" if cat_combiner else "python3 reduce_combiner.py",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=["a"],
             spec={
                 "mapper": {
@@ -2349,9 +2349,9 @@ for l in sys.stdin:
     row = json.loads(l)
     a, b = row["a"], row["b"]
     out_row = {"a": a, "struct": {"a": a**2, "b": str(a) * 3}}
-    os.write(1, json.dumps(out_row) + "\\n")
+    os.write(1, json.dumps(out_row).encode() + b"\\n")
     out_row = {"a": a, "struct": {"a": a**3, "b": str(a) * 5}}
-    os.write(4, json.dumps(out_row) + "\\n")
+    os.write(4, json.dumps(out_row).encode() + b"\\n")
 """
         create("file", "//tmp/mapper.py")
         write_file("//tmp/mapper.py", mapper)
@@ -2363,9 +2363,9 @@ for l in sys.stdin:
             in_="//tmp/t1",
             out="//tmp/t2",
             mapper_file=["//tmp/mapper.py"],
-            mapper_command="python mapper.py",
+            mapper_command="python3 mapper.py",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=[{"name": "a", "sort_order": sort_order}],
             spec={
                 "mapper": {
@@ -2440,7 +2440,7 @@ for l in sys.stdin:
             in_=["//tmp/in1", "//tmp/in2"],
             out="//tmp/out",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=[{"name": "a", "sort_order": sort_order}],
             spec={
                 "reducer": {"format": "json"},
@@ -2526,7 +2526,7 @@ for l in sys.stdin:
         }},
     }}
     out_row_1.update(key)
-    os.write(1, json.dumps(out_row_1) + "\\n")
+    os.write(1, json.dumps(out_row_1).encode() + b"\\n")
     out_row_2 = {{
         "struct1": {{
             "a1": a,
@@ -2534,7 +2534,7 @@ for l in sys.stdin:
         }},
     }}
     out_row_2.update(key)
-    os.write(4, json.dumps(out_row_2) + "\\n")
+    os.write(4, json.dumps(out_row_2).encode() + b"\\n")
 """
         create("file", "//tmp/mapper.py")
         write_file("//tmp/mapper.py", mapper.format(row_count=row_count).encode())
@@ -2578,9 +2578,9 @@ for l in sys.stdin:
             in_="//tmp/t1",
             out="//tmp/t2",
             mapper_file=["//tmp/mapper.py"],
-            mapper_command="python mapper.py",
+            mapper_command="python3 mapper.py",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=["key1", "key2", "key3"],
             spec={
                 "mapper": {
@@ -2729,7 +2729,7 @@ for l in sys.stdin:
             in_=["//tmp/in1", "//tmp/in2"],
             out="//tmp/out",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=["key1", "key2", "key3"],
             spec={
                 "reducer": {"format": "json"},
@@ -2777,7 +2777,7 @@ for l in sys.stdin:
                 out="//tmp/t2",
                 mapper_command="cat",
                 reducer_file=["//tmp/reducer.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 sort_by=sort_by,
                 spec={
                     "mapper": {
@@ -2853,7 +2853,7 @@ for l in sys.stdin:
                 in_=inputs,
                 out="//tmp/out",
                 reducer_file=["//tmp/reducer.py"],
-                reducer_command="python reducer.py",
+                reducer_command="python3 reducer.py",
                 sort_by=sort_by,
                 spec={
                     "reducer": {"format": "json"},
@@ -3198,7 +3198,7 @@ while True:
             in_=["//tmp/t_in1", "//tmp/t_in2"],
             out=["//tmp/t_out1", "//tmp/t_out2"],
             reduce_by="key",
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             reducer_file=["//tmp/reducer.py"],
             spec={
                 "reducer": {
@@ -3558,9 +3558,9 @@ for key, count in counts.items():
             in_="//tmp/t_in",
             out="//tmp/t_out",
             reduce_by="word",
-            mapper_command="python mapper.py",
+            mapper_command="python3 mapper.py",
             mapper_file=["//tmp/mapper.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             reducer_file=["//tmp/reducer.py"],
             spec={
                 "partition_count": 2,
@@ -3777,7 +3777,7 @@ for line in sys.stdin:
             out="//tmp/t_out",
             reduce_by=["x"],
             sort_by=sort_by,
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             reducer_file=["//tmp/reducer.py"],
             spec={
                 "sort_job_io": {

--- a/yt/yt/tests/integration/controller/test_reduce_operation.py
+++ b/yt/yt/tests/integration/controller/test_reduce_operation.py
@@ -2751,7 +2751,7 @@ for line in sys.stdin:
             in_="//tmp/in",
             out="//tmp/out",
             reduce_by="key",
-            command="python script.py",
+            command="python3 script.py",
             file="//tmp/script.py",
             spec={
                 "reducer": {"format": "json"},

--- a/yt/yt/tests/integration/dynamic_tables/test_map_reduce_over_dyntables.py
+++ b/yt/yt/tests/integration/dynamic_tables/test_map_reduce_over_dyntables.py
@@ -1009,10 +1009,10 @@ class MROverOrderedDynTablesHelper(YTEnvSetup):
 
         script = "\n".join(
             [
-                "#!/usr/bin/python",
+                "#!/usr/bin/env python3",
                 "import sys",
                 "import base64",
-                "print '{out=\"' + base64.standard_b64encode(sys.stdin.read()) + '\"}'",
+                "print('{out=\"' + base64.standard_b64encode(sys.stdin.buffer.read()).decode() + '\"}')",
             ]
         )
         create(b"file", b"//tmp/script.py", attributes={"executable": True})

--- a/yt/yt/tests/integration/formats/test_skiff_format.py
+++ b/yt/yt/tests/integration/formats/test_skiff_format.py
@@ -548,7 +548,7 @@ def read(n):
     bufs = []
     left = n
     while left > 0:
-        bufs.append(sys.stdin.read(left))
+        bufs.append(sys.stdin.buffer.read(left))
         left -= len(bufs[-1])
         if len(bufs[-1]) == 0:
             assert left == n or left == 0
@@ -569,8 +569,8 @@ while True:
     else:
         row["key1"] = one_key
         row["key2"] = another_key
-    sys.stderr.write(json.dumps(row) + b"\\n")
-    sys.stdout.write(json.dumps(row) + b"\\n")
+    sys.stderr.write(json.dumps(row) + "\\n")
+    sys.stdout.write(json.dumps(row) + "\\n")
 """
         create("file", "//tmp/reducer.py")
         write_file("//tmp/reducer.py", reducer)
@@ -591,7 +591,7 @@ while True:
             in_=["//tmp/in1", "//tmp/in2"],
             out="//tmp/out",
             reducer_file=["//tmp/reducer.py"],
-            reducer_command="python reducer.py",
+            reducer_command="python3 reducer.py",
             sort_by=["key1", "key2", "key3"],
             spec={
                 "reduce_job_io": {

--- a/yt/yt/tests/integration/node/test_dynamic_cpu_reclaim.py
+++ b/yt/yt/tests/integration/node/test_dynamic_cpu_reclaim.py
@@ -255,7 +255,7 @@ class TestNodeAbortsJobOnLackOfMemory(YTEnvSetup):
     @pytest.mark.skip(reason="Currently broken")
     def test_node_aborts_job_on_lack_of_memory(self):
         memory_consume_command = (
-            'python -c "import time\ncount = 100*1000*1000\nx = list(range(count))\ntime.sleep(1000)"'
+            'python3 -c "import time\ncount = 100*1000*1000\nx = list(range(count))\ntime.sleep(1000)"'
         )
         op1 = run_test_vanilla(
             with_breakpoint("BREAKPOINT; " + memory_consume_command, "Op1"),

--- a/yt/yt/tests/integration/node/test_jobs.py
+++ b/yt/yt/tests/integration/node/test_jobs.py
@@ -415,7 +415,7 @@ if job_index == 0:
             track=False,
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             job_count=job_count,
             spec={
                 "data_weight_per_job": 1,

--- a/yt/yt/tests/integration/node/test_user_job.py
+++ b/yt/yt/tests/integration/node/test_user_job.py
@@ -434,7 +434,7 @@ class TestSandboxTmpfs(YTEnvSetup):
         write_table("//tmp/t_input", {"foo": "bar"})
 
         op = map(
-            command="python -c 'import time; x = \"0\" * (200 * 1000 * 1000); time.sleep(2)'",
+            command="python3 -c 'import time; x = \"0\" * (200 * 1000 * 1000); time.sleep(2)'",
             in_="//tmp/t_input",
             out="//tmp/t_output",
             spec={
@@ -451,8 +451,7 @@ class TestSandboxTmpfs(YTEnvSetup):
         create("table", "//tmp/t_output")
         write_table("//tmp/t_input", {"foo": "bar"})
 
-        mapper = b"""
-#!/usr/bin/python
+        mapper = b"""#!/usr/bin/env python3
 
 import mmap, time
 
@@ -928,7 +927,7 @@ class TestSandboxTmpfsOverflow(YTEnvSetup):
                 "dd if=/dev/zero of=tmpfs_1/file  bs=1M  count=512; ls tmpfs_1/ >&2; "
                 "dd if=/dev/zero of=tmpfs_2/file  bs=1M  count=512; ls tmpfs_2/ >&2; "
                 "BREAKPOINT; "
-                "python -c 'import time; x = \"A\" * (200 * 1024 * 1024); time.sleep(100);'"
+                "python3 -c 'import time; x = \"A\" * (200 * 1024 * 1024); time.sleep(100);'"
             ),
             in_="//tmp/t_input",
             out="//tmp/t_output",
@@ -1524,7 +1523,7 @@ class TestJobStderr(YTEnvSetup):
         op = map(
             in_="//tmp/t1",
             out="//tmp/t2",
-            command='cat > /dev/null; python -c \'print("head" + "0" * 10000000); print("1" * 10000000 + "tail")\' >&2;',
+            command='cat > /dev/null; python3 -c \'print("head" + "0" * 10000000); print("1" * 10000000 + "tail")\' >&2;',
             spec={"max_failed_job_count": 1, "mapper": {"max_stderr_size": 1000000}},
         )
 
@@ -4006,7 +4005,7 @@ class TestCriJobStatistics(YTEnvSetup):
         write_table("//tmp/t_input", {"foo": "bar"})
 
         op = map(
-            command="python -c 'import time; x = \"X\" * (200 * 1000 * 1000); time.sleep(5)'",
+            command="python3 -c 'import time; x = \"X\" * (200 * 1000 * 1000); time.sleep(5)'",
             in_="//tmp/t_input",
             out="//tmp/t_output",
             spec={

--- a/yt/yt/tests/integration/proxies/proxy_format_config.py
+++ b/yt/yt/tests/integration/proxies/proxy_format_config.py
@@ -130,7 +130,7 @@ class _TestProxyFormatConfigBase(metaclass=ABCMeta):
             return yt.yson.dumps(data, yson_type=yson_type)
         elif format_name == "json":
             if tabular:
-                return b"\n".join(json.dumps(yt.yson.convert.yson_to_json(row)) for row in data)
+                return b"\n".join(json.dumps(yt.yson.convert.yson_to_json(row)).encode() for row in data)
             else:
                 return json.dumps(yt.yson.convert.yson_to_json(data))
         elif format_name == "yamr":

--- a/yt/yt/tests/integration/scheduler/test_scheduler_common.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_common.py
@@ -195,7 +195,7 @@ class TestSchedulerCommon(YTEnvSetup):
             track=False,
             in_="//tmp/t1",
             out="//tmp/t2",
-            command='python -c "import os; os.read(0, 1);"',
+            command='python3 -c "import os; os.read(0, 1);"',
             spec={"mapper": {"input_format": "dsv", "check_input_fully_consumed": True}, "max_failed_job_count": 2},
         )
 

--- a/yt/yt/tests/integration/scheduler/test_scheduler_job_tables.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_job_tables.py
@@ -400,7 +400,7 @@ class TestStderrTable(YTEnvSetup):
             map(
                 in_="//tmp/t_input",
                 out="//tmp/t_output",
-                command="""python -c 'import sys; s = "x" * (20 * 1024 * 1024) ; sys.stderr.write(s)'""",
+                command="""python3 -c 'import sys; s = "x" * (20 * 1024 * 1024) ; sys.stderr.write(s)'""",
                 spec={
                     "stderr_table_path": "//tmp/t_stderr",
                     "stderr_table_writer_config": {
@@ -420,7 +420,7 @@ class TestStderrTable(YTEnvSetup):
         map(
             in_="//tmp/t_input",
             out="//tmp/t_output",
-            command="""python -c 'import sys; s = "x" * (30 * 1024 * 1024) ; sys.stderr.write(s)'""",
+            command="""python3 -c 'import sys; s = "x" * (30 * 1024 * 1024) ; sys.stderr.write(s)'""",
             spec={
                 "stderr_table_path": "//tmp/t_stderr",
                 "stderr_table_writer_config": {
@@ -440,7 +440,7 @@ class TestStderrTable(YTEnvSetup):
         map(
             in_="//tmp/t_input",
             out="//tmp/t_output",
-            command="""python -c 'import sys; s = "x " * (30 * 1024 * 1024) ; sys.stderr.write(s)'""",
+            command="""python3 -c 'import sys; s = "x " * (30 * 1024 * 1024) ; sys.stderr.write(s)'""",
             spec=get_stderr_spec("//tmp/t_stderr"),
         )
         stderr_rows = read_table("//tmp/t_stderr", verbose=False)

--- a/yt/yt/tests/integration/scheduler/test_scheduler_operation_lifecycle.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_operation_lifecycle.py
@@ -1239,7 +1239,7 @@ class TestSchedulerProfilingOnOperationFinished(YTEnvSetup, PrepareTables):
             .at_scheduler(fixed_tags={"tree": "default", "pool": "unique_pool"})\
             .counter("scheduler/pools/metrics/metric_completed")
 
-        cmd = """python -c "import os; os.write(5, '{value_completed=117};')";"""
+        cmd = """python3 -c "import os; os.write(5, b'{value_completed=117};')";"""
         run_test_vanilla(cmd, spec={"pool": "unique_pool"})
 
         wait(lambda: metric_completed_counter.get() == 117)
@@ -1252,7 +1252,7 @@ class TestSchedulerProfilingOnOperationFinished(YTEnvSetup, PrepareTables):
             .at_scheduler(fixed_tags={"tree": "default", "pool": "unique_pool"}) \
             .counter("scheduler/pools/metrics/metric_failed")
 
-        cmd = """python -c "import os; os.write(5, '{value_failed=225};')"; exit 1"""
+        cmd = """python3 -c "import os; os.write(5, b'{value_failed=225};')"; exit 1"""
         op = run_test_vanilla(
             command=cmd,
             spec={"max_failed_job_count": 1, "pool": "unique_pool"},

--- a/yt/yt/tests/integration/scheduler/test_scheduler_pool_metrics.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_pool_metrics.py
@@ -123,7 +123,7 @@ class TestPoolMetrics(YTEnvSetup):
         # - writes something to stderr because we want to find our jobs in //sys/operations later
         map_cmd = (
             """for i in $(seq 10); do"""
-            """    python -c "import os; os.write(5, '{{value=$i}};')";"""
+            """    python3 -c "import os; os.write(5, b'{{value=$i}};')";"""
             """    dd if=/dev/urandom of={}/foo$i bs=1M count=1 oflag=direct;"""
             """    sync; sleep 0.5;"""
             """done;"""
@@ -494,7 +494,7 @@ class TestPoolMetrics(YTEnvSetup):
             output_format="json",
         )
 
-        map_cmd = """python -c 'import sys; import time; import json; row=json.loads(raw_input()); time.sleep(row["sleep"]); sys.exit(row["exit"])'"""
+        map_cmd = """python3 -c 'import sys; import time; import json; row=json.loads(input()); time.sleep(row["sleep"]); sys.exit(row["exit"])'"""
 
         profiler = profiler_factory().at_scheduler(fixed_tags={"tree": "default", "pool": "unique_pool"})
         total_time_counter = profiler.counter("scheduler/pools/metrics/total_time")
@@ -559,8 +559,8 @@ class TestPoolMetrics(YTEnvSetup):
         create("table", "//tmp/t_output")
         write_table("<append=%true>//tmp/t_input", {"foo": "bar"})
 
-        before_breakpoint = """for i in $(seq 10) ; do python -c "import os; os.write(5, '{value=$i};')" ; sleep 0.5 ; done ; sleep 5 ; """
-        after_breakpoint = """for i in $(seq 9 -1 5) ; do python -c "import os; os.write(5, '{value=$i};')" ; sleep 0.5 ; done ; cat ; sleep 5 ; echo done > /dev/stderr ; """
+        before_breakpoint = """for i in $(seq 10) ; do python3 -c "import os; os.write(5, b'{value=$i};')" ; sleep 0.5 ; done ; sleep 5 ; """
+        after_breakpoint = """for i in $(seq 9 -1 5) ; do python3 -c "import os; os.write(5, b'{value=$i};')" ; sleep 0.5 ; done ; cat ; sleep 5 ; echo done > /dev/stderr ; """
 
         profiler = profiler_factory().at_scheduler(fixed_tags={"tree": "default", "pool": "unique_pool"})
         total_time_counter = profiler.counter("scheduler/pools/metrics/total_time")

--- a/yt/yt/tests/integration/scheduler/test_scheduler_resource_limits.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_resource_limits.py
@@ -22,7 +22,7 @@ import builtins
 
 ###############################################################################################
 
-MEMORY_SCRIPT = """
+MEMORY_SCRIPT = """#!/usr/bin/env python3
 import time
 
 from random import randint
@@ -71,7 +71,7 @@ class TestSchedulerMemoryLimits(YTEnvSetup):
             track=False,
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python -c 'import time; a=[1]*100000000; time.sleep(10)'",
+            command="python3 -c 'import time; a=[1]*100000000; time.sleep(10)'",
             spec={"max_failed_job_count": 2, "mapper": {"memory_limit": 512 * 1024 * 1024}},
         )
 
@@ -85,7 +85,7 @@ class TestSchedulerMemoryLimits(YTEnvSetup):
             assert "Memory limit exceeded" in inner_error["message"]
             attributes = inner_error["attributes"]
             assert "processes" in attributes
-            expected_cmdline = ["python", "-c", "import time; a=[1]*100000000; time.sleep(10)"]
+            expected_cmdline = ["python3", "-c", "import time; a=[1]*100000000; time.sleep(10)"]
             assert expected_cmdline in builtins.map(lambda x: x["cmdline"], attributes["processes"])
 
     @authors("max42", "ignat")
@@ -138,7 +138,7 @@ class TestDisabledMemoryLimit(YTEnvSetup):
         map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python -c 'import time; a=[1]*1000000; time.sleep(10)'",
+            command="python3 -c 'import time; a=[1]*1000000; time.sleep(10)'",
             spec={"mapper": {"memory_limit": 1}},
         )
 
@@ -189,7 +189,7 @@ class TestMemoryReserveFactor(YTEnvSetup):
         op = map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             job_count=job_count,
             spec={
                 "resource_limits": {"cpu": 1},
@@ -269,7 +269,7 @@ class TestCumulativeMemoryStatistics(YTEnvSetup):
         op = map(
             in_="//tmp/t_in",
             out="//tmp/t_out",
-            command="python mapper.py",
+            command="python3 mapper.py",
             job_count=job_count,
             spec={
                 "resource_limits": {"cpu": 1},
@@ -355,7 +355,7 @@ class TestMemoryReserveMultiplier(YTEnvSetup):
 
         op = run_test_vanilla(
             track=True,
-            command="python mapper.py",
+            command="python3 mapper.py",
             job_count=1,
             spec={
                 "resource_limits": {"cpu": 1},
@@ -536,7 +536,7 @@ class TestResourceOverdraftAbort(YTEnvSetup):
         op_a = run_test_vanilla(
             track=False,
             command=with_breakpoint(
-                "python script_500.py & BREAKPOINT; python script_500.py",
+                "python3 script_500.py & BREAKPOINT; python3 script_500.py",
                 breakpoint_name="a",
             ),
             job_count=1,
@@ -567,7 +567,7 @@ class TestResourceOverdraftAbort(YTEnvSetup):
         op_b = run_test_vanilla(
             track=False,
             command=with_breakpoint(
-                "python script_500.py & BREAKPOINT; python script_500.py",
+                "python3 script_500.py & BREAKPOINT; python3 script_500.py",
                 breakpoint_name="b",
             ),
             job_count=1,

--- a/yt/yt/tests/integration/scheduler/test_scheduler_strategy.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_strategy.py
@@ -2741,7 +2741,7 @@ class TestSchedulerSuspiciousJobs(YTEnvSetup):
         # Jobs below are not suspicious, they are just stupid.
         op1 = map(
             track=False,
-            command='echo -ne "x = 1\nwhile True:\n    x = (x * x + 1) % 424243" | python',
+            command='echo -ne "x = 1\nwhile True:\n    x = (x * x + 1) % 424243" | python3',
             in_="//tmp/t",
             out="//tmp/t1",
         )


### PR DESCRIPTION
There is no reason to keep any python2 compatibility.
    
To be clear use conventional "#!/usr/bin/env python3" (which respects $PATH).
    
Migration is trivial:
- "python" -> "python3"
- "print" -> "print()"
- "raw_input()" -> "input()"
- "sys.stdin.read() -> "sys.stdin.buffer.read()"
    
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Get rid of python2 inside integration tests
Type: fix
Component: map-reduce

Better late than never.