### PR TITLE
Add option for CRI runtime endpoint in yt-local and integration tests

### DIFF
--- a/yt/python/yt/environment/helpers.py
+++ b/yt/python/yt/environment/helpers.py
@@ -477,14 +477,13 @@ def push_front_env_path(path):
 
 
 def find_cri_endpoint():
-    socket_path = "/run/containerd/containerd.sock"
-    endpoint = None
+    endpoint = os.getenv("CONTAINER_RUNTIME_ENDPOINT", "unix:///run/containerd/containerd.sock")
     try:
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.connect(socket_path)
-        endpoint = "unix://" + socket_path
+        sock.connect(endpoint.removeprefix("unix://"))
     except:  # noqa
-        logger.exception("CRI connection {} failed.".format(socket_path))
+        logger.exception("CRI connection {} failed".format(endpoint))
+        endpoint = None
     finally:
         sock.close()
     return endpoint

--- a/yt/python/yt/local/bin/yt_local
+++ b/yt/python/yt/local/bin/yt_local
@@ -212,6 +212,8 @@ def add_start_subparser(subparsers):
 
     parser.add_argument("--jobs-environment-type", type=str,
                         help="container environment for jobs: simple, porto, cri")
+    parser.add_argument("--cri-endpoint", type=str,
+                        help="CRI endpoint (default: unix:///run/containerd/containerd.sock) [$CONTAINER_RUNTIME_ENDPOINT]")
     parser.add_argument("--jobs-memory-limit", type=int,
                         help="memory limit for jobs in bytes")
     parser.add_argument("--jobs-cpu-limit", type=int,

--- a/yt/python/yt/local/commands.py
+++ b/yt/python/yt/local/commands.py
@@ -1,6 +1,12 @@
 from yt.environment import YTInstance
 from yt.environment.api import LocalYtConfig
-from yt.environment.helpers import wait_for_removing_file_lock, is_file_locked, is_dead, yatest_common
+from yt.environment.helpers import (
+    wait_for_removing_file_lock,
+    is_file_locked,
+    is_dead,
+    yatest_common,
+    find_cri_endpoint,
+)
 from yt.wrapper.constants import LOCAL_MODE_URL_PATTERN
 from yt.wrapper.common import generate_uuid, GB, MB
 from yt.common import YtError, require, is_process_alive, get_fqdn
@@ -153,6 +159,7 @@ def start(master_count=1,
           path=None,
           prepare_only=False,
           jobs_environment_type=None,
+          cri_endpoint=None,
           jobs_memory_limit=None,
           jobs_cpu_limit=None,
           jobs_user_slot_count=None,
@@ -222,6 +229,9 @@ def start(master_count=1,
         },
     }
 
+    if jobs_environment_type == "cri" and cri_endpoint is None:
+        cri_endpoint = find_cri_endpoint()
+
     yt_config = LocalYtConfig(
         master_count=master_count,
         clock_count=clock_count,
@@ -268,6 +278,7 @@ def start(master_count=1,
         log_compression_method=log_compression_method,
         port_range_start=port_range_start,
         jobs_environment_type=jobs_environment_type,
+        cri_endpoint=cri_endpoint,
         use_slot_user_id=False,
         jobs_resource_limits=jobs_resource_limits,
         node_port_set_size=node_port_set_size,


### PR DESCRIPTION
Get default from environment $CONTAINER_RUNTIME_ENDPOINT (as crictl does).

This is required for migrating to CRI-O.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.
