### PR TITLE
Add docker image id into TCriImageDescriptor

### DIFF
--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -24,19 +24,24 @@ using namespace NConcurrency;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+constexpr size_t AbbreviatedIdLength = 16;
+
 void FormatValue(TStringBuilderBase* builder, const TCriDescriptor& descriptor, TStringBuf /*spec*/)
 {
-    builder->AppendFormat("%v (%s)", descriptor.Id.substr(0, 12), descriptor.Name);
+    builder->AppendFormat("%v (%v)", descriptor.Id.substr(0, AbbreviatedIdLength), descriptor.Name);
 }
 
 void FormatValue(TStringBuilderBase* builder, const TCriPodDescriptor& descriptor, TStringBuf /*spec*/)
 {
-    builder->AppendFormat("%v (%s)", descriptor.Id.substr(0, 12), descriptor.Name);
+    builder->AppendFormat("%v (%s)", descriptor.Id.substr(0, AbbreviatedIdLength), descriptor.Name);
 }
 
 void FormatValue(TStringBuilderBase* builder, const TCriImageDescriptor& descriptor, TStringBuf /*spec*/)
 {
     builder->AppendString(descriptor.Image);
+    if (!descriptor.Id.empty()) {
+        builder->AppendFormat(" id=%v", descriptor.Id.substr(0, AbbreviatedIdLength));
+    }
 }
 
 static TError DecodeExitCode(int exitCode, const TString& reason)
@@ -705,7 +710,8 @@ private:
 
     void FillImageSpec(NProto::ImageSpec* spec, const TCriImageDescriptor& image)
     {
-        spec->set_image(image.Image);
+        spec->set_image(image.Id.empty() ? image.Image : image.Id);
+        spec->set_user_specified_image(image.Image);
     }
 
     void FillAuthConfig(NProto::AuthConfig* auth, const TCriAuthConfig& authConfig)

--- a/yt/yt/library/containers/cri/cri_executor.h
+++ b/yt/yt/library/containers/cri/cri_executor.h
@@ -27,6 +27,7 @@ struct TCriPodDescriptor
 struct TCriImageDescriptor
 {
     TString Image;
+    TString Id;
 };
 
 void FormatValue(TStringBuilderBase* builder, const TCriDescriptor& descriptor, TStringBuf spec);

--- a/yt/yt/library/containers/cri/image_cache.cpp
+++ b/yt/yt/library/containers/cri/image_cache.cpp
@@ -7,22 +7,21 @@ namespace NYT::NContainers::NCri {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TCriImageCacheEntry::TCriImageCacheEntry(TCriImageDescriptor imageId, TCriImageDescriptor imageName, i64 imageSize)
-    : TAsyncCacheValueBase(imageId.Image)
-    , ImageName_(std::move(imageName))
-    , ImageId_(std::move(imageId))
+TCriImageCacheEntry::TCriImageCacheEntry(TCriImageDescriptor image, i64 imageSize)
+    : TAsyncCacheValueBase(image.Id)
+    , Image_(std::move(image))
     , ImageSize_(imageSize)
 {
     SetLastUsageTime(TInstant::Now());
 }
 
-TCriImageCacheEntry::TCriImageCacheEntry(TCriImageDescriptor imageAlias, TCriImageCacheEntryPtr entry)
-    : TAsyncCacheValueBase(imageAlias.Image)
-    , ImageName_(std::move(imageAlias))
-    , ImageId_(entry->ImageId())
-    , ImageSize_(entry->GetImageSize())
-    , Parent_(std::move(entry))
+TCriImageCacheEntry::TCriImageCacheEntry(TCriImageDescriptor image, TCriImageCacheEntryPtr parent)
+    : TAsyncCacheValueBase(image.Image)
+    , Image_(std::move(image))
+    , ImageSize_(parent->GetImageSize())
+    , Parent_(std::move(parent))
 {
+    YT_VERIFY(Image_.Id == Parent_->Image_.Id);
     SetLastUsageTime(TInstant::Now());
 
     auto guard = Guard(Parent_->SpinLock_);
@@ -141,18 +140,18 @@ public:
         }
 
         return Executor_->GetImageStatus(image)
-            .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TCriImageApi::TRspImageStatusPtr& imageStatus) {
+            .Apply(BIND([this, this_ = MakeStrong(this), image = image] (
+                const TCriImageApi::TRspImageStatusPtr& imageStatus) mutable
+            {
                 if (!imageStatus->has_image()) {
                     return MakeFuture<TCriImageCacheEntryPtr>(TError("Docker image not found in cache (Image: %v)", image));
                 }
                 auto protoImage = imageStatus->image();
-                TCriImageDescriptor imageId{.Image = protoImage.id()};
                 if (!IsManagedImage(image)) {
-                    auto entry = New<TCriImageCacheEntry>(imageId, image, protoImage.size());
-                    YT_LOG_DEBUG("Unmanaged docker image found in cache (Image: %v, ImageId: %v)",
-                        image,
-                        imageId);
-                    return MakeFuture(entry);
+                    image.Id = protoImage.id();
+                    YT_LOG_DEBUG("Unmanaged docker image found in cache (Image: %v)", image);
+                    auto entry = New<TCriImageCacheEntry>(std::move(image), protoImage.size());
+                    return MakeFuture(std::move(entry));
                 }
                 auto cookie = BeginInsert(image.Image);
                 auto imageFuture = cookie.GetValue();
@@ -168,14 +167,12 @@ public:
         if (!IsManagedImage(image)) {
             // Bypass cache for unmanaged images.
             return Executor_->GetImageStatus(image)
-                .Apply(BIND([=] (const TCriImageApi::TRspImageStatusPtr& imageStatus) {
+                .Apply(BIND([image = image] (const TCriImageApi::TRspImageStatusPtr& imageStatus) mutable {
                     if (imageStatus->has_image()) {
                         auto protoImage = imageStatus->image();
-                        TCriImageDescriptor imageId{.Image = protoImage.id()};
-                        YT_LOG_DEBUG("Unmanaged docker image found in cache (Image: %v, ImageId: %v)",
-                            image,
-                            imageId);
-                        return New<TCriImageCacheEntry>(imageId, image, protoImage.size());
+                        image.Id = protoImage.id();
+                        YT_LOG_DEBUG("Unmanaged docker image found in cache (Image: %v)", image);
+                        return New<TCriImageCacheEntry>(std::move(image), protoImage.size());
                     } else {
                         THROW_ERROR_EXCEPTION("Unmanaged docker image not found in cache (Image: %v)",
                             image);
@@ -219,16 +216,13 @@ public:
                 return Executor_->GetImageStatus(image)
                     .Apply(BIND([=, this, this_ = MakeStrong(this), entry = std::move(entryOrError->Value())] (
                                 const TCriImageApi::TRspImageStatusPtr& imageStatus) mutable {
-                        if (!imageStatus->has_image()) {
-                            YT_LOG_DEBUG("Docker image was removed externally (Image: %v, ImageId: %v)",
-                                image,
-                                imageStatus->image().id());
+                        if (!imageStatus->has_image() || imageStatus->image().id() != entry->Image().Id) {
+                            YT_LOG_DEBUG("Docker image was removed externally (Image: %v)", entry->Image());
                             TryRemove(image.Image, /*forbidResurrection*/ true);
                             return PullImage(image, std::move(authConfig), pullPolicy);
                         }
-                        YT_LOG_DEBUG("Docker image found in cache (Image: %v, ImageId: %v, LastPullTime: %v, LastUsageTime: %v)",
-                            entry->ImageName(),
-                            entry->ImageId(),
+                        YT_LOG_DEBUG("Docker image found in cache (Image: %v, LastPullTime: %v, LastUsageTime: %v)",
+                            entry->Image(),
                             entry->GetLastPullTime(),
                             entry->GetLastUsageTime());
                         TouchImage(entry);
@@ -268,13 +262,15 @@ public:
                     image,
                     bool(authConfig));
                 return Executor_->PullImage(image, authConfig)
-                    .Apply(BIND([=, this, this_ = MakeStrong(this)] (const TCriImageApi::TRspPullImagePtr& result) {
-                        auto imageId = TCriImageDescriptor{.Image = result->image_ref()};
-                        return Executor_->GetImageStatus(imageId);
+                    .Apply(BIND([this, this_ = MakeStrong(this), image = image] (
+                        const TCriImageApi::TRspPullImagePtr& result) mutable
+                    {
+                        image.Id = result->image_ref();
+                        return Executor_->GetImageStatus(image);
                     }));
             }))
-            .Apply(BIND([=, this, this_ = MakeStrong(this), cookie = std::move(cookie)] (
-                        const TErrorOr<TCriImageApi::TRspImageStatusPtr>& imageStatusOrError) mutable
+            .Apply(BIND([this, this_ = MakeStrong(this), cookie = std::move(cookie), image = image] (
+                const TErrorOr<TCriImageApi::TRspImageStatusPtr>& imageStatusOrError) mutable
             {
                 if (!imageStatusOrError.IsOK()) {
                     YT_LOG_DEBUG(imageStatusOrError,
@@ -288,10 +284,8 @@ public:
                     THROW_ERROR_EXCEPTION("Docker image is not found in cache after pull");
                 }
                 auto& protoImage = imageStatus->image();
-                auto imageId = TCriImageDescriptor{.Image = protoImage.id()};
-                YT_LOG_DEBUG("Docker image pull finished (Image: %v, ImageId: %v)",
-                    image,
-                    imageId);
+                image.Id = protoImage.id();
+                YT_LOG_DEBUG("Docker image pull finished (Image: %v)", image);
                 auto imageFuture = cookie.GetValue();
                 DoInsertImage(cookie, protoImage, /*pullTime*/ TInstant::Now());
                 return imageFuture;
@@ -319,44 +313,47 @@ private:
 
     void DoInsertImage(TInsertCookie& cookie, const NCri::NProto::Image& protoImage, TInstant pullTime = TInstant::Zero())
     {
-        TCriImageDescriptor imageName{.Image = cookie.GetKey()};
-        TCriImageDescriptor imageId{.Image = protoImage.id()};
+        TCriImageDescriptor image{
+            .Image = cookie.GetKey(),
+            .Id = protoImage.id(),
+        };
         i64 imageSize = protoImage.size();
         bool pinned = false;
 
-        for (const auto& image : Config_->PinnedImages) {
-            if (image == imageName.Image) {
+        for (const auto& pinnedImage : Config_->PinnedImages) {
+            if (pinnedImage == image.Image) {
                 pinned = true;
                 break;
             }
         }
 
-        if (imageName.Image == imageId.Image) {
-            auto imageEntry = New<TCriImageCacheEntry>(imageId, imageId, imageSize);
+        if (image.Image == image.Id) {
+            auto imageEntry = New<TCriImageCacheEntry>(std::move(image), imageSize);
             cookie.EndInsert(std::move(imageEntry));
-        } else {
-            cookie.UpdateWeight(0);
-            auto imageCookie = BeginInsert(imageId.Image, imageSize);
-            if (imageCookie.IsActive()) {
-                auto imageEntry = New<TCriImageCacheEntry>(imageId, imageName, imageSize);
-                imageEntry->SetLastPullTime(pullTime);
-                imageCookie.EndInsert(std::move(imageEntry));
-            }
-            auto imageFuture = imageCookie.GetValue();
-            imageFuture.Subscribe(BIND([=, cookie = std::move(cookie)] (
-                        const TErrorOr<TCriImageCacheEntryPtr>& entryOrError) mutable
-            {
-                if (entryOrError.IsOK()) {
-                    auto& imageEntry = entryOrError.Value();
-                    auto aliasEntry = New<TCriImageCacheEntry>(imageName, imageEntry);
-                    aliasEntry->SetPinned(pinned);
-                    aliasEntry->SetLastPullTime(pullTime);
-                    cookie.EndInsert(std::move(aliasEntry));
-                } else {
-                    cookie.Cancel(entryOrError);
-                }
-            }));
+            return;
         }
+
+        cookie.UpdateWeight(0);
+        auto imageCookie = BeginInsert(image.Id, imageSize);
+        if (imageCookie.IsActive()) {
+            auto imageEntry = New<TCriImageCacheEntry>(image, imageSize);
+            imageEntry->SetLastPullTime(pullTime);
+            imageCookie.EndInsert(std::move(imageEntry));
+        }
+        auto imageFuture = imageCookie.GetValue();
+        imageFuture.Subscribe(BIND([=, cookie = std::move(cookie), image = std::move(image)] (
+            const TErrorOr<TCriImageCacheEntryPtr>& entryOrError) mutable
+        {
+            if (entryOrError.IsOK()) {
+                auto& imageEntry = entryOrError.Value();
+                auto aliasEntry = New<TCriImageCacheEntry>(std::move(image), imageEntry);
+                aliasEntry->SetPinned(pinned);
+                aliasEntry->SetLastPullTime(pullTime);
+                cookie.EndInsert(std::move(aliasEntry));
+            } else {
+                cookie.Cancel(entryOrError);
+            }
+        }));
     }
 
     TFuture<void> DoRemoveImage(TCriImageCacheEntryPtr entry)
@@ -367,9 +364,8 @@ private:
 
         // FIXME(khlebnikov): Remove sequence is slightly racy, should be ok for real life cases.
         if (entry->HasAliases() || Find(entry->GetKey())) {
-            YT_LOG_DEBUG("Retain docker image (Image: %v, ImageId: %v, ImageSize: %v, LastPullTime: %v, LastUsageTime: %v)",
-                entry->ImageName(),
-                entry->ImageId(),
+            YT_LOG_DEBUG("Retain docker image (Image: %v, ImageSize: %v, LastPullTime: %v, LastUsageTime: %v)",
+                entry->Image(),
                 entry->GetImageSize(),
                 entry->GetLastPullTime(),
                 entry->GetLastUsageTime());
@@ -380,26 +376,20 @@ private:
             return VoidFuture;
         }
 
-        YT_LOG_DEBUG("Removing docker image (Image: %v, ImageId: %v, ImageSize: %v, LastPullTime: %v, LastUsageTime: %v)",
-            entry->ImageName(),
-            entry->ImageId(),
+        YT_LOG_DEBUG("Removing docker image (Image: %v, ImageSize: %v, LastPullTime: %v, LastUsageTime: %v)",
+            entry->Image(),
             entry->GetImageSize(),
             entry->GetLastPullTime(),
             entry->GetLastUsageTime());
 
         TryRemoveValue(entry, /*forbidResurrection*/ true);
 
-        return Executor_->RemoveImage(entry->ImageId())
+        return Executor_->RemoveImage(entry->Image())
             .Apply(BIND([entry = std::move(entry)] (const TError& error) {
                 if (error.IsOK()) {
-                    YT_LOG_DEBUG("Docker image removed (Image: %v, ImageId: %v)",
-                        entry->ImageName(),
-                        entry->ImageId());
+                    YT_LOG_DEBUG("Docker image removed (Image: %v)", entry->Image());
                 } else {
-                    YT_LOG_WARNING(error,
-                        "Cannot remove docker image (Image: %v, ImageId: %v)",
-                        entry->ImageName(),
-                        entry->ImageId());
+                    YT_LOG_WARNING(error, "Cannot remove docker image (Image: %v)", entry->Image());
                 }
                 return error;
             }));
@@ -440,13 +430,11 @@ protected:
     void OnAdded(const TValuePtr& entry) override
     {
         if (entry->IsAlias()) {
-            YT_LOG_DEBUG("Docker image alias is added into cache (Image: %v, ImageId: %v)",
-                entry->ImageName(),
-                entry->ImageId());
+            YT_LOG_DEBUG("Docker image alias is added into cache (Image: %v)",
+                entry->Image());
         } else {
-            YT_LOG_DEBUG("Docker image entry is added into cache (Image: %v, ImageId: %v, ImageSize: %v)",
-                entry->ImageName(),
-                entry->ImageId(),
+            YT_LOG_DEBUG("Docker image entry is added into cache (Image: %v, ImageSize: %v)",
+                entry->Image(),
                 entry->GetImageSize());
             CacheSize_ += entry->GetImageSize();
         }
@@ -455,15 +443,13 @@ protected:
     void OnRemoved(const TValuePtr& entry) override
     {
         if (entry->IsAlias()) {
-            YT_LOG_DEBUG("Docker image alias is removed from cache (Image: %v, ImageId: %v, LastPullTime: %v, LastUsageTime: %v)",
-                entry->ImageName(),
-                entry->ImageId(),
+            YT_LOG_DEBUG("Docker image alias is removed from cache (Image: %v, LastPullTime: %v, LastUsageTime: %v)",
+                entry->Image(),
                 entry->GetLastPullTime(),
                 entry->GetLastUsageTime());
         } else {
-            YT_LOG_DEBUG("Docker image entry is removed from cache (Image: %v, ImageId: %v, ImageSize: %v, LastPullTime: %v, LastUsageTime: %v)",
-                entry->ImageName(),
-                entry->ImageId(),
+            YT_LOG_DEBUG("Docker image entry is removed from cache (Image: %v, ImageSize: %v, LastPullTime: %v, LastUsageTime: %v)",
+                entry->Image(),
                 entry->GetImageSize(),
                 entry->GetLastPullTime(),
                 entry->GetLastUsageTime());

--- a/yt/yt/library/containers/cri/image_cache.h
+++ b/yt/yt/library/containers/cri/image_cache.h
@@ -12,15 +12,18 @@ class TCriImageCacheEntry
     , private TIntrusiveListItem<TCriImageCacheEntry>
 {
 public:
-    TCriImageCacheEntry(TCriImageDescriptor imageId, TCriImageDescriptor imageName, i64 imageSize);
-    TCriImageCacheEntry(TCriImageDescriptor imageAlias, TCriImageCacheEntryPtr entry);
+    // Image entry identified by Id.
+    TCriImageCacheEntry(TCriImageDescriptor image, i64 imageSize);
+
+    // Alias image entry identified by Image name with tag or digest.
+    TCriImageCacheEntry(TCriImageDescriptor image, TCriImageCacheEntryPtr parent);
+
     ~TCriImageCacheEntry();
 
     bool IsAlias() const;
     bool HasAliases() const;
 
-    DEFINE_BYREF_RO_PROPERTY_NO_INIT(TCriImageDescriptor, ImageName);
-    DEFINE_BYREF_RO_PROPERTY_NO_INIT(TCriImageDescriptor, ImageId);
+    DEFINE_BYREF_RO_PROPERTY_NO_INIT(TCriImageDescriptor, Image);
     DEFINE_BYVAL_RO_PROPERTY_NO_INIT(i64, ImageSize);
     DEFINE_BYREF_RO_PROPERTY_NO_INIT(TCriImageCacheEntryPtr, Parent);
 

--- a/yt/yt/server/lib/job_proxy/config.h
+++ b/yt/yt/server/lib/job_proxy/config.h
@@ -347,6 +347,9 @@ struct TJobProxyInternalConfig
     //! Docker image to build root volume as part of a container.
     std::optional<TString> DockerImage;
 
+    //! Docker image id in local cache.
+    std::optional<TString> DockerImageId;
+
     // COMPAT(artemagafonov): RootFS is always writable, so the flag should be removed after the update of all nodes.
     bool MakeRootFSWritable;
 

--- a/yt/yt/server/node/exec_node/job.cpp
+++ b/yt/yt/server/node/exec_node/job.cpp
@@ -2404,6 +2404,7 @@ void TJob::OnWorkspacePreparationFinished(const TErrorOr<TJobWorkspaceBuildingRe
             GpuCheckVolume_ = result.GpuCheckVolume;
             // Workspace builder may add or replace docker image.
             DockerImage_ = result.DockerImage;
+            DockerImageId_ = result.DockerImageId;
             SetupCommandCount_ = result.SetupCommandCount;
 
             THROW_ERROR_EXCEPTION_IF_FAILED(
@@ -3003,6 +3004,7 @@ TJobProxyInternalConfigPtr TJob::CreateConfig()
     } else {
         // Pass docker image if root volume is not materialized yet.
         proxyInternalConfig->DockerImage = DockerImage_;
+        proxyInternalConfig->DockerImageId = DockerImageId_;
     }
 
     if (RootVolume_ || DockerImage_) {

--- a/yt/yt/server/node/exec_node/job.h
+++ b/yt/yt/server/node/exec_node/job.h
@@ -383,6 +383,7 @@ private:
     std::vector<NDataNode::TArtifactKey> RootVolumeLayerArtifactKeys_;
     std::vector<NDataNode::TArtifactKey> GpuCheckVolumeLayerArtifactKeys_;
     std::optional<TString> DockerImage_;
+    std::optional<TString> DockerImageId_;
 
     std::optional<TVirtualSandboxData> VirtualSandboxData_;
 

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1205,6 +1205,7 @@ private:
         // Run job proxy in docker image specified for the job.
         // For now CRI job-environment does not isolate user jobs from job proxy.
         spec->Image.Image = config->DockerImage.value_or(ConcreteConfig_->JobProxyImage);
+        spec->Image.Id = config->DockerImageId.value_or("");
 
         spec->Labels[YTJobIdLabel] = ToString(jobId);
 

--- a/yt/yt/server/node/exec_node/job_workspace_builder.cpp
+++ b/yt/yt/server/node/exec_node/job_workspace_builder.cpp
@@ -731,15 +731,16 @@ private:
                         YT_LOG_WARNING(imageOrError, "Failed to prepare root volume (Image: %v)", imageDescriptor);
 
                         THROW_ERROR_EXCEPTION(NExecNode::EErrorCode::DockerImagePullingFailed, "Failed to pull docker image")
-                            << TErrorAttribute("docker_image", *dockerImage)
+                            << TErrorAttribute("docker_image", imageDescriptor.Image)
                             << TErrorAttribute("authenticated", authenticated)
                             << imageOrError;
                     }
 
-                    const auto& imageId = imageOrError.Value()->ImageId();
-                    YT_LOG_INFO("Root volume prepared (ImageId: %v)", imageId);
+                    const auto& cachedImage = imageOrError.Value()->Image();
+                    YT_LOG_INFO("Root volume prepared (Image: %v)", cachedImage);
 
-                    ResultHolder_.DockerImage = imageId.Image;
+                    ResultHolder_.DockerImage = cachedImage.Image;
+                    ResultHolder_.DockerImageId = cachedImage.Id;
 
                     SetNowTime(TimePoints_.PrepareRootVolumeFinishTime);
                 }));

--- a/yt/yt/server/node/exec_node/job_workspace_builder.h
+++ b/yt/yt/server/node/exec_node/job_workspace_builder.h
@@ -66,6 +66,7 @@ struct TJobWorkspaceBuildingResult
     IVolumePtr RootVolume;
     IVolumePtr GpuCheckVolume;
     std::optional<TString> DockerImage;
+    std::optional<TString> DockerImageId;
     std::vector<TString> TmpfsPaths;
     std::vector<NContainers::TBind> RootBinds;
     int SetupCommandCount = 0;


### PR DESCRIPTION
Modern CRI-O requires both original docker image reference and its local id.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type: feature
Component: map-reduce

Allow to use CRI-O for CRI job environment
