### PR TITLE
Retry CRI container remove if it is starting

### DIFF
--- a/yt/yt/library/containers/cri/config.cpp
+++ b/yt/yt/library/containers/cri/config.cpp
@@ -1,6 +1,8 @@
 #include "config.h"
 #include "cri_api.h"
 
+#include <yt/yt/library/re2/re2.h>
+
 namespace NYT::NContainers::NCri {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,6 +37,9 @@ void TCriExecutorConfig::Register(TRegistrar registrar)
             // https://github.com/containerd/containerd/issues/9160
             "failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to create new parent process: namespace path: lstat /proc/0/ns/ipc: no such file or directory: unknown",
         });
+
+    registrar.Parameter("retry_error_pattern", &TThis::RetryErrorPattern)
+        .DefaultNew("^failed to set removing state for container .*: container is in starting state, can't be removed");
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/library/containers/cri/config.h
+++ b/yt/yt/library/containers/cri/config.h
@@ -6,6 +6,8 @@
 
 #include <yt/yt/core/rpc/config.h>
 
+#include <yt/yt/library/re2/public.h>
+
 namespace NYT::NContainers::NCri {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -37,6 +39,9 @@ struct TCriExecutorConfig
 
     //! Retry requests on generic error with these message prefixes.
     std::vector<std::string> RetryErrorPrefixes;
+
+    //! Retry requests on generic error with matched message.
+    NRe2::TRe2Ptr RetryErrorPattern;
 
     REGISTER_YSON_STRUCT(TCriExecutorConfig);
 

--- a/yt/yt/library/containers/cri/ya.make
+++ b/yt/yt/library/containers/cri/ya.make
@@ -6,6 +6,7 @@ PEERDIR(
     yt/yt/core
     yt/yt/core/rpc/grpc
     yt/yt/contrib/cri-api
+    yt/yt/library/re2
 )
 
 SRCS(


### PR DESCRIPTION
Workaround for containerd design flaw.
Match error using regex because prefix matching isn't specific enough.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type: fix
Component: map-reduce

Retry CRI container remove, workaround for containerd design flaw.
