### PR TITLE
Add controller agent config flag "translate_internal_images_into_layers"

### DIFF
--- a/yt/yt/server/controller_agent/config.cpp
+++ b/yt/yt/server/controller_agent/config.cpp
@@ -699,6 +699,13 @@ void TDockerRegistryConfig::Register(TRegistrar registrar)
         .Default(false);
     registrar.Parameter("forward_internal_images_to_job_specs", &TThis::ForwardInternalImagesToJobSpecs)
         .Default(false);
+    registrar.Parameter("translate_internal_images_into_layers", &TThis::TranslateInternalImagesIntoLayers)
+        .Default(true);
+    registrar.Postprocessor([&] (TDockerRegistryConfig* options) {
+        if (!options->TranslateInternalImagesIntoLayers && !options->ForwardInternalImagesToJobSpecs) {
+            THROW_ERROR_EXCEPTION("At least one of forward_internal_images_to_job_specs or translate_internal_images_into_layers must be enabled");
+        }
+    });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/controller_agent/config.h
+++ b/yt/yt/server/controller_agent/config.h
@@ -761,6 +761,8 @@ struct TDockerRegistryConfig
 
     bool ForwardInternalImagesToJobSpecs = false;
 
+    bool TranslateInternalImagesIntoLayers = true;
+
     REGISTER_YSON_STRUCT(TDockerRegistryConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -11239,7 +11239,7 @@ std::vector<TRichYPath> TOperationControllerBase::GetLayerPaths(
         TDockerImageSpec dockerImage(*userJobSpec->DockerImage, Config->DockerRegistry);
 
         // External docker images are not compatible with any additional layers.
-        if (!dockerImage.IsInternal()) {
+        if (!dockerImage.IsInternal() || !Config->DockerRegistry->TranslateInternalImagesIntoLayers) {
             return {};
         }
 


### PR DESCRIPTION
Allows to disable translation from docker image into layers when
- exec nodes are unable to handle them correctly
- internal registry does not provide correct metadata

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

<Your description.>

