### PR TITLE
Refactor block device I/O statistics

### DIFF
--- a/yt/yt/core/misc/fs.cpp
+++ b/yt/yt/core/misc/fs.cpp
@@ -21,6 +21,7 @@
 #if defined(_unix_)
     #include <sys/mount.h>
     #include <sys/stat.h>
+    #include <sys/types.h>
     #include <fcntl.h>
 #endif
 
@@ -28,8 +29,8 @@
     #include <mntent.h>
     #include <sys/vfs.h>
     #include <sys/quota.h>
-    #include <sys/types.h>
     #include <sys/sendfile.h>
+    #include <sys/sysmacros.h>
 #elif defined(_freebsd_) || defined(_darwin_)
     #include <sys/param.h>
     #include <sys/mount.h>
@@ -383,7 +384,7 @@ TPathStatistics GetPathStatistics(const TString& path)
     statistics.ModificationTime = TInstant::Seconds(fileStat.st_mtime);
     statistics.AccessTime = TInstant::Seconds(fileStat.st_atime);
     statistics.INode = fileStat.st_ino;
-    statistics.DeviceId = fileStat.st_dev;
+    statistics.DeviceId = {major(fileStat.st_dev), minor(fileStat.st_dev)};
 
     return statistics;
 #else
@@ -1158,10 +1159,11 @@ TError AttachFindOutput(TError error, const TString& path)
         << TErrorAttribute("find_output", findOutput);
 }
 
-int GetDeviceId(const TString& path)
+TDeviceId GetDeviceId(const TString& path)
 {
 #ifdef _linux_
-    return Stat(path).st_dev;
+    auto deviceId = Stat(path).st_dev;
+    return {major(deviceId), minor(deviceId)};
 #else
     Y_UNUSED(path);
     YT_UNIMPLEMENTED();

--- a/yt/yt/core/misc/fs.h
+++ b/yt/yt/core/misc/fs.h
@@ -105,11 +105,16 @@ TDiskSpaceStatistics GetDiskSpaceStatistics(const TString& path);
 //! Creates the #path and parent directories if they don't exists.
 void MakeDirRecursive(const TString& path, int mode = 0777);
 
+constexpr ui32 UnnamedDeviceMajor = 0;
+
+//! Device major:minor pair.
+using TDeviceId = std::pair<ui32, ui32>;
+
 struct TPathStatistics
 {
     i64 Size = -1;
     ui64 INode;
-    int DeviceId;
+    TDeviceId DeviceId;
     TInstant ModificationTime;
     TInstant AccessTime;
 };
@@ -234,8 +239,8 @@ void Splice(
 TError AttachLsofOutput(TError error, const TString& path);
 TError AttachFindOutput(TError error, const TString& path);
 
-//! Returns id of device path belongs to.
-int GetDeviceId(const TString& path);
+//! Returns id of device (major:minor) path belongs to.
+TDeviceId GetDeviceId(const TString& path);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/core/misc/proc.cpp
+++ b/yt/yt/core/misc/proc.cpp
@@ -1533,55 +1533,6 @@ static bool TryParseField(const TVector<TString>& fields, int index, TDuration& 
     return false;
 }
 
-TDiskStat ParseDiskStat(const TString& statLine)
-{
-    auto buffer = SplitString(statLine, " ");
-    TDiskStat result;
-    TryParseField(buffer, 0, result.MajorNumber);
-    TryParseField(buffer, 1, result.MinorNumber);
-    TryParseField(buffer, 2, result.DeviceName);
-    TryParseField(buffer, 3, result.ReadsCompleted);
-    TryParseField(buffer, 4, result.ReadsMerged);
-    TryParseField(buffer, 5, result.SectorsRead);
-    TryParseField(buffer, 6, result.TimeSpentReading);
-    TryParseField(buffer, 7, result.WritesCompleted);
-    TryParseField(buffer, 8, result.WritesMerged);
-    TryParseField(buffer, 9, result.SectorsWritten);
-    TryParseField(buffer, 10, result.TimeSpentWriting);
-    TryParseField(buffer, 11, result.IOCurrentlyInProgress);
-    TryParseField(buffer, 12, result.TimeSpentDoingIO);
-    TryParseField(buffer, 13, result.WeightedTimeSpentDoingIO);
-    TryParseField(buffer, 14, result.DiscardsCompleted);
-    TryParseField(buffer, 15, result.DiscardsMerged);
-    TryParseField(buffer, 16, result.SectorsDiscarded);
-    TryParseField(buffer, 17, result.TimeSpentDiscarding);
-    return result;
-}
-
-THashMap<TString, TDiskStat> GetDiskStats()
-{
-#ifdef _linux_
-    THashMap<TString, TDiskStat> result;
-    static const TString path("/proc/diskstats");
-    TFileInput diskStatsFile(path);
-    auto data = diskStatsFile.ReadAll();
-    auto lines = SplitString(data, "\n");
-
-    for (const auto& line : lines) {
-        auto strippedLine = Strip(line);
-        if (strippedLine.empty()) {
-            continue;
-        }
-        auto parsed = ParseDiskStat(line);
-        result[parsed.DeviceName] = parsed;
-    }
-
-    return result;
-#else
-    return {};
-#endif
-}
-
 TBlockDeviceStat ParseBlockDeviceStat(const TString& statLine)
 {
     auto buffer = SplitString(statLine, " ");

--- a/yt/yt/core/misc/proc.h
+++ b/yt/yt/core/misc/proc.h
@@ -8,6 +8,8 @@
 
 #include <util/system/file.h>
 
+#include <yt/yt/core/misc/fs.h>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -280,7 +282,7 @@ struct TMemoryMapping
 
     ui64 Offset = 0;
 
-    std::optional<int> DeviceId;
+    std::optional<NFS::TDeviceId> DeviceId;
 
     std::optional<ui64> INode;
 

--- a/yt/yt/core/misc/proc.h
+++ b/yt/yt/core/misc/proc.h
@@ -331,6 +331,10 @@ struct TBlockDeviceStat
 TBlockDeviceStat ParseBlockDeviceStat(const TString& statLine);
 
 std::optional<TBlockDeviceStat> GetBlockDeviceStat(const TString& deviceName);
+std::optional<TBlockDeviceStat> GetBlockDeviceStat(NFS::TDeviceId deviceId);
+
+NFS::TDeviceId GetBlockDeviceId(const TString& deviceName);
+TString GetBlockDeviceName(NFS::TDeviceId deviceId);
 std::vector<TString> ListDisks();
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/misc/proc.h
+++ b/yt/yt/core/misc/proc.h
@@ -302,36 +302,6 @@ std::vector<TMemoryMapping> GetProcessMemoryMappings(int pid);
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// See https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
-// for fields info.
-struct TDiskStat
-{
-    i32 MajorNumber = 0;
-    i32 MinorNumber = 0;
-    TString DeviceName;
-
-    i64 ReadsCompleted = 0;
-    i64 ReadsMerged = 0;
-    i64 SectorsRead = 0;
-    TDuration TimeSpentReading;
-
-    i64 WritesCompleted = 0;
-    i64 WritesMerged = 0;
-    i64 SectorsWritten = 0;
-    TDuration TimeSpentWriting;
-
-    i64 IOCurrentlyInProgress = 0;
-    TDuration TimeSpentDoingIO;
-    TDuration WeightedTimeSpentDoingIO;
-
-    i64 DiscardsCompleted = 0;
-    i64 DiscardsMerged = 0;
-    i64 SectorsDiscarded = 0;
-    TDuration TimeSpentDiscarding;
-};
-
-TDiskStat ParseDiskStat(const TString& statLine);
-
 // See https://docs.kernel.org/block/stat.html for more info.
 struct TBlockDeviceStat
 {
@@ -360,8 +330,6 @@ struct TBlockDeviceStat
 
 TBlockDeviceStat ParseBlockDeviceStat(const TString& statLine);
 
-//! DeviceName to stat info
-THashMap<TString, TDiskStat> GetDiskStats();
 std::optional<TBlockDeviceStat> GetBlockDeviceStat(const TString& deviceName);
 std::vector<TString> ListDisks();
 

--- a/yt/yt/core/misc/unittests/proc_ut.cpp
+++ b/yt/yt/core/misc/unittests/proc_ut.cpp
@@ -152,6 +152,12 @@ TEST(TProcTest, BlockDeviceStat)
         for (const TString& disk : ListDisks()) {
             auto stat = GetBlockDeviceStat(disk);
             EXPECT_TRUE(stat);
+            auto deviceId = GetBlockDeviceId(disk);
+            EXPECT_NE(deviceId.first, NFS::UnnamedDeviceMajor) << "disk=" << disk;
+            auto deviceName = GetBlockDeviceName(deviceId);
+            EXPECT_EQ(deviceName, disk);
+            stat = GetBlockDeviceStat(deviceId);
+            EXPECT_TRUE(stat);
         }
     }
 }

--- a/yt/yt/core/misc/unittests/proc_ut.cpp
+++ b/yt/yt/core/misc/unittests/proc_ut.cpp
@@ -126,45 +126,6 @@ TEST(TProcTest, CgroupList)
     }
 }
 
-TEST(TProcTest, DiskStat)
-{
-    {
-        auto parsed = ParseDiskStat("259       1 nvme0n1 372243 70861 50308550 175935 635314 559065 105338106 2777004 0 415304 3236956 38920 4 80436632 905059");
-        EXPECT_EQ(parsed.MajorNumber, 259);
-        EXPECT_EQ(parsed.MinorNumber, 1);
-        EXPECT_EQ(parsed.DeviceName, "nvme0n1");
-
-        EXPECT_EQ(parsed.ReadsCompleted, 372243);
-        EXPECT_EQ(parsed.ReadsMerged, 70861);
-        EXPECT_EQ(parsed.SectorsRead, 50308550);
-        EXPECT_EQ(parsed.TimeSpentReading, TDuration::MilliSeconds(175935));
-
-        EXPECT_EQ(parsed.WritesCompleted, 635314);
-
-        EXPECT_EQ(parsed.DiscardsCompleted, 38920);
-        EXPECT_EQ(parsed.DiscardsMerged, 4);
-        EXPECT_EQ(parsed.SectorsDiscarded, 80436632);
-        EXPECT_EQ(parsed.TimeSpentDiscarding, TDuration::MilliSeconds(905059));
-    }
-    {
-        auto parsed = ParseDiskStat("259       1 nvme0n1 372243 trash 50308550 trash");
-        EXPECT_EQ(parsed.MajorNumber, 259);
-        EXPECT_EQ(parsed.MinorNumber, 1);
-        EXPECT_EQ(parsed.DeviceName, "nvme0n1");
-
-        EXPECT_EQ(parsed.ReadsCompleted, 372243);
-        EXPECT_EQ(parsed.ReadsMerged, 0);
-        EXPECT_EQ(parsed.SectorsRead, 50308550);
-        EXPECT_EQ(parsed.TimeSpentReading, TDuration::MilliSeconds(0));
-    }
-    {
-        auto stats = GetDiskStats();
-        for (const TString& disk : ListDisks()) {
-            EXPECT_TRUE(IsIn(stats, disk));
-        }
-    }
-}
-
 TEST(TProcTest, BlockDeviceStat)
 {
     {

--- a/yt/yt/core/misc/unittests/proc_ut.cpp
+++ b/yt/yt/core/misc/unittests/proc_ut.cpp
@@ -77,7 +77,7 @@ TEST(TProcTest, TestParseMemoryMappings)
     EXPECT_EQ(smaps[1].End, 0x7fbb7b278000u);
     EXPECT_EQ(smaps[1].Permissions, EMemoryMappingPermission::Read | EMemoryMappingPermission::Execute | EMemoryMappingPermission::Private);
     EXPECT_EQ(smaps[1].Offset, 0xffu);
-    EXPECT_EQ(smaps[1].DeviceId, 1048637);
+    EXPECT_EQ(smaps[1].DeviceId, NFS::TDeviceId(0, 0x13d));
     EXPECT_EQ(*smaps[1].INode, 406536u);
     EXPECT_EQ(*smaps[1].Path, "/lib/x86_64-linux-gnu/ld-2.28.so");
     EXPECT_EQ(smaps[1].Statistics.Size, 156_KB);

--- a/yt/yt/server/job_proxy/tmpfs_manager.cpp
+++ b/yt/yt/server/job_proxy/tmpfs_manager.cpp
@@ -76,7 +76,7 @@ i64 TTmpfsManager::GetAggregatedTmpfsUsage() const
     return aggregatedTmpfsUsage;
 }
 
-bool TTmpfsManager::IsTmpfsDevice(int deviceId) const
+bool TTmpfsManager::IsTmpfsDevice(NFS::TDeviceId deviceId) const
 {
     return TmpfsDeviceIds.contains(deviceId);
 }

--- a/yt/yt/server/job_proxy/tmpfs_manager.h
+++ b/yt/yt/server/job_proxy/tmpfs_manager.h
@@ -2,6 +2,8 @@
 
 #include "public.h"
 
+#include <yt/yt/core/misc/fs.h>
+
 #include <yt/yt/server/lib/job_proxy/config.h>
 
 namespace NYT::NJobProxy {
@@ -23,7 +25,7 @@ public:
 
     //! Returns |true| if |deviceId| is a device id of some tmpfs volume
     //! and |false| otherwise.
-    bool IsTmpfsDevice(int deviceId) const;
+    bool IsTmpfsDevice(NFS::TDeviceId deviceId) const;
 
     bool HasTmpfsVolumes() const;
 
@@ -34,7 +36,7 @@ private:
     mutable std::vector<i64> MaxTmpfsUsage_;
     mutable i64 MaxAggregatedTmpfsUsage_ = 0;
 
-    THashSet<int> TmpfsDeviceIds;
+    THashSet<NFS::TDeviceId> TmpfsDeviceIds;
 
     struct TTmpfsVolumeStatitsitcs
     {


### PR DESCRIPTION
- Store block device id as major:minor pair
  They are more readable and useful as major-minor pair.
  ID anyway should be that size, because libc dev_t is 64-bit.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- Remove /proc/diskstats parser
  This code is unused.
  Fetching statistics for all disks at once is very ineffective.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- Add functions for working with block device statistics by major:minor
  Storage devices not always have predictable names,
  but we can easily translate filesystem path into major:minor.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- Fetch location disk statistics by device id.
  Translate disk name or path into device id at the initialization.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type: fix
Component: Make collection disk I/O statistics k8s compatible

<Your description.>

