### PR TITLE
yt/core/http: handle end wildcard "/{$}" in http path pattern

### DIFF
--- a/yt/yt/core/http/unittests/http_ut.cpp
+++ b/yt/yt/core/http/unittests/http_ut.cpp
@@ -1377,6 +1377,21 @@ TEST(THttpHandlerMatchingTest, Simple)
     EXPECT_EQ(h3.Get(), handlers3->Match(TStringBuf("/a")).Get());
     EXPECT_EQ(h2.Get(), handlers3->Match(TStringBuf("/a/")).Get());
     EXPECT_EQ(h2.Get(), handlers3->Match(TStringBuf("/a/b")).Get());
+
+    {
+        auto handlers = New<TRequestPathMatcher>();
+        handlers->Add("/{$}", h1);
+        handlers->Add("/a/{$}", h2);
+        handlers->Add("/a/b", h3);
+
+        EXPECT_EQ(h1.Get(), handlers->Match(TStringBuf("/")).Get());
+        EXPECT_EQ(h2.Get(), handlers->Match(TStringBuf("/a")).Get());
+        EXPECT_EQ(h2.Get(), handlers->Match(TStringBuf("/a/")).Get());
+        EXPECT_EQ(h3.Get(), handlers->Match(TStringBuf("/a/b")).Get());
+        EXPECT_FALSE(handlers->Match(TStringBuf("/a/b/")).Get());
+        EXPECT_FALSE(handlers->Match(TStringBuf("/a/c")).Get());
+        EXPECT_FALSE(handlers->Match(TStringBuf("/d")).Get());
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Pattern "/path/{$}" matches only "/path/" and "/path".
Required for proper directory handling without careless matching everything.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>



---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

