### PR TITLE
Fix contrib/libs/metrohash for aarch64

### DIFF
--- a/contrib/libs/metrohash/src/metrohash.h
+++ b/contrib/libs/metrohash/src/metrohash.h
@@ -19,6 +19,8 @@
 
 #include "metrohash64.h"
 #include "metrohash128.h"
+#ifdef __x86_64__
 #include "metrohash128crc.h"
+#endif
 
 #endif // #ifndef METROHASH_METROHASH_H

--- a/contrib/libs/metrohash/ya.make
+++ b/contrib/libs/metrohash/ya.make
@@ -10,11 +10,13 @@ ADDINCL(GLOBAL contrib/libs/metrohash/src)
 
 NO_UTIL()
 
-CFLAGS(-msse4.2)
+IF (ARCH_X86_64)
+    CFLAGS(-msse4.2)
+    SRC(src/metrohash128crc.cpp)
+ENDIF()
 
 SRCS(
     src/metrohash128.cpp
-    src/metrohash128crc.cpp
     src/metrohash64.cpp
 )
 


### PR DESCRIPTION
Metro128crc uses SSE4.2 CRC32C. ARM v8.1 has CRC32C too,
but this hash function seems pretty much obsolete and unused.

Link: https://github.com/jandrewrogers/MetroHash/pull/19
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
