### PR TITLE
Fix compilation contrib/libs/librdkafka for arm64

### DIFF
--- a/contrib/libs/librdkafka/config-linux-aarch64.h
+++ b/contrib/libs/librdkafka/config-linux-aarch64.h
@@ -1,0 +1,3 @@
+#include "config-linux.h"
+
+#define WITH_CRC32C_HW 0

--- a/contrib/libs/librdkafka/config.h
+++ b/contrib/libs/librdkafka/config.h
@@ -4,6 +4,8 @@
 #   include "config-osx-arm64.h"
 #elif defined(__APPLE__) && (defined(__x86_64__) || defined(_M_X64))
 #   include "config-osx-x86_64.h"
+#elif defined(__linux__) && (defined(__aarch64__) || defined(_M_ARM64))
+#   include "config-linux-aarch64.h"
 #else
 #   include "config-linux.h"
 #endif


### PR DESCRIPTION
"WITH_CRC32C_HW" uses SSE4.2 CRC32C. ARM v8.1 has CRC32C too,
but support is not implemented in upstream yet.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
