### PR TITLE
Disable fastops in clickhouse for non-x86_64

### DIFF
--- a/contrib/clickhouse/includes/configs/clickhouse_config.h
+++ b/contrib/clickhouse/includes/configs/clickhouse_config.h
@@ -27,7 +27,7 @@
 #define USE_GWP_ASAN 0
 #define USE_H3 1
 #define USE_S2_GEOMETRY 0
-#define USE_FASTOPS 1
+#define USE_FASTOPS defined(__x86_64__)
 #define USE_SQIDS 0
 #define USE_IDNA 0
 #define USE_NLP 0

--- a/contrib/clickhouse/src/ya.make
+++ b/contrib/clickhouse/src/ya.make
@@ -35,7 +35,6 @@ PEERDIR(
     contrib/libs/croaring
     contrib/libs/double-conversion
     contrib/libs/farmhash
-    contrib/libs/fastops/fastops
     contrib/libs/fmt
     contrib/libs/icu
     contrib/libs/libc_compat
@@ -120,6 +119,12 @@ ADDINCL(
     library/cpp/clickhouse_deps/incbin_stub
     library/cpp/consistent_hashing
 )
+
+IF (ARCH_X86_64)
+    PEERDIR(
+        contrib/libs/fastops/fastops
+    )
+ENDIF()
 
 NO_COMPILER_WARNINGS()
 


### PR DESCRIPTION
Fastops is implemented only for x86_64 AVX and AVX2.
"Plain" implementation call "fmath" which is also x86_64-only.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
