### PR TITLE
Add generic divideImpl to clickhouse

### DIFF
--- a/contrib/clickhouse/src/ya.make
+++ b/contrib/clickhouse/src/ya.make
@@ -2547,6 +2547,8 @@ SRCS(
     TableFunctions/registerTableFunctions.cpp
 )
 
+SRC(Functions/divide/divideImpl.cpp -DNAMESPACE=Generic)
+
 SRC_C_SSE2(Functions/divide/divideImpl.cpp -DNAMESPACE=SSE2)
 
 SRC_C_AVX2(Functions/divide/divideImpl.cpp -DNAMESPACE=AVX2)


### PR DESCRIPTION
Fix compilation without SSE2/AVX2, for example for arm64.

Link: https://github.com/ClickHouse/ClickHouse/blob/master/src/Functions/divide/CMakeLists.txt
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
