### PR TITLE
YQL fix complete logic

### DIFF
--- a/yql/essentials/sql/v1/complete/c3_engine.h
+++ b/yql/essentials/sql/v1/complete/c3_engine.h
@@ -11,15 +11,12 @@
 #include <util/generic/string.h>
 #include <util/generic/vector.h>
 
-#include <vector>
 #include <unordered_set>
 
 namespace NSQLComplete {
 
-    // std::vector is used to prevent copying from c3 results
     struct TSuggestedToken {
         TTokenId Number;
-        std::vector<TRuleId> ParserCallStack;
     };
 
     class IC3Engine {
@@ -93,15 +90,7 @@ namespace NSQLComplete {
         static TVector<TSuggestedToken> Converted(c3::CandidatesCollection candidates) {
             TVector<TSuggestedToken> converted;
             for (const auto& [token, _] : candidates.tokens) {
-                std::vector<TRuleId> parserCallStack;
-
-                if (
-                    auto rules = candidates.rules.find(token);
-                    rules != std::end(candidates.rules)) {
-                    parserCallStack = std::move(rules->second.ruleList);
-                }
-
-                converted.emplace_back(token, std::move(parserCallStack));
+                converted.emplace_back(token);
             }
             return converted;
         }

--- a/yql/essentials/sql/v1/complete/sql_context.cpp
+++ b/yql/essentials/sql/v1/complete/sql_context.cpp
@@ -39,7 +39,6 @@ namespace NSQLComplete {
         TCompletionContext Analyze(TCompletionInput input) override {
             auto prefix = input.Text.Head(input.CursorPosition);
             auto tokens = C3.Complete(prefix);
-            FilterIdKeywords(tokens);
             return {
                 .Keywords = SiftedKeywords(tokens),
             };
@@ -65,18 +64,11 @@ namespace NSQLComplete {
             const auto& keywordRules = Grammar->GetKeywordRules();
 
             std::unordered_set<TRuleId> preferredRules;
-            preferredRules.insert(std::begin(keywordRules), std::end(keywordRules));
-            return preferredRules;
-        }
 
-        void FilterIdKeywords(TVector<TSuggestedToken>& tokens) {
-            const auto& keywordRules = Grammar->GetKeywordRules();
-            auto [first, last] = std::ranges::remove_if(tokens, [&](const TSuggestedToken& token) {
-                return AnyOf(token.ParserCallStack, [&](TRuleId rule) {
-                    return Find(keywordRules, rule) != std::end(keywordRules);
-                });
-            });
-            tokens.erase(first, last);
+            // Excludes tokens obtained from keyword rules
+            preferredRules.insert(std::begin(keywordRules), std::end(keywordRules));
+
+            return preferredRules;
         }
 
         TVector<TString> SiftedKeywords(const TVector<TSuggestedToken>& tokens) {


### PR DESCRIPTION
## Why these changes are proposed?

I figured out that all this time I did not understand how `antlr4-c3` really works.

It is configured with 

```ts
ignoredTokens: Set<number>
preferredRules: Set<number>
```

On completion, it returns

```ts
class CandidatesCollection {
    tokens: Map<number, TokenList>
    rules: Map<number, ICandidateRule>
}

class ICandidateRule {
    startTokenIndex: number
    ruleList: RuleList
}

type TokenList = number[]
type RuleList = number[]
```

I thought that `rules` is a mapping from a `TokenId` to a `ParserCallStack`, but it totally is not true, as `rules` key is in fact a `RuleId`.

The documentation says

> Whenever the c3 engine hits a __lexer token__ ... it will check the call stack for it and, if that contains any of the **preferred rules**, will select that **instead** of the __lexer token__.

> [Preferred] Rules which replace any candidate token they contain.

So when we add the rule `X` to `preferredRules`, then when `C3` hits a lexer token with a `Parser Call Stack` containing the rule `X`, it will not add it to `CandidatesCollection::tokens`, but instead it will add an entry to `CandidatesCollection::rules` with a `Parser Call Stack`. It used when we have `ID_PLAIN` in a grammar, but this `ID_PLAIN` has different meaning depending on the context (`Parser Call Stack`), e.g. it can be a Table Name, Column Name and so on... So we can ask C3 not to include `ID_PLAIN` in `CandidatesCollection::tokens`, but instead emit `rules` like `table_id`, `column_id` and so on into the `CandidatesCollection::rules`.

So we have a `Parser Call Stack` for `rules`, but not for `tokens`.

## How it works correctly now then?

Described in the comments section.

## How to live on?

- [BAD ] Make a rule for each token to capture keywords at `CandidatesCollection::rules`.
- [GOOD] Extend `antlr4-c3` to include `Parser Call Stack` for `CandidatesCollection::tokens`.
