### PR TITLE
Add "internal_registry_alternative_addresses" for alternative "internal_registry_address"

### DIFF
--- a/yt/yt/server/controller_agent/config.cpp
+++ b/yt/yt/server/controller_agent/config.cpp
@@ -693,6 +693,8 @@ void TDockerRegistryConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("internal_registry_address", &TThis::InternalRegistryAddress)
         .Default();
+    registrar.Parameter("internal_registry_alternative_addresses", &TThis::InternalRegistryAlternativeAddresses)
+        .Default();
     registrar.Parameter("use_yt_token_for_internal_registry", &TThis::UseYtTokenForInternalRegistry)
         .Default(false);
     registrar.Parameter("forward_internal_images_to_job_specs", &TThis::ForwardInternalImagesToJobSpecs)
@@ -701,6 +703,10 @@ void TDockerRegistryConfig::Register(TRegistrar registrar)
         .Default(true);
 
     registrar.Postprocessor([&] (TDockerRegistryConfig* options) {
+        if (options->InternalRegistryAddress) {
+            options->InternalRegistryAlternativeAddresses.push_back(*options->InternalRegistryAddress);
+        }
+
         if (!options->TranslateInternalImagesIntoLayers && !options->ForwardInternalImagesToJobSpecs) {
             THROW_ERROR_EXCEPTION("At least one of forward_internal_images_to_job_specs or translate_internal_images_into_layers must be enabled");
         }

--- a/yt/yt/server/controller_agent/config.h
+++ b/yt/yt/server/controller_agent/config.h
@@ -758,8 +758,11 @@ DEFINE_REFCOUNTED_TYPE(TJobTrackerConfig)
 struct TDockerRegistryConfig
     : public NYTree::TYsonStruct
 {
-    //! FQDN of internal docker registry for docker images stored in Cypress.
-    std::string InternalRegistryAddress;
+    //! Address (FQDN[:PORT]) of internal docker registry for docker images stored in Cypress.
+    std::optional<std::string> InternalRegistryAddress;
+
+    //! Alternative addresses for internal docker registry.
+    std::vector<std::string> InternalRegistryAlternativeAddresses;
 
     bool UseYtTokenForInternalRegistry = false;
 

--- a/yt/yt/server/controller_agent/controllers/helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/helpers.cpp
@@ -25,6 +25,7 @@
 #include <yt/yt/client/table_client/row_buffer.h>
 #include <yt/yt/client/table_client/timestamped_schema_helpers.h>
 
+#include <util/string/builder.h>
 #include <util/string/split.h>
 
 namespace NYT::NControllerAgent::NControllers {
@@ -304,10 +305,12 @@ TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegi
     if (!StringSplitter(dockerImage).Split('/').Limit(2).TryCollectInto(&Registry, &imageRef) ||
         Registry.find_first_of(".:") == TString::npos)
     {
-        Registry = "";
+        // Use main internal registry address.
+        Registry = config->InternalRegistryAddress.value_or("");
+        IsInternal = true;
         imageRef = dockerImage;
     } else if (std::ranges::find(internalRegistries, Registry) != internalRegistries.end()) {
-        Registry = "";
+        IsInternal = true;
     }
 
     if (!StringSplitter(imageRef).Split('@').Limit(2).TryCollectInto(&imageTag, &Digest)) {
@@ -323,9 +326,26 @@ TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegi
     }
 }
 
-bool TDockerImageSpec::IsInternal() const
+TString TDockerImageSpec::GetDockerImage() const
 {
-    return Registry.empty();
+    TStringBuilder reference;
+
+    reference.Preallocate(Registry.length() + Image.length() + Tag.length() + Digest.length() + 3);
+    if (Registry != "") {
+        reference.AppendString(Registry);
+        reference.AppendChar('/');
+    }
+    reference.AppendString(Image);
+    if (Tag != "") {
+        reference.AppendChar(':');
+        reference.AppendString(Tag);
+    }
+    if (Digest != "") {
+        reference.AppendChar('@');
+        reference.AppendString(Digest);
+    }
+
+    return reference.Flush();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/controller_agent/controllers/helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/helpers.cpp
@@ -295,6 +295,7 @@ void SafeUpdateAggregatedJobStatistics(
 
 TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config)
 {
+    const auto& internalRegistries = config->InternalRegistryAlternativeAddresses;
     TStringBuf imageRef;
     TStringBuf imageTag;
 
@@ -305,7 +306,7 @@ TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegi
     {
         Registry = "";
         imageRef = dockerImage;
-    } else if (Registry == config->InternalRegistryAddress) {
+    } else if (std::ranges::find(internalRegistries, Registry) != internalRegistries.end()) {
         Registry = "";
     }
 

--- a/yt/yt/server/controller_agent/controllers/helpers.h
+++ b/yt/yt/server/controller_agent/controllers/helpers.h
@@ -90,9 +90,10 @@ struct TDockerImageSpec
     TString Tag;
     TString Digest;
 
-    TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config);
+    bool IsInternal = false;
 
-    bool IsInternal() const;
+    TDockerImageSpec(const TString& dockerImage, const TDockerRegistryConfigPtr& config);
+    TString GetDockerImage() const;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -10178,13 +10178,13 @@ void TOperationControllerBase::InitUserJobSpecTemplate(
 
     jobSpec->set_start_queue_consumer_registration_manager(jobSpecConfig->StartQueueConsumerRegistrationManager);
 
-    // Pass external docker image into job spec as is.
+    // Pass normalized docker image reference into job spec.
     if (jobSpecConfig->DockerImage) {
         TDockerImageSpec dockerImageSpec(*jobSpecConfig->DockerImage, Config->DockerRegistry);
-        if (!dockerImageSpec.IsInternal() || Config->DockerRegistry->ForwardInternalImagesToJobSpecs) {
-            jobSpec->set_docker_image(*jobSpecConfig->DockerImage);
+        if (!dockerImageSpec.IsInternal || Config->DockerRegistry->ForwardInternalImagesToJobSpecs) {
+            jobSpec->set_docker_image(dockerImageSpec.GetDockerImage());
         }
-        if (dockerImageSpec.IsInternal() && Config->DockerRegistry->UseYtTokenForInternalRegistry) {
+        if (dockerImageSpec.IsInternal && Config->DockerRegistry->UseYtTokenForInternalRegistry) {
             GenerateDockerAuthFromToken(SecureVault, AuthenticatedUser, jobSpec);
         }
     }
@@ -11296,7 +11296,7 @@ std::vector<TRichYPath> TOperationControllerBase::GetLayerPaths(
         TDockerImageSpec dockerImage(*userJobSpec->DockerImage, Config->DockerRegistry);
 
         // External docker images are not compatible with any additional layers.
-        if (!dockerImage.IsInternal() || !Config->DockerRegistry->TranslateInternalImagesIntoLayers) {
+        if (!dockerImage.IsInternal || !Config->DockerRegistry->TranslateInternalImagesIntoLayers) {
             return {};
         }
 

--- a/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
+++ b/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
@@ -29,7 +29,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "image:latest");
     }
 
     {
@@ -38,7 +39,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "image:tag");
     }
 
     {
@@ -47,7 +49,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "");
         EXPECT_EQ(image.Digest, "hash:digest");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "image@hash:digest");
     }
 
     {
@@ -56,7 +59,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "hash:digest");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "image:tag@hash:digest");
     }
 
     {
@@ -65,7 +69,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "home/user/image");
         EXPECT_EQ(image.Tag, "latest");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "home/user/image:latest");
     }
 
     {
@@ -74,7 +79,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "home/user/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "home/user/image:tag");
     }
 
     {
@@ -83,7 +89,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "localhost:5000/image:latest");
     }
 
     {
@@ -92,25 +99,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
-    }
-
-    {
-        TDockerImageSpec image("localhost:5000/image", defaultConfig);
-        EXPECT_EQ(image.Registry, "localhost:5000");
-        EXPECT_EQ(image.Image, "image");
-        EXPECT_EQ(image.Tag, "latest");
-        EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
-    }
-
-    {
-        TDockerImageSpec image("localhost:5000/image:tag", defaultConfig);
-        EXPECT_EQ(image.Registry, "localhost:5000");
-        EXPECT_EQ(image.Image, "image");
-        EXPECT_EQ(image.Tag, "tag");
-        EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "localhost:5000/image:tag");
     }
 
     {
@@ -119,7 +109,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "");
         EXPECT_EQ(image.Digest, "hash:digest");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "localhost:5000/image@hash:digest");
     }
 
     {
@@ -128,7 +119,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "hash:digest");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "localhost:5000/image:tag@hash:digest");
     }
 
     {
@@ -137,7 +129,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "external.registry/image:latest");
     }
 
     {
@@ -146,7 +139,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "external.registry/image:tag");
     }
 
     {
@@ -155,7 +149,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "latest");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "external.registry:8888/image:latest");
     }
 
     {
@@ -164,7 +159,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "external.registry:8888/image:tag");
     }
 
     {
@@ -173,7 +169,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "internal.registry/project/image:tag");
     }
 
     {
@@ -182,7 +179,8 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "external.registry/project/image:tag");
     }
 
     {
@@ -191,34 +189,58 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "hash:digest");
-        EXPECT_EQ(image.IsInternal(), false);
+        EXPECT_EQ(image.IsInternal, false);
+        EXPECT_EQ(image.GetDockerImage(), "external.registry/project/image:tag@hash:digest");
+    }
+
+    {
+        TDockerImageSpec image("home/user/image", internalConfig);
+        EXPECT_EQ(image.Registry, "internal.registry");
+        EXPECT_EQ(image.Image, "home/user/image");
+        EXPECT_EQ(image.Tag, "latest");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "internal.registry/home/user/image:latest");
+    }
+
+    {
+        TDockerImageSpec image("home/user/image:tag", internalConfig);
+        EXPECT_EQ(image.Registry, "internal.registry");
+        EXPECT_EQ(image.Image, "home/user/image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "internal.registry/home/user/image:tag");
     }
 
     {
         TDockerImageSpec image("internal.registry/project/image:tag", internalConfig);
-        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Registry, "internal.registry");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "internal.registry/project/image:tag");
     }
 
     {
         TDockerImageSpec image("internal.registry:8080/project/image:tag", internalConfig);
-        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Registry, "internal.registry:8080");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "internal.registry:8080/project/image:tag");
     }
 
     {
         TDockerImageSpec image("alt.internal.registry/project/image:tag", internalConfig);
-        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Registry, "alt.internal.registry");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");
         EXPECT_EQ(image.Digest, "");
-        EXPECT_EQ(image.IsInternal(), true);
+        EXPECT_EQ(image.IsInternal, true);
+        EXPECT_EQ(image.GetDockerImage(), "alt.internal.registry/project/image:tag");
     }
 }
 

--- a/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
+++ b/yt/yt/server/controller_agent/unittests/docker_image_ut.cpp
@@ -14,7 +14,12 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
     auto defaultConfig = New<TDockerRegistryConfig>();
     auto internalConfig = New<TDockerRegistryConfig>();
 
+    defaultConfig->Postprocess();
+
     internalConfig->InternalRegistryAddress = "internal.registry";
+    internalConfig->InternalRegistryAlternativeAddresses.push_back("internal.registry:8080");
+    internalConfig->InternalRegistryAlternativeAddresses.push_back("alt.internal.registry");
+    internalConfig->Postprocess();
 
     // Format: [REGISTRY[:PORT]/]IMAGE[:TAG][@DIGEST]
 
@@ -191,6 +196,24 @@ TEST(TDockerImageSpecTest, TestDockerImageParser)
 
     {
         TDockerImageSpec image("internal.registry/project/image:tag", internalConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "project/image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("internal.registry:8080/project/image:tag", internalConfig);
+        EXPECT_EQ(image.Registry, "");
+        EXPECT_EQ(image.Image, "project/image");
+        EXPECT_EQ(image.Tag, "tag");
+        EXPECT_EQ(image.Digest, "");
+        EXPECT_EQ(image.IsInternal(), true);
+    }
+
+    {
+        TDockerImageSpec image("alt.internal.registry/project/image:tag", internalConfig);
         EXPECT_EQ(image.Registry, "");
         EXPECT_EQ(image.Image, "project/image");
         EXPECT_EQ(image.Tag, "tag");


### PR DESCRIPTION
- Add "internal_registry_alternative_addresses" for alternative "internal_registry_address"
  When internal registry has several alternative endpoints or DNS CNAMEs
  all these addresses should be considered as references to internal registry.

- Add registry address for internal images passed to job spec
  Normalize docker image reference passed into job spec.
  This allows to omit registry address for internal docker images in
  operation spec - controller agent will add it to job spec.
