### PR TITLE
Fix build instruction

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -82,7 +82,7 @@
 
     ```
     cd build
-    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=../ytsaurus/clang.toolchain -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=../ytsaurus/cmake/conan_provider.cmake ../ytsaurus
+    cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DREQUIRED_LLVM_TOOLING_VERSION=16 -DCMAKE_TOOLCHAIN_FILE=../ytsaurus/clang.toolchain -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=../ytsaurus/cmake/conan_provider.cmake ../ytsaurus
     ```
 
     To build just run:


### PR DESCRIPTION
Need to specify REQUIRED_LLVM_TOOLING_VERSION=16 while running cmake otherwise there may be an error
that some of llvm tools are not found (e.g. `llvm-link not found`)