### PR TITLE
Fixing backtrace for arm64

### DIFF
--- a/library/cpp/yt/backtrace/unittests/ya.make
+++ b/library/cpp/yt/backtrace/unittests/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/library/cpp/yt/ya_cpp.make.inc)
 PEERDIR(
     library/cpp/testing/gtest
     library/cpp/yt/backtrace
+    library/cpp/yt/backtrace/cursors/dummy
     library/cpp/yt/backtrace/cursors/interop
     library/cpp/yt/backtrace/cursors/frame_pointer
     library/cpp/yt/backtrace/cursors/libunwind


### PR DESCRIPTION
For now it crashes for arm64 target.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
