### PR TITLE
Support RegisterChunkReplicasOnStoresUpdate for ordered tables

### DIFF
--- a/yt/yt/server/node/tablet_node/compression_dictionary_builder.cpp
+++ b/yt/yt/server/node/tablet_node/compression_dictionary_builder.cpp
@@ -816,17 +816,8 @@ private:
         }
 
         if (tabletSnapshot->Settings.MountConfig->RegisterChunkReplicasOnStoresUpdate) {
-            // TODO(kvk1920): Consider using chunk + location instead of chunk + node + medium.
-            auto replicasInfo = chunkWriter->GetWrittenChunkReplicasInfo();
-            TAllyReplicasInfo newReplicas;
-            newReplicas.Revision = replicasInfo.ConfirmationRevision;
-            newReplicas.Replicas.reserve(replicasInfo.Replicas.size());
-            for (auto replica : replicasInfo.Replicas) {
-                newReplicas.Replicas.push_back(replica);
-            }
-
             const auto& chunkReplicaCache = Bootstrap_->GetConnection()->GetChunkReplicaCache();
-            chunkReplicaCache->UpdateReplicas(chunkWriter->GetChunkId(), newReplicas);
+            chunkReplicaCache->UpdateReplicas(chunkWriter->GetChunkId(), TAllyReplicasInfo::FromChunkWriter(chunkWriter));
         }
 
         YT_LOG_DEBUG("Compression dictionary builder finished writing dictionary hunk chunk "

--- a/yt/yt/server/node/tablet_node/sorted_store_manager.cpp
+++ b/yt/yt/server/node/tablet_node/sorted_store_manager.cpp
@@ -1173,23 +1173,10 @@ TStoreFlushCallback TSortedStoreManager::MakeStoreFlushCallback(
 
         if (mountConfig->RegisterChunkReplicasOnStoresUpdate) {
             const auto& chunkReplicaCache = TabletContext_->GetChunkReplicaCache();
-            // TODO(kvk1920): Consider using chunk + location instead of chunk + node + medium.
-            auto registerReplicas = [&] (const IChunkWriterPtr& chunkWriter) {
-                const auto& replicasInfo = chunkWriter->GetWrittenChunkReplicasInfo();
-                NChunkClient::TAllyReplicasInfo newReplicas;
-                newReplicas.Revision = replicasInfo.ConfirmationRevision;
-                newReplicas.Replicas.reserve(replicasInfo.Replicas.size());
-                for (auto replica : replicasInfo.Replicas) {
-                    newReplicas.Replicas.push_back(replica);
-                }
-
-                chunkReplicaCache->UpdateReplicas(chunkWriter->GetChunkId(), newReplicas);
-            };
-
-            registerReplicas(storeChunkWriter);
+            chunkReplicaCache->UpdateReplicas(storeChunkWriter->GetChunkId(), NChunkClient::TAllyReplicasInfo::FromChunkWriter(storeChunkWriter));
 
             if (hunkChunkPayloadWriter->HasHunks()) {
-                registerReplicas(hunkChunkWriter);
+                chunkReplicaCache->UpdateReplicas(hunkChunkWriter->GetChunkId(), NChunkClient::TAllyReplicasInfo::FromChunkWriter(hunkChunkWriter));
             }
         }
 

--- a/yt/yt/server/node/tablet_node/store_compactor.cpp
+++ b/yt/yt/server/node/tablet_node/store_compactor.cpp
@@ -531,28 +531,17 @@ private:
 
         if (TabletSnapshot_->Settings.MountConfig->RegisterChunkReplicasOnStoresUpdate) {
             const auto& chunkReplicaCache = Bootstrap_->GetConnection()->GetChunkReplicaCache();
-            auto registerReplicas = [&] (TChunkId chunkId, const auto& replicasInfo) {
-                // TODO(kvk1920): Consider using chunk + location instead of chunk + node + medium.
-                NChunkClient::TAllyReplicasInfo newReplicas;
-                newReplicas.Revision = replicasInfo.ConfirmationRevision;
-                newReplicas.Replicas.reserve(replicasInfo.Replicas.size());
-                for (auto replica : replicasInfo.Replicas) {
-                    newReplicas.Replicas.push_back(replica);
-                }
-
-                chunkReplicaCache->UpdateReplicas(chunkId, newReplicas);
-            };
 
             for (const auto& writer : Writers_) {
                 for (const auto& [chunkId, replicasInfo] : writer->GetWrittenChunkReplicasInfos()) {
-                    registerReplicas(chunkId, replicasInfo);
+                    chunkReplicaCache->UpdateReplicas(chunkId, TAllyReplicasInfo::FromWrittenChunkReplicasInfo(replicasInfo));
                 }
             }
 
             if (HunkChunkPayloadWriter_->HasHunks()) {
-                registerReplicas(
+                chunkReplicaCache->UpdateReplicas(
                     HunkChunkWriter_->GetChunkId(),
-                    HunkChunkWriter_->GetWrittenChunkReplicasInfo());
+                    TAllyReplicasInfo::FromChunkWriter(HunkChunkWriter_));
             }
         }
 

--- a/yt/yt/ytlib/chunk_client/helpers.cpp
+++ b/yt/yt/ytlib/chunk_client/helpers.cpp
@@ -3,6 +3,7 @@
 #include "chunk_meta_extensions.h"
 #include "chunk_service_proxy.h"
 #include "chunk_spec.h"
+#include "chunk_writer.h"
 #include "config.h"
 #include "data_slice_descriptor.h"
 #include "erasure_reader.h"
@@ -1031,6 +1032,23 @@ TAllyReplicasInfo TAllyReplicasInfo::FromChunkReplicas(
     result.Revision = revision;
 
     return result;
+}
+
+TAllyReplicasInfo TAllyReplicasInfo::FromWrittenChunkReplicasInfo(TWrittenChunkReplicasInfo replicasInfo)
+{
+    TAllyReplicasInfo result;
+    result.Replicas.reserve(replicasInfo.Replicas.size());
+    for (auto replica : replicasInfo.Replicas) {
+        result.Replicas.push_back(replica);
+    }
+    result.Revision = replicasInfo.ConfirmationRevision;
+
+    return result;
+}
+
+TAllyReplicasInfo TAllyReplicasInfo::FromChunkWriter(const IChunkWriterPtr& chunkWriter)
+{
+    return FromWrittenChunkReplicasInfo(chunkWriter->GetWrittenChunkReplicasInfo());
 }
 
 void ToProto(

--- a/yt/yt/ytlib/chunk_client/helpers.cpp
+++ b/yt/yt/ytlib/chunk_client/helpers.cpp
@@ -1036,6 +1036,7 @@ TAllyReplicasInfo TAllyReplicasInfo::FromChunkReplicas(
 
 TAllyReplicasInfo TAllyReplicasInfo::FromWrittenChunkReplicasInfo(TWrittenChunkReplicasInfo replicasInfo)
 {
+    // TODO(kvk1920): Consider using chunk + location instead of chunk + node + medium.
     TAllyReplicasInfo result;
     result.Replicas.reserve(replicasInfo.Replicas.size());
     for (auto replica : replicasInfo.Replicas) {

--- a/yt/yt/ytlib/chunk_client/helpers.h
+++ b/yt/yt/ytlib/chunk_client/helpers.h
@@ -310,6 +310,11 @@ struct TAllyReplicasInfo
     static TAllyReplicasInfo FromChunkReplicas(
         const TChunkReplicaWithMediumList& chunkReplicas,
         NHydra::TRevision revision = NHydra::NullRevision);
+
+    static TAllyReplicasInfo FromWrittenChunkReplicasInfo(TWrittenChunkReplicasInfo replicasInfo);
+    //! Populates replicas from writer's written chunk replicas info.
+    //! Writer must implement GetWrittenChunkReplicasInfo and be successfully closed.
+    static TAllyReplicasInfo FromChunkWriter(const IChunkWriterPtr& chunkWriter);
 };
 
 void ToProto(


### PR DESCRIPTION
May not be as necessary for ordered tables as it is for sorted tables, but still a useful improvement. Coincidentally, it helps out the effort in #1102, which is my main reason for this PR.

* Changelog entry
Type: feature
Component: dynamic-tables

Support RegisterChunkReplicasOnStoresUpdate for ordered tables. Reduces the number of master requests required for reading flushed chunks via tablet node API.

