### PR TITLE
Enable decommission_through_extra_peers by default

### DIFF
--- a/yt/python/yt/environment/default_config.py
+++ b/yt/python/yt/environment/default_config.py
@@ -169,6 +169,8 @@ def get_dynamic_master_config():
             orphans_check_period = 100;
         };
 
+        extra_peer_drop_delay = 100;
+
         multicell_gossip = {
             table_statistics_gossip_period = 100;
             tablet_cell_statistics_gossip_period = 100;

--- a/yt/yt/server/master/tablet_server/config.cpp
+++ b/yt/yt/server/master/tablet_server/config.cpp
@@ -184,7 +184,7 @@ void TDynamicTabletManagerConfig::Register(TRegistrar registrar)
     registrar.Parameter("enable_bulk_insert", &TThis::EnableBulkInsert)
         .Default(false);
     registrar.Parameter("decommission_through_extra_peers", &TThis::DecommissionThroughExtraPeers)
-        .Default(false);
+        .Default(true);
     registrar.Parameter("synchronize_tablet_cell_leader_switches", &TThis::SynchronizeTabletCellLeaderSwitches)
         .Default(true)
         .DontSerializeDefault();

--- a/yt/yt/tests/integration/dynamic_tables/test_dynamic_tables.py
+++ b/yt/yt/tests/integration/dynamic_tables/test_dynamic_tables.py
@@ -422,6 +422,12 @@ class DynamicTablesSingleCellBase(DynamicTablesBase):
 
     @authors("gritukan")
     def test_dynamic_peer_count(self):
+        # We don't want decommission to interfere with manual peer count changes.
+        set(
+            "//sys/@config/tablet_manager/decommission_through_extra_peers",
+            False,
+        )
+
         create_tablet_cell_bundle("b", attributes={"options": {"peer_count": 1}})
         sync_create_cells(1, tablet_cell_bundle="b")
         cell_id = ls("//sys/tablet_cells")[0]

--- a/yt/yt/tests/integration/dynamic_tables/test_tablet_actions.py
+++ b/yt/yt/tests/integration/dynamic_tables/test_tablet_actions.py
@@ -1405,6 +1405,12 @@ class TabletBalancerBase(TabletActionsBase):
 
     @authors("ifsmirnov")
     def test_tablet_balancer_with_active_action(self):
+        # There are no extra peers available for the "broken" bundle below.
+        set(
+            "//sys/@config/tablet_manager/decommission_through_extra_peers",
+            False,
+        )
+
         node = ls("//sys/cluster_nodes")[0]
         set("//sys/cluster_nodes/{0}/@user_tags".format(node), ["custom"])
 


### PR DESCRIPTION
This option has been used in production for quite a long time and is definitely stable enough. Users have little chance of knowing about it, so it is best to enable it by default.

* Changelog entry
Type: feature
Component: dynamic-tables

Enable decommission_through_extra_peers by default. This option significantly reduces downtime of tablet node maintenance.

