### PR TITLE
Allow TLS 1.3 for HTTPS proxies and bus RPC

### DIFF
--- a/yt/yt/core/bus/tcp/ssl_context.cpp
+++ b/yt/yt/core/bus/tcp/ssl_context.cpp
@@ -36,7 +36,7 @@ public:
             THROW_ERROR_EXCEPTION("Failed to set min protocol version: %v", GetLastSslErrorString());
         }
 
-        if (SSL_CTX_set_max_proto_version(SslCtx_.get(), TLS1_2_VERSION) != 1) {
+        if (SSL_CTX_set_max_proto_version(SslCtx_.get(), TLS1_3_VERSION) != 1) {
             THROW_ERROR_EXCEPTION("Failed to set max protocol version: %v", GetLastSslErrorString());
         }
 

--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -91,7 +91,7 @@ struct TSslContextImpl
             THROW_ERROR_EXCEPTION("SSL_CTX_set_min_proto_version failed")
                 << GetSslErrors();
         }
-        if (SSL_CTX_set_max_proto_version(Context, TLS1_2_VERSION) == 0) {
+        if (SSL_CTX_set_max_proto_version(Context, TLS1_3_VERSION) == 0) {
             THROW_ERROR_EXCEPTION("SSL_CTX_set_max_proto_version failed")
                 << GetSslErrors();
         }


### PR DESCRIPTION
That should be done years ago.

* Allow TLS 1.3 for https and bus rps
Type: feature
Component: proxy

Better late than never.
