### PR TITLE
Increase default value for replication_reader_timeout for erasure reader

### DIFF
--- a/yt/yt/client/chunk_client/config.cpp
+++ b/yt/yt/client/chunk_client/config.cpp
@@ -229,7 +229,7 @@ void TErasureReaderConfig::Register(TRegistrar registrar)
     registrar.Parameter("slow_reader_expiration_timeout", &TThis::SlowReaderExpirationTimeout)
         .Default(TDuration::Minutes(2));
     registrar.Parameter("replication_reader_timeout", &TThis::ReplicationReaderTimeout)
-        .Default(TDuration::Seconds(60));
+        .Default(TDuration::Seconds(300));
     registrar.Parameter("replication_reader_failure_timeout", &TThis::ReplicationReaderFailureTimeout)
         .Default(TDuration::Minutes(10));
 }


### PR DESCRIPTION
[Reader timeout for a block request is 120 seconds](https://github.com/ytsaurus/ytsaurus/blob/386f6e47fbbd9434679ab672990ed6c3b63ea75f/yt/yt/client/chunk_client/config.cpp#L102-L103). Timeout for the whole reader should be bigger than that and should be reasonable