### PR TITLE
Add CRI-O and crictl into ytserver docker image

### DIFF
--- a/yt/docker/ya-build/ytsaurus/package.json
+++ b/yt/docker/ya-build/ytsaurus/package.json
@@ -6,13 +6,14 @@
         "version": "local-{revision}",
     },
     "include": [
-      "yt/docker/ya-build/base/package.json",
+        "yt/docker/ya-build/base/package.json",
     ],
     "params": {
         "format": "docker",
         "docker_target": "ytsaurus",
         "docker_build_arg": {
-            "PYTHON_BUILD_BASE": "build-ytsaurus-python-binaries"
+            "PYTHON_BUILD_BASE": "build-ytsaurus-python-binaries",
+            "SERVER_IMAGE_BASE": "base-server-crio",
         },
     },
     "data": [

--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -4,6 +4,10 @@
 ARG BASE_REPOSITORY="ghcr.io/ytsaurus/ytsaurus-nightly"
 ARG BASE_IMAGE="latest"
 
+# Args for base-server-crio
+ARG K8S_VERSION="v1.32"
+ARG CRIO_VERSION="v1.32"
+
 # Args for odin.
 ARG PYTHON_RUNTIME_VERSION="3.11"
 
@@ -16,6 +20,8 @@ ARG ODIN_CHECKS_DATA_DIR="${ODIN_RUNTIME_ROOT}/checks-data"
 # Flow control args.
 # copy-ytsaurus-python-binaries or build-ytsaurus-python-binaries
 ARG PYTHON_BUILD_BASE="copy-ytsaurus-python-binaries"
+# base-server or base-server-crio
+ARG SERVER_IMAGE_BASE="base-server"
 
 ##########################################################################################
 
@@ -147,7 +153,7 @@ RUN rm -rf /tmp/ytsaurus_python
 
 ##########################################################################################
 
-FROM base-ytsaurus-python-packages AS base-exec
+FROM base-ytsaurus-python-packages AS base-server
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
   containerd \
@@ -167,7 +173,38 @@ RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release
 
 ##########################################################################################
 
-FROM base-exec AS ytsaurus-bloated
+FROM base-server AS base-server-crio
+
+ARG K8S_VERSION
+ARG CRIO_VERSION
+
+ADD --chmod=644 https://pkgs.k8s.io/core:/stable:/${K8S_VERSION}/deb/Release.key \
+            /etc/apt/keyrings/kubernetes-apt-keyring.asc
+
+ADD --chmod=644 https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_VERSION}/deb/Release.key \
+            /etc/apt/keyrings/cri-o-apt-keyring.asc
+
+# Install CRI-O, see https://cri-o.io/
+RUN <<-EOT
+#!/bin/bash
+set -eux -o pipefail
+
+cat <<EOF >/etc/apt/sources.list.d/kubernetes.list
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/${K8S_VERSION}/deb/ /
+EOF
+
+cat <<EOF >/etc/apt/sources.list.d/cri-o.list
+deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.asc] https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${CRIO_VERSION}/deb/ /
+EOF
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -q --error-on=any
+apt-get install -y cri-tools cri-o
+EOT
+
+##########################################################################################
+
+FROM ${SERVER_IMAGE_BASE} AS ytsaurus-bloated
 
 # YTsaurus binary.
 COPY ./ytserver-all /usr/bin/ytserver-all
@@ -267,7 +304,7 @@ COPY ./credits/chyt-controller.CREDITS /usr/bin/strawberry-controller.CREDITS
 
 ##########################################################################################
 
-FROM base-exec AS local-bloated
+FROM ${SERVER_IMAGE_BASE} AS local-bloated
 
 COPY ./ytserver-all /usr/bin/ytserver-all
 COPY ./ytserver-yql-agent /usr/bin/ytserver-yql-agent


### PR DESCRIPTION
CRI-O is a modern cloud-native CRI service implementation.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Add CRI-O and crictl into ytsaurus server docker image
Type: feature
Component: misc-server

Add alternative to containerd.
