### PR TITLE
Add package for ytsaurus arm64 docker image

### DIFF
--- a/yt/docker/ya-build/base/README.md
+++ b/yt/docker/ya-build/base/README.md
@@ -1,8 +1,25 @@
 # Base artifacts for ytsaurus images
 
-This folder contains package.json that is meant to be included from ytsaurus and query-tracker packages. It contains common parts like:
+This folder contains package fragments that are meant to be included from ytsaurus and query-tracker packages.
+Package fragments are split into files: {section}-{group}[-{variant}].json
 
-- ytserver-all
-- python binaries
+Section is package json sections like "build" or "data".
+
+Each group contains common parts like:
+
+### common
 - Dockerfile
+- certificates
+
+### server
+- ytserver-all
 - ytserver-all credits
+- init scripts
+
+### python
+- python binaries
+
+Group names in json must include "::" to disarm ya package ingenious mangling.
+Otherwise names wouldn't match across different fragments.
+
+Variant reflects target platform, architecture and combination of any other options.

--- a/yt/docker/ya-build/base/build-python-linux-aarch64.json
+++ b/yt/docker/ya-build/base/build-python-linux-aarch64.json
@@ -1,0 +1,38 @@
+{
+    "build": {
+        "build::python_binaries": {
+            "targets": [
+                "yt/yt/python/yson_shared",
+                "yt/yt/python/driver/native_shared",
+                "yt/yt/python/driver/rpc_shared",
+            ],
+            "build_type": "release",
+            "thinlto": true,
+            "target-platforms": [
+                "default-linux-aarch64",
+            ],
+            "flags": [
+                {
+                    "name": "USE_ARCADIA_PYTHON",
+                    "value": "no",
+                },
+                {
+                    "name": "USE_LOCAL_PYTHON",
+                    "value": "yes",
+                },
+                {
+                    "name": "PYTHON_BIN",
+                    "value": "python3",
+                },
+                {
+                    "name": "PYTHON_CONFIG",
+                    "value": "python3-config",
+                },
+                {
+                    "name": "STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+}

--- a/yt/docker/ya-build/base/build-python-linux-x86_64.json
+++ b/yt/docker/ya-build/base/build-python-linux-x86_64.json
@@ -1,0 +1,38 @@
+{
+    "build": {
+        "build::python_binaries": {
+            "targets": [
+                "yt/yt/python/yson_shared",
+                "yt/yt/python/driver/native_shared",
+                "yt/yt/python/driver/rpc_shared",
+            ],
+            "build_type": "release",
+            "thinlto": true,
+            "target-platforms": [
+                "default-linux-x86_64",
+            ],
+            "flags": [
+                {
+                    "name": "USE_ARCADIA_PYTHON",
+                    "value": "no",
+                },
+                {
+                    "name": "USE_LOCAL_PYTHON",
+                    "value": "yes",
+                },
+                {
+                    "name": "PYTHON_BIN",
+                    "value": "python3",
+                },
+                {
+                    "name": "PYTHON_CONFIG",
+                    "value": "python3-config",
+                },
+                {
+                    "name": "STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+}

--- a/yt/docker/ya-build/base/build-server-linux-aarch64.json
+++ b/yt/docker/ya-build/base/build-server-linux-aarch64.json
@@ -1,0 +1,20 @@
+{
+    "build": {
+        "build::server_binaries": {
+            "targets": [
+                "yt/yt/server/all",
+            ],
+            "build_type": "profile",
+            "thinlto": true,
+            "target-platforms": [
+                "default-linux-aarch64",
+            ],
+            "flags": [
+                {
+                    "name": "NO_STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+}

--- a/yt/docker/ya-build/base/build-server-linux-x86_64.json
+++ b/yt/docker/ya-build/base/build-server-linux-x86_64.json
@@ -1,0 +1,20 @@
+{
+    "build": {
+        "build::server_binaries": {
+            "targets": [
+                "yt/yt/server/all",
+            ],
+            "build_type": "profile",
+            "thinlto": true,
+            "target-platforms": [
+                "default-linux-x86_64",
+            ],
+            "flags": [
+                {
+                    "name": "NO_STRIP",
+                    "value": "yes",
+                },
+            ],
+        },
+    },
+}

--- a/yt/docker/ya-build/base/data-common.json
+++ b/yt/docker/ya-build/base/data-common.json
@@ -1,0 +1,22 @@
+{
+    "data": [
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/Dockerfile",
+            },
+            "destination": {
+                "path": "/Dockerfile",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "certs/cacert.pem",
+            },
+            "destination": {
+                "path": "/certs/cacert.pem",
+            },
+        },
+    ],
+}

--- a/yt/docker/ya-build/base/data-python.json
+++ b/yt/docker/ya-build/base/data-python.json
@@ -1,0 +1,52 @@
+{
+    "data": [
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/python",
+            },
+            "destination": {
+                "path": "/yt/python",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/yt/python",
+            },
+            "destination": {
+                "path": "/yt/yt/python",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+                "build_key": "build::python_binaries",
+                "path": "yt/yt/python/yson_shared/yson_lib.so",
+            },
+            "destination": {
+                "path": "/artifacts/libyson_lib.so",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+                "build_key": "build::python_binaries",
+                "path": "yt/yt/python/driver/native_shared/driver_lib.so",
+            },
+            "destination": {
+                "path": "/artifacts/libdriver_lib.so",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+                "build_key": "build::python_binaries",
+                "path": "yt/yt/python/driver/rpc_shared/driver_rpc_lib.so",
+            },
+            "destination": {
+                "path": "/artifacts/libdriver_rpc_lib.so",
+            },
+        },
+    ],
+}

--- a/yt/docker/ya-build/base/data-server.json
+++ b/yt/docker/ya-build/base/data-server.json
@@ -1,0 +1,36 @@
+{
+    "data": [
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/docker/ytsaurus/credits/ytsaurus/ytserver-all.CREDITS",
+            },
+            "destination": {
+                "path": "/credits/ytserver-all.CREDITS",
+            },
+        },
+        {
+            "source": {
+                "type": "BUILD_OUTPUT",
+                "build_key": "build::server_binaries",
+                "path": "yt/yt/server/all/ytserver-all",
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+        {
+            "source": {
+                "type": "ARCADIA",
+                "path": "yt/python/yt/environment",
+                "files": [
+                    "init_queue_agent_state.py",
+                    "init_operations_archive.py",
+                ],
+            },
+            "destination": {
+                "path": "/",
+            },
+        },
+    ],
+}

--- a/yt/docker/ya-build/base/package.json
+++ b/yt/docker/ya-build/base/package.json
@@ -5,6 +5,13 @@
         "description": "Base ytsaurus parts for building images. ytserver-all, python binaries, certs, Dockerfile, credits",
         "version": "{revision}",
     },
+    "include": [
+        "yt/docker/ya-build/base/build-server-linux-x86_64.json",
+        "yt/docker/ya-build/base/build-python-linux-x86_64.json",
+        "yt/docker/ya-build/base/data-common.json",
+        "yt/docker/ya-build/base/data-server.json",
+        "yt/docker/ya-build/base/data-python.json",
+    ],
     "params": {
         "format": "docker",
         "docker_target": "base-exec",
@@ -12,144 +19,4 @@
             "PYTHON_BUILD_BASE": "build-ytsaurus-python-binaries",
         },
     },
-    "build": {
-        "build_server_binaries": {
-            "targets": [
-                "yt/yt/server/all",
-            ],
-            "build_type": "profile",
-            "thinlto": true,
-            "target-platforms": [
-                "default-linux-x86_64",
-            ],
-            "flags": [
-                {
-                    "name": "NO_STRIP",
-                    "value": "yes",
-                },
-            ],
-        },
-        "build_python_binaries": {
-            "targets": [
-                "yt/yt/python/yson_shared",
-                "yt/yt/python/driver/native_shared",
-                "yt/yt/python/driver/rpc_shared",
-            ],
-            "build_type": "release",
-            "thinlto": true,
-            "target-platforms": [
-                "default-linux-x86_64",
-            ],
-            "flags": [
-                {
-                    "name": "USE_ARCADIA_PYTHON",
-                    "value": "no",
-                },
-                {
-                    "name": "USE_LOCAL_PYTHON",
-                    "value": "yes",
-                },
-                {
-                    "name": "PYTHON_BIN",
-                    "value": "python3",
-                },
-                {
-                    "name": "PYTHON_CONFIG",
-                    "value": "python3-config",
-                },
-                {
-                    "name": "STRIP",
-                    "value": "yes",
-                },
-            ],
-        },
-    },
-    "data": [
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/docker/ytsaurus/Dockerfile",
-            },
-            "destination": {
-                "path": "/Dockerfile",
-            },
-        },
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "certs/cacert.pem",
-            },
-            "destination": {
-                "path": "/certs/cacert.pem",
-            },
-        },
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/python",
-            },
-            "destination": {
-                "path": "/yt/python",
-            },
-        },
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/yt/python",
-            },
-            "destination": {
-                "path": "/yt/yt/python",
-            },
-        },
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/docker/ytsaurus/credits/ytsaurus/ytserver-all.CREDITS",
-            },
-            "destination": {
-                "path": "/credits/ytserver-all.CREDITS",
-            },
-        },
-        {
-            "source": {
-                "type": "BUILD_OUTPUT",
-                "build_key": "build_server_binaries",
-                "path": "yt/yt/server/all/ytserver-all",
-            },
-            "destination": {
-                "path": "/",
-            },
-        },
-        {
-            "source": {
-                "type": "BUILD_OUTPUT",
-                "build_key": "build_python_binaries",
-                "path": "yt/yt/python/yson_shared/yson_lib.so",
-            },
-            "destination": {
-                "path": "/artifacts/libyson_lib.so",
-            },
-        },
-        {
-            "source": {
-                "type": "BUILD_OUTPUT",
-                "build_key": "build_python_binaries",
-                "path": "yt/yt/python/driver/native_shared/driver_lib.so",
-            },
-            "destination": {
-                "path": "/artifacts/libdriver_lib.so",
-            },
-        },
-        {
-            "source": {
-                "type": "BUILD_OUTPUT",
-                "build_key": "build_python_binaries",
-                "path": "yt/yt/python/driver/rpc_shared/driver_rpc_lib.so",
-            },
-            "destination": {
-                "path": "/artifacts/libdriver_rpc_lib.so",
-            },
-        },
-    ],
 }
-

--- a/yt/docker/ya-build/query-tracker/package.json
+++ b/yt/docker/ya-build/query-tracker/package.json
@@ -13,7 +13,7 @@
         },
     },
     "include": [
-      "yt/docker/ya-build/base/package.json",
+        "yt/docker/ya-build/base/package.json",
     ],
     "data": [
         {

--- a/yt/docker/ya-build/ytsaurus-server-override/package.json
+++ b/yt/docker/ya-build/ytsaurus-server-override/package.json
@@ -5,60 +5,13 @@
         "description": "Core YTsaurus image built with yt client libraries from existing base image",
         "version": "local-{revision}",
     },
+    "include": [
+        "yt/docker/ya-build/base/build-server-linux-x86_64.json",
+        "yt/docker/ya-build/base/data-common.json",
+        "yt/docker/ya-build/base/data-server.json",
+    ],
     "params": {
         "format": "docker",
         "docker_target": "ytsaurus-server-override",
     },
-    "build": {
-        "build_server_binaries": {
-            "targets": [
-                "yt/yt/server/all",
-            ],
-            "build_type": "profile",
-            "thinlto": true,
-            "target-platforms": [
-                "default-linux-x86_64",
-            ],
-            "flags": [
-                {
-                    "name": "NO_STRIP",
-                    "value": "yes",
-                },
-            ],
-        },
-    },
-    "data": [
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/docker/ytsaurus/Dockerfile",
-            },
-            "destination": {
-                "path": "/Dockerfile",
-            },
-        },
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/python/yt/environment",
-                "files": [
-                    "init_queue_agent_state.py",
-                    "init_operations_archive.py",
-                ],
-            },
-            "destination": {
-                "path": "/",
-            },
-        },
-        {
-            "source": {
-                "type": "BUILD_OUTPUT",
-		        "build_key": "build_server_binaries",
-                "path": "yt/yt/server/all/ytserver-all",
-            },
-            "destination": {
-                "path": "/",
-            },
-        },
-    ],
 }

--- a/yt/docker/ya-build/ytsaurus/package-linux-aarch64.json
+++ b/yt/docker/ya-build/ytsaurus/package-linux-aarch64.json
@@ -1,0 +1,24 @@
+{
+    "meta": {
+        "name": "ytsaurus",
+        "maintainer": "YT team",
+        "description": "Core YTsaurus image built with yt client libraries from source files",
+        "version": "local-{revision}",
+    },
+    "include": [
+        "yt/docker/ya-build/base/build-server-linux-aarch64.json",
+        "yt/docker/ya-build/base/build-python-linux-aarch64.json",
+        "yt/docker/ya-build/base/data-common.json",
+        "yt/docker/ya-build/base/data-server.json",
+        "yt/docker/ya-build/base/data-python.json",
+    ],
+    "params": {
+        "format": "docker",
+        "docker_target": "ytsaurus",
+        "docker_build_arg": {
+            "PYTHON_BUILD_BASE": "build-ytsaurus-python-binaries",
+            "SERVER_IMAGE_BASE": "base-server-crio",
+        },
+        "docker_platform" : "linux/arm64",
+    },
+}

--- a/yt/docker/ya-build/ytsaurus/package.json
+++ b/yt/docker/ya-build/ytsaurus/package.json
@@ -6,7 +6,11 @@
         "version": "local-{revision}",
     },
     "include": [
-        "yt/docker/ya-build/base/package.json",
+        "yt/docker/ya-build/base/build-server-linux-x86_64.json",
+        "yt/docker/ya-build/base/build-python-linux-x86_64.json",
+        "yt/docker/ya-build/base/data-common.json",
+        "yt/docker/ya-build/base/data-server.json",
+        "yt/docker/ya-build/base/data-python.json",
     ],
     "params": {
         "format": "docker",
@@ -16,19 +20,4 @@
             "SERVER_IMAGE_BASE": "base-server-crio",
         },
     },
-    "data": [
-        {
-            "source": {
-                "type": "ARCADIA",
-                "path": "yt/python/yt/environment",
-                "files": [
-                    "init_queue_agent_state.py",
-                    "init_operations_archive.py",
-                ],
-            },
-            "destination": {
-                "path": "/",
-            },
-        },
-    ],
 }

--- a/yt/docker/ya-build/ytsaurus/ya.make
+++ b/yt/docker/ya-build/ytsaurus/ya.make
@@ -2,6 +2,7 @@ UNION()
 
 FILES(
     package.json
+    package-linux-aarch64.json
 )
 
 END()

--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -106,7 +106,8 @@ FROM base AS build-ytsaurus-python-binaries
 
 ARG PROTOC_VERSION="3.20.1"
 
-RUN curl -sL -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
+RUN PROTOC_ARCH=$(uname -m | sed -e 's/aarch64/aarch_64/') \
+    && curl -sL -o protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip \
     && unzip protoc.zip -d /usr/local \
     && rm protoc.zip
 

--- a/yt/docker/ytsaurus/Dockerfile
+++ b/yt/docker/ytsaurus/Dockerfile
@@ -161,10 +161,10 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install 
   openjdk-17-jdk \
   java-common
 
-RUN ln -s /usr/lib/jvm/java-11-openjdk-amd64 /opt/jdk11
-RUN ln -s /usr/lib/jvm/java-17-openjdk-amd64 /opt/jdk17
-
-RUN update-java-alternatives --set java-1.11.0-openjdk-amd64
+RUN HOST_ARCH=$(dpkg --print-architecture) \
+  && ln -s /usr/lib/jvm/java-11-openjdk-${HOST_ARCH} /opt/jdk11 \
+  && ln -s /usr/lib/jvm/java-17-openjdk-${HOST_ARCH} /opt/jdk17 \
+  && update-java-alternatives --set java-1.11.0-openjdk-${HOST_ARCH}
 
 # Default python to be used by python3 jobs, for compatibility with jupyter tutorial.
 RUN ln -s /usr/bin/python3.8 /usr/bin/python3 -f

--- a/yt/python/packages/build_ytsaurus_packages.sh
+++ b/yt/python/packages/build_ytsaurus_packages.sh
@@ -119,7 +119,7 @@ for package in ${packages[@]}; do
         python3 setup.py bdist_wheel --py-limited-api cp34 --dist-dir ${dist_dir}
         if [[ ${apply_auditwheel} == "true" ]]; then
             for wheel in ${dist_dir}/${package_undescored}*.whl; do
-                auditwheel repair "$wheel" -w "${dist_dir}" --plat manylinux2014_x86_64
+                auditwheel repair "$wheel" -w "${dist_dir}" --plat "manylinux2014_$(uname -m)"
                 # Remove original wheel.
                 rm "$wheel"
             done


### PR DESCRIPTION
- Add ytsaurus arm64 package
  Requirements for cross-compiling at x86_64 host:
  
  - multiarch
  
  - Symlink hack for pyconfig.h headers
  
  - binfmnt and static qemu-user for docker build
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- Fix building python wheel for arm64
  
- Fix jvm install in docker for arm64
  
---

* Package for arm64 ytsaurus server docker image
Type: feature
Component: misc-server

Required components and fixes for building arm64 docker

