### PR TITLE
Quote variables in conditionals to prevent syntax errors when empty

### DIFF
--- a/yt/docker/local/run_local_cluster.sh
+++ b/yt/docker/local/run_local_cluster.sh
@@ -248,7 +248,7 @@ fi
 
 yt_run_params=""
 params=""
-if [ ${enable_debug_logging} == true ]; then
+if [ "${enable_debug_logging}" == true ]; then
     params="--enable-debug-logging"
     yt_backend_tmp="$(realpath ~/)/yt.backend_tmp_$(date +%Y%m%d_%H%M%S)"
     # mkdir $yt_backend_tmp
@@ -264,15 +264,15 @@ if [ ${enable_debug_logging} == true ]; then
     ) >&2
 fi
 
-if [ ${with_auth} == true ]; then
+if [ "${with_auth}" == true ]; then
     params="${params} --enable-auth --create-admin-user"
 fi
 
-if [ ${init_operations_archive} == true ]; then
+if [ "${init_operations_archive}" == true ]; then
     params="${params} --init-operations-archive"
 fi
 
-if [ ${publish_ports} == true ]; then
+if [ "${publish_ports}" == true ]; then
     ports=""
     max_port=$(($port_range_start + 100))
     for port in $(seq $port_range_start $max_port); do
@@ -314,7 +314,7 @@ so you have to provide another port via --proxy-port option."
 fi
 
 
-if [ ${run_prometheus} == true ]; then
+if [ "${run_prometheus}" == true ]; then
 
     targets="['host.docker.internal:${port_range_start}'"
     min_port=$(($port_range_start + 1))


### PR DESCRIPTION
The trivial fix of `yt/docker/local/run_local_cluster.sh` to prevent errors like that

```
./run_local_cluster.sh: line 317: [: ==: unary operator expected   # <-------------- Error

Congratulations! Local cluster is up and running. To use the cluster web interface, point your browser to http://localhost:8001. Or, if you prefer command-line tool 'yt', use it like this: 'yt --proxy localhost:8000 <command>'.

When you finish with the local interface,stop it by running a command:
        docker stop yt.backend yt.frontend
or
        ./run_local_cluster.sh --stop
```

---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.
