### PR TITLE
YQL-19616 Add unified lexer tests and fix lexer/regex

### DIFF
--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -363,6 +363,23 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
         UNIT_ASSERT_TOKENIZED(lexer, "/* yql\n * yql\n */", "COMMENT(/* yql\n * yql\n */) EOF");
     }
 
+    Y_UNIT_TEST_ON_EACH_LEXER(RecursiveMultiLineComment) {
+        auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
+        if (!ANSI) {
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* yql */", "COMMENT(/* /* yql */) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* yql */ */", "COMMENT(/* /* yql */) WS( ) ASTERISK(*) SLASH(/) EOF");
+        } else {
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* yql */", "COMMENT(/* /* yql */) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/* yql */ */", "COMMENT(/* yql */) WS( ) ASTERISK(*) SLASH(/) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* /* yql */ */", "COMMENT(/* /* /* yql */ */) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* yql */ */ */", "COMMENT(/* /* yql */ */) WS( ) ASTERISK(*) SLASH(/) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* yql */ */", "COMMENT(/* /* yql */ */) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/*/*/*/", "COMMENT(/*/*/) ASTERISK(*) SLASH(/) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/*/**/*/*/*/", "COMMENT(/*/**/*/) ASTERISK(*) SLASH(/) ASTERISK(*) SLASH(/) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "/* /* */ a /* /* */", "COMMENT(/* /* */ a /* /* */) EOF");
+        }
+    }
+
     Y_UNIT_TEST_ON_EACH_LEXER(SimpleQuery) {
         auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
         UNIT_ASSERT_TOKENIZED(lexer, "select 1", "SELECT WS( ) DIGITS(1) EOF");

--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -344,6 +344,18 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
         UNIT_ASSERT_TOKENIZED(lexer, "`local/table`", "ID_QUOTED(`local/table`) EOF");
     }
 
+    Y_UNIT_TEST_ON_EACH_LEXER(Number) {
+        auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
+        UNIT_ASSERT_TOKENIZED(lexer, "1", "DIGITS(1) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "123", "DIGITS(123) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "123u", "INTEGER_VALUE(123u) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "123ui", "INTEGER_VALUE(123ui) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "123.45", "REAL(123.45) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "123.45E10", "REAL(123.45E10) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "123.45E+10", "REAL(123.45E+10) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "1E+10", "REAL(1E+10) EOF");
+    }
+
     Y_UNIT_TEST_ON_EACH_LEXER(SingleLineString) {
         auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
         UNIT_ASSERT_TOKENIZED(lexer, "\"\"", "STRING_VALUE(\"\") EOF");
@@ -386,6 +398,7 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
     Y_UNIT_TEST_ON_EACH_LEXER(SimpleQuery) {
         auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
         UNIT_ASSERT_TOKENIZED(lexer, "select 1", "SELECT WS( ) DIGITS(1) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "SELect 1", "SELECT WS( ) DIGITS(1) EOF");
     }
 
     Y_UNIT_TEST_ON_EACH_LEXER(ComplexQuery) {

--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -14,6 +14,8 @@
 
 #include <library/cpp/testing/unittest/registar.h>
 
+#include <util/string/ascii.h>
+
 #define UNIT_ASSERT_TOKENIZED(LEXER, QUERY, TOKENS) \
     do {                                            \
         auto tokens = Tokenized((LEXER), (QUERY));  \
@@ -65,7 +67,7 @@ TVector<TString> GetTokenViews(ILexer::TPtr& lexer, const TString& query) {
 
 TString ToString(TParsedToken token) {
     TString& string = token.Name;
-    if (token.Name != token.Content && token.Name != "EOF") {
+    if (!AsciiEqualsIgnoreCase(token.Name, token.Content) && token.Name != "EOF") {
         string += "(";
         string += token.Content;
         string += ")";
@@ -379,6 +381,11 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
         UNIT_ASSERT_TOKENIZED(lexer, "/* yql */", "COMMENT(/* yql */) EOF");
         UNIT_ASSERT_TOKENIZED(lexer, "/* yql */ */", "COMMENT(/* yql */) WS( ) ASTERISK(*) SLASH(/) EOF");
         UNIT_ASSERT_TOKENIZED(lexer, "/* yql\n * yql\n */", "COMMENT(/* yql\n * yql\n */) EOF");
+    }
+
+    Y_UNIT_TEST_ON_EACH_LEXER(SimpleQuery) {
+        auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
+        UNIT_ASSERT_TOKENIZED(lexer, "select 1", "SELECT WS( ) DIGITS(1) EOF");
     }
 
 } // Y_UNIT_TEST_SUITE(SQLv1Lexer)

--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -1,4 +1,5 @@
 #include "lexer.h"
+#include "lexer_ut.h"
 
 #include <yql/essentials/core/issue/yql_issue.h>
 #include <yql/essentials/sql/settings/translation_settings.h>
@@ -252,5 +253,9 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
         };
 
         UNIT_ASSERT_VALUES_EQUAL(actual, expected);
+    }
+
+    Y_UNIT_TEST_ON_EACH_LEXER(N) {
+        
     }
 }

--- a/yql/essentials/sql/v1/lexer/lexer_ut.h
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "lexer.h"
+
+#define Y_UNIT_TEST_ON_EACH_LEXER_NAME(ANSI, ANTLR4, FLAVOR) \
+    TestLexerName_ANSI_##ANSI##_ANTLR4_##ANTLR4##_FLAVOR_##FLAVOR
+
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, false, Default) = "antlr3";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, true, Default) = "antlr4";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, false, Default) = "antlr3_ansi";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, true, Default) = "antlr4_ansi";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, true, Pure) = "antlr4_pure";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, true, Pure) = "antlr4_pure_ansi";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, false, Regex) = "regex";
+constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, false, Regex) = "regex_ansi";
+
+#define Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, ANSI, ANTLR4, FLAVOR)                              \
+    TCurrentTest::AddTest(                                                                       \
+        Y_UNIT_TEST_ON_EACH_LEXER_NAME(ANSI, ANTLR4, FLAVOR),                                    \
+        static_cast<void (*)(NUnitTest::TTestContext&)>(&N<ANSI, ANTLR4, ELexerFlavor::FLAVOR>), \
+        /* forceFork = */ false)
+
+#define Y_UNIT_TEST_ON_EACH_LEXER(N)                                      \
+    template <bool ANSI, bool ANTLR4, ELexerFlavor FLAVOR>                \
+    void N(NUnitTest::TTestContext&);                                     \
+    struct TTestRegistration##N {                                         \
+        TTestRegistration##N() {                                          \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, false, false, Default); \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, false, true, Default);  \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, true, false, Default);  \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, true, true, Default);   \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, false, true, Pure);     \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, true, true, Pure);      \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, false, false, Regex);   \
+            Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, true, false, Regex);    \
+        }                                                                 \
+    };                                                                    \
+    static TTestRegistration##N testRegistration##N;                      \
+    template <bool ANSI, bool ANTLR4, ELexerFlavor FLAVOR>                \
+    void N(NUnitTest::TTestContext&)

--- a/yql/essentials/sql/v1/lexer/lexer_ut.h
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.h
@@ -2,21 +2,18 @@
 
 #include "lexer.h"
 
-#define Y_UNIT_TEST_ON_EACH_LEXER_NAME(ANSI, ANTLR4, FLAVOR) \
-    TestLexerName_ANSI_##ANSI##_ANTLR4_##ANTLR4##_FLAVOR_##FLAVOR
-
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, false, Default) = "antlr3";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, true, Default) = "antlr4";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, false, Default) = "antlr3_ansi";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, true, Default) = "antlr4_ansi";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, true, Pure) = "antlr4_pure";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, true, Pure) = "antlr4_pure_ansi";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(false, false, Regex) = "regex";
-constexpr const char* Y_UNIT_TEST_ON_EACH_LEXER_NAME(true, false, Regex) = "regex_ansi";
+#define LEXER_NAME_ANSI_false_ANTLR4_false_FLAVOR_Default "antlr3"
+#define LEXER_NAME_ANSI_false_ANTLR4_true_FLAVOR_Default "antlr4"
+#define LEXER_NAME_ANSI_true_ANTLR4_false_FLAVOR_Default "antlr3_ansi"
+#define LEXER_NAME_ANSI_true_ANTLR4_true_FLAVOR_Default "antlr4_ansi"
+#define LEXER_NAME_ANSI_false_ANTLR4_true_FLAVOR_Pure "antlr4_pure"
+#define LEXER_NAME_ANSI_true_ANTLR4_true_FLAVOR_Pure "antlr4_pure_ansi"
+#define LEXER_NAME_ANSI_false_ANTLR4_false_FLAVOR_Regex "regex"
+#define LEXER_NAME_ANSI_true_ANTLR4_false_FLAVOR_Regex "regex_ansi"
 
 #define Y_UNIT_TEST_ON_EACH_LEXER_ADD_TEST(N, ANSI, ANTLR4, FLAVOR)                              \
     TCurrentTest::AddTest(                                                                       \
-        Y_UNIT_TEST_ON_EACH_LEXER_NAME(ANSI, ANTLR4, FLAVOR),                                    \
+        #N "::" LEXER_NAME_ANSI_##ANSI##_ANTLR4_##ANTLR4##_FLAVOR_##FLAVOR,                      \
         static_cast<void (*)(NUnitTest::TTestContext&)>(&N<ANSI, ANTLR4, ELexerFlavor::FLAVOR>), \
         /* forceFork = */ false)
 

--- a/yql/essentials/sql/v1/lexer/regex/lexer.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.cpp
@@ -72,7 +72,7 @@ namespace NSQLTranslationV1 {
 
             size_t keywordCount = MatchKeyword(prefix, matches);
             MatchPunctuation(prefix, matches);
-            size_t otherCount = MatchRegex(prefix, matches);
+            MatchRegex(prefix, matches);
             MatchComment(prefix, matches);
 
             if (matches.empty()) {
@@ -92,10 +92,6 @@ namespace NSQLTranslationV1 {
                            return m.Name == name;
                        });
             };
-
-            Y_ENSURE(
-                otherCount <= 1 ||
-                (otherCount == 2 && isMatched("DIGITS") && isMatched("INTEGER_VALUE")));
 
             size_t conflicts = CountIf(matches, [&](const TParsedToken& m) {
                 return m.Content.length() == max->Content.length();

--- a/yql/essentials/sql/v1/lexer/regex/lexer.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.cpp
@@ -10,6 +10,7 @@
 #include <util/generic/algorithm.h>
 #include <util/generic/string.h>
 #include <util/string/subst.h>
+#include <util/string/ascii.h>
 
 namespace NSQLTranslationV1 {
 
@@ -23,15 +24,15 @@ namespace NSQLTranslationV1 {
         TRegexLexer(
             bool ansi,
             NSQLReflect::TLexerGrammar grammar,
-            const THashMap<TString, TString>& RegexByOtherNameMap)
+            const TVector<std::tuple<TString, TString>>& RegexByOtherName)
             : Grammar_(std::move(grammar))
             , Ansi_(ansi)
         {
-            for (auto& [token, regex] : RegexByOtherNameMap) {
+            for (const auto& [token, regex] : RegexByOtherName) {
                 if (token == CommentTokenName) {
                     CommentRegex_.Reset(new RE2(regex));
                 } else {
-                    OtherRegexes_.emplace(std::move(token), std::move(regex));
+                    OtherRegexes_.emplace_back(token, new RE2(regex));
                 }
             }
         }
@@ -74,13 +75,17 @@ namespace NSQLTranslationV1 {
             size_t otherCount = MatchRegex(prefix, matches);
             MatchComment(prefix, matches);
 
-            auto max = MaxElementBy(matches, [](const TParsedToken& m) {
-                return m.Content.length();
-            });
-
-            if (max == std::end(matches)) {
+            if (matches.empty()) {
                 return {};
             }
+
+            auto maxLength = MaxElementBy(matches, [](const TParsedToken& m) {
+                                 return m.Content.length();
+                             })->Content.length();
+
+            auto max = FindIf(matches, [&](const TParsedToken& m) {
+                return m.Content.length() == maxLength;
+            });
 
             auto isMatched = [&](const TStringBuf name) {
                 return std::end(matches) != FindIf(matches, [&](const auto& m) {
@@ -108,7 +113,7 @@ namespace NSQLTranslationV1 {
         bool MatchKeyword(const TStringBuf prefix, TParsedTokenList& matches) {
             size_t count = 0;
             for (const auto& keyword : Grammar_.KeywordNames) {
-                if (prefix.substr(0, keyword.length()) == keyword) {
+                if (AsciiEqualsIgnoreCase(prefix.substr(0, keyword.length()), keyword)) {
                     matches.emplace_back(keyword, keyword);
                     count += 1;
                 }
@@ -131,7 +136,7 @@ namespace NSQLTranslationV1 {
         size_t MatchRegex(const TStringBuf prefix, TParsedTokenList& matches) {
             size_t count = 0;
             for (const auto& [token, regex] : OtherRegexes_) {
-                if (const TStringBuf match = TryMatchRegex(prefix, regex); !match.empty()) {
+                if (const TStringBuf match = TryMatchRegex(prefix, *regex); !match.empty()) {
                     matches.emplace_back(token, TString(match));
                     count += 1;
                 }
@@ -216,7 +221,7 @@ namespace NSQLTranslationV1 {
         }
 
         NSQLReflect::TLexerGrammar Grammar_;
-        THashMap<TString, RE2> OtherRegexes_;
+        TVector<std::tuple<TString, THolder<RE2>>> OtherRegexes_;
         THolder<RE2> CommentRegex_;
         bool Ansi_;
     };
@@ -228,19 +233,19 @@ namespace NSQLTranslationV1 {
             explicit TFactory(bool ansi)
                 : Ansi_(ansi)
                 , Grammar_(NSQLReflect::LoadLexerGrammar())
-                , RegexByOtherNameMap_(MakeRegexByOtherNameMap(Grammar_, Ansi_))
+                , RegexByOtherName_(MakeRegexByOtherName(Grammar_, Ansi_))
             {
             }
 
             NSQLTranslation::ILexer::TPtr MakeLexer() const override {
                 return NSQLTranslation::ILexer::TPtr(
-                    new TRegexLexer(Ansi_, Grammar_, RegexByOtherNameMap_));
+                    new TRegexLexer(Ansi_, Grammar_, RegexByOtherName_));
             }
 
         private:
             bool Ansi_;
             NSQLReflect::TLexerGrammar Grammar_;
-            THashMap<TString, TString> RegexByOtherNameMap_;
+            TVector<std::tuple<TString, TString>> RegexByOtherName_;
         };
 
     } // namespace

--- a/yql/essentials/sql/v1/lexer/regex/regex.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/regex.cpp
@@ -227,12 +227,12 @@ namespace NSQLTranslationV1 {
         TRewriteRule UnwrapQuotedSpace_;
     };
 
-    THashMap<TString, TString> MakeRegexByOtherNameMap(const NSQLReflect::TLexerGrammar& grammar, bool ansi) {
+    TVector<std::tuple<TString, TString>> MakeRegexByOtherName(const NSQLReflect::TLexerGrammar& grammar, bool ansi) {
         TLexerGrammarToRegexTranslator translator(grammar, ansi);
 
-        THashMap<TString, TString> regexes;
+        TVector<std::tuple<TString, TString>> regexes;
         for (const auto& token : grammar.OtherNames) {
-            regexes.emplace(token, translator.ToRegex(token));
+            regexes.emplace_back(token, translator.ToRegex(token));
         }
         return regexes;
     }

--- a/yql/essentials/sql/v1/lexer/regex/regex.h
+++ b/yql/essentials/sql/v1/lexer/regex/regex.h
@@ -8,7 +8,7 @@ namespace NSQLTranslationV1 {
 
     // Makes regexes only for tokens from OtherNames,
     // as keywords and punctuation are trivially matched.
-    THashMap<TString, TString> MakeRegexByOtherNameMap(
+    TVector<std::tuple<TString, TString>> MakeRegexByOtherName(
         const NSQLReflect::TLexerGrammar& grammar, bool ansi);
 
 } // namespace NSQLTranslationV1

--- a/yql/essentials/sql/v1/lexer/ut/ya.make
+++ b/yql/essentials/sql/v1/lexer/ut/ya.make
@@ -4,8 +4,11 @@ PEERDIR(
     yql/essentials/core/issue
     yql/essentials/parser/lexer_common
     yql/essentials/sql/v1/lexer/antlr3
+    yql/essentials/sql/v1/lexer/antlr3_ansi
     yql/essentials/sql/v1/lexer/antlr4
+    yql/essentials/sql/v1/lexer/antlr4_ansi
     yql/essentials/sql/v1/lexer/antlr4_pure
+    yql/essentials/sql/v1/lexer/antlr4_pure_ansi
     yql/essentials/sql/v1/lexer/regex
 )
 

--- a/yql/essentials/sql/v1/reflect/sql_reflect.cpp
+++ b/yql/essentials/sql/v1/reflect/sql_reflect.cpp
@@ -134,7 +134,7 @@ namespace NSQLReflect {
         auto [name, block] = ParseLexerRule(std::move(line));
 
         if (!name.StartsWith(FragmentPrefix)) {
-            grammar.OtherNames.emplace(name);
+            grammar.OtherNames.emplace_back(name);
         }
 
         SubstGlobal(name, FragmentPrefix, "");

--- a/yql/essentials/sql/v1/reflect/sql_reflect.h
+++ b/yql/essentials/sql/v1/reflect/sql_reflect.h
@@ -1,15 +1,16 @@
 #pragma once
 
 #include <util/generic/string.h>
-#include <util/generic/hash_set.h>
 #include <util/generic/hash.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/vector.h>
 
 namespace NSQLReflect {
 
     struct TLexerGrammar {
         THashSet<TString> KeywordNames;
         THashSet<TString> PunctuationNames;
-        THashSet<TString> OtherNames;
+        TVector<TString> OtherNames;
         THashMap<TString, TString> BlockByName;
     };
 


### PR DESCRIPTION
- [x] Add unified lexer tests at `sql/v1/lexer/lexer_ut.cpp`.
- [x] Fix `lexer/regex` to be case-insensitive.
- [x] Fix `lexer/regex` to prefer `DIGITS` over `INTEGER_VALUE` by preserving lexer rules order at `TLexerGrammar`.