### PR TITLE
Remove `path` and `acl` error attributes from Access Denied error in `get-job-stderr` and other methods

### DIFF
--- a/yt/yt/ytlib/scheduler/helpers.cpp
+++ b/yt/yt/ytlib/scheduler/helpers.cpp
@@ -495,11 +495,6 @@ void ValidateCheckPermissionsResults(
             "Operation access denied")
             << TErrorAttribute("user", userStr)
             << TErrorAttribute("required_permissions", permissionSet);
-        if (accessControlRule.IsAcoName()) {
-            error = error << TErrorAttribute("path", accessControlRule.GetAclString());
-        } else {
-            error = error << TErrorAttribute("acl", accessControlRule.GetAclString());
-        }
         if (operationId) {
             error = error
                 << TErrorAttribute("operation_id", operationId);


### PR DESCRIPTION
Issue: #1174 

Remove `path` and `acl` error attributes from Access Denied error in `get-job-stderr` and other methods.

I don't think it needs to be mentioned in changelog
