### PR TITLE
YQL-19616 Fix lexer/regex keywords matching

### DIFF
--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -68,7 +68,7 @@ TVector<TString> GetTokenViews(ILexer::TPtr& lexer, const TString& query) {
 
 TString ToString(TParsedToken token) {
     TString& string = token.Name;
-    if (!AsciiEqualsIgnoreCase(token.Name, token.Content) && token.Name != "EOF") {
+    if (token.Name != token.Content && token.Name != "EOF") {
         string += "(";
         string += token.Content;
         string += ")";
@@ -306,6 +306,7 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
         UNIT_ASSERT_TOKENIZED(lexer, "SELECT", "SELECT EOF");
         UNIT_ASSERT_TOKENIZED(lexer, "INSERT", "INSERT EOF");
         UNIT_ASSERT_TOKENIZED(lexer, "FROM", "FROM EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "from", "FROM(from) EOF");
     }
 
     Y_UNIT_TEST_ON_EACH_LEXER(Punctuation) {
@@ -418,8 +419,8 @@ Y_UNIT_TEST_SUITE(SQLv1Lexer) {
 
     Y_UNIT_TEST_ON_EACH_LEXER(SimpleQuery) {
         auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
-        UNIT_ASSERT_TOKENIZED(lexer, "select 1", "SELECT WS( ) DIGITS(1) EOF");
-        UNIT_ASSERT_TOKENIZED(lexer, "SELect 1", "SELECT WS( ) DIGITS(1) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "select 1", "SELECT(select) WS( ) DIGITS(1) EOF");
+        UNIT_ASSERT_TOKENIZED(lexer, "SELect 1", "SELECT(SELect) WS( ) DIGITS(1) EOF");
     }
 
     Y_UNIT_TEST_ON_EACH_LEXER(ComplexQuery) {

--- a/yql/essentials/sql/v1/lexer/regex/lexer.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.cpp
@@ -109,8 +109,9 @@ namespace NSQLTranslationV1 {
         bool MatchKeyword(const TStringBuf prefix, TParsedTokenList& matches) {
             size_t count = 0;
             for (const auto& keyword : Grammar_.KeywordNames) {
-                if (AsciiEqualsIgnoreCase(prefix.substr(0, keyword.length()), keyword)) {
-                    matches.emplace_back(keyword, keyword);
+                const TStringBuf content = prefix.substr(0, keyword.length());
+                if (AsciiEqualsIgnoreCase(content, keyword)) {
+                    matches.emplace_back(keyword, TString(content));
                     count += 1;
                 }
             }


### PR DESCRIPTION
This is a bugfix of `(lexer/regex "select 1") == (("SELECT", "SELECT") : _)`, as the expected is `(("SELECT", "select") : _)`