### PR TITLE
Add sanity check for docker registry config

### DIFF
--- a/yt/yt/server/controller_agent/config.cpp
+++ b/yt/yt/server/controller_agent/config.cpp
@@ -707,6 +707,10 @@ void TDockerRegistryConfig::Register(TRegistrar registrar)
             options->InternalRegistryAlternativeAddresses.push_back(*options->InternalRegistryAddress);
         }
 
+        if (options->UseYtTokenForInternalRegistry && !options->InternalRegistryAddress) {
+            THROW_ERROR_EXCEPTION("Enabling \"use_yt_token_for_internal_registry\" without \"internal_registry_address\" is unsafe, tokens could leak outside");
+        }
+
         if (!options->TranslateInternalImagesIntoLayers && !options->ForwardInternalImagesToJobSpecs) {
             THROW_ERROR_EXCEPTION("At least one of forward_internal_images_to_job_specs or translate_internal_images_into_layers must be enabled");
         }


### PR DESCRIPTION
Setting use_yt_token_for_internal_registry = %true should be used
together with setting internal_registry_address = "{registry-fqdn}".
Otherwise docker pull requests with yt token as docker_auth for
internal docker images could be redirected to external registry
whatever is set default in CRI runtime service.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: fix
Component: misc-server



