### PR TITLE
YQL-19747 Complete after PRAGMA and multi-token names

### DIFF
--- a/yql/essentials/sql/v1/complete/name/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/name_service.h
@@ -13,6 +13,10 @@ namespace NSQLComplete {
         TString Indentifier;
     };
 
+    struct TPragmaName: TIndentifier {
+        using TConstraints = std::monostate;
+    };
+
     struct TTypeName: TIndentifier {
         using TConstraints = std::monostate;
     };
@@ -22,19 +26,23 @@ namespace NSQLComplete {
     };
 
     using TGenericName = std::variant<
+        TPragmaName,
         TTypeName,
         TFunctionName>;
 
     struct TNameRequest {
         struct {
-            std::optional<TTypeName::TConstraints> TypeName;
+            std::optional<TPragmaName::TConstraints> Pragma;
+            std::optional<TTypeName::TConstraints> Type;
             std::optional<TTypeName::TConstraints> Function;
         } Constraints;
         TString Prefix = "";
         size_t Limit = 128;
 
         bool IsEmpty() const {
-            return !Constraints.TypeName && !Constraints.Function;
+            return !Constraints.Pragma && 
+                   !Constraints.Type && 
+                   !Constraints.Function;
         }
     };
 

--- a/yql/essentials/sql/v1/complete/name/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/name_service.h
@@ -18,7 +18,7 @@ namespace NSQLComplete {
     };
 
     struct TPragmaName: TIndentifier {
-        struct TConstraints : TNamespaced {};
+        struct TConstraints: TNamespaced {};
     };
 
     struct TTypeName: TIndentifier {
@@ -26,7 +26,7 @@ namespace NSQLComplete {
     };
 
     struct TFunctionName: TIndentifier {
-        struct TConstraints : TNamespaced {};
+        struct TConstraints: TNamespaced {};
     };
 
     using TGenericName = std::variant<
@@ -44,8 +44,8 @@ namespace NSQLComplete {
         size_t Limit = 128;
 
         bool IsEmpty() const {
-            return !Constraints.Pragma && 
-                   !Constraints.Type && 
+            return !Constraints.Pragma &&
+                   !Constraints.Type &&
                    !Constraints.Function;
         }
     };

--- a/yql/essentials/sql/v1/complete/name/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/name_service.h
@@ -13,8 +13,12 @@ namespace NSQLComplete {
         TString Indentifier;
     };
 
+    struct TNamespaced {
+        TString Namespace;
+    };
+
     struct TPragmaName: TIndentifier {
-        using TConstraints = std::monostate;
+        struct TConstraints : TNamespaced {};
     };
 
     struct TTypeName: TIndentifier {
@@ -22,7 +26,7 @@ namespace NSQLComplete {
     };
 
     struct TFunctionName: TIndentifier {
-        using TConstraints = std::monostate;
+        struct TConstraints : TNamespaced {};
     };
 
     using TGenericName = std::variant<
@@ -34,7 +38,7 @@ namespace NSQLComplete {
         struct {
             std::optional<TPragmaName::TConstraints> Pragma;
             std::optional<TTypeName::TConstraints> Type;
-            std::optional<TTypeName::TConstraints> Function;
+            std::optional<TFunctionName::TConstraints> Function;
         } Constraints;
         TString Prefix = "";
         size_t Limit = 128;

--- a/yql/essentials/sql/v1/complete/name/static/frequency.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.cpp
@@ -14,6 +14,7 @@ namespace NSQLComplete {
             const char* Sum = "sum";
         } Key;
         struct {
+            const char* Pragma = "PRAGMA";
             const char* Type = "TYPE";
             const char* Func = "FUNC";
             const char* Module = "MODULE";
@@ -53,14 +54,17 @@ namespace NSQLComplete {
     TFrequencyData Convert(TVector<TFrequencyItem> items) {
         TFrequencyData data;
         for (auto& item : items) {
-            if (item.Parent == Json.Parent.Type ||
+            if (item.Parent == Json.Parent.Pragma ||
+                item.Parent == Json.Parent.Type ||
                 item.Parent == Json.Parent.Func ||
                 item.Parent == Json.Parent.ModuleFunc ||
                 item.Parent == Json.Parent.Module) {
                 item.Rule = ToLowerUTF8(item.Rule);
             }
 
-            if (item.Parent == Json.Parent.Type) {
+            if (item.Parent == Json.Parent.Pragma) {
+                data.Pragmas[item.Rule] += item.Sum;
+            } else if (item.Parent == Json.Parent.Type) {
                 data.Types[item.Rule] += item.Sum;
             } else if (item.Parent == Json.Parent.Func ||
                        item.Parent == Json.Parent.ModuleFunc) {

--- a/yql/essentials/sql/v1/complete/name/static/frequency.h
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.h
@@ -6,6 +6,7 @@
 namespace NSQLComplete {
 
     struct TFrequencyData {
+        THashMap<TString, size_t> Pragmas;
         THashMap<TString, size_t> Types;
         THashMap<TString, size_t> Functions;
     };

--- a/yql/essentials/sql/v1/complete/name/static/json_name_set.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/json_name_set.cpp
@@ -26,6 +26,10 @@ namespace NSQLComplete {
         return keys;
     }
 
+    TVector<TString> ParsePragmas(NJson::TJsonValue json) {
+        return ParseNames(json.GetArraySafe());
+    }
+
     TVector<TString> ParseTypes(NJson::TJsonValue json) {
         return ParseNames(json.GetArraySafe());
     }
@@ -48,6 +52,7 @@ namespace NSQLComplete {
 
     NameSet MakeDefaultNameSet() {
         return {
+            .Pragmas = ParsePragmas(LoadJsonResource("pragmas_opensource.json")),
             .Types = ParseTypes(LoadJsonResource("types.json")),
             .Functions = Merge(
                 ParseFunctions(LoadJsonResource("sql_functions.json")),

--- a/yql/essentials/sql/v1/complete/name/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/name_service.cpp
@@ -88,6 +88,7 @@ namespace NSQLComplete {
                 AppendAs<TFunctionName>(response.RankedNames, names);
             }
 
+            // FIXME(YQL-19747): Ranking is broken. FixPrefix should be done after crop.
             Ranking_->CropToSortedPrefix(response.RankedNames, request.Limit);
 
             return NThreading::MakeFuture(std::move(response));

--- a/yql/essentials/sql/v1/complete/name/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/name_service.cpp
@@ -41,6 +41,7 @@ namespace NSQLComplete {
             : NameSet_(std::move(names))
             , Ranking_(std::move(ranking))
         {
+            Sort(NameSet_.Pragmas, NoCaseCompare);
             Sort(NameSet_.Types, NoCaseCompare);
             Sort(NameSet_.Functions, NoCaseCompare);
         }
@@ -48,7 +49,13 @@ namespace NSQLComplete {
         TFuture<TNameResponse> Lookup(TNameRequest request) override {
             TNameResponse response;
 
-            if (request.Constraints.TypeName) {
+            if (request.Constraints.Pragma) {
+                AppendAs<TPragmaName>(
+                    response.RankedNames,
+                    FilteredByPrefix(request.Prefix, NameSet_.Pragmas));
+            }
+
+            if (request.Constraints.Type) {
                 AppendAs<TTypeName>(
                     response.RankedNames,
                     FilteredByPrefix(request.Prefix, NameSet_.Types));

--- a/yql/essentials/sql/v1/complete/name/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/name_service.cpp
@@ -35,7 +35,7 @@ namespace NSQLComplete {
         }
     }
 
-    TString Prefixed(const TStringBuf requestPrefix, const TNamespaced& namespaced, const TStringBuf delimeter) {
+    TString Prefixed(const TStringBuf requestPrefix, const TStringBuf delimeter, const TNamespaced& namespaced) {
         TString prefix;
         if (!namespaced.Namespace.empty()) {
             prefix += namespaced.Namespace;
@@ -45,7 +45,7 @@ namespace NSQLComplete {
         return prefix;
     }
 
-    void FixPrefix(TString& name, const TNamespaced& namespaced, const TStringBuf delimeter) {
+    void FixPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
         if (namespaced.Namespace.empty()) {
             return;
         }
@@ -56,12 +56,10 @@ namespace NSQLComplete {
         std::visit([&](auto& name) -> size_t {
             using T = std::decay_t<decltype(name)>;
             if constexpr (std::is_same_v<T, TPragmaName>) {
-                FixPrefix(name.Indentifier, *request.Constraints.Pragma, ".");
-            }
-            if constexpr (std::is_same_v<T, TTypeName>) {
+                FixPrefix(name.Indentifier, ".", *request.Constraints.Pragma);
             }
             if constexpr (std::is_same_v<T, TFunctionName>) {
-                FixPrefix(name.Indentifier, *request.Constraints.Function, "::");
+                FixPrefix(name.Indentifier, "::", *request.Constraints.Function);
             }
             return 0;
         }, name);
@@ -82,7 +80,7 @@ namespace NSQLComplete {
             TNameResponse response;
 
             if (request.Constraints.Pragma) {
-                auto prefix = Prefixed(request.Prefix, *request.Constraints.Pragma, ".");
+                auto prefix = Prefixed(request.Prefix, ".", *request.Constraints.Pragma);
                 auto names = FilteredByPrefix(prefix, NameSet_.Pragmas);
                 AppendAs<TPragmaName>(response.RankedNames, names);
             }
@@ -94,7 +92,7 @@ namespace NSQLComplete {
             }
 
             if (request.Constraints.Function) {
-                auto prefix = Prefixed(request.Prefix, *request.Constraints.Function, "::");
+                auto prefix = Prefixed(request.Prefix, "::", *request.Constraints.Function);
                 auto names = FilteredByPrefix(prefix, NameSet_.Functions);
                 AppendAs<TFunctionName>(response.RankedNames, names);
             }

--- a/yql/essentials/sql/v1/complete/name/static/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/static/name_service.h
@@ -7,6 +7,7 @@
 namespace NSQLComplete {
 
     struct NameSet {
+        TVector<TString> Pragmas;
         TVector<TString> Types;
         TVector<TString> Functions;
     };

--- a/yql/essentials/sql/v1/complete/name/static/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/ranking.cpp
@@ -59,6 +59,12 @@ namespace NSQLComplete {
 
                 auto identifier = ToLowerUTF8(ContentView(name));
 
+                if constexpr (std::is_same_v<T, TPragmaName>) {
+                    if (auto weight = Frequency_.Pragmas.FindPtr(identifier)) {
+                        return *weight;
+                    }
+                }
+
                 if constexpr (std::is_same_v<T, TFunctionName>) {
                     if (auto weight = Frequency_.Functions.FindPtr(identifier)) {
                         return *weight;

--- a/yql/essentials/sql/v1/complete/name/static/ya.make
+++ b/yql/essentials/sql/v1/complete/name/static/ya.make
@@ -13,6 +13,7 @@ PEERDIR(
 )
 
 RESOURCE(
+    yql/essentials/data/language/pragmas_opensource.json pragmas_opensource.json
     yql/essentials/data/language/types.json types.json
     yql/essentials/data/language/sql_functions.json sql_functions.json
     yql/essentials/data/language/udfs_basic.json udfs_basic.json

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -85,10 +85,12 @@ namespace NSQLComplete {
                 .Limit = Configuration.Limit - candidates.size(),
             };
 
-            if (context.IsTypeName) {
-                request.Constraints.TypeName = TTypeName::TConstraints();
+            if (context.IsPragmaName) {
+                request.Constraints.Pragma = TPragmaName::TConstraints();
             }
-
+            if (context.IsTypeName) {
+                request.Constraints.Type = TTypeName::TConstraints();
+            }
             if (context.IsFunctionName) {
                 request.Constraints.Function = TFunctionName::TConstraints();
             }
@@ -107,6 +109,9 @@ namespace NSQLComplete {
             for (auto& name : names) {
                 candidates.emplace_back(std::visit([](auto&& name) -> TCandidate {
                     using T = std::decay_t<decltype(name)>;
+                    if constexpr (std::is_base_of_v<TPragmaName, T>) {
+                        return {ECandidateKind::PragmaName, std::move(name.Indentifier)};
+                    }
                     if constexpr (std::is_base_of_v<TTypeName, T>) {
                         return {ECandidateKind::TypeName, std::move(name.Indentifier)};
                     }
@@ -162,6 +167,9 @@ void Out<NSQLComplete::ECandidateKind>(IOutputStream& out, NSQLComplete::ECandid
         case NSQLComplete::ECandidateKind::Keyword:
             out << "Keyword";
             break;
+        case NSQLComplete::ECandidateKind::PragmaName:
+            out << "PragmaName";
+            break;    
         case NSQLComplete::ECandidateKind::TypeName:
             out << "TypeName";
             break;

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -56,6 +56,8 @@ namespace NSQLComplete {
 
             if (ctx.Pragma && !ctx.Pragma->Namespace.empty()) {
                 position -= ctx.Pragma->Namespace.size() + 1;
+            } else if (ctx.Function && !ctx.Function->Namespace.empty()) {
+                position -= ctx.Function->Namespace.size() + 2;
             }
 
             return {
@@ -97,7 +99,7 @@ namespace NSQLComplete {
             if (context.IsTypeName) {
                 request.Constraints.Type = TTypeName::TConstraints();
             }
-            if (context.IsFunctionName) {
+            if (context.Function) {
                 request.Constraints.Function = TFunctionName::TConstraints();
             }
 

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -36,7 +36,7 @@ namespace NSQLComplete {
             }
 
             TLocalSyntaxContext context = SyntaxAnalysis->Analyze(input);
-            
+
             TStringBuf prefix = input.Text.Head(input.CursorPosition);
             TCompletedToken completedToken = GetCompletedToken(prefix);
 
@@ -175,7 +175,7 @@ void Out<NSQLComplete::ECandidateKind>(IOutputStream& out, NSQLComplete::ECandid
             break;
         case NSQLComplete::ECandidateKind::PragmaName:
             out << "PragmaName";
-            break;    
+            break;
         case NSQLComplete::ECandidateKind::TypeName:
             out << "TypeName";
             break;

--- a/yql/essentials/sql/v1/complete/sql_complete.h
+++ b/yql/essentials/sql/v1/complete/sql_complete.h
@@ -20,6 +20,7 @@ namespace NSQLComplete {
 
     enum class ECandidateKind {
         Keyword,
+        PragmaName,
         TypeName,
         FunctionName,
     };

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -269,14 +269,36 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     }
 
     Y_UNIT_TEST(Pragma) {
-        TVector<TCandidate> expected = {
-            {Keyword, "ANSI"},
-            {PragmaName, "yson.CastToString"}
-        };
-
         auto engine = MakeSqlCompletionEngineUT();
-        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"PRAGMA "}), expected);
-        // UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"PRAGMA yson."}), expected);
+        {
+            TVector<TCandidate> expected = {
+                {Keyword, "ANSI"},
+                {PragmaName, "yson.CastToString"}
+            };
+            auto completion = engine->Complete({"PRAGMA "});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "");
+        }
+        {
+            TVector<TCandidate> expected = {
+                {PragmaName, "yson.CastToString"}
+            };
+            {
+                auto completion = engine->Complete({"PRAGMA yson"});
+                UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+                UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson");
+            }
+            {
+                auto completion = engine->Complete({"PRAGMA yson."});
+                UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+                UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson.");
+            }
+            {
+                auto completion = engine->Complete({"PRAGMA yson.cast"});
+                UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+                UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson.cast");
+            }
+        }
     }
 
     Y_UNIT_TEST(Select) {
@@ -404,6 +426,10 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT Nothing(Option"}), expected);
         }
+    }
+
+    Y_UNIT_TEST(FunctioName) {
+        // TODO(YQL-19747): Check `SELECT DateTime::` completion.
     }
 
     Y_UNIT_TEST(UTF8Wide) {

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -40,6 +40,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     using ECandidateKind::FunctionName;
     using ECandidateKind::Keyword;
     using ECandidateKind::TypeName;
+    using ECandidateKind::PragmaName;
 
     TLexerSupplier MakePureLexerSupplier() {
         NSQLTranslationV1::TLexers lexers;
@@ -55,6 +56,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     ISqlCompletionEngine::TPtr MakeSqlCompletionEngineUT() {
         TLexerSupplier lexer = MakePureLexerSupplier();
         NameSet names = {
+            .Pragmas = {"yson.CastToString"},
             .Types = {"Uint64"},
             .Functions = {"StartsWith"},
         };
@@ -269,10 +271,12 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     Y_UNIT_TEST(Pragma) {
         TVector<TCandidate> expected = {
             {Keyword, "ANSI"},
+            {PragmaName, "yson.CastToString"}
         };
 
         auto engine = MakeSqlCompletionEngineUT();
         UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"PRAGMA "}), expected);
+        // UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"PRAGMA yson."}), expected);
     }
 
     Y_UNIT_TEST(Select) {

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -594,6 +594,10 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
 
     Y_UNIT_TEST(Ranking) {
         TFrequencyData frequency = {
+            .Pragmas = {
+                {"yt.defaultmemorylimit", 16},
+                {"yt.annotations", 8},
+            },
             .Types = {
                 {"int32", 128},
                 {"int64", 64},
@@ -610,6 +614,15 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         };
         auto service = MakeStaticNameService(MakeDefaultNameSet(), MakeDefaultRanking(frequency));
         auto engine = MakeSqlCompletionEngine(MakePureLexerSupplier(), std::move(service));
+        {
+            TVector<TCandidate> expectedPrefix = {
+                {PragmaName, "DefaultMemoryLimit"},
+                {PragmaName, "Annotations"},
+            };
+            auto actualPrefix = Complete(engine, {"PRAGMA yt."});
+            actualPrefix.crop(expectedPrefix.size());
+            UNIT_ASSERT_VALUES_EQUAL(actualPrefix, expectedPrefix);
+        }
         {
             TVector<TCandidate> expected = {
                 {TypeName, "Int32"},

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -283,21 +283,25 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {PragmaName, "yson.CastToString"}
             };
-            {
-                auto completion = engine->Complete({"PRAGMA yson"});
-                UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
-                UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson");
-            }
-            {
-                auto completion = engine->Complete({"PRAGMA yson."});
-                UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
-                UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson.");
-            }
-            {
-                auto completion = engine->Complete({"PRAGMA yson.cast"});
-                UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
-                UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson.cast");
-            }
+            auto completion = engine->Complete({"PRAGMA yson"});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson");
+        }
+        {
+            TVector<TCandidate> expected = {
+                {PragmaName, "CastToString"}
+            };
+            auto completion = engine->Complete({"PRAGMA yson."});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "");
+        }
+        {
+            TVector<TCandidate> expected = {
+                {PragmaName, "CastToString"}
+            };
+            auto completion = engine->Complete({"PRAGMA yson.cast"});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "cast");
         }
     }
 
@@ -435,28 +439,37 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         // TODO(YQL-19747): Check `SELECT DateTime::` completion.
 =======
     Y_UNIT_TEST(FunctionName) {
-        TVector<TCandidate> expected = {
-            {FunctionName, "DateTime::Split("},
-        };
         auto engine = MakeSqlCompletionEngineUT();
         {
+            TVector<TCandidate> expected = {
+                {FunctionName, "DateTime::Split("},
+            };
             auto completion = engine->Complete({"SELECT Date"});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "Date");
         }
         {
+            TVector<TCandidate> expected = {
+                {FunctionName, "Split("},
+            };
             auto completion = engine->Complete({"SELECT DateTime:"});
             UNIT_ASSERT(completion.Candidates.empty());
         }
         {
+            TVector<TCandidate> expected = {
+                {FunctionName, "Split("},
+            };
             auto completion = engine->Complete({"SELECT DateTime::"});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
-            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "DateTime::");
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "");
         }
         {
+            TVector<TCandidate> expected = {
+                {FunctionName, "Split("},
+            };
             auto completion = engine->Complete({"SELECT DateTime::s"});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
-            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "DateTime::s");
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "s");
         }
 >>>>>>> 7237d79f4a9 (YQL-19747 Fix namespaced function completion)
     }

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -414,7 +414,6 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT OPTIONAL<"}), expected);
     }
 
-<<<<<<< HEAD
     Y_UNIT_TEST(TypeNameAsArgument) {
         auto engine = MakeSqlCompletionEngineUT();
         {
@@ -431,9 +430,6 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         }
     }
 
-    Y_UNIT_TEST(FunctioName) {
-        // TODO(YQL-19747): Check `SELECT DateTime::` completion.
-=======
     Y_UNIT_TEST(FunctionName) {
         auto engine = MakeSqlCompletionEngineUT();
         {
@@ -467,7 +463,6 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "s");
         }
->>>>>>> 7237d79f4a9 (YQL-19747 Fix namespaced function completion)
     }
 
     Y_UNIT_TEST(UTF8Wide) {

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -58,7 +58,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         NameSet names = {
             .Pragmas = {"yson.CastToString"},
             .Types = {"Uint64"},
-            .Functions = {"StartsWith"},
+            .Functions = {"StartsWith", "DateTime::Split"},
         };
         auto ranking = MakeDefaultRanking({});
         INameService::TPtr service = MakeStaticNameService(std::move(names), std::move(ranking));
@@ -333,6 +333,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "TRUE"},
             {Keyword, "TUPLE"},
             {Keyword, "VARIANT"},
+            {FunctionName, "DateTime::Split("},
             {FunctionName, "StartsWith("},
         };
 
@@ -370,6 +371,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "TRUE"},
             {Keyword, "TUPLE"},
             {Keyword, "VARIANT"},
+            {FunctionName, "DateTime::Split("},
             {FunctionName, "StartsWith("},
         };
 
@@ -412,6 +414,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT OPTIONAL<"}), expected);
     }
 
+<<<<<<< HEAD
     Y_UNIT_TEST(TypeNameAsArgument) {
         auto engine = MakeSqlCompletionEngineUT();
         {
@@ -430,6 +433,32 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
 
     Y_UNIT_TEST(FunctioName) {
         // TODO(YQL-19747): Check `SELECT DateTime::` completion.
+=======
+    Y_UNIT_TEST(FunctionName) {
+        TVector<TCandidate> expected = {
+            {FunctionName, "DateTime::Split("},
+        };
+        auto engine = MakeSqlCompletionEngineUT();
+        {
+            auto completion = engine->Complete({"SELECT Date"});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "Date");
+        }
+        {
+            auto completion = engine->Complete({"SELECT DateTime:"});
+            UNIT_ASSERT(completion.Candidates.empty());
+        }
+        {
+            auto completion = engine->Complete({"SELECT DateTime::"});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "DateTime::");
+        }
+        {
+            auto completion = engine->Complete({"SELECT DateTime::s"});
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "DateTime::s");
+        }
+>>>>>>> 7237d79f4a9 (YQL-19747 Fix namespaced function completion)
     }
 
     Y_UNIT_TEST(UTF8Wide) {
@@ -440,9 +469,9 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
 
     Y_UNIT_TEST(WordBreak) {
         auto engine = MakeSqlCompletionEngineUT();
-        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT ("}).size(), 29);
-        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT (1)"}).size(), 30);
-        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT 1;"}).size(), 35);
+        UNIT_ASSERT_GE(Complete(engine, {"SELECT ("}).size(), 29);
+        UNIT_ASSERT_GE(Complete(engine, {"SELECT (1)"}).size(), 30);
+        UNIT_ASSERT_GE(Complete(engine, {"SELECT 1;"}).size(), 35);
     }
 
     Y_UNIT_TEST(Typing) {

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -39,8 +39,8 @@ public:
 Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     using ECandidateKind::FunctionName;
     using ECandidateKind::Keyword;
-    using ECandidateKind::TypeName;
     using ECandidateKind::PragmaName;
+    using ECandidateKind::TypeName;
 
     TLexerSupplier MakePureLexerSupplier() {
         NSQLTranslationV1::TLexers lexers;
@@ -273,32 +273,28 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         {
             TVector<TCandidate> expected = {
                 {Keyword, "ANSI"},
-                {PragmaName, "yson.CastToString"}
-            };
+                {PragmaName, "yson.CastToString"}};
             auto completion = engine->Complete({"PRAGMA "});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "");
         }
         {
             TVector<TCandidate> expected = {
-                {PragmaName, "yson.CastToString"}
-            };
+                {PragmaName, "yson.CastToString"}};
             auto completion = engine->Complete({"PRAGMA yson"});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson");
         }
         {
             TVector<TCandidate> expected = {
-                {PragmaName, "CastToString"}
-            };
+                {PragmaName, "CastToString"}};
             auto completion = engine->Complete({"PRAGMA yson."});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "");
         }
         {
             TVector<TCandidate> expected = {
-                {PragmaName, "CastToString"}
-            };
+                {PragmaName, "CastToString"}};
             auto completion = engine->Complete({"PRAGMA yson.cast"});
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "cast");

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -551,11 +551,11 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         }
         {
             TVector<TCandidate> expected = {
+                {PragmaName, "yson.DisableStrict"},
                 {PragmaName, "yson.AutoConvert"},
+                {PragmaName, "yson.Strict"},
                 {PragmaName, "yson.CastToString"},
                 {PragmaName, "yson.DisableCastToString"},
-                {PragmaName, "yson.DisableStrict"},
-                {PragmaName, "yson.Strict"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"PRAGMA yson"}), expected);
         }

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -549,6 +549,16 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT OPTIONAL<U"}), expected);
         }
+        {
+            TVector<TCandidate> expected = {
+                {PragmaName, "yson.AutoConvert"},
+                {PragmaName, "yson.CastToString"},
+                {PragmaName, "yson.DisableCastToString"},
+                {PragmaName, "yson.DisableStrict"},
+                {PragmaName, "yson.Strict"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"PRAGMA yson"}), expected);
+        }
     }
 
     Y_UNIT_TEST(OnFailingNameService) {

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -150,14 +150,12 @@ namespace NSQLComplete {
             if (tokens.size() < 4) {
                 pragma.Namespace = "";
             } else if (
-                tokens[tokens.size() - 3].Name == "ID_PLAIN" && 
-                tokens[tokens.size() - 2].Name == "DOT"
-            ) {
+                tokens[tokens.size() - 3].Name == "ID_PLAIN" &&
+                tokens[tokens.size() - 2].Name == "DOT") {
                 pragma.Namespace = tokens[tokens.size() - 3].Content;
             } else if (
-                tokens[tokens.size() - 4].Name == "ID_PLAIN" && 
-                tokens[tokens.size() - 3].Name == "DOT"
-            ) {
+                tokens[tokens.size() - 4].Name == "ID_PLAIN" &&
+                tokens[tokens.size() - 3].Name == "DOT") {
                 pragma.Namespace = tokens[tokens.size() - 4].Content;
             }
 
@@ -183,14 +181,12 @@ namespace NSQLComplete {
             if (tokens.size() < 4) {
                 function.Namespace = "";
             } else if (
-                tokens[tokens.size() - 3].Name == "ID_PLAIN" && 
-                tokens[tokens.size() - 2].Name == "NAMESPACE"
-            ) {
+                tokens[tokens.size() - 3].Name == "ID_PLAIN" &&
+                tokens[tokens.size() - 2].Name == "NAMESPACE") {
                 function.Namespace = tokens[tokens.size() - 3].Content;
             } else if (
-                tokens[tokens.size() - 4].Name == "ID_PLAIN" && 
-                tokens[tokens.size() - 3].Name == "NAMESPACE"
-            ) {
+                tokens[tokens.size() - 4].Name == "ID_PLAIN" &&
+                tokens[tokens.size() - 3].Name == "NAMESPACE") {
                 function.Namespace = tokens[tokens.size() - 4].Content;
             }
 
@@ -201,9 +197,8 @@ namespace NSQLComplete {
             NSQLTranslation::TParsedTokenList tokens;
             NYql::TIssues issues;
             if (!NSQLTranslation::Tokenize( // TODO(YQL-19747): Tokenize query as TStringBuf
-                    *Lexer_, TString(text), /* queryName = */ "", 
-                    tokens, issues, /* maxErrors = */ 0)
-            ) {
+                    *Lexer_, TString(text), /* queryName = */ "",
+                    tokens, issues, /* maxErrors = */ 0)) {
                 return {};
             }
             return tokens;

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -55,6 +55,7 @@ namespace NSQLComplete {
             auto candidates = C3.Complete(prefix);
             return {
                 .Keywords = SiftedKeywords(candidates),
+                .IsPragmaName = IsPragmaNameMatched(candidates),
                 .IsTypeName = IsTypeNameMatched(candidates),
                 .IsFunctionName = IsFunctionNameMatched(candidates),
             };
@@ -129,6 +130,12 @@ namespace NSQLComplete {
                 name.pop_back();
             }
             return name;
+        }
+
+        bool IsPragmaNameMatched(const TC3Candidates& candidates) {
+            return AnyOf(candidates.Rules, [&](const TMatchedRule& rule) {
+                return IsLikelyPragmaStack(rule.ParserCallStack);
+            });
         }
 
         bool IsTypeNameMatched(const TC3Candidates& candidates) {

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -54,8 +54,6 @@ namespace NSQLComplete {
 
             auto candidates = C3.Complete(prefix);
 
-            // TODO(YQL-19747): Actually we tokenize 3 times now. On statement split,
-            //                  on c3 call and on a pragma lookbehind.
             NSQLTranslation::TParsedTokenList tokens = Tokenized(prefix);
 
             return {

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -10,8 +10,12 @@
 namespace NSQLComplete {
 
     struct TLocalSyntaxContext {
+        struct TPragma {
+            TString Namespace;
+        };
+
         TVector<TString> Keywords;
-        bool IsPragmaName;
+        std::optional<TPragma> Pragma;
         bool IsTypeName;
         bool IsFunctionName;
     };

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -14,10 +14,14 @@ namespace NSQLComplete {
             TString Namespace;
         };
 
+        struct TFunction {
+            TString Namespace;
+        };
+
         TVector<TString> Keywords;
         std::optional<TPragma> Pragma;
         bool IsTypeName;
-        bool IsFunctionName;
+        std::optional<TFunction> Function;
     };
 
     class ILocalSyntaxAnalysis {

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -11,6 +11,7 @@ namespace NSQLComplete {
 
     struct TLocalSyntaxContext {
         TVector<TString> Keywords;
+        bool IsPragmaName;
         bool IsTypeName;
         bool IsFunctionName;
     };

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
@@ -85,7 +85,8 @@ namespace NSQLComplete {
         return EndsWith({RULE(Unary_casual_subexpr), RULE(Id_expr)}, stack) ||
                EndsWith({RULE(Unary_casual_subexpr),
                          RULE(Atom_expr),
-                         RULE(An_id_or_type)}, stack);
+                         RULE(An_id_or_type)}, stack) ||
+               EndsWith({RULE(Atom_expr), RULE(Id_or_type)}, stack);
     }
 
     std::unordered_set<TRuleId> GetC3PreferredRules() {

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
@@ -26,6 +26,7 @@ namespace NSQLComplete {
 
     const TVector<TRuleId> PragmaNameRules = {
         RULE(Opt_id_prefix_or_type),
+        RULE(An_id),
     };
 
     const TVector<TRuleId> TypeNameRules = {
@@ -67,7 +68,8 @@ namespace NSQLComplete {
     }
 
     bool IsLikelyPragmaStack(const TParserCallStack& stack) {
-        return EndsWith({RULE(Pragma_stmt), RULE(Opt_id_prefix_or_type)}, stack);
+        return EndsWith({RULE(Pragma_stmt), RULE(Opt_id_prefix_or_type)}, stack) ||
+               EndsWith({RULE(Pragma_stmt), RULE(An_id)}, stack);
     }
 
     bool IsLikelyTypeStack(const TParserCallStack& stack) {

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
@@ -24,6 +24,10 @@ namespace NSQLComplete {
         RULE(Keyword_compat),
     };
 
+    const TVector<TRuleId> PragmaNameRules = {
+        RULE(Opt_id_prefix_or_type),
+    };
+
     const TVector<TRuleId> TypeNameRules = {
         RULE(Type_name_simple),
         RULE(An_id_or_type),
@@ -62,6 +66,10 @@ namespace NSQLComplete {
         return Find(stack, rule) != std::end(stack);
     }
 
+    bool IsLikelyPragmaStack(const TParserCallStack& stack) {
+        return EndsWith({RULE(Pragma_stmt), RULE(Opt_id_prefix_or_type)}, stack);
+    }
+
     bool IsLikelyTypeStack(const TParserCallStack& stack) {
         return EndsWith({RULE(Type_name_simple)}, stack) ||
                (Contains({RULE(Invoke_expr),
@@ -81,6 +89,7 @@ namespace NSQLComplete {
     std::unordered_set<TRuleId> GetC3PreferredRules() {
         std::unordered_set<TRuleId> preferredRules;
         preferredRules.insert(std::begin(KeywordRules), std::end(KeywordRules));
+        preferredRules.insert(std::begin(PragmaNameRules), std::end(PragmaNameRules));
         preferredRules.insert(std::begin(TypeNameRules), std::end(TypeNameRules));
         preferredRules.insert(std::begin(FunctionNameRules), std::end(FunctionNameRules));
         return preferredRules;

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.h
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.h
@@ -4,6 +4,8 @@
 
 namespace NSQLComplete {
 
+    bool IsLikelyPragmaStack(const TParserCallStack& stack);
+
     bool IsLikelyTypeStack(const TParserCallStack& stack);
 
     bool IsLikelyFunctionStack(const TParserCallStack& stack);


### PR DESCRIPTION
- [x] Complete after PRAGMA
- [x] Complete multi-token names correctly, for example, `yt.` returns only `DisableStrict`, not `yt.DisableStrict` and `DateTime::` returns `Split`, not `DateTime::Split`.

I tried to implement it using `CompletedToken` edition, but not all completion environments support candidates with various `contextLen` (`Replxx` does not). So I decided that completions should rewrite only the current token, not sequences. For example, on `DateTime::Spl` rewrite only `Spl`. It makes sense as multi-token names have some namespace separated by a punctuation, so used types only namespace and gets names inside of it.