### PR TITLE
YQL-19747 Complete type name as a function argument

### DIFF
--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -386,6 +386,15 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT OPTIONAL<"}), expected);
     }
 
+    Y_UNIT_TEST(TypeNameAsArgument) {
+        TVector<TCandidate> expected = {
+            {TypeName, "Uint64"},
+        };
+
+        auto engine = MakeSqlCompletionEngineUT();
+        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT Nothing(Uint"}), expected);
+    }
+
     Y_UNIT_TEST(UTF8Wide) {
         auto engine = MakeSqlCompletionEngineUT();
         UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"\xF0\x9F\x98\x8A"}).size(), 0);

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -387,12 +387,19 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     }
 
     Y_UNIT_TEST(TypeNameAsArgument) {
-        TVector<TCandidate> expected = {
-            {TypeName, "Uint64"},
-        };
-
         auto engine = MakeSqlCompletionEngineUT();
-        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT Nothing(Uint"}), expected);
+        {
+            TVector<TCandidate> expected = {
+                {TypeName, "Uint64"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT Nothing(Uint"}), expected);
+        }
+        {
+            TVector<TCandidate> expected = {
+                {Keyword, "OPTIONAL<"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"SELECT Nothing(Option"}), expected);
+        }
     }
 
     Y_UNIT_TEST(UTF8Wide) {

--- a/yql/essentials/sql/v1/complete/syntax/grammar.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/grammar.cpp
@@ -7,7 +7,7 @@ namespace NSQLComplete {
     class TSqlGrammar: public ISqlGrammar {
     public:
         TSqlGrammar(const NSQLReflect::TLexerGrammar& grammar)
-            : Vocabulary(GetVocabularyP())
+            : Parser(MakeDummyParser())
             , AllTokens(ComputeAllTokens())
             , KeywordTokens(ComputeKeywordTokens(grammar))
             , PunctuationTokens(ComputePunctuationTokens(grammar))
@@ -15,7 +15,7 @@ namespace NSQLComplete {
         }
 
         const antlr4::dfa::Vocabulary& GetVocabulary() const override {
-            return *Vocabulary;
+            return Parser->getVocabulary();
         }
 
         const std::unordered_set<TTokenId>& GetAllTokens() const override {
@@ -30,9 +30,13 @@ namespace NSQLComplete {
             return PunctuationTokens;
         }
 
+        const std::string& SymbolizedRule(TRuleId rule) const override {
+            return Parser->getRuleNames().at(rule);
+        }
+
     private:
-        static const antlr4::dfa::Vocabulary* GetVocabularyP() {
-            return &NALADefaultAntlr4::SQLv1Antlr4Parser(nullptr).getVocabulary();
+        static THolder<antlr4::Parser> MakeDummyParser() {
+            return MakeHolder<NALADefaultAntlr4::SQLv1Antlr4Parser>(nullptr);
         }
 
         std::unordered_set<TTokenId> ComputeAllTokens() {
@@ -72,7 +76,7 @@ namespace NSQLComplete {
             return punctuationTokens;
         }
 
-        const antlr4::dfa::Vocabulary* Vocabulary;
+        const THolder<antlr4::Parser> Parser;
         const std::unordered_set<TTokenId> AllTokens;
         const std::unordered_set<TTokenId> KeywordTokens;
         const std::unordered_set<TTokenId> PunctuationTokens;

--- a/yql/essentials/sql/v1/complete/syntax/grammar.h
+++ b/yql/essentials/sql/v1/complete/syntax/grammar.h
@@ -5,6 +5,7 @@
 #include <contrib/libs/antlr4_cpp_runtime/src/Vocabulary.h>
 
 #include <unordered_set>
+#include <string>
 
 #ifdef TOKEN_QUERY // Conflict with the winnt.h
     #undef TOKEN_QUERY
@@ -19,6 +20,7 @@ namespace NSQLComplete {
     class ISqlGrammar {
     public:
         virtual const antlr4::dfa::Vocabulary& GetVocabulary() const = 0;
+        virtual const std::string& SymbolizedRule(TRuleId rule) const = 0;
         virtual const std::unordered_set<TTokenId>& GetAllTokens() const = 0;
         virtual const std::unordered_set<TTokenId>& GetKeywordTokens() const = 0;
         virtual const std::unordered_set<TTokenId>& GetPunctuationTokens() const = 0;


### PR DESCRIPTION
As I understand, type name should not be completed at `SELECT |`, so I added a check that we are at `invoke_expr` context.

Currently composite type keywords are suggested at `SELECT |` and also are uppercased. I will fix it separately when this merged during 
- https://github.com/users/vityaman/projects/5?pane=issue&itemId=105056723&issue=vityaman%7Cydb%7C8

---

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/users/vityaman/projects/5/views/1?pane=issue&itemId=105056423&issue=vityaman%7Cydb%7C7