### PR TITLE
YQL-19747 Remove default completion engine factory

### DIFF
--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -4,10 +4,6 @@
 #include <yql/essentials/sql/v1/complete/name/static/name_service.h>
 #include <yql/essentials/sql/v1/complete/syntax/local.h>
 
-// FIXME(YQL-19747): unwanted dependency on a lexer implementation
-#include <yql/essentials/sql/v1/lexer/antlr4_pure/lexer.h>
-#include <yql/essentials/sql/v1/lexer/antlr4_pure_ansi/lexer.h>
-
 #include <util/generic/algorithm.h>
 #include <util/charset/utf8.h>
 
@@ -150,21 +146,6 @@ namespace NSQLComplete {
         ILocalSyntaxAnalysis::TPtr SyntaxAnalysis;
         INameService::TPtr Names;
     };
-
-    // FIXME(YQL-19747): unwanted dependency on a lexer implementation
-    ISqlCompletionEngine::TPtr MakeSqlCompletionEngine() {
-        NSQLTranslationV1::TLexers lexers;
-        lexers.Antlr4Pure = NSQLTranslationV1::MakeAntlr4PureLexerFactory();
-        lexers.Antlr4PureAnsi = NSQLTranslationV1::MakeAntlr4PureAnsiLexerFactory();
-
-        INameService::TPtr names = MakeStaticNameService(MakeDefaultNameSet(), MakeDefaultRanking());
-
-        return MakeSqlCompletionEngine([lexers = std::move(lexers)](bool ansi) {
-            return NSQLTranslationV1::MakeLexer(
-                lexers, ansi, /* antlr4 = */ true,
-                NSQLTranslationV1::ELexerFlavor::Pure);
-        }, std::move(names));
-    }
 
     ISqlCompletionEngine::TPtr MakeSqlCompletionEngine(
         TLexerSupplier lexer,

--- a/yql/essentials/sql/v1/complete/sql_complete.h
+++ b/yql/essentials/sql/v1/complete/sql_complete.h
@@ -52,9 +52,6 @@ namespace NSQLComplete {
 
     using TLexerSupplier = std::function<NSQLTranslation::ILexer::TPtr(bool ansi)>;
 
-    // FIXME(YQL-19747): unwanted dependency on a lexer implementation
-    ISqlCompletionEngine::TPtr MakeSqlCompletionEngine();
-
     ISqlCompletionEngine::TPtr MakeSqlCompletionEngine(
         TLexerSupplier lexer,
         INameService::TPtr names,

--- a/yql/essentials/sql/v1/complete/ya.make
+++ b/yql/essentials/sql/v1/complete/ya.make
@@ -6,9 +6,6 @@ SRCS(
 
 PEERDIR(
     yql/essentials/sql/v1/lexer
-    # FIXME(YQL-19747): unwanted dependency on a lexer implementation
-    yql/essentials/sql/v1/lexer/antlr4_pure
-    yql/essentials/sql/v1/lexer/antlr4_pure_ansi
     yql/essentials/sql/v1/complete/antlr4
     yql/essentials/sql/v1/complete/name
     yql/essentials/sql/v1/complete/name/static


### PR DESCRIPTION
This is to decouple from the `sql/v1/lexer` implementation.

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/18
- Following https://github.com/ydb-platform/ydb/pull/16820