### PR TITLE
YQL-19747 Rank keywords just by plain usages

### DIFF
--- a/yql/essentials/sql/v1/complete/antlr4/vocabulary.cpp
+++ b/yql/essentials/sql/v1/complete/antlr4/vocabulary.cpp
@@ -1,0 +1,14 @@
+#include "vocabulary.h"
+
+namespace NSQLComplete {
+
+    std::string Display(const antlr4::dfa::Vocabulary& vocabulary, TTokenId tokenType) {
+        auto name = vocabulary.getDisplayName(tokenType);
+        if (2 <= name.length() && name.starts_with('\'') && name.ends_with('\'')) {
+            name.erase(static_cast<std::string::size_type>(0), 1);
+            name.pop_back();
+        }
+        return name;
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/antlr4/vocabulary.h
+++ b/yql/essentials/sql/v1/complete/antlr4/vocabulary.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "defs.h"
+
+#include <contrib/libs/antlr4_cpp_runtime/src/Vocabulary.h>
+
+#include <string>
+
+namespace NSQLComplete {
+
+    std::string Display(const antlr4::dfa::Vocabulary& vocabulary, TTokenId tokenType);
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/antlr4/ya.make
+++ b/yql/essentials/sql/v1/complete/antlr4/ya.make
@@ -1,5 +1,9 @@
 LIBRARY()
 
+SRCS(
+    vocabulary.cpp
+)
+
 PEERDIR(
     contrib/libs/antlr4_cpp_runtime
     contrib/libs/antlr4-c3

--- a/yql/essentials/sql/v1/complete/name/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/name_service.h
@@ -19,6 +19,10 @@ namespace NSQLComplete {
         TString Namespace;
     };
 
+    struct TKeyword {
+        TString Content;
+    };
+
     struct TPragmaName: TIndentifier {
         struct TConstraints: TNamespaced {};
     };
@@ -38,12 +42,14 @@ namespace NSQLComplete {
     };
 
     using TGenericName = std::variant<
+        TKeyword,
         TPragmaName,
         TTypeName,
         TFunctionName,
         THintName>;
 
     struct TNameRequest {
+        TVector<TString> Keywords;
         struct {
             std::optional<TPragmaName::TConstraints> Pragma;
             std::optional<TTypeName::TConstraints> Type;
@@ -54,7 +60,8 @@ namespace NSQLComplete {
         size_t Limit = 128;
 
         bool IsEmpty() const {
-            return !Constraints.Pragma &&
+            return Keywords.empty() &&
+                   !Constraints.Pragma &&
                    !Constraints.Type &&
                    !Constraints.Function &&
                    !Constraints.Hint;

--- a/yql/essentials/sql/v1/complete/name/static/frequency.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.cpp
@@ -17,6 +17,7 @@ namespace NSQLComplete {
             const char* Pragma = "PRAGMA";
             const char* Type = "TYPE";
             const char* Func = "FUNC";
+            const char* Keyword = "KEYWORD";
             const char* Module = "MODULE";
             const char* ModuleFunc = "MODULE_FUNC";
             const char* ReadHint = "READ_HINT";
@@ -59,6 +60,7 @@ namespace NSQLComplete {
             if (item.Parent == Json.Parent.Pragma ||
                 item.Parent == Json.Parent.Type ||
                 item.Parent == Json.Parent.Func ||
+                item.Parent == Json.Parent.Keyword ||
                 item.Parent == Json.Parent.ModuleFunc ||
                 item.Parent == Json.Parent.Module ||
                 item.Parent == Json.Parent.ReadHint ||
@@ -70,6 +72,8 @@ namespace NSQLComplete {
                 data.Pragmas[item.Rule] += item.Sum;
             } else if (item.Parent == Json.Parent.Type) {
                 data.Types[item.Rule] += item.Sum;
+            } else if (item.Parent == Json.Parent.Keyword) {
+                data.Keywords[item.Rule] += item.Sum;
             } else if (item.Parent == Json.Parent.Module) {
                 // Ignore, unsupported: Modules
             } else if (item.Parent == Json.Parent.Func ||

--- a/yql/essentials/sql/v1/complete/name/static/frequency.h
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.h
@@ -6,6 +6,7 @@
 namespace NSQLComplete {
 
     struct TFrequencyData {
+        THashMap<TString, size_t> Keywords;
         THashMap<TString, size_t> Pragmas;
         THashMap<TString, size_t> Types;
         THashMap<TString, size_t> Functions;

--- a/yql/essentials/sql/v1/complete/name/static/frequency_ut.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/frequency_ut.cpp
@@ -10,6 +10,7 @@ Y_UNIT_TEST_SUITE(FrequencyTests) {
         TFrequencyData actual = ParseJsonFrequencyData(R"([
             {"parent":"FUNC","rule":"ABC","sum":1},
             {"parent":"TYPE","rule":"BIGINT","sum":7101},
+            {"parent":"KEYWORD","rule":"UNION","sum":65064443},
             {"parent":"MODULE_FUNC","rule":"Compress::BZip2","sum":2},
             {"parent":"MODULE","rule":"re2","sum":3094},
             {"parent":"READ_HINT","rule":"COLUMNS","sum":826110},
@@ -18,6 +19,9 @@ Y_UNIT_TEST_SUITE(FrequencyTests) {
         ])");
 
         TFrequencyData expected = {
+            .Keywords = {
+                {"union", 65064443},
+            },
             .Types = {
                 {"bigint", 7101},
             },
@@ -31,8 +35,10 @@ Y_UNIT_TEST_SUITE(FrequencyTests) {
             },
         };
 
+        UNIT_ASSERT_VALUES_EQUAL(actual.Keywords, expected.Keywords);
         UNIT_ASSERT_VALUES_EQUAL(actual.Types, expected.Types);
         UNIT_ASSERT_VALUES_EQUAL(actual.Functions, expected.Functions);
+        UNIT_ASSERT_VALUES_EQUAL(actual.Hints, expected.Hints);
     }
 
     Y_UNIT_TEST(FrequencyDataResouce) {

--- a/yql/essentials/sql/v1/complete/name/static/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/ranking.cpp
@@ -57,28 +57,34 @@ namespace NSQLComplete {
             return std::visit([this](const auto& name) -> size_t {
                 using T = std::decay_t<decltype(name)>;
 
-                auto identifier = ToLowerUTF8(ContentView(name));
+                auto content = ToLowerUTF8(ContentView(name));
+
+                if constexpr (std::is_same_v<T, TKeyword>) {
+                    if (auto weight = Frequency_.Keywords.FindPtr(content)) {
+                        return *weight;
+                    }
+                }
 
                 if constexpr (std::is_same_v<T, TPragmaName>) {
-                    if (auto weight = Frequency_.Pragmas.FindPtr(identifier)) {
+                    if (auto weight = Frequency_.Pragmas.FindPtr(content)) {
                         return *weight;
                     }
                 }
 
                 if constexpr (std::is_same_v<T, TFunctionName>) {
-                    if (auto weight = Frequency_.Functions.FindPtr(identifier)) {
+                    if (auto weight = Frequency_.Functions.FindPtr(content)) {
                         return *weight;
                     }
                 }
 
                 if constexpr (std::is_same_v<T, TTypeName>) {
-                    if (auto weight = Frequency_.Types.FindPtr(identifier)) {
+                    if (auto weight = Frequency_.Types.FindPtr(content)) {
                         return *weight;
                     }
                 }
 
                 if constexpr (std::is_same_v<T, THintName>) {
-                    if (auto weight = Frequency_.Hints.FindPtr(identifier)) {
+                    if (auto weight = Frequency_.Hints.FindPtr(content)) {
                         return *weight;
                     }
                 }
@@ -94,6 +100,9 @@ namespace NSQLComplete {
         const TStringBuf ContentView(const TGenericName& name Y_LIFETIME_BOUND) const {
             return std::visit([](const auto& name) -> TStringBuf {
                 using T = std::decay_t<decltype(name)>;
+                if constexpr (std::is_base_of_v<TKeyword, T>) {
+                    return name.Content;
+                }
                 if constexpr (std::is_base_of_v<TIndentifier, T>) {
                     return name.Indentifier;
                 }

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -622,6 +622,10 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
 
     Y_UNIT_TEST(Ranking) {
         TFrequencyData frequency = {
+            .Keywords = {
+                {"select", 2},
+                {"insert", 4},
+            },
             .Pragmas = {
                 {"yt.defaultmemorylimit", 16},
                 {"yt.annotations", 8},
@@ -646,6 +650,13 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         };
         auto service = MakeStaticNameService(MakeDefaultNameSet(), MakeDefaultRanking(frequency));
         auto engine = MakeSqlCompletionEngine(MakePureLexerSupplier(), std::move(service));
+        {
+            TVector<TCandidate> expected = {
+                {Keyword, "INSERT"},
+                {Keyword, "SELECT"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(CompleteTop(expected.size(), engine, {""}), expected);
+        }
         {
             TVector<TCandidate> expected = {
                 {PragmaName, "DefaultMemoryLimit"},

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -324,6 +324,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "CURRENT_TIMESTAMP"},
             {Keyword, "DICT<"},
             {Keyword, "DISTINCT"},
+            {FunctionName, "DateTime::Split("},
             {Keyword, "EMPTY_ACTION"},
             {Keyword, "ENUM"},
             {Keyword, "EXISTS("},
@@ -340,12 +341,11 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "SET<"},
             {Keyword, "STREAM"},
             {Keyword, "STRUCT"},
+            {FunctionName, "StartsWith("},
             {Keyword, "TAGGED<"},
             {Keyword, "TRUE"},
             {Keyword, "TUPLE"},
             {Keyword, "VARIANT"},
-            {FunctionName, "DateTime::Split("},
-            {FunctionName, "StartsWith("},
         };
 
         auto engine = MakeSqlCompletionEngineUT();
@@ -362,6 +362,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "CURRENT_TIME"},
             {Keyword, "CURRENT_TIMESTAMP"},
             {Keyword, "DICT<"},
+            {FunctionName, "DateTime::Split("},
             {Keyword, "EMPTY_ACTION"},
             {Keyword, "ENUM"},
             {Keyword, "EXISTS("},
@@ -378,12 +379,11 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "SET<"},
             {Keyword, "STREAM<"},
             {Keyword, "STRUCT"},
+            {FunctionName, "StartsWith("},
             {Keyword, "TAGGED<"},
             {Keyword, "TRUE"},
             {Keyword, "TUPLE"},
             {Keyword, "VARIANT"},
-            {FunctionName, "DateTime::Split("},
-            {FunctionName, "StartsWith("},
         };
 
         auto engine = MakeSqlCompletionEngineUT();
@@ -415,8 +415,8 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {Keyword, "STRUCT"},
             {Keyword, "TAGGED<"},
             {Keyword, "TUPLE"},
-            {Keyword, "VARIANT<"},
             {TypeName, "Uint64"},
+            {Keyword, "VARIANT<"},
         };
 
         auto engine = MakeSqlCompletionEngineUT();
@@ -490,8 +490,8 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     Y_UNIT_TEST(InsertTableHintName) {
         TVector<TCandidate> expected = {
             {Keyword, "COLUMNS"},
-            {Keyword, "SCHEMA"},
             {HintName, "EXPIRATION"},
+            {Keyword, "SCHEMA"},
         };
 
         auto engine = MakeSqlCompletionEngineUT();
@@ -592,7 +592,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     Y_UNIT_TEST(OnFailingNameService) {
         auto service = MakeHolder<TFailingNameService>();
         auto engine = MakeSqlCompletionEngine(MakePureLexerSupplier(), std::move(service));
-        UNIT_ASSERT_NO_EXCEPTION(Complete(engine, {""}));
+        UNIT_ASSERT_EXCEPTION(Complete(engine, {""}), TDummyException);
         UNIT_ASSERT_EXCEPTION(Complete(engine, {"SELECT OPTIONAL<U"}), TDummyException);
         UNIT_ASSERT_EXCEPTION(Complete(engine, {"SELECT CAST (1 AS "}).size(), TDummyException);
     }
@@ -679,10 +679,10 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         }
         {
             TVector<TCandidate> expected = {
-                {Keyword, "COLUMNS"},
-                {Keyword, "SCHEMA"},
                 {HintName, "XLOCK"},
                 {HintName, "UNORDERED"},
+                {Keyword, "COLUMNS"},
+                {HintName, "FORCEINFERSCHEMA"},
             };
             UNIT_ASSERT_VALUES_EQUAL(CompleteTop(expected.size(), engine, {"SELECT * FROM a WITH "}), expected);
         }

--- a/yql/essentials/sql/v1/complete/syntax/format.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/format.cpp
@@ -1,0 +1,38 @@
+#include "format.h"
+
+#include "grammar.h"
+
+#include <yql/essentials/sql/v1/complete/antlr4/vocabulary.h>
+
+#include <util/generic/hash_set.h>
+
+namespace NSQLComplete {
+
+    TString FormatKeywords(const TVector<TString>& seq) {
+        static const THashSet<std::string> Keywords = [] {
+            const auto& grammar = GetSqlGrammar();
+            const auto& vocabulary = grammar.GetVocabulary();
+
+            THashSet<std::string> keywords;
+            for (auto& token : grammar.GetKeywordTokens()) {
+                keywords.emplace(Display(vocabulary, token));
+            }
+            return keywords;
+        }();
+
+        if (seq.empty()) {
+            return "";
+        }
+
+        TString text = seq[0];
+        for (size_t i = 1; i < seq.size(); ++i) {
+            const auto& token = seq[i];
+            if (Keywords.contains(token)) {
+                text += " ";
+            }
+            text += token;
+        }
+        return text;
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/syntax/format.h
+++ b/yql/essentials/sql/v1/complete/syntax/format.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+
+namespace NSQLComplete {
+
+    TString FormatKeywords(const TVector<TString>& seq);
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -5,11 +5,13 @@
 #include <yql/essentials/sql/v1/lexer/lexer.h>
 
 #include <util/generic/string.h>
-#include <util/generic/vector.h>
+#include <util/generic/hash.h>
 
 namespace NSQLComplete {
 
     struct TLocalSyntaxContext {
+        using TKeywords = THashMap<TString, TVector<TString>>;
+
         struct TPragma {
             TString Namespace;
         };
@@ -22,7 +24,7 @@ namespace NSQLComplete {
             EStatementKind StatementKind;
         };
 
-        TVector<TString> Keywords;
+        TKeywords Keywords;
         std::optional<TPragma> Pragma;
         bool IsTypeName;
         std::optional<TFunction> Function;

--- a/yql/essentials/sql/v1/complete/syntax/ya.make
+++ b/yql/essentials/sql/v1/complete/syntax/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 SRCS(
     ansi.cpp
+    format.cpp
     grammar.cpp
     local.cpp
     parser_call_stack.cpp

--- a/yql/essentials/sql/v1/complete/text/case.cpp
+++ b/yql/essentials/sql/v1/complete/text/case.cpp
@@ -1,0 +1,14 @@
+#include "case.h"
+
+namespace NSQLComplete {
+
+    bool NoCaseCompare(const TString& lhs, const TString& rhs) {
+        return std::lexicographical_compare(
+            std::begin(lhs), std::end(lhs),
+            std::begin(rhs), std::end(rhs),
+            [](const char lhs, const char rhs) {
+                return ToLower(lhs) < ToLower(rhs);
+            });
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/text/case.cpp
+++ b/yql/essentials/sql/v1/complete/text/case.cpp
@@ -1,14 +1,11 @@
 #include "case.h"
 
+#include <util/string/ascii.h>
+
 namespace NSQLComplete {
 
     bool NoCaseCompare(const TString& lhs, const TString& rhs) {
-        return std::lexicographical_compare(
-            std::begin(lhs), std::end(lhs),
-            std::begin(rhs), std::end(rhs),
-            [](const char lhs, const char rhs) {
-                return ToLower(lhs) < ToLower(rhs);
-            });
+        return AsciiCompareIgnoreCase(lhs, rhs) < 0;
     }
 
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/text/case.h
+++ b/yql/essentials/sql/v1/complete/text/case.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <util/generic/string.h>
+
+namespace NSQLComplete {
+
+    inline bool NoCaseCompare(const TString& lhs, const TString& rhs) {
+        return std::lexicographical_compare(
+            std::begin(lhs), std::end(lhs),
+            std::begin(rhs), std::end(rhs),
+            [](const char lhs, const char rhs) {
+                return ToLower(lhs) < ToLower(rhs);
+            });
+    }
+
+    inline auto NoCaseCompareLimit(size_t size) {
+        return [size](const TString& lhs, const TString& rhs) -> bool {
+            return strncasecmp(lhs.data(), rhs.data(), size) < 0;
+        };
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/text/case.h
+++ b/yql/essentials/sql/v1/complete/text/case.h
@@ -4,14 +4,7 @@
 
 namespace NSQLComplete {
 
-    inline bool NoCaseCompare(const TString& lhs, const TString& rhs) {
-        return std::lexicographical_compare(
-            std::begin(lhs), std::end(lhs),
-            std::begin(rhs), std::end(rhs),
-            [](const char lhs, const char rhs) {
-                return ToLower(lhs) < ToLower(rhs);
-            });
-    }
+    bool NoCaseCompare(const TString& lhs, const TString& rhs);
 
     inline auto NoCaseCompareLimit(size_t size) {
         return [size](const TString& lhs, const TString& rhs) -> bool {

--- a/yql/essentials/sql/v1/complete/text/ya.make
+++ b/yql/essentials/sql/v1/complete/text/ya.make
@@ -1,6 +1,7 @@
 LIBRARY()
 
 SRCS(
+    case.cpp
     word.cpp
 )
 


### PR DESCRIPTION
- [x] Rank keywords just by plain usages
- [x] `LocalSyntaxAnalysis` now returns a mapping `:: Keyword -> [Following Keywords]`.
- [x] Extracted keyword sequence formatting from `syntax/local` to `syntax/format`.
- [x] Extracted token display logic from `syntax/local` to `antlr4/vocabulary` as it is ANTLR dependent.

---

Example

```python
$ ./yql_complete <<< "select "              
[Keyword] CAST(
[Keyword] NULL
[Keyword] NOT
[FunctionName] If(
[FunctionName] Yson::ConvertToString(
[FunctionName] Count(
[FunctionName] Sum(
[FunctionName] Unwrap(
[FunctionName] Coalesce(
[Keyword] DISTINCT
[Keyword] ALL
[Keyword] CASE
[FunctionName] Max(
[Keyword] FALSE
[FunctionName] Some(
```

---

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/17
