### PR TITLE
Close access to operations_archive

### DIFF
--- a/yt/python/yt/environment/init_operations_archive.py
+++ b/yt/python/yt/environment/init_operations_archive.py
@@ -865,7 +865,7 @@ def get_latest_version():
     return migration.get_latest_version()
 
 
-def create_tables(client, target_version=None, override_tablet_cell_bundle="default", shard_count=1, archive_path=DEFAULT_ARCHIVE_PATH):
+def create_tables(client, target_version=None, override_tablet_cell_bundle="default", shard_count=1, archive_path=DEFAULT_ARCHIVE_PATH, close_access=True):
     """ Creates operation archive tables of given version """
     migration = prepare_migration(client, archive_path)
 
@@ -882,6 +882,9 @@ def create_tables(client, target_version=None, override_tablet_cell_bundle="defa
         shard_count=shard_count,
         override_tablet_cell_bundle=override_tablet_cell_bundle,
     )
+
+    if close_access:
+        client.set("//sys/operations_archive/@inherit_acl", False)
 
 
 # Warning! This function does NOT perform actual transformations, it only creates tables with latest schemas.

--- a/yt/yt/tests/integration/scheduler/test_scheduler_acls.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_acls.py
@@ -62,7 +62,6 @@ class TestSchedulerAcls(YTEnvSetup):
     NUM_MASTERS = 1
     NUM_NODES = 3
     NUM_SCHEDULERS = 1
-    USE_PORTO = True
 
     DELTA_NODE_CONFIG = {
         "exec_node": {


### PR DESCRIPTION
This change sets `inherit_acl = %false` to `//sys/operations_archive`

The main goal is to see how many tests will break and estimate impact