### PR TITLE
Close operations archive with fix

### DIFF
--- a/yt/python/yt/environment/init_operations_archive.py
+++ b/yt/python/yt/environment/init_operations_archive.py
@@ -865,7 +865,7 @@ def get_latest_version():
     return migration.get_latest_version()
 
 
-def create_tables(client, target_version=None, override_tablet_cell_bundle="default", shard_count=1, archive_path=DEFAULT_ARCHIVE_PATH):
+def create_tables(client, target_version=None, override_tablet_cell_bundle="default", shard_count=1, archive_path=DEFAULT_ARCHIVE_PATH, close_access=True):
     """ Creates operation archive tables of given version """
     migration = prepare_migration(client, archive_path)
 
@@ -882,6 +882,9 @@ def create_tables(client, target_version=None, override_tablet_cell_bundle="defa
         shard_count=shard_count,
         override_tablet_cell_bundle=override_tablet_cell_bundle,
     )
+
+    if close_access:
+        client.set("//sys/operations_archive/@inherit_acl", False)
 
 
 # Warning! This function does NOT perform actual transformations, it only creates tables with latest schemas.

--- a/yt/yt/tests/integration/scheduler/test_scheduler_acls.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_acls.py
@@ -62,7 +62,6 @@ class TestSchedulerAcls(YTEnvSetup):
     NUM_MASTERS = 1
     NUM_NODES = 3
     NUM_SCHEDULERS = 1
-    USE_PORTO = True
 
     DELTA_NODE_CONFIG = {
         "exec_node": {

--- a/yt/yt/ytlib/api/native/client_operation_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_operation_info_impl.cpp
@@ -459,7 +459,7 @@ TOperationId TClient::ResolveOperationAlias(
     lookupOptions.KeepMissingRows = true;
     lookupOptions.Timeout = deadline - Now();
 
-    auto rowset = WaitFor(LookupRows(
+    auto rowset = WaitFor(GetOperationsArchiveClient()->LookupRows(
         GetOperationsArchiveOperationAliasesPath(),
         NRecords::TOperationAliasDescriptor::Get()->GetNameTable(),
         MakeSharedRange(std::move(keys), std::move(rowBuffer)),
@@ -963,7 +963,7 @@ THashMap<TOperationId, TOperation> TClient::LookupOperationsInArchiveTyped(
     }
 
     auto columnFilter = NTableClient::TColumnFilter(columns);
-    auto rowset = LookupOperationsInArchive(this, ids, columnFilter, timeout)
+    auto rowset = LookupOperationsInArchive(GetOperationsArchiveClient(), ids, columnFilter, timeout)
         .ValueOrThrow();
     auto records = ToOptionalRecords<NRecords::TOrderedByIdPartial>(rowset);
 
@@ -1093,7 +1093,7 @@ THashMap<TOperationId, TOperation> TClient::DoListOperationsFromArchive(
         selectOptions.InputRowLimit = std::numeric_limits<i64>::max();
         selectOptions.MemoryLimitPerNode = 100_MB;
 
-        auto resultCounts = WaitFor(SelectRows(builder.Build(), selectOptions))
+        auto resultCounts = WaitFor(GetOperationsArchiveClient()->SelectRows(builder.Build(), selectOptions))
             .ValueOrThrow();
 
         auto records = ToRecords<NRecords::TOrderedByStartTimePartial>(resultCounts.Rowset);
@@ -1209,7 +1209,7 @@ THashMap<TOperationId, TOperation> TClient::DoListOperationsFromArchive(
     selectOptions.Timeout = deadline - Now();
     selectOptions.InputRowLimit = std::numeric_limits<i64>::max();
     selectOptions.MemoryLimitPerNode = 100_MB;
-    auto rowsItemsId = WaitFor(SelectRows(builder.Build(), selectOptions))
+    auto rowsItemsId = WaitFor(GetOperationsArchiveClient()->SelectRows(builder.Build(), selectOptions))
         .ValueOrThrow();
     auto records = ToRecords<NRecords::TOrderedByStartTimePartial>(rowsItemsId.Rowset);
 
@@ -1371,7 +1371,7 @@ TListOperationsResult TClient::DoListOperations(const TListOperationsOptions& ol
 
         auto columnFilter = NTableClient::TColumnFilter(columnIndices);
         auto rowsetOrError = LookupOperationsInArchive(
-            this,
+            GetOperationsArchiveClient(),
             ids,
             columnFilter,
             options.ArchiveFetchingTimeout);


### PR DESCRIPTION
This change sets `inherit_acl = %false` to `//sys/operations_archive`, **and fixes some scheduler commands that use operations archive**

The main goal is to see how many tests will break and estimate impact

Just operations archive change: https://github.com/ytsaurus/ytsaurus/pull/1199