### PR TITLE
YQL-19747 Extract NormalizeName from yql/.../core/ast

### DIFF
--- a/yql/essentials/ast/yql_expr.cpp
+++ b/yql/essentials/ast/yql_expr.cpp
@@ -3830,60 +3830,6 @@ const TTypeAnnotationNode& RemoveOptionality(const TTypeAnnotationNode& type) {
     return ETypeAnnotationKind::Optional == type.GetKind() ? *type.Cast<TOptionalExprType>()->GetItemType() : type;
 }
 
-TMaybe<TIssue> NormalizeName(TPosition position, TString& name) {
-    const ui32 inputLength = name.length();
-    ui32 startCharPos = 0;
-    ui32 totalSkipped = 0;
-    bool atStart = true;
-    bool justSkippedUnderscore = false;
-    for (ui32 i = 0; i < inputLength; ++i) {
-        const char c = name.at(i);
-        if (c == '_') {
-            if (!atStart) {
-                if (justSkippedUnderscore) {
-                    return TIssue(position, TStringBuilder() << "\"" << name << "\" looks weird, has multiple consecutive underscores");
-                }
-                justSkippedUnderscore = true;
-                ++totalSkipped;
-                continue;
-            } else {
-                ++startCharPos;
-            }
-        }
-        else {
-            atStart = false;
-            justSkippedUnderscore = false;
-        }
-    }
-
-    if (totalSkipped >= 5) {
-        return TIssue(position, TStringBuilder() << "\"" << name << "\" looks weird, has multiple consecutive underscores");
-    }
-
-    ui32 outPos = startCharPos;
-    for (ui32 i = startCharPos; i < inputLength; i++) {
-        const char c = name.at(i);
-        if (c == '_') {
-            continue;
-        } else {
-            name[outPos] = AsciiToLower(c);
-            ++outPos;
-        }
-    }
-
-    name.resize(outPos);
-    Y_ABORT_UNLESS(inputLength - outPos == totalSkipped);
-
-    return Nothing();
-}
-
-TString NormalizeName(const TStringBuf& name) {
-    TString result(name);
-    TMaybe<TIssue> error = NormalizeName(TPosition(), result);
-    YQL_ENSURE(error.Empty(), "" << error->GetMessage());
-    return result;
-}
-
 void TDefaultTypeAnnotationVisitor::Visit(const TUnitExprType& type) {
     Y_UNUSED(type);
 }

--- a/yql/essentials/ast/yql_expr.h
+++ b/yql/essentials/ast/yql_expr.h
@@ -9,6 +9,7 @@
 #include "yql_pos_handle.h"
 
 #include <yql/essentials/core/url_lister/interface/url_lister_manager.h>
+#include <yql/essentials/core/sql_types/normalize_name.h>
 #include <yql/essentials/utils/yql_panic.h>
 #include <yql/essentials/public/issue/yql_issue_manager.h>
 #include <yql/essentials/public/udf/udf_data_type.h>
@@ -2953,9 +2954,6 @@ const TTypeAnnotationNode* GetSeqItemType(const TTypeAnnotationNode* seq);
 const TTypeAnnotationNode& GetSeqItemType(const TTypeAnnotationNode& seq);
 
 const TTypeAnnotationNode& RemoveOptionality(const TTypeAnnotationNode& type);
-
-TMaybe<TIssue> NormalizeName(TPosition position, TString& name);
-TString NormalizeName(const TStringBuf& name);
 
 } // namespace NYql
 

--- a/yql/essentials/core/sql_types/normalize_name.cpp
+++ b/yql/essentials/core/sql_types/normalize_name.cpp
@@ -1,0 +1,64 @@
+#include "normalize_name.h"
+
+#include <yql/essentials/utils/yql_panic.h>
+
+#include <util/string/builder.h>
+#include <util/string/ascii.h>
+
+namespace NYql {
+
+    TMaybe<TIssue> NormalizeName(TPosition position, TString& name) {
+        const ui32 inputLength = name.length();
+        ui32 startCharPos = 0;
+        ui32 totalSkipped = 0;
+        bool atStart = true;
+        bool justSkippedUnderscore = false;
+        for (ui32 i = 0; i < inputLength; ++i) {
+            const char c = name.at(i);
+            if (c == '_') {
+                if (!atStart) {
+                    if (justSkippedUnderscore) {
+                        return TIssue(position, TStringBuilder() << "\"" << name << "\" looks weird, has multiple consecutive underscores");
+                    }
+                    justSkippedUnderscore = true;
+                    ++totalSkipped;
+                    continue;
+                } else {
+                    ++startCharPos;
+                }
+            }
+            else {
+                atStart = false;
+                justSkippedUnderscore = false;
+            }
+        }
+    
+        if (totalSkipped >= 5) {
+            return TIssue(position, TStringBuilder() << "\"" << name << "\" looks weird, has multiple consecutive underscores");
+        }
+    
+        ui32 outPos = startCharPos;
+        for (ui32 i = startCharPos; i < inputLength; i++) {
+            const char c = name.at(i);
+            if (c == '_') {
+                continue;
+            } else {
+                name[outPos] = AsciiToLower(c);
+                ++outPos;
+            }
+        }
+    
+        name.resize(outPos);
+        Y_ABORT_UNLESS(inputLength - outPos == totalSkipped);
+    
+        return Nothing();
+    }
+
+    TString NormalizeName(const TStringBuf& name) {
+        TString result(name);
+        TMaybe<TIssue> error = NormalizeName(TPosition(), result);
+        YQL_ENSURE(error.Empty(), "" << error->GetMessage());
+        return result;
+    }
+
+}

--- a/yql/essentials/core/sql_types/normalize_name.cpp
+++ b/yql/essentials/core/sql_types/normalize_name.cpp
@@ -26,17 +26,16 @@ namespace NYql {
                 } else {
                     ++startCharPos;
                 }
-            }
-            else {
+            } else {
                 atStart = false;
                 justSkippedUnderscore = false;
             }
         }
-    
+
         if (totalSkipped >= 5) {
             return TIssue(position, TStringBuilder() << "\"" << name << "\" looks weird, has multiple consecutive underscores");
         }
-    
+
         ui32 outPos = startCharPos;
         for (ui32 i = startCharPos; i < inputLength; i++) {
             const char c = name.at(i);
@@ -47,10 +46,10 @@ namespace NYql {
                 ++outPos;
             }
         }
-    
+
         name.resize(outPos);
         Y_ABORT_UNLESS(inputLength - outPos == totalSkipped);
-    
+
         return Nothing();
     }
 
@@ -61,4 +60,4 @@ namespace NYql {
         return result;
     }
 
-}
+} // namespace NYql

--- a/yql/essentials/core/sql_types/normalize_name.h
+++ b/yql/essentials/core/sql_types/normalize_name.h
@@ -10,4 +10,4 @@ namespace NYql {
     TMaybe<TIssue> NormalizeName(TPosition position, TString& name);
     TString NormalizeName(const TStringBuf& name);
 
-}
+} // namespace NYql

--- a/yql/essentials/core/sql_types/normalize_name.h
+++ b/yql/essentials/core/sql_types/normalize_name.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <yql/essentials/core/issue/yql_issue.h>
+
+#include <util/generic/string.h>
+#include <util/generic/fwd.h>
+
+namespace NYql {
+
+    TMaybe<TIssue> NormalizeName(TPosition position, TString& name);
+    TString NormalizeName(const TStringBuf& name);
+
+}

--- a/yql/essentials/core/sql_types/normalize_name_ut.cpp
+++ b/yql/essentials/core/sql_types/normalize_name_ut.cpp
@@ -1,9 +1,8 @@
-#include "yql_expr_type_annotation.h"
+#include "normalize_name.h"
 
 #include <library/cpp/testing/unittest/registar.h>
 
-
-namespace NYql {
+using namespace NYql;
 
 Y_UNIT_TEST_SUITE(Misc) {
     Y_UNIT_TEST(NormalizeName) {
@@ -49,5 +48,3 @@ Y_UNIT_TEST_SUITE(Misc) {
         CheckIssues("_a_B_c_d_e_f", "_a_B_c_d_e_f");
     }
 }
-
-} // namespace NYql

--- a/yql/essentials/core/sql_types/normalize_name_ut.cpp
+++ b/yql/essentials/core/sql_types/normalize_name_ut.cpp
@@ -47,4 +47,4 @@ Y_UNIT_TEST_SUITE(Misc) {
         CheckIssues("a_B_c_d_e_f", "a_B_c_d_e_f");
         CheckIssues("_a_B_c_d_e_f", "_a_B_c_d_e_f");
     }
-}
+} // Y_UNIT_TEST_SUITE(Misc)

--- a/yql/essentials/core/sql_types/ut/ya.make
+++ b/yql/essentials/core/sql_types/ut/ya.make
@@ -1,6 +1,8 @@
 UNITTEST_FOR(yql/essentials/core/sql_types)
+
 SRCS(
     match_recognize_ut.cpp
+    normalize_name_ut.cpp
 )
 
 PEERDIR(

--- a/yql/essentials/core/sql_types/ya.make
+++ b/yql/essentials/core/sql_types/ya.make
@@ -4,13 +4,18 @@ SRCS(
     block.h
     match_recognize.h
     match_recognize.cpp
+    normalize_name.cpp
     simple_types.h
     simple_types.cpp
     yql_atom_enums.h
     yql_callable_names.h
 )
-GENERATE_ENUM_SERIALIZATION(match_recognize.h)
 
+PEERDIR(
+    yql/essentials/core/issue
+)
+
+GENERATE_ENUM_SERIALIZATION(match_recognize.h)
 GENERATE_ENUM_SERIALIZATION(yql_atom_enums.h)
 
 END()

--- a/yql/essentials/core/ut/ya.make
+++ b/yql/essentials/core/ut/ya.make
@@ -4,7 +4,6 @@ SRCS(
     yql_column_order_ut.cpp
     yql_expr_constraint_ut.cpp
     yql_expr_optimize_ut.cpp
-    yql_expr_type_annotation_ut.cpp
     yql_library_compiler_ut.cpp
     yql_opt_utils_ut.cpp
     yql_udf_index_ut.cpp


### PR DESCRIPTION
We need the `NYql::NormalizeName` at `yql/.../sql/v1/complete`, but do not want to depend on the entire `yql/.../core/ast` module, so moving it to `yql/.../core/sql_types` module.

We need it to find equivalent names for a proper candidates ranking as `MULTI_AGGREGATE_BY` and `MultiAggregateBy` are equivalent and their frequencies should be merged. Also we can apply this function to `NameRequest::prefix` and suggest `MULTI_AGGREGATE_BY` on `prefix.StartsWith("multia")`.

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/21
