### PR TITLE
YQL-19616 Fix lexer/regex ASCII and UTF-8 recognition

### DIFF
--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -492,6 +492,7 @@ SELECT
         UNIT_ASSERT_TOKENIZED(lexer, "\v", "[INVALID] EOF"); // Vertical Tabulation
         UNIT_ASSERT_TOKENIZED(lexer, "\f", "WS(\x0C) EOF");  // Form Feed
         UNIT_ASSERT_TOKENIZED(lexer, "\r", "WS(\r) EOF");    // Carriage Return
+        UNIT_ASSERT_TOKENIZED(lexer, "\r\n", "WS(\r) WS(\n) EOF");
     }
 
     Y_UNIT_TEST_ON_EACH_LEXER(AsciiEscapeCanon) {

--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -513,4 +513,14 @@ SELECT
         }
     }
 
+    Y_UNIT_TEST_ON_EACH_LEXER(Utf8BOM) {
+        auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
+        if (ANTLR4 || FLAVOR == ELexerFlavor::Regex) {
+            UNIT_ASSERT_TOKENIZED(lexer, "\xEF\xBB\xBF 1", "WS( ) DIGITS(1) EOF");
+            UNIT_ASSERT_TOKENIZED(lexer, "\xEF\xBB\xBF \xEF\xBB\xBF", "[INVALID] WS( ) EOF");
+        } else {
+            UNIT_ASSERT_TOKENIZED(lexer, "\xEF\xBB\xBF 1", "[INVALID] WS( ) DIGITS(1) EOF");
+        }
+    }
+
 } // Y_UNIT_TEST_SUITE(SQLv1Lexer)

--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -494,4 +494,22 @@ SELECT
         UNIT_ASSERT_TOKENIZED(lexer, "\r", "WS(\r) EOF");    // Carriage Return
     }
 
+    Y_UNIT_TEST_ON_EACH_LEXER(AsciiEscapeCanon) {
+        static THashMap<char, TString> canon;
+
+        auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
+
+        for (char c = 0; c < std::numeric_limits<char>::max(); ++c) {
+            TString input;
+            input += c;
+
+            TString& expected = canon[c];
+            if (expected.empty()) {
+                expected = Tokenized(lexer, input);
+            }
+
+            UNIT_ASSERT_TOKENIZED(lexer, input, expected);
+        }
+    }
+
 } // Y_UNIT_TEST_SUITE(SQLv1Lexer)

--- a/yql/essentials/sql/v1/lexer/lexer_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/lexer_ut.cpp
@@ -484,4 +484,14 @@ SELECT
             "SEMICOLON(;) EOF");
     }
 
+    Y_UNIT_TEST_ON_EACH_LEXER(AsciiEscape) {
+        auto lexer = MakeLexer(Lexers, ANSI, ANTLR4, FLAVOR);
+        UNIT_ASSERT_TOKENIZED(lexer, "\0", "EOF");           // Null character
+        UNIT_ASSERT_TOKENIZED(lexer, "\t", "WS(\t) EOF");    // Horizontal Tab
+        UNIT_ASSERT_TOKENIZED(lexer, "\n", "WS(\n) EOF");    // Line Feed
+        UNIT_ASSERT_TOKENIZED(lexer, "\v", "[INVALID] EOF"); // Vertical Tabulation
+        UNIT_ASSERT_TOKENIZED(lexer, "\f", "WS(\x0C) EOF");  // Form Feed
+        UNIT_ASSERT_TOKENIZED(lexer, "\r", "WS(\r) EOF");    // Carriage Return
+    }
+
 } // Y_UNIT_TEST_SUITE(SQLv1Lexer)

--- a/yql/essentials/sql/v1/lexer/regex/lexer.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.cpp
@@ -21,6 +21,8 @@ namespace NSQLTranslationV1 {
         static constexpr const char* CommentTokenName = "COMMENT";
         static constexpr const char* StringValueName = "STRING_VALUE";
 
+        static constexpr const TStringBuf Utf8BOM = "\xEF\xBB\xBF";
+
     public:
         TRegexLexer(
             bool ansi,
@@ -51,7 +53,13 @@ namespace NSQLTranslationV1 {
             NYql::TIssues& issues,
             size_t maxErrors) override {
             size_t errors = 0;
-            for (size_t pos = 0; pos < query.size();) {
+
+            size_t pos = 0;
+            if (query.StartsWith(Utf8BOM)) {
+                pos += Utf8BOM.size();
+            }
+
+            while (pos < query.size()) {
                 TParsedToken matched = Match(TStringBuf(query, pos));
 
                 if (matched.Name.empty() && maxErrors == errors) {

--- a/yql/essentials/sql/v1/lexer/regex/regex.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/regex.cpp
@@ -135,7 +135,7 @@ namespace NSQLTranslationV1 {
                 R"(\bEOF\b)", R"($)"));
 
             rules.emplace_back(RegexRewriteRule(
-                R"('\\u000C' \|)", ""));
+                R"('\\u000C' \|)", R"('\\f' |)"));
         }
 
         void Finalize(TString& text) {

--- a/yql/essentials/sql/v1/lexer/regex/regex_ut.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/regex_ut.cpp
@@ -76,7 +76,7 @@ Y_UNIT_TEST_SUITE(SqlRegexTests) {
         CheckRegex(
             /* ansi = */ false,
             "WS",
-            R"(( |\r|\t|\n))");
+            R"(( |\r|\t|\f|\n))");
     }
 
     Y_UNIT_TEST(Comment) {


### PR DESCRIPTION
We faced a `lexer/regex` error on input

```
xxd 3.sql
00000000: 7365 6c65 6374 200c 2020 310a            select .  1.
```

This is because `\f` was unexpected.

Also we had a problem on UTF-8 BOM character.

- Related to https://github.com/ydb-platform/ydb/issues/15129
- Related to https://github.com/vityaman/ydb/issues/11
