### PR TITLE
Add password strength validation in set_user_password request

### DIFF
--- a/yt/python/yt/wrapper/auth_commands.py
+++ b/yt/python/yt/wrapper/auth_commands.py
@@ -1,6 +1,15 @@
+from .config import get_config
 from .driver import make_request, make_formatted_request
 
 from hashlib import sha256
+
+
+def validate_password_strength(password):
+    """
+    Validate that password conforms to complexity requirements. In future
+    should be expanded with more requirements.
+    """
+    return len(password) >= 12 and len(password) <= 128
 
 
 def encode_sha256(password):
@@ -10,6 +19,9 @@ def encode_sha256(password):
 def set_user_password(user, new_password, current_password=None,
                       client=None):
     """Updates user password."""
+    if get_config(client)["enable_password_strength_validation"] is True and \
+            not validate_password_strength(new_password):
+        raise ValueError("The password length must be between 12 and 128 characters")
     params = {"user": user, "new_password_sha256": encode_sha256(new_password)}
     if current_password is not None:
         params["current_password_sha256"] = encode_sha256(current_password)

--- a/yt/python/yt/wrapper/default_config.py
+++ b/yt/python/yt/wrapper/default_config.py
@@ -737,6 +737,10 @@ default_config = {
         # When dumping a table, the size of the result row groups will exceed the set value.
         "min_batch_row_count": 0,
     },
+
+    # if enabled, the password strength will be verified by the client when performing
+    # a set_user_password request
+    "enable_password_strength_validation": RemotePatchableBoolean(False, "python_enable_password_strength_validation"),
 }
 
 # pydoc :: default_config :: end

--- a/yt/python/yt/wrapper/tests/test_auth_commands.py
+++ b/yt/python/yt/wrapper/tests/test_auth_commands.py
@@ -1,0 +1,31 @@
+from .conftest import authors
+from .helpers import set_config_option
+
+from yt.wrapper.operation_commands import add_failed_operation_stderrs_to_error_message
+
+import yt.wrapper as yt
+
+import pytest
+import string
+import random
+
+
+@pytest.mark.usefixtures("yt_env_with_authentication")
+class TestAuthCommands(object):
+    @authors("pavel-bash")
+    @add_failed_operation_stderrs_to_error_message
+    def test_password_strength_validation(self):
+        password = ''.join(random.choice(string.ascii_letters) for i in range(11))
+        yt.set_user_password("admin", password)
+        with set_config_option("enable_password_strength_validation", True):
+            with pytest.raises(ValueError):
+                yt.set_user_password("admin", password)
+
+        password = ''.join(random.choice(string.ascii_letters) for i in range(12))
+        yt.set_user_password("admin", password)
+
+        password = ''.join(random.choice(string.ascii_letters) for i in range(129))
+        yt.set_user_password("admin", password)
+        with set_config_option("enable_password_strength_validation", True):
+            with pytest.raises(ValueError):
+                yt.set_user_password("admin", password)

--- a/yt/python/yt/wrapper/tests/test_auth_commands.py
+++ b/yt/python/yt/wrapper/tests/test_auth_commands.py
@@ -15,16 +15,16 @@ class TestAuthCommands(object):
     @authors("pavel-bash")
     @add_failed_operation_stderrs_to_error_message
     def test_password_strength_validation(self):
-        password = ''.join(random.choice(string.ascii_letters) for i in range(11))
+        password = "".join(random.choice(string.ascii_letters) for i in range(11))
         yt.set_user_password("admin", password)
         with set_config_option("enable_password_strength_validation", True):
             with pytest.raises(ValueError):
                 yt.set_user_password("admin", password)
 
-        password = ''.join(random.choice(string.ascii_letters) for i in range(12))
+        password = "".join(random.choice(string.ascii_letters) for i in range(12))
         yt.set_user_password("admin", password)
 
-        password = ''.join(random.choice(string.ascii_letters) for i in range(129))
+        password = "".join(random.choice(string.ascii_letters) for i in range(129))
         yt.set_user_password("admin", password)
         with set_config_option("enable_password_strength_validation", True):
             with pytest.raises(ValueError):

--- a/yt/python/yt/wrapper/tests/ya.make
+++ b/yt/python/yt/wrapper/tests/ya.make
@@ -152,6 +152,7 @@ TEST_SRCS(
     helpers.py
     test_acl_commands.py
     test_admin.py
+    test_auth_commands.py
     test_authentication.py
     test_batch_execution.py
     test_chaos_commands.py


### PR DESCRIPTION
# Description

There's no mechanism of password strength validation when setting a new password for the user. It's not possible with the current architecture to validate it server-side, so for now we're introducing a Python client configuration parameter to enforce the length. Other requirement can be added later.