### PR TITLE
Hide details about unsuccessful login attempts from the caller

### DIFF
--- a/yt/yt/library/auth_server/cypress_cookie_login.cpp
+++ b/yt/yt/library/auth_server/cypress_cookie_login.cpp
@@ -90,6 +90,7 @@ private:
             else {
                 ReplyError(rsp, error);
             }
+
             YT_LOG_DEBUG(error, "Failed to login user using password (ConnectionId: %v, User: %v)",
                 req->GetConnectionId(),
                 user);

--- a/yt/yt/library/auth_server/cypress_cookie_login.cpp
+++ b/yt/yt/library/auth_server/cypress_cookie_login.cpp
@@ -86,8 +86,7 @@ private:
             if (maskError) {
                 // Hide details about unsuccessful login attempts for security reasons.
                 ReplyError(rsp, TError("Incorrect login or password"));
-            }
-            else {
+            } else {
                 ReplyError(rsp, error);
             }
 
@@ -140,7 +139,7 @@ private:
 
             // Unknown error, reply 500.
             error = TError("Failed to fetch info for user %Qlv during logging", user) << error;
-            replyAndLogError(error, /*maskError*/ true, TString{user});
+            replyAndLogError(error, /*maskError*/ false, TString{user});
             throw;
         }
 

--- a/yt/yt/tests/integration/proxies/test_cypress_cookie_auth.py
+++ b/yt/yt/tests/integration/proxies/test_cypress_cookie_auth.py
@@ -48,10 +48,12 @@ class TestCypressCookieAuth(YTEnvSetup):
     def _get_proxy_address(self):
         return "http://" + self.Env.get_proxy_address()
 
-    def _check_login_page(self, rsp):
+    def _check_login_page(self, rsp, check_generic_msg = False):
         assert rsp.status_code == 401
         print_debug(rsp.content)
         assert rsp.headers["WWW-Authenticate"] == "Basic"
+        if check_generic_msg:
+            assert rsp.json()["message"] == "Incorrect login or password"
 
     def _try_login(self, user, password):
         auth = HTTPBasicAuth(user, password)
@@ -130,15 +132,15 @@ class TestCypressCookieAuth(YTEnvSetup):
     @authors("gritukan")
     def test_login_failed(self):
         # No such user.
-        self._check_login_page(self._try_login("v", "1234"))
+        self._check_login_page(self._try_login("v", "1234"), True)
 
         create_user("u")
         # User has no password set.
-        self._check_login_page(self._try_login("u", ""))
+        self._check_login_page(self._try_login("u", ""), True)
 
         set_user_password("u", "1234")
         # Invalid password.
-        self._check_login_page(self._try_login("u", "123"))
+        self._check_login_page(self._try_login("u", "123"), True)
 
     @authors("gritukan")
     def test_weird_password(self):

--- a/yt/yt/tests/integration/proxies/test_cypress_cookie_auth.py
+++ b/yt/yt/tests/integration/proxies/test_cypress_cookie_auth.py
@@ -48,7 +48,7 @@ class TestCypressCookieAuth(YTEnvSetup):
     def _get_proxy_address(self):
         return "http://" + self.Env.get_proxy_address()
 
-    def _check_login_page(self, rsp, check_generic_msg = False):
+    def _check_login_page(self, rsp, check_generic_msg=False):
         assert rsp.status_code == 401
         print_debug(rsp.content)
         assert rsp.headers["WWW-Authenticate"] == "Basic"


### PR DESCRIPTION
# Description

When the login attempt attempt is unsuccessful due to incorrect username and/or password, the system leaks sensitive information about the nature of the failure. This PR unifies the error messages, returned to the user.