### PR TITLE
Close access to //sys/operations, use operations archive client in get-job to access it

### DIFF
--- a/yt/yt/server/master/cell_master/world_initializer.cpp
+++ b/yt/yt/server/master/cell_master/world_initializer.cpp
@@ -401,6 +401,7 @@ private:
                     BuildYsonStringFluently()
                         .BeginMap()
                             .Item("opaque").Value(true)
+                            .Item("inherit_acl").Value(false)
                         .EndMap());
             }
 

--- a/yt/yt/ytlib/api/native/client_job_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_job_info_impl.cpp
@@ -2428,7 +2428,7 @@ TListJobsResult TClient::DoListJobs(
     // Get jobs from controller agent.
     auto controllerAgentAddress = FindControllerAgentAddressFromCypress(
         operationId,
-        MakeStrong(this));
+        GetOperationsArchiveClient());
     auto controllerAgentResultFuture = DoListJobsFromControllerAgentAsync(
         operationId,
         controllerAgentAddress,
@@ -2629,7 +2629,7 @@ std::optional<TJob> TClient::DoGetJobFromControllerAgent(
 {
     auto controllerAgentAddress = FindControllerAgentAddressFromCypress(
         operationId,
-        MakeStrong(this));
+        GetOperationsArchiveClient());
     if (!controllerAgentAddress) {
         return {};
     }


### PR DESCRIPTION
Issue: https://github.com/ytsaurus/ytsaurus/issues/1213. Part 3 where we close access to `//sys/operations`

This PR closes access to `//sys/operations` by default and adjusts APIs who relied on it