### PR TITLE
Add strict access control validation for scheduler commands

### DIFF
--- a/yt/python/yt/environment/init_operations_archive.py
+++ b/yt/python/yt/environment/init_operations_archive.py
@@ -924,7 +924,7 @@ def get_latest_version():
     return migration.get_latest_version()
 
 
-def create_tables(client, target_version=None, override_tablet_cell_bundle="default", shard_count=1, archive_path=DEFAULT_ARCHIVE_PATH):
+def create_tables(client, target_version=None, override_tablet_cell_bundle="default", shard_count=1, archive_path=DEFAULT_ARCHIVE_PATH, close_access=True):
     """ Creates operation archive tables of given version """
     migration = prepare_migration(client, archive_path)
 
@@ -941,6 +941,9 @@ def create_tables(client, target_version=None, override_tablet_cell_bundle="defa
         shard_count=shard_count,
         override_tablet_cell_bundle=override_tablet_cell_bundle,
     )
+
+    if close_access:
+        client.set("//sys/operations_archive/@inherit_acl", False)
 
 
 # Warning! This function does NOT perform actual transformations, it only creates tables with latest schemas.

--- a/yt/yt/client/api/operation_client.h
+++ b/yt/yt/client/api/operation_client.h
@@ -158,6 +158,10 @@ struct TListOperationsOptions
 
     TDuration ArchiveFetchingTimeout = TDuration::Seconds(3);
 
+    // These parameters cannot be set from list_operations command, they must be computed.
+    THashSet<std::string> UserTransitiveClosure = {};
+    bool StrictSchedulerCommandsAccessValidation = false;
+
     TListOperationsOptions()
     {
         ReadFrom = EMasterChannelKind::Cache;

--- a/yt/yt/server/master/cell_master/world_initializer.cpp
+++ b/yt/yt/server/master/cell_master/world_initializer.cpp
@@ -401,6 +401,7 @@ private:
                     BuildYsonStringFluently()
                         .BeginMap()
                             .Item("opaque").Value(true)
+                            .Item("inherit_acl").Value(false)
                         .EndMap());
             }
 

--- a/yt/yt/tests/integration/scheduler/test_scheduler_acls.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_acls.py
@@ -30,7 +30,7 @@ import pytest
 import random
 import string
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from contextlib import contextmanager
 from copy import deepcopy
 
@@ -56,9 +56,8 @@ def _update_op_parameters(**kwargs):
     update_op_parameters(kwargs.pop("operation_id"), **kwargs)
 
 
-class TestSchedulerAcls(YTEnvSetup):
+class TestSchedulerAclsBase(YTEnvSetup):
     ENABLE_MULTIDAEMON = False  # There are component restarts.
-    NUM_TEST_PARTITIONS = 6
     USE_DYNAMIC_TABLES = True
 
     NUM_MASTERS = 1
@@ -118,7 +117,7 @@ class TestSchedulerAcls(YTEnvSetup):
     }
 
     def setup_method(self, method):
-        super(TestSchedulerAcls, self).setup_method(method)
+        super(TestSchedulerAclsBase, self).setup_method(method)
 
         # Init operations archive.
         sync_create_cells(1)
@@ -166,8 +165,9 @@ class TestSchedulerAcls(YTEnvSetup):
     def _validate_access(user, should_have_access, action, **action_args):
         has_access = True
         authorization_error = None
+        result = None
         try:
-            action(authenticated_user=user, **action_args)
+            result = action(authenticated_user=user, **action_args)
         except YtError as e:
             if not e.contains_code(yt_error_codes.AuthorizationErrorCode):
                 raise
@@ -185,6 +185,7 @@ class TestSchedulerAcls(YTEnvSetup):
             )
             if not has_access:
                 message += ". Got error response {}".format(authorization_error)
+            message += ". Action result: {}".format(result)
             raise AssertionError(message)
 
     def _run_and_fail_op(self, should_update_operation_parameters):
@@ -248,6 +249,10 @@ class TestSchedulerAcls(YTEnvSetup):
             except YtError:
                 # TODO: Ensure it is "no such operation" error or operation has failed or aborted.
                 pass
+
+
+class TestSchedulerAcls(TestSchedulerAclsBase):
+    NUM_TEST_PARTITIONS = 17
 
     @authors("omgronny")
     @pytest.mark.parametrize("should_update_operation_parameters", [False, True])
@@ -337,6 +342,8 @@ class TestSchedulerAcls(YTEnvSetup):
         op, job_id = self._run_and_fail_op(should_update_operation_parameters=False)
         clean_operations()
         for action in actions:
+            # Wait for job to become available.
+            retry(lambda: action(operation_id=op.id, job_id=job_id))
             self._validate_access(self.no_rights_user, False, action, operation_id=op.id, job_id=job_id)
             self._validate_access(self.read_only_user, True, action, operation_id=op.id, job_id=job_id)
             self._validate_access(self.manage_only_user, False, action, operation_id=op.id, job_id=job_id)
@@ -844,3 +851,241 @@ class TestSchedulerAcls(YTEnvSetup):
             ),
             all_operations,
         )
+
+    @authors("aleksandr.gaev")
+    def test_list_operations_access_filter(self):
+        op = run_test_vanilla(
+            command=with_breakpoint("BREAKPOINT"),
+            spec=self.spec,
+        )
+        wait_breakpoint()
+
+        def validate_operations(list_result, expected):
+            assert [op["id"] for op in list_result["operations"]] == expected
+
+        set(f"//sys/users/{self.read_only_user}/@inherit_acl", False)
+
+        access_filter = {
+            "subject": self.read_only_user,
+            "permissions": ["read"],
+        }
+        allow_acl = [
+            make_ace("allow", self.no_rights_user, ["read"]),
+            make_ace("allow", self.manage_and_read_user, ["read"])
+        ]
+        set(f"//sys/users/{self.read_only_user}/@acl", allow_acl)
+        validate_operations(list_operations(authenticated_user=self.no_rights_user, access=access_filter), [op.id])
+        validate_operations(list_operations(authenticated_user=self.manage_and_read_user, access=access_filter), [op.id])
+        set(f"//sys/users/{self.read_only_user}/@acl", [])
+        validate_operations(list_operations(authenticated_user=self.no_rights_user, access=access_filter), [op.id])
+        validate_operations(list_operations(authenticated_user=self.manage_and_read_user, access=access_filter), [op.id])
+
+class TestSchedulerAclsStrictMode(TestSchedulerAclsBase):
+    NUM_TEST_PARTITIONS = 6
+
+    # NB(aleksandr.gaev): I have no idea why DELTA_DRIVER_CONFIG is needed and not cluster_connection config.
+    DELTA_DRIVER_CONFIG = {
+        "strict_scheduler_commands_access_validation": True,
+    }
+
+    # DELTA_PROXY_CONFIG = {
+    #     "cluster_connection": {
+    #         "strict_scheduler_commands_access_validation": True,
+    #     },
+    # }
+
+    @authors("omgronny", "aleksandr.gaev")
+    @pytest.mark.parametrize("use_acl", [False, True])
+    @pytest.mark.parametrize("should_archive_operation", [False, True])
+    @pytest.mark.parametrize("include_runtime", [False, True])
+    def test_aco_get_operation(self, use_acl, should_archive_operation, include_runtime):
+        spec = self.spec if use_acl else {"aco_name": "users"}
+        op = run_test_vanilla(
+            command=with_breakpoint("BREAKPOINT"),
+            spec=spec,
+        )
+        wait_breakpoint()
+
+        if should_archive_operation:
+            release_breakpoint()
+            clean_operations()
+
+        self._validate_access(self.no_rights_user, False, get_operation, op_id_or_alias=op.id, include_runtime=include_runtime)
+        self._validate_access(self.read_only_user, True, get_operation, op_id_or_alias=op.id, include_runtime=include_runtime)
+        self._validate_access(self.manage_only_user, False, get_operation, op_id_or_alias=op.id, include_runtime=include_runtime)
+        self._validate_access(self.manage_and_read_user, True, get_operation, op_id_or_alias=op.id, include_runtime=include_runtime)
+        self._validate_access(self.banned_from_managing_user, True, get_operation, op_id_or_alias=op.id, include_runtime=include_runtime)
+        self._validate_access(self.banned_user, False, get_operation, op_id_or_alias=op.id, include_runtime=include_runtime)
+
+    @authors("aleksandr.gaev")
+    @pytest.mark.parametrize("use_acl", [False, True])
+    @pytest.mark.parametrize("should_archive_operation", [False, True])
+    def test_get_job(self, use_acl, should_archive_operation):
+        spec = self.spec if use_acl else {"aco_name": "users"}
+        spec["max_failed_job_count"] = 1
+        op = run_test_vanilla(
+            command=with_breakpoint("BREAKPOINT; exit 1"),
+            spec=spec,
+        )
+
+        (job_id,) = wait_breakpoint()
+
+        if should_archive_operation:
+            release_breakpoint()
+            clean_operations()
+
+        # Wait for job to become available.
+        retry(lambda: get_job(op.id, job_id))
+
+        self._validate_access(self.no_rights_user, False, get_job, operation_id=op.id, job_id=job_id)
+        self._validate_access(self.read_only_user, True, get_job, operation_id=op.id, job_id=job_id)
+        self._validate_access(self.manage_only_user, False, get_job, operation_id=op.id, job_id=job_id)
+        self._validate_access(self.manage_and_read_user, True, get_job, operation_id=op.id, job_id=job_id)
+        self._validate_access(self.banned_from_managing_user, True, get_job, operation_id=op.id, job_id=job_id)
+        self._validate_access(self.banned_user, False, get_job, operation_id=op.id, job_id=job_id)
+
+    @authors("aleksandr.gaev")
+    @pytest.mark.parametrize("use_acl", [False, True])
+    @pytest.mark.parametrize("should_archive_operation", [False, True])
+    def test_list_jobs(self, use_acl, should_archive_operation):
+        spec = self.spec if use_acl else {"aco_name": "users"}
+        spec["max_failed_job_count"] = 1
+        op = run_test_vanilla(
+            command=with_breakpoint("BREAKPOINT; exit 1"),
+            spec=spec,
+        )
+
+        wait_breakpoint()
+
+        if should_archive_operation:
+            release_breakpoint()
+            clean_operations()
+
+        self._validate_access(self.no_rights_user, False, list_jobs, operation_id=op.id)
+        self._validate_access(self.read_only_user, True, list_jobs, operation_id=op.id)
+        self._validate_access(self.manage_only_user, False, list_jobs, operation_id=op.id)
+        self._validate_access(self.manage_and_read_user, True, list_jobs, operation_id=op.id)
+        self._validate_access(self.banned_from_managing_user, True, list_jobs, operation_id=op.id)
+        self._validate_access(self.banned_user, False, list_jobs, operation_id=op.id)
+
+    @authors("aleksandr.gaev")
+    @pytest.mark.parametrize("use_acl", [False, True])
+    @pytest.mark.parametrize("should_archive_operation", [False, True])
+    def test_list_operations(self, use_acl, should_archive_operation):
+        spec = self.spec if use_acl else {"aco_name": "users"}
+        before_start_time = datetime.utcnow().strftime(YT_DATETIME_FORMAT_STRING)
+        op = run_test_vanilla(
+            command=with_breakpoint("BREAKPOINT"),
+            spec=spec,
+        )
+        after_start_time = datetime.utcnow().strftime(YT_DATETIME_FORMAT_STRING)
+        wait_breakpoint()
+
+        if not use_acl:
+            # list_operations does not work with aco_name as expected.
+            cypress_operations = []
+            all_operations = []
+        elif should_archive_operation:
+            release_breakpoint()
+            clean_operations()
+            cypress_operations = []
+            all_operations = [op.id]
+        else:
+            cypress_operations = [op.id]
+            all_operations = [op.id]
+
+
+        def validate_operations(list_result, expected):
+            assert [op["id"] for op in list_result["operations"]] == expected
+
+        validate_operations(list_operations(authenticated_user=self.no_rights_user), [])
+        validate_operations(list_operations(authenticated_user=self.read_only_user), cypress_operations)
+        validate_operations(list_operations(authenticated_user=self.manage_only_user), [])
+        validate_operations(list_operations(authenticated_user=self.manage_and_read_user), cypress_operations)
+        validate_operations(list_operations(authenticated_user=self.banned_from_managing_user), cypress_operations)
+        validate_operations(list_operations(authenticated_user=self.banned_user), [])
+
+        validate_operations(
+            list_operations(
+                authenticated_user=self.no_rights_user,
+                include_archive=True,
+                from_time=before_start_time,
+                to_time=after_start_time,
+            ),
+            [],
+        )
+        validate_operations(
+            list_operations(
+                authenticated_user=self.read_only_user,
+                include_archive=True,
+                from_time=before_start_time,
+                to_time=after_start_time,
+            ),
+            all_operations,
+        )
+        validate_operations(
+            list_operations(
+                authenticated_user=self.manage_only_user,
+                include_archive=True,
+                from_time=before_start_time,
+                to_time=after_start_time,
+            ),
+            [],
+        )
+        validate_operations(
+            list_operations(
+                authenticated_user=self.manage_and_read_user,
+                include_archive=True,
+                from_time=before_start_time,
+                to_time=after_start_time,
+            ),
+            all_operations,
+        )
+        validate_operations(
+            list_operations(
+                authenticated_user=self.banned_from_managing_user,
+                include_archive=True,
+                from_time=before_start_time,
+                to_time=after_start_time,
+            ),
+            all_operations,
+        )
+        validate_operations(
+            list_operations(
+                authenticated_user=self.banned_user,
+                include_archive=True,
+                from_time=before_start_time,
+                to_time=after_start_time,
+            ),
+            [],
+        )
+
+    @authors("aleksandr.gaev")
+    def test_list_operations_access_filter(self):
+        op = run_test_vanilla(
+            command=with_breakpoint("BREAKPOINT"),
+            spec=self.spec,
+        )
+        wait_breakpoint()
+
+        def validate_operations(list_result, expected):
+            assert [op["id"] for op in list_result["operations"]] == expected
+
+        set(f"//sys/users/{self.read_only_user}/@inherit_acl", False)
+
+        access_filter = {
+            "subject": self.read_only_user,
+            "permissions": ["read"],
+        }
+        allow_acl = [
+            make_ace("allow", self.no_rights_user, ["read"]),
+            make_ace("allow", self.manage_and_read_user, ["read"])
+        ]
+        set(f"//sys/users/{self.read_only_user}/@acl", allow_acl)
+        validate_operations(list_operations(authenticated_user=self.no_rights_user, access=access_filter), [])
+        validate_operations(list_operations(authenticated_user=self.manage_and_read_user, access=access_filter), [op.id])
+        set(f"//sys/users/{self.read_only_user}/@acl", [])
+        with raises_yt_error("Access denied"):
+            list_operations(authenticated_user=self.no_rights_user, access=access_filter)
+        with raises_yt_error("Access denied"):
+            list_operations(authenticated_user=self.manage_and_read_user, access=access_filter)

--- a/yt/yt/ytlib/api/native/client_job_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_job_info_impl.cpp
@@ -2428,7 +2428,7 @@ TListJobsResult TClient::DoListJobs(
     // Get jobs from controller agent.
     auto controllerAgentAddress = FindControllerAgentAddressFromCypress(
         operationId,
-        MakeStrong(this));
+        GetOperationsArchiveClient());
     auto controllerAgentResultFuture = DoListJobsFromControllerAgentAsync(
         operationId,
         controllerAgentAddress,
@@ -2629,7 +2629,7 @@ std::optional<TJob> TClient::DoGetJobFromControllerAgent(
 {
     auto controllerAgentAddress = FindControllerAgentAddressFromCypress(
         operationId,
-        MakeStrong(this));
+        GetOperationsArchiveClient());
     if (!controllerAgentAddress) {
         return {};
     }

--- a/yt/yt/ytlib/api/native/client_job_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_job_info_impl.cpp
@@ -487,7 +487,7 @@ TJobSpec TClient::FetchJobSpecFromArchive(TJobId jobId)
     };
     auto keys = FromRecordKeys(TRange(std::array{recordKey}));
 
-    auto resultOrError = WaitFor(LookupRows(
+    auto resultOrError = WaitFor(GetOperationsArchiveClient()->LookupRows(
         GetOperationsArchiveJobSpecsPath(),
         NRecords::TJobSpecDescriptor::Get()->GetNameTable(),
         keys,
@@ -537,7 +537,7 @@ TOperationId TClient::TryGetOperationId(
     };
     auto keys = FromRecordKeys(TRange(std::array{recordKey}));
 
-    auto rowsetOrError = WaitFor(LookupRows(
+    auto rowsetOrError = WaitFor(GetOperationsArchiveClient()->LookupRows(
         GetOperationsArchiveOperationIdsPath(),
         NRecords::TOperationIdDescriptor::Get()->GetNameTable(),
         keys,
@@ -1149,7 +1149,7 @@ TSharedRef TClient::DoGetJobStderrFromArchive(
         };
         auto keys = FromRecordKeys(TRange(std::array{recordKey}));
 
-        auto rowset = WaitFor(LookupRows(
+        auto rowset = WaitFor(GetOperationsArchiveClient()->LookupRows(
             GetOperationsArchiveJobStderrsPath(),
             NRecords::TJobStderrDescriptor::Get()->GetNameTable(),
             keys,
@@ -1263,7 +1263,7 @@ std::vector<TJobTraceEvent> TClient::DoGetJobTraceFromTraceEventsTable(
         builder.AddWhereConjunct(Format("event_time <= %v", *options.ToTime));
     }
 
-    auto rowset = WaitFor(SelectRows(builder.Build(), GetDefaultSelectRowsOptions(deadline)))
+    auto rowset = WaitFor(GetOperationsArchiveClient()->SelectRows(builder.Build(), GetDefaultSelectRowsOptions(deadline)))
         .ValueOrThrow()
         .Rowset;
 
@@ -1371,7 +1371,7 @@ TSharedRef TClient::DoGetJobFailContextFromArchive(
         lookupOptions.ColumnFilter = NTableClient::TColumnFilter({*idMapping.FailContext});
         lookupOptions.KeepMissingRows = true;
 
-        auto rowset = WaitFor(LookupRows(
+        auto rowset = WaitFor(GetOperationsArchiveClient()->LookupRows(
             GetOperationsArchiveJobFailContextsPath(),
             NRecords::TJobFailContextDescriptor::Get()->GetNameTable(),
             std::move(keys),
@@ -1499,7 +1499,7 @@ TFuture<TListJobsStatistics> TClient::ListJobsStatisticsFromArchiveAsync(
     builder.AddGroupByExpression("job_type");
     builder.AddGroupByExpression("node_state");
 
-    return SelectRows(builder.Build(), GetDefaultSelectRowsOptions(deadline)).Apply(BIND([=] (const TSelectRowsResult& result) {
+    return GetOperationsArchiveClient()->SelectRows(builder.Build(), GetDefaultSelectRowsOptions(deadline)).Apply(BIND([=] (const TSelectRowsResult& result) {
         TListJobsStatistics statistics;
         for (auto row : result.Rowset->GetRows()) {
             // Skip jobs that was not fully written (usually it is written only by controller).
@@ -1874,7 +1874,7 @@ TFuture<std::vector<TJob>> TClient::DoListJobsFromArchiveAsync(
         AddOrderByExpression(&builder, options);
     }
 
-    return SelectRows(builder.Build(), GetDefaultSelectRowsOptions(deadline)).Apply(BIND(
+    return GetOperationsArchiveClient()->SelectRows(builder.Build(), GetDefaultSelectRowsOptions(deadline)).Apply(BIND(
         [operationId, attributes = std::move(attributes), this_ = MakeStrong(this)] (const TSelectRowsResult& result) {
         auto idMapping = NRecords::TJobPartial::TRecordDescriptor::TIdMapping(result.Rowset->GetNameTable());
         auto records = ToRecords<NRecords::TJobPartial>(result.Rowset->GetRows(), idMapping);
@@ -2593,7 +2593,7 @@ std::optional<TJob> TClient::DoGetJobFromArchive(
     lookupOptions.KeepMissingRows = true;
     lookupOptions.Timeout = deadline - Now();
 
-    auto rowset = WaitFor(LookupRows(
+    auto rowset = WaitFor(GetOperationsArchiveClient()->LookupRows(
         GetOperationsArchiveJobsPath(),
         jobsTable,
         keys,

--- a/yt/yt/ytlib/api/native/client_job_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_job_info_impl.cpp
@@ -2411,6 +2411,10 @@ TListJobsResult TClient::DoListJobs(
             operationId = ResolveOperationAlias(alias, optionsResult, deadline);
         });
 
+    if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation) {
+        ValidateOperationAccess(operationId, NullJobId, EPermissionSet(EPermission::Read));
+    }
+
     // Get jobs from archive.
     // Issue the requests in parallel.
     TFuture<std::vector<TJob>> archiveResultFuture;
@@ -2720,6 +2724,10 @@ TYsonString TClient::DoGetJob(
         [&] (const TString& alias) {
             operationId = ResolveOperationAlias(alias, options, deadline);
         });
+
+    if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation) {
+        ValidateOperationAccess(operationId, jobId, EPermissionSet(EPermission::Read));
+    }
 
     auto operationInfoFuture = GetOperation(operationId, TGetOperationOptions{
         .Attributes = {{"state"}},

--- a/yt/yt/ytlib/api/native/client_operation_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_operation_info_impl.cpp
@@ -449,7 +449,7 @@ TOperationId TClient::ResolveOperationAlias(
     lookupOptions.KeepMissingRows = true;
     lookupOptions.Timeout = deadline - Now();
 
-    auto rowset = WaitFor(LookupRows(
+    auto rowset = WaitFor(GetOperationsArchiveClient()->LookupRows(
         GetOperationsArchiveOperationAliasesPath(),
         NRecords::TOperationAliasDescriptor::Get()->GetNameTable(),
         MakeSharedRange(std::move(keys), std::move(rowBuffer)),
@@ -953,7 +953,7 @@ THashMap<TOperationId, TOperation> TClient::LookupOperationsInArchiveTyped(
     }
 
     auto columnFilter = NTableClient::TColumnFilter(columns);
-    auto rowset = LookupOperationsInArchive(this, ids, columnFilter, timeout)
+    auto rowset = LookupOperationsInArchive(GetOperationsArchiveClient(), ids, columnFilter, timeout)
         .ValueOrThrow();
     auto records = ToOptionalRecords<NRecords::TOrderedByIdPartial>(rowset);
 
@@ -1083,7 +1083,7 @@ THashMap<TOperationId, TOperation> TClient::DoListOperationsFromArchive(
         selectOptions.InputRowLimit = std::numeric_limits<i64>::max();
         selectOptions.MemoryLimitPerNode = 100_MB;
 
-        auto resultCounts = WaitFor(SelectRows(builder.Build(), selectOptions))
+        auto resultCounts = WaitFor(GetOperationsArchiveClient()->SelectRows(builder.Build(), selectOptions))
             .ValueOrThrow();
 
         auto records = ToRecords<NRecords::TOrderedByStartTimePartial>(resultCounts.Rowset);
@@ -1199,7 +1199,7 @@ THashMap<TOperationId, TOperation> TClient::DoListOperationsFromArchive(
     selectOptions.Timeout = deadline - Now();
     selectOptions.InputRowLimit = std::numeric_limits<i64>::max();
     selectOptions.MemoryLimitPerNode = 100_MB;
-    auto rowsItemsId = WaitFor(SelectRows(builder.Build(), selectOptions))
+    auto rowsItemsId = WaitFor(GetOperationsArchiveClient()->SelectRows(builder.Build(), selectOptions))
         .ValueOrThrow();
     auto records = ToRecords<NRecords::TOrderedByStartTimePartial>(rowsItemsId.Rowset);
 
@@ -1361,7 +1361,7 @@ TListOperationsResult TClient::DoListOperations(const TListOperationsOptions& ol
 
         auto columnFilter = NTableClient::TColumnFilter(columnIndices);
         auto rowsetOrError = LookupOperationsInArchive(
-            this,
+            GetOperationsArchiveClient(),
             ids,
             columnFilter,
             options.ArchiveFetchingTimeout);

--- a/yt/yt/ytlib/api/native/client_operation_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_operation_info_impl.cpp
@@ -494,6 +494,9 @@ static bool IsErrorRetriable(const TError& error)
     if (error.FindMatching(NTabletClient::EErrorCode::ColumnNotFound)) {
         return false;
     }
+    if (error.FindMatching(NSecurityClient::EErrorCode::AuthorizationError)) {
+        return false;
+    }
     return true;
 }
 
@@ -699,6 +702,22 @@ TOperation TClient::DoGetOperationImpl(
     return *archiveResult;
 }
 
+static std::optional<TAccessControlRule> GetOperationAccessControlRule(const TOperation& operation)
+{
+    if (operation.RuntimeParameters) {
+        auto runtimeParametersNode = ConvertToNode(operation.RuntimeParameters);
+        if (runtimeParametersNode->GetType() == ENodeType::Map) {
+            if (auto acl = runtimeParametersNode->AsMap()->FindChild("acl")) {
+                return ConvertTo<TSerializableAccessControlList>(acl);
+            }
+            if (auto acoName = runtimeParametersNode->AsMap()->FindChild("aco_name")) {
+                return ConvertTo<TString>(acoName);
+            }
+        }
+    }
+    return {};
+}
+
 TOperation TClient::DoGetOperation(
     const TOperationIdOrAlias& operationIdOrAlias,
     const TGetOperationOptions& options)
@@ -721,9 +740,14 @@ TOperation TClient::DoGetOperation(
         });
 
     const auto retryInterval = Connection_->GetConfig()->DefaultGetOperationRetryInterval;
+    auto getOperationOptions = options;
+    if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation && getOperationOptions.Attributes) {
+        // Request runtime_parameters to perform access control validation.
+        getOperationOptions.Attributes->insert("runtime_parameters");
+    }
     while (true) {
         try {
-            auto operation = DoGetOperationImpl(operationId, deadline, options);
+            auto operation = DoGetOperationImpl(operationId, deadline, getOperationOptions);
 
             // COMPAT(gepardo): this must be preserved until the operations without provided_spec (i.e. started before mid-2022)
             // are no longer in the operations archive.
@@ -731,6 +755,30 @@ TOperation TClient::DoGetOperation(
                 !operation.ProvidedSpec)
             {
                 operation.ProvidedSpec = operation.Spec;
+            }
+
+            if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation) {
+                auto accessControlRule = GetOperationAccessControlRule(operation);
+                if (accessControlRule) {
+                    NScheduler::ValidateOperationAccess(
+                        Options_.GetAuthenticatedUser(),
+                        operationId,
+                        EPermissionSet::Read,
+                        *accessControlRule,
+                        this,
+                        Logger());
+                } else {
+                    THROW_ERROR_EXCEPTION(
+                        "Failed to validate operation access, operation has no access control rule")
+                        << TErrorAttribute("operation_id", operationId);
+                }
+            }
+
+            if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation &&
+                options.Attributes &&
+                !options.Attributes->contains("runtime_parameters")) {
+                // Remove runtime_parameters field if it was not requested.
+                operation.RuntimeParameters = {};
             }
 
             return operation;
@@ -1046,6 +1094,13 @@ THashMap<TOperationId, TOperation> TClient::DoListOperationsFromArchive(
                 Format("is_substr(%Qv, filter_factors)", *options.SubstrFilter));
         }
 
+        if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation &&
+            !options.UserTransitiveClosure.contains(SuperusersGroupName)) {
+            builder->AddWhereConjunct(Format("NOT is_null(acl) AND _yt_has_permissions(acl, %Qv, %Qv)",
+                ConvertToYsonString(options.UserTransitiveClosure, EYsonFormat::Text),
+                ConvertToYsonString(EPermissionSet::Read, EYsonFormat::Text)));
+        }
+
         if (options.AccessFilter) {
             builder->AddWhereConjunct(Format("NOT is_null(acl) AND _yt_has_permissions(acl, %Qv, %Qv)",
                 ConvertToYsonString(options.AccessFilter->SubjectTransitiveClosure, EYsonFormat::Text),
@@ -1269,12 +1324,28 @@ TListOperationsResult TClient::DoListOperations(const TListOperationsOptions& ol
         options.SubstrFilter = to_lower(*options.SubstrFilter);
     }
 
+    auto client = GetOperationsArchiveClient();
+
+    if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation) {
+        client = this;
+    }
+
+    auto proxy = NObjectClient::CreateObjectServiceReadProxy(
+        client,
+        options.ReadFrom,
+        PrimaryMasterCellTagSentinel,
+        Connection_->GetStickyGroupSizeCache());
+
+    if (Connection_->GetConfig()->StrictSchedulerCommandsAccessValidation) {
+        options.StrictSchedulerCommandsAccessValidation = true;
+        options.UserTransitiveClosure = GetSubjectClosure(
+            Options_.GetAuthenticatedUser(),
+            proxy,
+            Connection_,
+            options);
+    }
+
     if (options.AccessFilter) {
-        auto proxy = NObjectClient::CreateObjectServiceReadProxy(
-            GetOperationsArchiveClient(),
-            options.ReadFrom,
-            PrimaryMasterCellTagSentinel,
-            Connection_->GetStickyGroupSizeCache());
         options.AccessFilter->SubjectTransitiveClosure = GetSubjectClosure(
             options.AccessFilter->Subject,
             proxy,

--- a/yt/yt/ytlib/api/native/config.cpp
+++ b/yt/yt/ytlib/api/native/config.cpp
@@ -456,6 +456,9 @@ void TConnectionDynamicConfig::Register(TRegistrar registrar)
     registrar.Parameter("enable_distributed_replication_collocation_attachment", &TThis::EnableDistributedReplicationCollocationAttachment)
         .Default(true);
 
+    registrar.Parameter("strict_scheduler_commands_access_validation", &TThis::StrictSchedulerCommandsAccessValidation)
+        .Default(false);
+
     registrar.Postprocessor([] (TConnectionDynamicConfig* config) {
         if (!config->UploadTransactionPingPeriod.has_value()) {
             config->UploadTransactionPingPeriod = config->UploadTransactionTimeout / 2;

--- a/yt/yt/ytlib/api/native/config.h
+++ b/yt/yt/ytlib/api/native/config.h
@@ -353,6 +353,9 @@ struct TConnectionDynamicConfig
 
     bool EnableDistributedReplicationCollocationAttachment;
 
+    //! Enables strict access validation in scheduler commands.
+    bool StrictSchedulerCommandsAccessValidation;
+
     REGISTER_YSON_STRUCT(TConnectionDynamicConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/ytlib/api/native/list_operations.cpp
+++ b/yt/yt/ytlib/api/native/list_operations.cpp
@@ -593,7 +593,8 @@ public:
         cursor->ParseMap([&] (TYsonPullParserCursor* cursor) {
             YT_VERIFY((*cursor)->GetType() == EYsonItemType::StringValue);
             auto key = (*cursor)->UncheckedAsString();
-            if (Options_.AccessFilter && key == TStringBuf("acl")) {
+            if (key == TStringBuf("acl") &&
+                (Options_.StrictSchedulerCommandsAccessValidation || Options_.AccessFilter)) {
                 cursor->Next();
                 HasAcl_ = true;
                 Deserialize(Acl_, cursor);
@@ -736,6 +737,21 @@ private:
             (Options_.ToTime && CurrentOperation_.StartTime >= *Options_.ToTime))
         {
             return false;
+        }
+
+        // Verify that the user has "read" access to the operation.
+        if (Options_.StrictSchedulerCommandsAccessValidation &&
+            !Options_.UserTransitiveClosure.contains(SuperusersGroupName)) {
+            if (!HasAcl_) {
+                return false;
+            }
+            auto userReadSecurityAction = CheckPermissionsByAclAndSubjectClosure(
+                Acl_,
+                Options_.UserTransitiveClosure,
+                EPermissionSet::Read);
+            if (userReadSecurityAction != ESecurityAction::Allow) {
+                return false;
+            }
         }
 
         if (Options_.AccessFilter) {


### PR DESCRIPTION
Issue: https://github.com/ytsaurus/ytsaurus/issues/1213. Part 4 where we introduce a feature flag to enforce strict access control validation for scheduler commands

This PR adds a feature flag `strict_scheduler_commands_access_validation` which fixes access control behaviour of scheduler commands (get-operation, get-job, list-operation, ...).

This PR consists of 3 commits: closure of `//sys/operations_archive`, closure of `//sys/operations` and actual feature.
Every commit has a separate PR. [Archive](https://github.com/ytsaurus/ytsaurus/pull/1215). [Cypress](https://github.com/ytsaurus/ytsaurus/pull/1216)

---

* Changelog entry
Type: feature
Component: proxy

Add a feature flag to enforce access control for scheduler commands (get-operation, get-job, ...)

