### PR TITLE
Remove address from internal job structures

### DIFF
--- a/yt/yt/server/controller_agent/controllers/data_balancer.cpp
+++ b/yt/yt/server/controller_agent/controllers/data_balancer.cpp
@@ -106,7 +106,7 @@ void TDataBalancer::TNode::Persist(const TPersistenceContext& context)
 void TDataBalancer::LogViolation(const TDataBalancer::TNode& node, i64 dataWeight)
 {
     YT_LOG_DEBUG("Data balancing violation (NodeAddress: %v, NodeId: %v, DataWeight: %v, NodeDataWeight: %v, NodeLimit: %v)",
-        node.Descriptor.Address,
+        NNodeTrackerClient::GetDefaultAddress(node.Descriptor.Addresses),
         node.Descriptor.Id,
         dataWeight,
         node.DataWeight,
@@ -137,8 +137,8 @@ void TDataBalancer::LogStatistics() const
         isFirst = false;
         char isActive = node.Active ? '+' : '-';
         line.AppendFormat("%v[%v]%v: %v/%v",
-            node.Descriptor.Address,
-            nodeId,
+            NNodeTrackerClient::GetDefaultAddress(node.Descriptor.Addresses),
+            node.Descriptor.Id,
             isActive,
             node.DataWeight,
             GetNodeDataWeightLimit(node));

--- a/yt/yt/server/controller_agent/controllers/job_info.cpp
+++ b/yt/yt/server/controller_agent/controllers/job_info.cpp
@@ -25,7 +25,6 @@ using namespace NYTree;
 
 TJobNodeDescriptor::TJobNodeDescriptor(const TExecNodeDescriptorPtr& other)
     : Id(other->Id)
-    , Address(other->Address)
     , Addresses(other->Addresses)
     , IOWeight(other->IOWeight)
 { }
@@ -35,7 +34,7 @@ void TJobNodeDescriptor::RegisterMetadata(auto&& registrar)
     PHOENIX_REGISTER_FIELD(1, Id);
     PHOENIX_REGISTER_FIELD(2, Addresses);
     PHOENIX_REGISTER_FIELD(3, IOWeight);
-    PHOENIX_REGISTER_FIELD(4, Address);
+    // COMPAT(aleksandr.gaev): index 4 is reserved for deleted field `Address`
 }
 
 PHOENIX_DEFINE_TYPE(TJobNodeDescriptor);

--- a/yt/yt/server/controller_agent/controllers/job_info.h
+++ b/yt/yt/server/controller_agent/controllers/job_info.h
@@ -31,7 +31,6 @@ struct TJobNodeDescriptor
     TJobNodeDescriptor(const NScheduler::TExecNodeDescriptorPtr& other);
 
     NNodeTrackerClient::TNodeId Id = NNodeTrackerClient::InvalidNodeId;
-    std::string Address;
     NNodeTrackerClient::TAddressMap Addresses;
     double IOWeight = 0.0;
 

--- a/yt/yt/server/controller_agent/controllers/sort_controller.cpp
+++ b/yt/yt/server/controller_agent/controllers/sort_controller.cpp
@@ -2131,13 +2131,13 @@ protected:
             YT_LOG_DEBUG("Partition assigned (Index: %v, DataWeight: %v, Address: %v)",
                 partition->Index,
                 partition->ChunkPoolOutput->GetDataWeightCounter()->GetTotal(),
-                node->Descriptor->Address);
+                NNodeTrackerClient::GetDefaultAddress(node->Descriptor->Addresses));
         }
 
         for (const auto& node : nodeHeap) {
             if (node->AssignedDataWeight > 0) {
                 YT_LOG_DEBUG("Node used (Address: %v, Weight: %.4lf, AssignedDataWeight: %v, AdjustedDataWeight: %v)",
-                    node->Descriptor->Address,
+                    NNodeTrackerClient::GetDefaultAddress(node->Descriptor->Addresses),
                     node->Weight,
                     node->AssignedDataWeight,
                     static_cast<i64>(node->AssignedDataWeight / node->Weight));

--- a/yt/yt/server/controller_agent/controllers/task.cpp
+++ b/yt/yt/server/controller_agent/controllers/task.cpp
@@ -940,7 +940,7 @@ std::expected<NScheduler::TJobResourcesWithQuota, EScheduleFailReason> TTask::Tr
         "Interruptible: %v)",
         joblet->JobId,
         joblet->JobType,
-        context.GetNodeDescriptor().Address,
+        NNodeTrackerClient::GetDefaultAddress(context.GetNodeDescriptor().Addresses),
         joblet->JobIndex,
         joblet->OutputCookie,
         joblet->InputStripeList->TotalChunkCount,

--- a/yt/yt/server/controller_agent/job_tracker.cpp
+++ b/yt/yt/server/controller_agent/job_tracker.cpp
@@ -3169,7 +3169,7 @@ const std::string& TJobTracker::GetNodeAddressForLogging(TNodeId nodeId)
         static const std::string NotReceivedAddress{"<address not received>"};
         return NotReceivedAddress;
     } else {
-        return nodeIt->second->Address;
+        return NNodeTrackerClient::GetDefaultAddress(nodeIt->second->Addresses);
     }
 }
 

--- a/yt/yt/server/controller_agent/scheduling_context.cpp
+++ b/yt/yt/server/controller_agent/scheduling_context.cpp
@@ -55,7 +55,7 @@ void TSchedulingContext::FormatCommonPart(TStringBuilderBase& builder) const
     builder.AppendFormat(
         "AllocationId: %v, NodeAddress: %v, PoolPath: %v",
         AllocationId_,
-        NodeDescriptor_.Address,
+        NNodeTrackerClient::GetDefaultAddress(NodeDescriptor_.Addresses),
         PoolPath_);
 }
 

--- a/yt/yt/server/lib/scheduler/exec_node_descriptor.h
+++ b/yt/yt/server/lib/scheduler/exec_node_descriptor.h
@@ -26,7 +26,6 @@ struct TExecNodeDescriptor
 
     TExecNodeDescriptor(
         NNodeTrackerClient::TNodeId id,
-        const std::string& address,
         const NNodeTrackerClient::TAddressMap& addresses,
         const std::optional<std::string>& dataCenter,
         double ioWeight,
@@ -40,8 +39,9 @@ struct TExecNodeDescriptor
 
     bool CanSchedule(const TSchedulingTagFilter& filter) const;
 
+    const std::string& GetDefaultAddress() const;
+
     NNodeTrackerClient::TNodeId Id = NNodeTrackerClient::InvalidNodeId;
-    std::string Address;
     NNodeTrackerClient::TAddressMap Addresses;
     std::optional<std::string> DataCenter;
     double IOWeight = 0.0;

--- a/yt/yt/server/scheduler/exec_node.cpp
+++ b/yt/yt/server/scheduler/exec_node.cpp
@@ -43,7 +43,6 @@ TExecNodeDescriptorPtr TExecNode::BuildExecDescriptor() const
 {
     return New<TExecNodeDescriptor>(
         Id_,
-        GetDefaultAddress(),
         GetAddresses(),
         NodeDescriptor_.GetDataCenter(),
         IOWeight_,

--- a/yt/yt/server/scheduler/fair_share_tree_allocation_scheduler.cpp
+++ b/yt/yt/server/scheduler/fair_share_tree_allocation_scheduler.cpp
@@ -1036,7 +1036,7 @@ void TScheduleAllocationsContext::AnalyzePreemptibleAllocations(
                 operationElement->GetId(),
                 operationState->SchedulingSegment,
                 NodeSchedulingSegment_,
-                SchedulingContext_->GetNodeDescriptor()->Address,
+                NNodeTrackerClient::GetDefaultAddress(SchedulingContext_->GetNodeDescriptor()->Addresses),
                 SchedulingContext_->GetNodeDescriptor()->DataCenter);
 
             forcefullyPreemptibleAllocations->insert(allocation.Get());
@@ -1267,7 +1267,7 @@ void TScheduleAllocationsContext::PreemptAllocationsAfterScheduling(
             FormatResources(SchedulingContext_->ResourceLimits()),
             FormatResources(SchedulingContext_->ResourceUsage()),
             SchedulingContext_->GetNodeDescriptor()->Id,
-            SchedulingContext_->GetNodeDescriptor()->Address);
+            NNodeTrackerClient::GetDefaultAddress(SchedulingContext_->GetNodeDescriptor()->Addresses));
     }
 }
 
@@ -1278,7 +1278,7 @@ void TScheduleAllocationsContext::AbortAllocationsSinceResourcesOvercommit() con
         FormatResources(SchedulingContext_->ResourceLimits()),
         FormatResources(SchedulingContext_->ResourceUsage()),
         SchedulingContext_->GetNodeDescriptor()->Id,
-        SchedulingContext_->GetNodeDescriptor()->Address);
+        NNodeTrackerClient::GetDefaultAddress(SchedulingContext_->GetNodeDescriptor()->Addresses));
 
     auto allocationInfos = CollectRunningAllocationsWithPreemptionInfo(SchedulingContext_, TreeSnapshot_);
     SortAllocationsWithPreemptionInfo(&allocationInfos);
@@ -1296,7 +1296,7 @@ void TScheduleAllocationsContext::AbortAllocationsSinceResourcesOvercommit() con
                 allocationInfo.Allocation->GetId(),
                 allocationInfo.OperationElement->GetId(),
                 allocationInfo.PreemptionStatus,
-                SchedulingContext_->GetNodeDescriptor()->Address);
+                NNodeTrackerClient::GetDefaultAddress(SchedulingContext_->GetNodeDescriptor()->Addresses));
 
             allocationInfo.Allocation->SetPreemptionReason("Preempted due to node resource ovecommit");
             PreemptAllocation(allocationInfo.Allocation, allocationInfo.OperationElement, EAllocationPreemptionReason::ResourceOvercommit);
@@ -1731,7 +1731,7 @@ bool TScheduleAllocationsContext::ScheduleAllocation(TSchedulerOperationElement*
             FormatResources(SchedulingContext_->GetConditionalDiscountForOperation(element->GetTreeIndex())),
             FormatResources(element->AggregatedMinNeededAllocationResources()),
             element->GroupedNeededResources(),
-            SchedulingContext_->GetNodeDescriptor()->Address);
+            NNodeTrackerClient::GetDefaultAddress(SchedulingContext_->GetNodeDescriptor()->Addresses));
 
         OnMinNeededResourcesUnsatisfied(
             element,
@@ -2409,7 +2409,7 @@ void TScheduleAllocationsContext::LogStageStatistics()
         StageState_->TotalHeapElementCount,
         StageState_->DeactivationReasons,
         SchedulingContext_->CanStartMoreAllocations(),
-        SchedulingContext_->GetNodeDescriptor()->Address,
+        NNodeTrackerClient::GetDefaultAddress(SchedulingContext_->GetNodeDescriptor()->Addresses),
         NodeSchedulingSegment_,
         StageState_->MaxSchedulingIndex);
 }
@@ -2532,7 +2532,7 @@ void TFairShareTreeAllocationScheduler::ProcessSchedulingHeartbeat(
     if (!nodeState) {
         YT_LOG_DEBUG("Skipping scheduling heartbeat because node is not registered in tree (NodeId: %v, NodeAddress: %v)",
             nodeId,
-            schedulingContext->GetNodeDescriptor()->Address);
+            NNodeTrackerClient::GetDefaultAddress(schedulingContext->GetNodeDescriptor()->Addresses));
 
         return;
     }
@@ -2567,7 +2567,7 @@ void TFairShareTreeAllocationScheduler::ProcessSchedulingHeartbeat(
             ? "enabled"
             : "disabled",
         nodeState->Descriptor->Id,
-        nodeState->Descriptor->Address);
+        NNodeTrackerClient::GetDefaultAddress(nodeState->Descriptor->Addresses));
 
     nodeState->SpecifiedSchedulingSegment = [&] () -> std::optional<ESchedulingSegment> {
         const auto& schedulingOptions = nodeState->Descriptor->SchedulingOptions;
@@ -2581,7 +2581,7 @@ void TFairShareTreeAllocationScheduler::ProcessSchedulingHeartbeat(
         } catch (const std::exception& ex) {
             YT_LOG_DEBUG(ex, "Failed to parse specified scheduling segment (NodeId: %v, NodeAddress: %v)",
                 nodeState->Descriptor->Id,
-                nodeState->Descriptor->Address);
+                NNodeTrackerClient::GetDefaultAddress(nodeState->Descriptor->Addresses));
 
             return {};
         }

--- a/yt/yt/server/scheduler/operation_controller_impl.cpp
+++ b/yt/yt/server/scheduler/operation_controller_impl.cpp
@@ -751,7 +751,7 @@ TFuture<TControllerScheduleAllocationResultPtr> TOperationControllerImpl::Schedu
     YT_LOG_TRACE(
         "Allocation schedule request enqueued (AllocationId: %v, NodeAddress: %v)",
         allocationId,
-        context->GetNodeDescriptor()->Address);
+        NNodeTrackerClient::GetDefaultAddress(context->GetNodeDescriptor()->Addresses));
 
     return nodeShard->BeginScheduleAllocation(incarnationId, OperationId_, allocationId);
 }

--- a/yt/yt/server/scheduler/scheduling_segment_manager.cpp
+++ b/yt/yt/server/scheduler/scheduling_segment_manager.cpp
@@ -844,7 +844,7 @@ void TSchedulingSegmentManager::ValidateInfinibandClusterTags(TUpdateSchedulingS
     for (const auto& [nodeId, node] : context->NodeStates) {
         auto error = validateNodeDescriptor(*node.Descriptor);
         if (!error.IsOK()) {
-            error = error << TErrorAttribute("node_address", node.Descriptor->Address);
+            error = error << TErrorAttribute("node_address", NNodeTrackerClient::GetDefaultAddress(node.Descriptor->Addresses));
             context->Error = TError("Node's infiniband cluster tags validation failed in tree %Qv", TreeId_)
                 << std::move(error);
             break;
@@ -956,7 +956,7 @@ void TSchedulingSegmentManager::DoRebalanceSegments(TUpdateSchedulingSegmentsCon
             auto oldSegment = nextAvailableNode->SchedulingSegment;
 
             YT_LOG_DEBUG("Moving node to a new scheduling segment (Address: %v, OldSegment: %v, NewSegment: %v, Module: %v, Penalty: %v)",
-                nextAvailableNode->Descriptor->Address,
+                NNodeTrackerClient::GetDefaultAddress(nextAvailableNode->Descriptor->Addresses),
                 nextAvailableNode->SchedulingSegment,
                 newSegment,
                 GetNodeModule(*nextAvailableNode),
@@ -1210,7 +1210,7 @@ void TSchedulingSegmentManager::GetMovableNodes(
                 "RunningAllocationIds: %v, RunningAllocationStatistics: %v, LastRunningAllocationStatisticsUpdateTime: %v, "
                 "MovableNodeIndex: %v, AggressivelyMovableNodeIndex: %v)",
                 nodeId,
-                node.Descriptor->Address,
+                NNodeTrackerClient::GetDefaultAddress(node.Descriptor->Addresses),
                 node.SchedulingSegment,
                 node.SpecifiedSchedulingSegment,
                 GetNodeModule(node),
@@ -1242,7 +1242,7 @@ void TSchedulingSegmentManager::SetNodeSegment(
 
     context->MovedNodes.push_back(TSetNodeSchedulingSegmentOptions{
         .NodeId = node->Descriptor->Id,
-        .NodeAddress = node->Descriptor->Address,
+        .NodeAddress = NNodeTrackerClient::GetDefaultAddress(node->Descriptor->Addresses),
         .OldSegment = node->SchedulingSegment,
         .NewSegment = segment,
     });
@@ -1381,7 +1381,7 @@ void TSchedulingSegmentManager::BuildGpuNodeInfo(
     }
 
     fluent
-        .Item(nodeState.Descriptor->Address).BeginMap()
+        .Item(NNodeTrackerClient::GetDefaultAddress(nodeState.Descriptor->Addresses)).BeginMap()
             .Item("id").Value(nodeState.Descriptor->Id)
             .Item("scheduling_segment").Value(nodeState.SchedulingSegment)
             .Item("specified_scheduling_segment").Value(nodeState.SpecifiedSchedulingSegment)
@@ -1409,7 +1409,7 @@ void TSchedulingSegmentManager::BuildPersistentState(TUpdateSchedulingSegmentsCo
             nodeId,
             TPersistentNodeSchedulingSegmentState{
                 .Segment = node.SchedulingSegment,
-                .Address = node.Descriptor->Address,
+                .Address = NNodeTrackerClient::GetDefaultAddress(node.Descriptor->Addresses),
             });
     }
 

--- a/yt/yt/ytlib/controller_agent/serialize.h
+++ b/yt/yt/ytlib/controller_agent/serialize.h
@@ -63,6 +63,7 @@ DEFINE_ENUM(ESnapshotVersion,
     ((GangRanks)                             (301803))
     ((ChunkStripeKeyNoIndex)                 (301804))
     ((OrderedAndSortedJobSizeAdjuster)       (301805))
+    ((RemoveAddressFromJob)                  (301806))
 );
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a followup on [this comment](https://github.com/ytsaurus/ytsaurus/pull/1052#issuecomment-2668200727)

Removing `Address` field from `TJobNodeDescriptor` and `TExecNodeDescriptor` in favour of `Addresses`. Loading from older snapshots will load `Address` and put it as a default address into `Addresses`
