### PR TITLE
YQL-19747 Introduce SchemaGateway interface

### DIFF
--- a/yql/essentials/sql/v1/complete/name/object/schema_gateway.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/schema_gateway.cpp
@@ -1,0 +1,6 @@
+#include "schema_gateway.h"
+
+template <>
+void Out<NSQLComplete::TFolderEntry>(IOutputStream& out, const NSQLComplete::TFolderEntry& entry) {
+    out << "{" << entry.Type << ", " << entry.Name << "}";
+}

--- a/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
+++ b/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
@@ -21,7 +21,7 @@ namespace NSQLComplete {
     };
 
     struct TListRequest {
-        TString System;
+        TString Cluster;
 
         // `Path` structure is defined by a `System`.
         // Can end with a folder entry name hint.

--- a/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
+++ b/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
@@ -34,7 +34,7 @@ namespace NSQLComplete {
     };
 
     struct TListResponse {
-        size_t NameHintLength;
+        size_t NameHintLength = 0;
         TVector<TFolderEntry> Entries;
     };
 

--- a/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
+++ b/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
@@ -30,7 +30,7 @@ namespace NSQLComplete {
         TString Path;
 
         TListFilter Filter;
-        TMaybe<size_t> Limit;
+        size_t Limit = 128;
     };
 
     struct TListResponse {

--- a/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
+++ b/yql/essentials/sql/v1/complete/name/object/schema_gateway.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <library/cpp/threading/future/core/future.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/hash_set.h>
+#include <util/generic/maybe.h>
+
+namespace NSQLComplete {
+
+    struct TFolderEntry {
+        TString Type;
+        TString Name;
+
+        friend bool operator==(const TFolderEntry& lhs, const TFolderEntry& rhs) = default;
+    };
+
+    struct TListFilter {
+        TMaybe<THashSet<TString>> Types;
+    };
+
+    struct TListRequest {
+        TString System;
+
+        // `Path` structure is defined by a `System`.
+        // Can end with a folder entry name hint.
+        // For example, `/local/exa` lists a folder `/local`,
+        // but can rank and filter entries by a hint `exa`.
+        TString Path;
+
+        TListFilter Filter;
+        TMaybe<size_t> Limit;
+    };
+
+    struct TListResponse {
+        size_t NameHintLength;
+        TVector<TFolderEntry> Entries;
+    };
+
+    class ISchemaGateway {
+    public:
+        using TPtr = THolder<ISchemaGateway>;
+
+        virtual ~ISchemaGateway() = default;
+        virtual NThreading::TFuture<TListResponse> List(const TListRequest& request) = 0;
+    };
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/object/static/schema_gateway.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/static/schema_gateway.cpp
@@ -9,6 +9,8 @@ namespace NSQLComplete {
     namespace {
 
         class TSchemaGateway: public ISchemaGateway {
+            static constexpr size_t MaxLimit = 4 * 1024;
+
         public:
             explicit TSchemaGateway(THashMap<TString, TVector<TFolderEntry>> data)
                 : Data_(std::move(data))
@@ -31,9 +33,8 @@ namespace NSQLComplete {
                     return types && !types->contains(entry.Type);
                 });
 
-                if (request.Limit) {
-                    entries.crop(*request.Limit);
-                }
+                Y_ENSURE(request.Limit <= MaxLimit);
+                entries.crop(request.Limit);
 
                 TListResponse response = {
                     .NameHintLength = prefix.size(),

--- a/yql/essentials/sql/v1/complete/name/object/static/schema_gateway.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/static/schema_gateway.cpp
@@ -1,0 +1,67 @@
+#include "schema_gateway.h"
+
+#include <yql/essentials/sql/v1/complete/text/case.h>
+
+#include <util/charset/utf8.h>
+
+namespace NSQLComplete {
+
+    namespace {
+
+        class TSchemaGateway: public ISchemaGateway {
+        public:
+            explicit TSchemaGateway(THashMap<TString, TVector<TFolderEntry>> data)
+                : Data_(std::move(data))
+            {
+                for (const auto& [k, _] : Data_) {
+                    Y_ENSURE(k.StartsWith("/"), k << " must start with the '/'");
+                    Y_ENSURE(k.EndsWith("/"), k << " must end with the '/'");
+                }
+            }
+
+            NThreading::TFuture<TListResponse> List(const TListRequest& request) override {
+                auto [path, prefix] = ParsePath(request.Path);
+
+                TVector<TFolderEntry> entries = Data_[path];
+                EraseIf(entries, [prefix = ToLowerUTF8(prefix)](const TFolderEntry& entry) {
+                    return !entry.Name.StartsWith(prefix);
+                });
+
+                EraseIf(entries, [types = std::move(request.Filter.Types)](const TFolderEntry& entry) {
+                    return types && !types->contains(entry.Type);
+                });
+
+                if (request.Limit) {
+                    entries.crop(*request.Limit);
+                }
+
+                TListResponse response = {
+                    .NameHintLength = prefix.size(),
+                    .Entries = std::move(entries),
+                };
+
+                return NThreading::MakeFuture(std::move(response));
+            }
+
+        private:
+            static std::tuple<TStringBuf, TStringBuf> ParsePath(TString path Y_LIFETIME_BOUND) {
+                size_t pos = path.find_last_of('/');
+                if (pos == TString::npos) {
+                    return {"", path};
+                }
+
+                TStringBuf head, tail;
+                TStringBuf(path).SplitAt(pos + 1, head, tail);
+                return {head, tail};
+            }
+
+            THashMap<TString, TVector<TFolderEntry>> Data_;
+        };
+
+    } // namespace
+
+    ISchemaGateway::TPtr MakeStaticSchemaGateway(THashMap<TString, TVector<TFolderEntry>> fs) {
+        return MakeHolder<TSchemaGateway>(std::move(fs));
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/object/static/schema_gateway.h
+++ b/yql/essentials/sql/v1/complete/name/object/static/schema_gateway.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <yql/essentials/sql/v1/complete/name/object/schema_gateway.h>
+
+namespace NSQLComplete {
+
+    ISchemaGateway::TPtr MakeStaticSchemaGateway(THashMap<TString, TVector<TFolderEntry>> fs);
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/object/static/schema_gateway_ut.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/static/schema_gateway_ut.cpp
@@ -1,0 +1,123 @@
+#include "schema_gateway.h"
+
+#include <library/cpp/testing/unittest/registar.h>
+
+using namespace NSQLComplete;
+
+Y_UNIT_TEST_SUITE(StaticSchemaGatewayTests) {
+
+    ISchemaGateway::TPtr MakeStaticSchemaGatewayUT() {
+        THashMap<TString, TVector<TFolderEntry>> fs = {
+            {"/", {{"Folder", "local"},
+                   {"Folder", "test"},
+                   {"Folder", "prod"}}},
+            {"/local/", {{"Table", "example"},
+                         {"Table", "account"},
+                         {"Table", "abacaba"}}},
+            {"/test/", {{"Folder", "service"},
+                        {"Table", "meta"}}},
+            {"/test/service/", {{"Table", "example"}}},
+        };
+        return MakeStaticSchemaGateway(std::move(fs));
+    }
+
+    Y_UNIT_TEST(ListFolderBasic) {
+        auto gateway = MakeStaticSchemaGatewayUT();
+        {
+            TVector<TFolderEntry> expected = {
+                {"Folder", "local"},
+                {"Folder", "test"},
+                {"Folder", "prod"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/"}).GetValueSync().Entries, expected);
+        }
+        {
+            TVector<TFolderEntry> expected = {
+                {"Table", "example"},
+                {"Table", "account"},
+                {"Table", "abacaba"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/local/"}).GetValueSync().Entries, expected);
+        }
+        {
+            TVector<TFolderEntry> expected = {
+                {"Folder", "service"},
+                {"Table", "meta"},
+            };
+            UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/test/"}).GetValueSync().Entries, expected);
+        }
+        {
+            TVector<TFolderEntry> expected = {
+                {"Table", "example"}};
+            UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/test/service/"}).GetValueSync().Entries, expected);
+        }
+    }
+
+    Y_UNIT_TEST(ListFolderHint) {
+        auto gateway = MakeStaticSchemaGatewayUT();
+        {
+            TVector<TFolderEntry> expected = {
+                {"Folder", "local"},
+            };
+            auto actual = gateway->List({.Path = "/l"}).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(actual.Entries, expected);
+            UNIT_ASSERT_VALUES_EQUAL(actual.NameHintLength, 1);
+        }
+        {
+            TVector<TFolderEntry> expected = {
+                {"Table", "account"},
+                {"Table", "abacaba"},
+            };
+            auto actual = gateway->List({.Path = "/local/a"}).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(actual.Entries, expected);
+            UNIT_ASSERT_VALUES_EQUAL(actual.NameHintLength, 1);
+        }
+        {
+            TVector<TFolderEntry> expected = {
+                {"Folder", "service"},
+            };
+            auto actual = gateway->List({.Path = "/test/service"}).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(actual.Entries, expected);
+            UNIT_ASSERT_VALUES_EQUAL(actual.NameHintLength, 7);
+        }
+    }
+
+    Y_UNIT_TEST(ListFolderFilterByType) {
+        auto gateway = MakeStaticSchemaGatewayUT();
+        {
+            TVector<TFolderEntry> expected = {
+                {"Folder", "service"},
+            };
+            TListRequest request = {
+                .Path = "/test/",
+                .Filter = {
+                    .Types = THashSet<TString>{"Folder"},
+                },
+            };
+            UNIT_ASSERT_VALUES_EQUAL(gateway->List(request).GetValueSync().Entries, expected);
+        }
+        {
+            TVector<TFolderEntry> expected = {
+                {"Table", "meta"},
+            };
+            TListRequest request = {
+                .Path = "/test/",
+                .Filter = {
+                    .Types = THashSet<TString>{"Table"},
+                },
+            };
+            UNIT_ASSERT_VALUES_EQUAL(gateway->List(request).GetValueSync().Entries, expected);
+        }
+    }
+
+    Y_UNIT_TEST(ListFolderLimit) {
+        auto gateway = MakeStaticSchemaGatewayUT();
+        UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/", .Limit = 0}).GetValueSync().Entries.size(), 0);
+        UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/", .Limit = 1}).GetValueSync().Entries.size(), 1);
+        UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/", .Limit = 2}).GetValueSync().Entries.size(), 2);
+        UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/", .Limit = 3}).GetValueSync().Entries.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/", .Limit = 4}).GetValueSync().Entries.size(), 3);
+        UNIT_ASSERT_VALUES_EQUAL(gateway->List({.Path = "/", .Limit = 5}).GetValueSync().Entries.size(), 3);
+    }
+
+} // Y_UNIT_TEST_SUITE(StaticSchemaGatewayTests)

--- a/yql/essentials/sql/v1/complete/name/object/static/ut/ya.make
+++ b/yql/essentials/sql/v1/complete/name/object/static/ut/ya.make
@@ -1,0 +1,7 @@
+UNITTEST_FOR(yql/essentials/sql/v1/complete/name/object/static)
+
+SRCS(
+    schema_gateway_ut.cpp
+)
+
+END()

--- a/yql/essentials/sql/v1/complete/name/object/static/ya.make
+++ b/yql/essentials/sql/v1/complete/name/object/static/ya.make
@@ -1,0 +1,15 @@
+LIBRARY()
+
+SRCS(
+    schema_gateway.cpp
+)
+
+PEERDIR(
+    yql/essentials/sql/v1/complete/name/object
+)
+
+END()
+
+RECURSE_FOR_TESTS(
+    ut
+)

--- a/yql/essentials/sql/v1/complete/name/object/ya.make
+++ b/yql/essentials/sql/v1/complete/name/object/ya.make
@@ -1,0 +1,15 @@
+LIBRARY()
+
+SRCS(
+    schema_gateway.cpp
+)
+
+PEERDIR(
+    library/cpp/threading/future
+)
+
+END()
+
+RECURSE(
+    static
+)

--- a/yql/essentials/sql/v1/complete/name/ya.make
+++ b/yql/essentials/sql/v1/complete/name/ya.make
@@ -8,5 +8,6 @@ END()
 
 RECURSE(
     fallback
+    object
     static
 )


### PR DESCRIPTION
I decided to be lazy and specify the only method `List` for a `SchemaGateway`, as `Describe` will be needed only when we would like to add column completions and I think this will not happen on the nearest ~2 weeks, because just listing a schema let us to complete a lot of objects: folders, tables, indexes, roles, users... While implementing these objects completions I will think about schema synthesis at background. I think that more time to think of the API design is better.

I decided not to add some constructions like `std::variant` and other things to make it easier to use and more elegant, because actually we want to keep it simple to implement. So the interface is as dump and simple as possible. I named it the `SchemaGateway` because there maybe will be a `Schema` that will be a wrapper around `SchemaGateway` with that fancy and expressive C++ constructions.

Errors are not specified because I did not come up with an idea how to recover from them. I think that all errors should be just propagated and somewhere written to some error listener and on error replaced with a `pure EmptyResponse`.

I added a `StaticSchemaGateway` to show an expected behaviour from an implementation and also to use it in `sql/v1/complete` unit tests.

---

- Related to https://github.com/ytsaurus/ytsaurus/pull/1209
- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/14