### PR TITLE
YQL-19747 Normalize names for ranking and filtering

### DIFF
--- a/yql/essentials/sql/v1/complete/name/static/frequency.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.cpp
@@ -1,6 +1,6 @@
 #include "frequency.h"
 
-#include <yql/essentials/core/sql_types/normalize_name.h>
+#include "name_index.h"
 
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/resource/resource.h>
@@ -56,7 +56,7 @@ namespace NSQLComplete {
         }
     };
 
-    TFrequencyData Convert(TVector<TFrequencyItem> items) {
+    TFrequencyData Convert(TVector<TFrequencyItem> items, auto normalize) {
         TFrequencyData data;
         for (auto& item : items) {
             if (item.Parent == Json.Parent.Pragma ||
@@ -67,7 +67,7 @@ namespace NSQLComplete {
                 item.Parent == Json.Parent.Module ||
                 item.Parent == Json.Parent.ReadHint ||
                 item.Parent == Json.Parent.InsertHint) {
-                item.Rule = NYql::NormalizeName(item.Rule);
+                item.Rule = normalize(item.Rule);
             }
 
             if (item.Parent == Json.Parent.Pragma) {
@@ -91,14 +91,24 @@ namespace NSQLComplete {
         return data;
     }
 
+    TFrequencyData ParseJsonFrequencyData(const TStringBuf text, auto normalize) {
+        return Convert(TFrequencyItem::ParseListFromJsonText(text), normalize);
+    }
+
     TFrequencyData ParseJsonFrequencyData(const TStringBuf text) {
-        return Convert(TFrequencyItem::ParseListFromJsonText(text));
+        return ParseJsonFrequencyData(text, NormalizeName);
     }
 
     TFrequencyData LoadFrequencyData() {
         TString text;
         Y_ENSURE(NResource::FindExact("rules_corr_basic.json", &text));
-        return ParseJsonFrequencyData(text);
+        return ParseJsonFrequencyData(text, NormalizeName);
+    }
+
+    TFrequencyData LoadFrequencyDataForPrunning() {
+        TString text;
+        Y_ENSURE(NResource::FindExact("rules_corr_basic.json", &text));
+        return ParseJsonFrequencyData(text, UnchangedName);
     }
 
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/static/frequency.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.cpp
@@ -1,5 +1,7 @@
 #include "frequency.h"
 
+#include <yql/essentials/core/sql_types/normalize_name.h>
+
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/resource/resource.h>
 
@@ -65,7 +67,7 @@ namespace NSQLComplete {
                 item.Parent == Json.Parent.Module ||
                 item.Parent == Json.Parent.ReadHint ||
                 item.Parent == Json.Parent.InsertHint) {
-                item.Rule = ToLowerUTF8(item.Rule);
+                item.Rule = NYql::NormalizeName(item.Rule);
             }
 
             if (item.Parent == Json.Parent.Pragma) {

--- a/yql/essentials/sql/v1/complete/name/static/frequency.h
+++ b/yql/essentials/sql/v1/complete/name/static/frequency.h
@@ -17,4 +17,6 @@ namespace NSQLComplete {
 
     TFrequencyData LoadFrequencyData();
 
+    TFrequencyData LoadFrequencyDataForPrunning();
+
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/static/frequency_ut.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/frequency_ut.cpp
@@ -31,7 +31,7 @@ Y_UNIT_TEST_SUITE(FrequencyTests) {
             },
             .Hints = {
                 {"columns", 826110},
-                {"column_groups", 225},
+                {"columngroups", 225},
             },
         };
 

--- a/yql/essentials/sql/v1/complete/name/static/json_name_set.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/json_name_set.cpp
@@ -94,16 +94,15 @@ namespace NSQLComplete {
 
         for (auto& [_, group] : groups) {
             Sort(group, [](const auto& lhs, const auto& rhs) {
-                const auto& [_, lhs_freq] = lhs;
-                const auto& [__, rhs_freq] = rhs;
-                return lhs_freq < rhs_freq;
+                return std::get<1>(lhs) < std::get<1>(rhs);
             });
         }
 
         names = TVector<TString>();
+        names.reserve(groups.size());
         for (auto& [_, group] : groups) {
             Y_ASSERT(!group.empty());
-            names.emplace_back(std::get<0>(group.back()));
+            names.emplace_back(std::move(std::get<0>(group.back())));
         }
         return names;
     }

--- a/yql/essentials/sql/v1/complete/name/static/json_name_set.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/json_name_set.cpp
@@ -1,5 +1,8 @@
 #include "name_service.h"
 
+#include "frequency.h"
+#include "name_index.h"
+
 #include <library/cpp/json/json_reader.h>
 #include <library/cpp/resource/resource.h>
 
@@ -78,15 +81,53 @@ namespace NSQLComplete {
         return hints;
     }
 
+    TVector<TString> Pruned(TVector<TString> names, const THashMap<TString, size_t>& frequency) {
+        THashMap<TString, TVector<std::tuple<TString, size_t>>> groups;
+
+        for (auto& [normalized, original] : BuildNameIndex(std::move(names), NormalizeName)) {
+            size_t freq = 0;
+            if (const size_t* it = frequency.FindPtr(original)) {
+                freq = *it;
+            }
+            groups[normalized].emplace_back(std::move(original), freq);
+        }
+
+        for (auto& [_, group] : groups) {
+            Sort(group, [](const auto& lhs, const auto& rhs) {
+                const auto& [_, lhs_freq] = lhs;
+                const auto& [__, rhs_freq] = rhs;
+                return lhs_freq < rhs_freq;
+            });
+        }
+
+        names = TVector<TString>();
+        for (auto& [_, group] : groups) {
+            Y_ASSERT(!group.empty());
+            names.emplace_back(std::get<0>(group.back()));
+        }
+        return names;
+    }
+
+    NameSet Pruned(NameSet names) {
+        auto frequency = LoadFrequencyDataForPrunning();
+        names.Pragmas = Pruned(std::move(names.Pragmas), frequency.Pragmas);
+        names.Types = Pruned(std::move(names.Types), frequency.Types);
+        names.Functions = Pruned(std::move(names.Functions), frequency.Functions);
+        for (auto& [k, h] : names.Hints) {
+            h = Pruned(h, frequency.Hints);
+        }
+        return names;
+    }
+
     NameSet MakeDefaultNameSet() {
-        return {
+        return Pruned({
             .Pragmas = ParsePragmas(LoadJsonResource("pragmas_opensource.json")),
             .Types = ParseTypes(LoadJsonResource("types.json")),
             .Functions = Merge(
                 ParseFunctions(LoadJsonResource("sql_functions.json")),
                 ParseUdfs(LoadJsonResource("udfs_basic.json"))),
             .Hints = ParseHints(LoadJsonResource("statements_opensource.json")),
-        };
+        });
     }
 
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/static/name_index.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/name_index.cpp
@@ -1,0 +1,21 @@
+#include "name_index.h"
+
+#include <yql/essentials/core/sql_types/normalize_name.h>
+
+#include <util/charset/utf8.h>
+
+namespace NSQLComplete {
+
+    TString NormalizeName(const TString& name) {
+        return NYql::NormalizeName(name);
+    }
+
+    TString LowerizeName(const TString& name) {
+        return ToLowerUTF8(name);
+    }
+
+    TString UnchangedName(const TString& name) {
+        return name;
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/static/name_index.h
+++ b/yql/essentials/sql/v1/complete/name/static/name_index.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <yql/essentials/sql/v1/complete/text/case.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/algorithm.h>
+
+namespace NSQLComplete {
+
+    struct TNameIndexEntry {
+        TString Normalized;
+        TString Original;
+    };
+
+    using TNameIndex = TVector<TNameIndexEntry>;
+
+    inline bool NameIndexCompare(const TNameIndexEntry& lhs, const TNameIndexEntry& rhs) {
+        return NoCaseCompare(lhs.Normalized, rhs.Normalized);
+    }
+
+    inline auto NameIndexCompareLimit(size_t limit) {
+        return [cmp = NoCaseCompareLimit(limit)](const TNameIndexEntry& lhs, const TNameIndexEntry& rhs) {
+            return cmp(lhs.Normalized, rhs.Normalized);
+        };
+    }
+
+    TNameIndex BuildNameIndex(TVector<TString> originals, auto normalize) {
+        TNameIndex index;
+        for (auto& original : originals) {
+            TNameIndexEntry entry = {
+                .Normalized = normalize(original),
+                .Original = std::move(original),
+            };
+            index.emplace_back(std::move(entry));
+        }
+
+        Sort(index, NameIndexCompare);
+        return index;
+    }
+
+    TString NormalizeName(const TString& name);
+
+    TString LowerizeName(const TString& name);
+
+    TString UnchangedName(const TString& name);
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/static/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/static/ranking.cpp
@@ -4,6 +4,8 @@
 
 #include <yql/essentials/sql/v1/complete/name/name_service.h>
 
+#include <yql/essentials/core/sql_types/normalize_name.h>
+
 #include <util/charset/utf8.h>
 
 namespace NSQLComplete {
@@ -57,7 +59,7 @@ namespace NSQLComplete {
             return std::visit([this](const auto& name) -> size_t {
                 using T = std::decay_t<decltype(name)>;
 
-                auto content = ToLowerUTF8(ContentView(name));
+                auto content = NYql::NormalizeName(ContentView(name));
 
                 if constexpr (std::is_same_v<T, TKeyword>) {
                     if (auto weight = Frequency_.Keywords.FindPtr(content)) {

--- a/yql/essentials/sql/v1/complete/name/static/ya.make
+++ b/yql/essentials/sql/v1/complete/name/static/ya.make
@@ -8,6 +8,7 @@ SRCS(
 )
 
 PEERDIR(
+    yql/essentials/core/sql_types
     yql/essentials/sql/v1/complete/name
     yql/essentials/sql/v1/complete/text
 )

--- a/yql/essentials/sql/v1/complete/name/static/ya.make
+++ b/yql/essentials/sql/v1/complete/name/static/ya.make
@@ -3,6 +3,7 @@ LIBRARY()
 SRCS(
     frequency.cpp
     json_name_set.cpp
+    name_index.cpp
     name_service.cpp
     ranking.cpp
 )

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -604,7 +604,6 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         }
         {
             TVector<TCandidate> expected = {
-                {HintName, "IGNORETYPEV3"},
                 {HintName, "IGNORE_TYPE_V3"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"REDUCE a WITH ig"}), expected);
@@ -648,10 +647,9 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         auto engine = MakeSqlCompletionEngine(MakePureLexerSupplier(), std::move(service));
 
         TVector<TCandidate> expected = {
-            {HintName, "IGNORETYPEV3"},
             {HintName, "IGNORE_TYPE_V3"},
         };
-        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"REDUCE a WITH ignore_t"}), expected);
+        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"REDUCE a WITH ignoret"}), expected);
     }
 
     Y_UNIT_TEST(Ranking) {
@@ -727,7 +725,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {HintName, "XLOCK"},
                 {HintName, "UNORDERED"},
                 {Keyword, "COLUMNS"},
-                {HintName, "FORCEINFERSCHEMA"},
+                {HintName, "FORCE_INFER_SCHEMA"},
             };
             UNIT_ASSERT_VALUES_EQUAL(CompleteTop(expected.size(), engine, {"SELECT * FROM a WITH "}), expected);
         }

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -604,8 +604,8 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         }
         {
             TVector<TCandidate> expected = {
-                {HintName, "IGNORE_TYPE_V3"},
                 {HintName, "IGNORETYPEV3"},
+                {HintName, "IGNORE_TYPE_V3"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"REDUCE a WITH ig"}), expected);
         }
@@ -640,6 +640,18 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         UNIT_ASSERT_GE(Complete(engine, {"SELECT CAST (1 AS U"}).size(), 6);
         UNIT_ASSERT_GE(Complete(engine, {"SELECT CAST (1 AS "}).size(), 47);
         UNIT_ASSERT_GE(Complete(engine, {"SELECT "}).size(), 55);
+    }
+
+    Y_UNIT_TEST(NameNormalization) {
+        auto set = MakeDefaultNameSet();
+        auto service = MakeStaticNameService(std::move(set), MakeDefaultRanking());
+        auto engine = MakeSqlCompletionEngine(MakePureLexerSupplier(), std::move(service));
+
+        TVector<TCandidate> expected = {
+            {HintName, "IGNORETYPEV3"},
+            {HintName, "IGNORE_TYPE_V3"},
+        };
+        UNIT_ASSERT_VALUES_EQUAL(Complete(engine, {"REDUCE a WITH ignore_t"}), expected);
     }
 
     Y_UNIT_TEST(Ranking) {


### PR DESCRIPTION
I was lazy to search for a most frequent used name among equivalent by the relation `(a ~ b) iff (NormalizeName(a) = NormalizeName(b))`. Because it seems that names we receive from JSONs are canonized and therefore in a preferable style by the opinion of the YQL language designers. But because of duplicates at `statements_opensource.json` we have, for example, both `IGNORETYPEV3` and `IGNORE_TYPE_V3` in candidates list. I think that we should just remove `IGNORETYPEV3` from the JSON.

---

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/21
