### PR TITLE
transaction commits and aborts should validate ACLs

### DIFF
--- a/yt/yt/server/master/cell_master/serialize.h
+++ b/yt/yt/server/master/cell_master/serialize.h
@@ -184,6 +184,7 @@ DEFINE_ENUM(EMasterReign,
     ((CheckNodeWriteSessions)                                       (2947))  // koloshmet
     ((DontValidateLockCountOnExternalCells)                         (2948))  // h0pless
     ((DedicatedChunkHostInRoleValidation)                           (2949))  // cherepashka
+    ((PersistFinalizedTransactionUsers)                             (2950))  // faucct
 );
 
 static_assert(TEnumTraits<EMasterReign>::IsMonotonic, "Master reign enum is not monotonic");

--- a/yt/yt/server/master/transaction_server/transaction_manager.cpp
+++ b/yt/yt/server/master/transaction_server/transaction_manager.cpp
@@ -2575,7 +2575,6 @@ private:
 
         const auto& securityManager = Bootstrap_->GetSecurityManager();
         TAuthenticatedUserGuard userGuard(securityManager);
-        securityManager->ValidatePermission(transaction, EPermission::Write);
 
         auto prerequisiteTransactionIds = FromProto<std::vector<TTransactionId>>(request->prerequisite_transaction_ids());
 

--- a/yt/yt/tests/integration/master/test_master_transactions.py
+++ b/yt/yt/tests/integration/master/test_master_transactions.py
@@ -483,13 +483,12 @@ class TestMasterTransactions(YTEnvSetup):
     @authors("faucct")
     def test_not_owner(self):
         create_user("u")
-        set("//sys/schemas/transaction/@acl", [*get("//sys/schemas/transaction/@acl"), {
+        tx = start_transaction(attributes={"acl": [{
             "action": "deny",
             "subjects": ["u"],
             "permissions": ["write"],
             "inheritance_mode": "object_and_descendants",
-        }])
-        tx = start_transaction()
+        }]})
         create("map_node", "//tmp/wut", tx=tx)
         with pytest.raises(YtError):
             abort_transaction(tx, authenticated_user="u")


### PR DESCRIPTION
It was not being validated for commits and also the authentication identity was being changed to root.