### PR TITLE
feat cell-balancer: get pod_id from cypress annotations

### DIFF
--- a/yt/yt/server/cell_balancer/bundle_scheduler.h
+++ b/yt/yt/server/cell_balancer/bundle_scheduler.h
@@ -183,8 +183,8 @@ public:
     TIndexedEntries<TAllocationRequest> ChangedAllocations;
     TIndexedEntries<TDeallocationRequest> NewDeallocations;
     TIndexedEntries<TBundleControllerState> ChangedStates;
-    TMutationMap<TInstanceAnnotations> ChangeNodeAnnotations;
-    TMutationMap<TInstanceAnnotations> ChangedProxyAnnotations;
+    TMutationMap<TBundleControllerInstanceAnnotations> ChangeNodeAnnotations;
+    TMutationMap<TBundleControllerInstanceAnnotations> ChangedProxyAnnotations;
 
     THashSet<TBundleMutation<std::string>> CompletedAllocations;
 
@@ -301,7 +301,7 @@ TIndexedEntries<TBundleControllerState> MergeBundleStates(
     const TSchedulerInputState& schedulerState,
     const TSchedulerMutations& mutations);
 
-std::string GetPodIdForInstance(const std::string& name);
+std::string GetPodIdForInstance(const TCypressAnnotationsPtr& cypressAnnotations, const std::string& name);
 
 std::string GetInstanceSize(const NBundleControllerClient::TInstanceResourcesPtr& resource);
 

--- a/yt/yt/server/cell_balancer/cypress_bindings.cpp
+++ b/yt/yt/server/cell_balancer/cypress_bindings.cpp
@@ -422,7 +422,7 @@ void TDrillsModeOperationState::Register(TRegistrar registrar)
         .Default();
 }
 
-void TInstanceAnnotations::Register(TRegistrar registrar)
+void TBundleControllerInstanceAnnotations::Register(TRegistrar registrar)
 {
     registrar.Parameter("yp_cluster", &TThis::YPCluster)
         .Default();
@@ -439,6 +439,12 @@ void TInstanceAnnotations::Register(TRegistrar registrar)
     registrar.Parameter("deallocation_strategy", &TThis::DeallocationStrategy)
         .Default();
     registrar.Parameter("data_center", &TThis::DataCenter)
+        .Optional();
+}
+
+void TCypressAnnotations::Register(TRegistrar registrar)
+{
+    registrar.Parameter("pod_id", &TThis::PodId)
         .Optional();
 }
 
@@ -497,7 +503,9 @@ void TTabletNodeInfo::Register(TRegistrar registrar)
         .Default();
     RegisterAttribute(registrar, "user_tags", &TThis::UserTags)
         .Default();
-    RegisterAttribute(registrar, "bundle_controller_annotations", &TThis::Annotations)
+    RegisterAttribute(registrar, "bundle_controller_annotations", &TThis::BundleControllerAnnotations)
+        .DefaultNew();
+    RegisterAttribute(registrar, "annotations", &TThis::CypressAnnotations)
         .DefaultNew();
     RegisterAttribute(registrar, "tablet_slots", &TThis::TabletSlots)
         .Default();
@@ -541,7 +549,9 @@ void TRpcProxyInfo::Register(TRegistrar registrar)
         .Default();
     RegisterAttribute(registrar, "role", &TThis::Role)
         .Default();
-    RegisterAttribute(registrar, "bundle_controller_annotations", &TThis::Annotations)
+    RegisterAttribute(registrar, "bundle_controller_annotations", &TThis::BundleControllerAnnotations)
+        .DefaultNew();
+    RegisterAttribute(registrar, "annotations", &TThis::CypressAnnotations)
         .DefaultNew();
     RegisterAttribute(registrar, "cms_maintenance_requests", &TThis::CmsMaintenanceRequests)
         .Default();

--- a/yt/yt/server/cell_balancer/cypress_bindings.h
+++ b/yt/yt/server/cell_balancer/cypress_bindings.h
@@ -30,7 +30,8 @@ DECLARE_REFCOUNTED_STRUCT(TDeallocationRequestSpec)
 DECLARE_REFCOUNTED_STRUCT(TDeallocationRequestStatus)
 DECLARE_REFCOUNTED_STRUCT(TDeallocationRequest)
 DECLARE_REFCOUNTED_STRUCT(TDeallocationRequestState)
-DECLARE_REFCOUNTED_STRUCT(TInstanceAnnotations)
+DECLARE_REFCOUNTED_STRUCT(TBundleControllerInstanceAnnotations)
+DECLARE_REFCOUNTED_STRUCT(TCypressAnnotations)
 DECLARE_REFCOUNTED_STRUCT(TTabletNodeInfo)
 DECLARE_REFCOUNTED_STRUCT(TTabletNodeMemoryStatistics)
 DECLARE_REFCOUNTED_STRUCT(TMemoryCategory)
@@ -641,7 +642,7 @@ DEFINE_REFCOUNTED_TYPE(TBundleControllerState)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct TInstanceAnnotations
+struct TBundleControllerInstanceAnnotations
     : public NYTree::TYsonStruct
 {
     std::string YPCluster;
@@ -655,12 +656,26 @@ struct TInstanceAnnotations
 
     std::optional<std::string> DataCenter;
 
-    REGISTER_YSON_STRUCT(TInstanceAnnotations);
+    REGISTER_YSON_STRUCT(TBundleControllerInstanceAnnotations);
 
     static void Register(TRegistrar registrar);
 };
 
-DEFINE_REFCOUNTED_TYPE(TInstanceAnnotations)
+DEFINE_REFCOUNTED_TYPE(TBundleControllerInstanceAnnotations)
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCypressAnnotations
+    : public NYTree::TYsonStruct
+{
+    std::optional<std::string> PodId;
+
+    REGISTER_YSON_STRUCT(TCypressAnnotations);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TCypressAnnotations)
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -748,7 +763,8 @@ struct TTabletNodeInfo
     std::string State;
     THashSet<std::string> Tags;
     THashSet<std::string> UserTags;
-    TInstanceAnnotationsPtr Annotations;
+    TBundleControllerInstanceAnnotationsPtr BundleControllerAnnotations;
+    TCypressAnnotationsPtr CypressAnnotations;
     std::vector<TTabletSlotPtr> TabletSlots;
     THashMap<std::string, TCmsMaintenanceRequestPtr> CmsMaintenanceRequests;
     TInstant LastSeenTime;
@@ -781,7 +797,8 @@ struct TRpcProxyInfo
 {
     bool Banned;
     std::string Role;
-    TInstanceAnnotationsPtr Annotations;
+    TBundleControllerInstanceAnnotationsPtr BundleControllerAnnotations;
+    TCypressAnnotationsPtr CypressAnnotations;
     THashMap<std::string, TCmsMaintenanceRequestPtr> CmsMaintenanceRequests;
     TInstant ModificationTime;
 

--- a/yt/yt/server/cell_balancer/orchid_bindings.cpp
+++ b/yt/yt/server/cell_balancer/orchid_bindings.cpp
@@ -115,13 +115,14 @@ void PopulateInstances(
     for (const auto& name : bundleInstances) {
         auto instance = New<TInstanceInfo>();
         const auto& instanceInfo = GetOrCrash(instanciesInfo, name);
-        const auto& annotations = instanceInfo->Annotations;
+        const auto& bundleControllerAnnotations = instanceInfo->BundleControllerAnnotations;
+        const auto& cypressAnnotations = instanceInfo->CypressAnnotations;
 
-        instance->Resource = annotations->Resource;
-        instance->PodId = GetPodIdForInstance(name);
-        instance->YPCluster = annotations->YPCluster;
+        instance->Resource = bundleControllerAnnotations->Resource;
+        instance->PodId = GetPodIdForInstance(cypressAnnotations, name);
+        instance->YPCluster = bundleControllerAnnotations->YPCluster;
 
-        instance->DataCenter = annotations->DataCenter;
+        instance->DataCenter = bundleControllerAnnotations->DataCenter;
 
         instancies[name] = instance;
     }


### PR DESCRIPTION
This PR allows bundle controller to read pod ids from cypress annotations instead of relying on hostname format. Also, some minor refactoring to not mix up BundleControllerAnnotations with CypressAnnotations.