### PR TITLE
YQL-19747 Use TMaybe

### DIFF
--- a/yql/essentials/sql/v1/complete/name/service/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.h
@@ -6,6 +6,7 @@
 
 #include <util/generic/vector.h>
 #include <util/generic/string.h>
+#include <util/generic/maybe.h>
 
 namespace NSQLComplete {
 
@@ -51,10 +52,10 @@ namespace NSQLComplete {
     struct TNameRequest {
         TVector<TString> Keywords;
         struct {
-            std::optional<TPragmaName::TConstraints> Pragma;
-            std::optional<TTypeName::TConstraints> Type;
-            std::optional<TFunctionName::TConstraints> Function;
-            std::optional<THintName::TConstraints> Hint;
+            TMaybe<TPragmaName::TConstraints> Pragma;
+            TMaybe<TTypeName::TConstraints> Type;
+            TMaybe<TFunctionName::TConstraints> Function;
+            TMaybe<THintName::TConstraints> Hint;
         } Constraints;
         TString Prefix = "";
         size_t Limit = 128;

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -121,10 +121,10 @@ namespace NSQLComplete {
             return keywords;
         }
 
-        std::optional<TLocalSyntaxContext::TPragma> PragmaMatch(
+        TMaybe<TLocalSyntaxContext::TPragma> PragmaMatch(
             const TParsedTokenList& tokens, const TC3Candidates& candidates) {
             if (!AnyOf(candidates.Rules, RuleAdapted(IsLikelyPragmaStack))) {
-                return std::nullopt;
+                return Nothing();
             }
 
             TLocalSyntaxContext::TPragma pragma;
@@ -140,10 +140,10 @@ namespace NSQLComplete {
             return AnyOf(candidates.Rules, RuleAdapted(IsLikelyTypeStack));
         }
 
-        std::optional<TLocalSyntaxContext::TFunction> FunctionMatch(
+        TMaybe<TLocalSyntaxContext::TFunction> FunctionMatch(
             const TParsedTokenList& tokens, const TC3Candidates& candidates) {
             if (!AnyOf(candidates.Rules, RuleAdapted(IsLikelyFunctionStack))) {
-                return std::nullopt;
+                return Nothing();
             }
 
             TLocalSyntaxContext::TFunction function;
@@ -155,16 +155,16 @@ namespace NSQLComplete {
             return function;
         }
 
-        std::optional<TLocalSyntaxContext::THint> HintMatch(const TC3Candidates& candidates) {
+        TMaybe<TLocalSyntaxContext::THint> HintMatch(const TC3Candidates& candidates) {
             // TODO(YQL-19747): detect local contexts with a single iteration through the candidates.Rules
             auto rule = FindIf(candidates.Rules, RuleAdapted(IsLikelyHintStack));
             if (rule == std::end(candidates.Rules)) {
-                return std::nullopt;
+                return Nothing();
             }
 
             auto stmt = StatementKindOf(rule->ParserCallStack);
-            if (stmt == std::nullopt) {
-                return std::nullopt;
+            if (stmt.Empty()) {
+                return Nothing();
             }
 
             return TLocalSyntaxContext::THint{

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -6,6 +6,7 @@
 
 #include <util/generic/string.h>
 #include <util/generic/hash.h>
+#include <util/generic/maybe.h>
 
 namespace NSQLComplete {
 
@@ -25,10 +26,10 @@ namespace NSQLComplete {
         };
 
         TKeywords Keywords;
-        std::optional<TPragma> Pragma;
+        TMaybe<TPragma> Pragma;
         bool IsTypeName = false;
-        std::optional<TFunction> Function;
-        std::optional<THint> Hint;
+        TMaybe<TFunction> Function;
+        TMaybe<THint> Hint;
     };
 
     class ILocalSyntaxAnalysis {

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
@@ -101,7 +101,7 @@ namespace NSQLComplete {
                Contains({RULE(External_call_param), RULE(An_id)}, stack);
     }
 
-    std::optional<EStatementKind> StatementKindOf(const TParserCallStack& stack) {
+    TMaybe<EStatementKind> StatementKindOf(const TParserCallStack& stack) {
         for (TRuleId rule : std::ranges::views::reverse(stack)) {
             if (rule == RULE(Process_core) || rule == RULE(Reduce_core) || rule == RULE(Select_core)) {
                 return EStatementKind::Select;
@@ -110,7 +110,7 @@ namespace NSQLComplete {
                 return EStatementKind::Insert;
             }
         }
-        return std::nullopt;
+        return Nothing();
     }
 
     std::unordered_set<TRuleId> GetC3PreferredRules() {

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.h
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.h
@@ -3,6 +3,8 @@
 #include <yql/essentials/sql/v1/complete/antlr4/defs.h>
 #include <yql/essentials/sql/v1/complete/core/statement.h>
 
+#include <util/generic/maybe.h>
+
 namespace NSQLComplete {
 
     bool IsLikelyPragmaStack(const TParserCallStack& stack);
@@ -13,7 +15,7 @@ namespace NSQLComplete {
 
     bool IsLikelyHintStack(const TParserCallStack& stack);
 
-    std::optional<EStatementKind> StatementKindOf(const TParserCallStack& stack);
+    TMaybe<EStatementKind> StatementKindOf(const TParserCallStack& stack);
 
     std::unordered_set<TRuleId> GetC3PreferredRules();
 


### PR DESCRIPTION
Just replaced `std::optional` usages with `TMaybe` to prevent this refactoring noise in future PRs.

---

- Related to `YQL-19747`
- Related to https://github.com/ydb-platform/ydb/issues/9056
