### PR TITLE
Explicitly set ignore_system_modules in qt init

### DIFF
--- a/yt/python/yt/environment/init_query_tracker_state.py
+++ b/yt/python/yt/environment/init_query_tracker_state.py
@@ -1278,7 +1278,15 @@ def main():
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
 
     args = build_arguments_parser().parse_args()
-    client = YtClient(proxy=args.proxy, token=config["token"])
+    client = YtClient(
+        proxy=args.proxy,
+        token=config["token"],
+        config={
+            "pickling": {
+                "ignore_system_modules": False,
+            },
+        },
+    )
 
     target_version = args.target_version
     if args.latest:


### PR DESCRIPTION
link https://github.com/ytsaurus/ytsaurus/issues/768

We enable ignore_system_modules on our new clusters, while QT relies on "pickling" its dependencies. I suggest explicitly specifying this option in the client's config if it's needed. It doesn't affect the "binary build" in Yandex.

---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type: fix
Component: query-tracker

Explicitly set ignore_system_modules in the init script
