### PR TITLE
YQL-19747 Publish ParseUdfs, ParseTypes and others

### DIFF
--- a/yql/essentials/sql/v1/complete/name/service/static/name_set_json.h
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_set_json.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <yql/essentials/sql/v1/complete/core/statement.h>
+
+#include <library/cpp/json/json_value.h>
+
+#include <util/generic/string.h>
+#include <util/generic/vector.h>
+#include <util/generic/hash.h>
+
+namespace NSQLComplete {
+
+    TVector<TString> ParsePragmas(NJson::TJsonValue json);
+
+    TVector<TString> ParseTypes(NJson::TJsonValue json);
+
+    TVector<TString> ParseFunctions(NJson::TJsonValue json);
+
+    TVector<TString> ParseUdfs(NJson::TJsonValue json);
+
+    THashMap<EStatementKind, TVector<TString>> ParseHints(NJson::TJsonValue json);
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/service/static/ya.make
+++ b/yql/essentials/sql/v1/complete/name/service/static/ya.make
@@ -1,10 +1,10 @@
 LIBRARY()
 
 SRCS(
-    name_set_json.cpp
-    name_set.cpp
     name_index.cpp
     name_service.cpp
+    name_set_json.cpp
+    name_set.cpp
 )
 
 PEERDIR(


### PR DESCRIPTION
A client might want to have completions of its own private UDFs. Then a client should make a JSON document and parse it to create a custom `TNameSet`.

---

- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/36
