### PR TITLE
YQL-19747 Introduce Union and split Static NameServices

### DIFF
--- a/yql/essentials/sql/v1/complete/name/service/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.cpp
@@ -23,32 +23,13 @@ namespace NSQLComplete {
 
     } // namespace
 
-    TPragmaName TNameConstraints::Qualified(TPragmaName unqualified) const {
-        SetPrefix(unqualified.Indentifier, ".", *Pragma);
-        return unqualified;
-    }
-
-    TPragmaName TNameConstraints::Unqualified(TPragmaName qualified) const {
-        FixPrefix(qualified.Indentifier, ".", *Pragma);
-        return qualified;
-    }
-
-    TFunctionName TNameConstraints::Qualified(TFunctionName unqualified) const {
-        SetPrefix(unqualified.Indentifier, "::", *Function);
-        return unqualified;
-    }
-
-    TFunctionName TNameConstraints::Unqualified(TFunctionName qualified) const {
-        FixPrefix(qualified.Indentifier, "::", *Function);
-        return qualified;
-    }
-
     TGenericName TNameConstraints::Qualified(TGenericName unqualified) const {
         return std::visit([&](auto&& name) -> TGenericName {
             using T = std::decay_t<decltype(name)>;
-            if constexpr (std::is_same_v<T, TPragmaName> ||
-                          std::is_same_v<T, TFunctionName>) {
-                return Qualified(std::move(name));
+            if constexpr (std::is_same_v<T, TPragmaName>) {
+                SetPrefix(name.Indentifier, ".", *Pragma);
+            } else if constexpr (std::is_same_v<T, TFunctionName>) {
+                SetPrefix(name.Indentifier, "::", *Function);
             }
             return name;
         }, std::move(unqualified));
@@ -57,9 +38,10 @@ namespace NSQLComplete {
     TGenericName TNameConstraints::Unqualified(TGenericName qualified) const {
         return std::visit([&](auto&& name) -> TGenericName {
             using T = std::decay_t<decltype(name)>;
-            if constexpr (std::is_same_v<T, TPragmaName> ||
-                          std::is_same_v<T, TFunctionName>) {
-                return Unqualified(std::move(name));
+            if constexpr (std::is_same_v<T, TPragmaName>) {
+                FixPrefix(name.Indentifier, ".", *Pragma);
+            } else if constexpr (std::is_same_v<T, TFunctionName>) {
+                FixPrefix(name.Indentifier, "::", *Function);
             }
             return name;
         }, std::move(qualified));

--- a/yql/essentials/sql/v1/complete/name/service/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.cpp
@@ -1,0 +1,82 @@
+#include "name_service.h"
+
+namespace NSQLComplete {
+
+    namespace {
+
+        void SetPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
+            if (namespaced.Namespace.empty()) {
+                return;
+            }
+
+            name.prepend(delimeter);
+            name.prepend(namespaced.Namespace);
+        }
+
+        void FixPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
+            if (namespaced.Namespace.empty()) {
+                return;
+            }
+
+            name.remove(0, namespaced.Namespace.size() + delimeter.size());
+        }
+
+    } // namespace
+
+    TPragmaName TNameConstraints::Qualified(TPragmaName unqualified) const {
+        SetPrefix(unqualified.Indentifier, ".", *Pragma);
+        return unqualified;
+    }
+
+    TPragmaName TNameConstraints::Unqualified(TPragmaName qualified) const {
+        FixPrefix(qualified.Indentifier, ".", *Pragma);
+        return qualified;
+    }
+
+    TFunctionName TNameConstraints::Qualified(TFunctionName unqualified) const {
+        SetPrefix(unqualified.Indentifier, "::", *Function);
+        return unqualified;
+    }
+
+    TFunctionName TNameConstraints::Unqualified(TFunctionName qualified) const {
+        FixPrefix(qualified.Indentifier, "::", *Function);
+        return qualified;
+    }
+
+    TGenericName TNameConstraints::Qualified(TGenericName unqualified) const {
+        return std::visit([&](auto&& name) -> TGenericName {
+            using T = std::decay_t<decltype(name)>;
+            if constexpr (std::is_same_v<T, TPragmaName> ||
+                          std::is_same_v<T, TFunctionName>) {
+                return Qualified(std::move(name));
+            }
+            return name;
+        }, std::move(unqualified));
+    }
+
+    TGenericName TNameConstraints::Unqualified(TGenericName qualified) const {
+        return std::visit([&](auto&& name) -> TGenericName {
+            using T = std::decay_t<decltype(name)>;
+            if constexpr (std::is_same_v<T, TPragmaName> ||
+                          std::is_same_v<T, TFunctionName>) {
+                return Unqualified(std::move(name));
+            }
+            return name;
+        }, std::move(qualified));
+    }
+
+    TVector<TGenericName> TNameConstraints::Qualified(TVector<TGenericName> unqualified) const {
+        for (auto& name : unqualified) {
+            name = Qualified(std::move(name));
+        }
+        return unqualified;
+    }
+
+    TVector<TGenericName> TNameConstraints::Unqualified(TVector<TGenericName> qualified) const {
+        for (auto& name : qualified) {
+            name = Unqualified(std::move(name));
+        }
+        return qualified;
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/service/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.h
@@ -55,10 +55,6 @@ namespace NSQLComplete {
         TMaybe<TFunctionName::TConstraints> Function;
         TMaybe<THintName::TConstraints> Hint;
 
-        TPragmaName Qualified(TPragmaName unqualified) const;
-        TPragmaName Unqualified(TPragmaName qualified) const;
-        TFunctionName Qualified(TFunctionName unqualified) const;
-        TFunctionName Unqualified(TFunctionName qualified) const;
         TGenericName Qualified(TGenericName unqualified) const;
         TGenericName Unqualified(TGenericName qualified) const;
         TVector<TGenericName> Qualified(TVector<TGenericName> unqualified) const;

--- a/yql/essentials/sql/v1/complete/name/service/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.h
@@ -10,7 +10,7 @@
 
 namespace NSQLComplete {
 
-    using NThreading::TFuture;
+    using NThreading::TFuture; // TODO(YQL-19747): remove
 
     struct TIndentifier {
         TString Indentifier;
@@ -49,14 +49,25 @@ namespace NSQLComplete {
         TFunctionName,
         THintName>;
 
+    struct TNameConstraints {
+        TMaybe<TPragmaName::TConstraints> Pragma;
+        TMaybe<TTypeName::TConstraints> Type;
+        TMaybe<TFunctionName::TConstraints> Function;
+        TMaybe<THintName::TConstraints> Hint;
+
+        TPragmaName Qualified(TPragmaName unqualified) const;
+        TPragmaName Unqualified(TPragmaName qualified) const;
+        TFunctionName Qualified(TFunctionName unqualified) const;
+        TFunctionName Unqualified(TFunctionName qualified) const;
+        TGenericName Qualified(TGenericName unqualified) const;
+        TGenericName Unqualified(TGenericName qualified) const;
+        TVector<TGenericName> Qualified(TVector<TGenericName> unqualified) const;
+        TVector<TGenericName> Unqualified(TVector<TGenericName> qualified) const;
+    };
+
     struct TNameRequest {
         TVector<TString> Keywords;
-        struct {
-            TMaybe<TPragmaName::TConstraints> Pragma;
-            TMaybe<TTypeName::TConstraints> Type;
-            TMaybe<TFunctionName::TConstraints> Function;
-            TMaybe<THintName::TConstraints> Hint;
-        } Constraints;
+        TNameConstraints Constraints;
         TString Prefix = "";
         size_t Limit = 128;
 

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
@@ -23,12 +23,14 @@ namespace NSQLComplete {
 
         void CropToSortedPrefix(
             TVector<TGenericName>& names,
+            const TNameConstraints& constraints,
             size_t limit) const override {
             limit = std::min(limit, names.size());
 
             TVector<TRow> rows;
             rows.reserve(names.size());
             for (TGenericName& name : names) {
+                name = constraints.Qualified(std::move(name));
                 size_t weight = Weight(name);
                 rows.emplace_back(std::move(name), weight);
             }
@@ -50,7 +52,7 @@ namespace NSQLComplete {
             rows.crop(limit);
 
             for (size_t i = 0; i < limit; ++i) {
-                names[i] = std::move(rows[i].Name);
+                names[i] = constraints.Unqualified(std::move(rows[i].Name));
             }
         }
 

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
@@ -21,7 +21,9 @@ namespace NSQLComplete {
         {
         }
 
-        void CropToSortedPrefix(TVector<TGenericName>& names, size_t limit) const override {
+        void CropToSortedPrefix(
+            TVector<TGenericName>& names,
+            size_t limit) const override {
             limit = std::min(limit, names.size());
 
             TVector<TRow> rows;

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.h
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.h
@@ -11,7 +11,9 @@ namespace NSQLComplete {
     public:
         using TPtr = TIntrusivePtr<IRanking>;
 
-        virtual void CropToSortedPrefix(TVector<TGenericName>& names, size_t limit) const = 0;
+        virtual void CropToSortedPrefix(
+            TVector<TGenericName>& names,
+            size_t limit) const = 0;
         virtual ~IRanking() = default;
     };
 

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.h
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.h
@@ -13,6 +13,7 @@ namespace NSQLComplete {
 
         virtual void CropToSortedPrefix(
             TVector<TGenericName>& names,
+            const TNameConstraints& constraints,
             size_t limit) const = 0;
         virtual ~IRanking() = default;
     };

--- a/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
@@ -3,6 +3,7 @@
 #include "name_index.h"
 
 #include <yql/essentials/sql/v1/complete/name/service/ranking/ranking.h>
+#include <yql/essentials/sql/v1/complete/name/service/union/name_service.h>
 #include <yql/essentials/sql/v1/complete/text/case.h>
 
 namespace NSQLComplete {
@@ -40,14 +41,30 @@ namespace NSQLComplete {
         }
     }
 
-    TString Prefixed(const TStringBuf requestPrefix, const TStringBuf delimeter, const TNamespaced& namespaced) {
-        TString prefix;
+    void SetPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
         if (!namespaced.Namespace.empty()) {
-            prefix += namespaced.Namespace;
-            prefix += delimeter;
+            name.prepend(delimeter);
+            name.prepend(namespaced.Namespace);
         }
-        prefix += requestPrefix;
-        return prefix;
+    }
+
+    void SetPrefix(TGenericName& name, const TNameRequest& request) {
+        std::visit([&](auto& name) -> size_t {
+            using T = std::decay_t<decltype(name)>;
+            if constexpr (std::is_same_v<T, TPragmaName>) {
+                SetPrefix(name.Indentifier, ".", *request.Constraints.Pragma);
+            }
+            if constexpr (std::is_same_v<T, TFunctionName>) {
+                SetPrefix(name.Indentifier, "::", *request.Constraints.Function);
+            }
+            return 0;
+        }, name);
+    }
+
+    void SetPrefix(TVector<TGenericName>& names, const TNameRequest& request) {
+        for (auto& name : names) {
+            SetPrefix(name, request);
+        }
     }
 
     void FixPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
@@ -70,49 +87,147 @@ namespace NSQLComplete {
         }, name);
     }
 
-    class TStaticNameService: public INameService {
+    void FixPrefix(TVector<TGenericName>& names, const TNameRequest& request) {
+        for (auto& name : names) {
+            FixPrefix(name, request);
+        }
+    }
+
+    class TRankingNameService: public INameService {
+    private:
+        auto Ranking(TNameRequest request) const {
+            return [request = std::move(request), this](auto f) {
+                TNameResponse response = f.ExtractValue();
+                SetPrefix(response.RankedNames, request);
+                Ranking_->CropToSortedPrefix(response.RankedNames, request.Limit);
+                FixPrefix(response.RankedNames, request);
+                return response;
+            };
+        }
+
     public:
-        explicit TStaticNameService(TNameSet names, IRanking::TPtr ranking)
-            : Pragmas_(BuildNameIndex(std::move(names.Pragmas), NormalizeName))
-            , Types_(BuildNameIndex(std::move(names.Types), NormalizeName))
-            , Functions_(BuildNameIndex(std::move(names.Functions), NormalizeName))
-            , Hints_([hints = std::move(names.Hints)] {
+        explicit TRankingNameService(IRanking::TPtr ranking)
+            : Ranking_(std::move(ranking))
+        {
+        }
+
+        NThreading::TFuture<TNameResponse> Lookup(TNameRequest request) const override {
+            return LookupUnranked(request).Apply(Ranking(request));
+        }
+
+        virtual NThreading::TFuture<TNameResponse> LookupUnranked(TNameRequest request) const = 0;
+
+    private:
+        IRanking::TPtr Ranking_;
+    };
+
+    class TKeywordNameService: public TRankingNameService {
+    public:
+        explicit TKeywordNameService(IRanking::TPtr ranking)
+            : TRankingNameService(std::move(ranking))
+        {
+        }
+
+        NThreading::TFuture<TNameResponse> LookupUnranked(TNameRequest request) const override {
+            TNameResponse response;
+            Sort(request.Keywords, NoCaseCompare);
+            AppendAs<TKeyword>(
+                response.RankedNames,
+                FilteredByPrefix(request.Prefix, request.Keywords));
+            return NThreading::MakeFuture<TNameResponse>(std::move(response));
+        }
+    };
+
+    class TPragmaNameService: public TRankingNameService {
+    public:
+        explicit TPragmaNameService(IRanking::TPtr ranking, TVector<TString> pragmas)
+            : TRankingNameService(std::move(ranking))
+            , Pragmas_(BuildNameIndex(std::move(pragmas), NormalizeName))
+        {
+        }
+
+        NThreading::TFuture<TNameResponse> LookupUnranked(TNameRequest request) const override {
+            TNameResponse response;
+            if (request.Constraints.Pragma) {
+                SetPrefix(request.Prefix, ".", *request.Constraints.Pragma);
+                AppendAs<TPragmaName>(
+                    response.RankedNames,
+                    FilteredByPrefix(request.Prefix, Pragmas_));
+                FixPrefix(request.Prefix, ".", *request.Constraints.Pragma);
+            }
+            FixPrefix(response.RankedNames, request);
+            return NThreading::MakeFuture<TNameResponse>(std::move(response));
+        }
+
+    private:
+        TNameIndex Pragmas_;
+    };
+
+    class TTypesNameService: public TRankingNameService {
+    public:
+        explicit TTypesNameService(IRanking::TPtr ranking, TVector<TString> types)
+            : TRankingNameService(std::move(ranking))
+            , Types_(BuildNameIndex(std::move(types), NormalizeName))
+        {
+        }
+
+        NThreading::TFuture<TNameResponse> LookupUnranked(TNameRequest request) const override {
+            TNameResponse response;
+            if (request.Constraints.Type) {
+                AppendAs<TTypeName>(
+                    response.RankedNames,
+                    FilteredByPrefix(request.Prefix, Types_));
+            }
+            return NThreading::MakeFuture<TNameResponse>(std::move(response));
+        }
+
+    private:
+        TNameIndex Types_;
+    };
+
+    class TFunctionsNameService: public TRankingNameService {
+    public:
+        explicit TFunctionsNameService(IRanking::TPtr ranking, TVector<TString> functions)
+            : TRankingNameService(std::move(ranking))
+            , Functions_(BuildNameIndex(std::move(functions), NormalizeName))
+        {
+        }
+
+        NThreading::TFuture<TNameResponse> LookupUnranked(TNameRequest request) const override {
+            TNameResponse response;
+            if (request.Constraints.Function) {
+                SetPrefix(request.Prefix, "::", *request.Constraints.Function);
+                AppendAs<TFunctionName>(
+                    response.RankedNames,
+                    FilteredByPrefix(request.Prefix, Functions_));
+                FixPrefix(request.Prefix, "::", *request.Constraints.Function);
+            }
+            FixPrefix(response.RankedNames, request);
+            return NThreading::MakeFuture<TNameResponse>(std::move(response));
+        }
+
+    private:
+        TNameIndex Functions_;
+    };
+
+    class THintsNameService: public TRankingNameService {
+    public:
+        explicit THintsNameService(
+            IRanking::TPtr ranking,
+            THashMap<EStatementKind, TVector<TString>> hints)
+            : TRankingNameService(std::move(ranking))
+            , Hints_([hints = std::move(hints)] {
                 THashMap<EStatementKind, TNameIndex> index;
                 for (auto& [k, hints] : hints) {
                     index.emplace(k, BuildNameIndex(std::move(hints), NormalizeName));
                 }
                 return index;
             }())
-            , Ranking_(std::move(ranking))
         {
         }
 
-        TFuture<TNameResponse> Lookup(TNameRequest request) const override {
+        NThreading::TFuture<TNameResponse> LookupUnranked(TNameRequest request) const override {
             TNameResponse response;
-
-            Sort(request.Keywords, NoCaseCompare);
-            AppendAs<TKeyword>(
-                response.RankedNames,
-                FilteredByPrefix(request.Prefix, request.Keywords));
-
-            if (request.Constraints.Pragma) {
-                auto prefix = Prefixed(request.Prefix, ".", *request.Constraints.Pragma);
-                auto names = FilteredByPrefix(prefix, Pragmas_);
-                AppendAs<TPragmaName>(response.RankedNames, names);
-            }
-
-            if (request.Constraints.Type) {
-                AppendAs<TTypeName>(
-                    response.RankedNames,
-                    FilteredByPrefix(request.Prefix, Types_));
-            }
-
-            if (request.Constraints.Function) {
-                auto prefix = Prefixed(request.Prefix, "::", *request.Constraints.Function);
-                auto names = FilteredByPrefix(prefix, Functions_);
-                AppendAs<TFunctionName>(response.RankedNames, names);
-            }
-
             if (request.Constraints.Hint) {
                 const auto stmt = request.Constraints.Hint->Statement;
                 if (const auto* hints = Hints_.FindPtr(stmt)) {
@@ -121,32 +236,27 @@ namespace NSQLComplete {
                         FilteredByPrefix(request.Prefix, *hints));
                 }
             }
-
-            Ranking_->CropToSortedPrefix(response.RankedNames, request.Limit);
-
-            for (auto& name : response.RankedNames) {
-                FixPrefix(name, request);
-            }
-
-            return NThreading::MakeFuture(std::move(response));
+            return NThreading::MakeFuture<TNameResponse>(std::move(response));
         }
 
     private:
-        TNameIndex Pragmas_;
-        TNameIndex Types_;
-        TNameIndex Functions_;
         THashMap<EStatementKind, TNameIndex> Hints_;
-        IRanking::TPtr Ranking_;
     };
 
     INameService::TPtr MakeStaticNameService(TNameSet names, TFrequencyData frequency) {
-        return INameService::TPtr(new TStaticNameService(
+        return MakeStaticNameService(
             Pruned(std::move(names), frequency),
-            MakeDefaultRanking(std::move(frequency))));
+            MakeDefaultRanking(std::move(frequency)));
     }
 
     INameService::TPtr MakeStaticNameService(TNameSet names, IRanking::TPtr ranking) {
-        return MakeIntrusive<TStaticNameService>(std::move(names), std::move(ranking));
+        return MakeUnionNameService({
+                                        new TKeywordNameService(ranking),
+                                        new TPragmaNameService(ranking, std::move(names.Pragmas)),
+                                        new TTypesNameService(ranking, std::move(names.Types)),
+                                        new TFunctionsNameService(ranking, std::move(names.Functions)),
+                                        new THintsNameService(ranking, std::move(names.Hints)),
+                                    }, ranking);
     }
 
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
@@ -55,7 +55,7 @@ namespace NSQLComplete {
         out = constraints.Unqualified(std::move(out));
     }
 
-    class TRankingNameService: public INameService {
+    class IRankingNameService: public INameService {
     private:
         auto Ranking(TNameRequest request) const {
             return [request = std::move(request), this](auto f) {
@@ -69,7 +69,7 @@ namespace NSQLComplete {
         }
 
     public:
-        explicit TRankingNameService(IRanking::TPtr ranking)
+        explicit IRankingNameService(IRanking::TPtr ranking)
             : Ranking_(std::move(ranking))
         {
         }
@@ -84,10 +84,10 @@ namespace NSQLComplete {
         IRanking::TPtr Ranking_;
     };
 
-    class TKeywordNameService: public TRankingNameService {
+    class TKeywordNameService: public IRankingNameService {
     public:
         explicit TKeywordNameService(IRanking::TPtr ranking)
-            : TRankingNameService(std::move(ranking))
+            : IRankingNameService(std::move(ranking))
         {
         }
 
@@ -101,10 +101,10 @@ namespace NSQLComplete {
         }
     };
 
-    class TPragmaNameService: public TRankingNameService {
+    class TPragmaNameService: public IRankingNameService {
     public:
         explicit TPragmaNameService(IRanking::TPtr ranking, TVector<TString> pragmas)
-            : TRankingNameService(std::move(ranking))
+            : IRankingNameService(std::move(ranking))
             , Pragmas_(BuildNameIndex(std::move(pragmas), NormalizeName))
         {
         }
@@ -125,10 +125,10 @@ namespace NSQLComplete {
         TNameIndex Pragmas_;
     };
 
-    class TTypeNameService: public TRankingNameService {
+    class TTypeNameService: public IRankingNameService {
     public:
         explicit TTypeNameService(IRanking::TPtr ranking, TVector<TString> types)
-            : TRankingNameService(std::move(ranking))
+            : IRankingNameService(std::move(ranking))
             , Types_(BuildNameIndex(std::move(types), NormalizeName))
         {
         }
@@ -149,10 +149,10 @@ namespace NSQLComplete {
         TNameIndex Types_;
     };
 
-    class TFunctionNameService: public TRankingNameService {
+    class TFunctionNameService: public IRankingNameService {
     public:
         explicit TFunctionNameService(IRanking::TPtr ranking, TVector<TString> functions)
-            : TRankingNameService(std::move(ranking))
+            : IRankingNameService(std::move(ranking))
             , Functions_(BuildNameIndex(std::move(functions), NormalizeName))
         {
         }
@@ -173,12 +173,12 @@ namespace NSQLComplete {
         TNameIndex Functions_;
     };
 
-    class THintNameService: public TRankingNameService {
+    class THintNameService: public IRankingNameService {
     public:
         explicit THintNameService(
             IRanking::TPtr ranking,
             THashMap<EStatementKind, TVector<TString>> hints)
-            : TRankingNameService(std::move(ranking))
+            : IRankingNameService(std::move(ranking))
             , Hints_([hints = std::move(hints)] {
                 THashMap<EStatementKind, TNameIndex> index;
                 for (auto& [k, hints] : hints) {

--- a/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
@@ -46,12 +46,10 @@ namespace NSQLComplete {
         auto Ranking(TNameRequest request) const {
             return [request = std::move(request), this](auto f) {
                 TNameResponse response = f.ExtractValue();
-                auto& names = response.RankedNames;
-
-                names = request.Constraints.Qualified(std::move(names));
-                Ranking_->CropToSortedPrefix(names, request.Limit);
-                names = request.Constraints.Unqualified(std::move(names));
-
+                Ranking_->CropToSortedPrefix(
+                    response.RankedNames,
+                    request.Constraints,
+                    request.Limit);
                 return response;
             };
         }

--- a/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
@@ -201,13 +201,14 @@ namespace NSQLComplete {
     }
 
     INameService::TPtr MakeStaticNameService(TNameSet names, IRanking::TPtr ranking) {
-        return MakeUnionNameService({
-                                        new TKeywordNameService(ranking),
-                                        new TPragmaNameService(ranking, std::move(names.Pragmas)),
-                                        new TTypesNameService(ranking, std::move(names.Types)),
-                                        new TFunctionsNameService(ranking, std::move(names.Functions)),
-                                        new THintsNameService(ranking, std::move(names.Hints)),
-                                    }, ranking);
+        TVector<INameService::TPtr> children = {
+            new TKeywordNameService(ranking),
+            new TPragmaNameService(ranking, std::move(names.Pragmas)),
+            new TTypesNameService(ranking, std::move(names.Types)),
+            new TFunctionsNameService(ranking, std::move(names.Functions)),
+            new THintsNameService(ranking, std::move(names.Hints)),
+        };
+        return MakeUnionNameService(std::move(children), ranking);
     }
 
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/service/static/ya.make
+++ b/yql/essentials/sql/v1/complete/name/service/static/ya.make
@@ -11,6 +11,7 @@ PEERDIR(
     yql/essentials/core/sql_types
     yql/essentials/sql/v1/complete/name/service
     yql/essentials/sql/v1/complete/name/service/ranking
+    yql/essentials/sql/v1/complete/name/service/union
     yql/essentials/sql/v1/complete/text
 )
 

--- a/yql/essentials/sql/v1/complete/name/service/union/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/union/name_service.cpp
@@ -21,7 +21,6 @@ namespace NSQLComplete {
                 for (const auto& c : Children_) {
                     fs.emplace_back(c->Lookup(request));
                 }
-
                 return NThreading::WaitAll(fs)
                     .Apply([fs, this, limit = request.Limit](auto) { return Union(fs, limit); });
             }
@@ -29,14 +28,12 @@ namespace NSQLComplete {
         private:
             TNameResponse Union(TVector<NThreading::TFuture<TNameResponse>> fs, size_t limit) const {
                 TNameResponse united;
-
                 for (auto f : fs) {
                     TNameResponse response = f.ExtractValue();
                     std::ranges::move(
                         response.RankedNames,
                         std::back_inserter(united.RankedNames));
                 }
-
                 Ranking_->CropToSortedPrefix(united.RankedNames, limit);
                 return united;
             }

--- a/yql/essentials/sql/v1/complete/name/service/union/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/union/name_service.cpp
@@ -1,0 +1,58 @@
+#include "name_service.h"
+
+#include <library/cpp/threading/future/wait/wait.h>
+
+namespace NSQLComplete {
+
+    namespace {
+
+        class TNameService: public INameService {
+        public:
+            TNameService(
+                TVector<INameService::TPtr> children,
+                IRanking::TPtr ranking)
+                : Children_(std::move(children))
+                , Ranking_(std::move(ranking))
+            {
+            }
+
+            NThreading::TFuture<TNameResponse> Lookup(TNameRequest request) const override {
+                TVector<NThreading::TFuture<TNameResponse>> fs;
+                for (const auto& c : Children_) {
+                    fs.emplace_back(c->Lookup(request));
+                }
+
+                return NThreading::WaitAll(fs)
+                    .Apply([fs, this, limit = request.Limit](auto) { return Union(fs, limit); });
+            }
+
+        private:
+            TNameResponse Union(TVector<NThreading::TFuture<TNameResponse>> fs, size_t limit) const {
+                TNameResponse united;
+
+                for (auto f : fs) {
+                    TNameResponse response = f.ExtractValue();
+                    std::ranges::move(
+                        response.RankedNames,
+                        std::back_inserter(united.RankedNames));
+                }
+
+                Ranking_->CropToSortedPrefix(united.RankedNames, limit);
+                return united;
+            }
+
+            TVector<INameService::TPtr> Children_;
+            IRanking::TPtr Ranking_;
+        };
+
+    } // namespace
+
+    INameService::TPtr MakeUnionNameService(
+        TVector<INameService::TPtr> children,
+        IRanking::TPtr ranking) {
+        return INameService::TPtr(new TNameService(
+            std::move(children),
+            std::move(ranking)));
+    }
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/service/union/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/service/union/name_service.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <yql/essentials/sql/v1/complete/name/service/ranking/ranking.h>
+#include <yql/essentials/sql/v1/complete/name/service/name_service.h>
+
+namespace NSQLComplete {
+
+    INameService::TPtr MakeUnionNameService(
+        TVector<INameService::TPtr> children,
+        IRanking::TPtr ranking);
+
+} // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/service/union/ya.make
+++ b/yql/essentials/sql/v1/complete/name/service/union/ya.make
@@ -1,0 +1,12 @@
+LIBRARY()
+
+SRCS(
+    name_service.cpp
+)
+
+PEERDIR(
+    yql/essentials/sql/v1/complete/name/service
+    yql/essentials/sql/v1/complete/name/service/ranking
+)
+
+END()

--- a/yql/essentials/sql/v1/complete/name/service/ya.make
+++ b/yql/essentials/sql/v1/complete/name/service/ya.make
@@ -9,4 +9,5 @@ END()
 RECURSE(
     ranking
     static
+    union
 )

--- a/yql/essentials/sql/v1/complete/name/service/ya.make
+++ b/yql/essentials/sql/v1/complete/name/service/ya.make
@@ -1,5 +1,9 @@
 LIBRARY()
 
+SRCS(
+    name_service.cpp
+)
+
 PEERDIR(
     yql/essentials/sql/v1/complete/core
 )

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -303,6 +303,13 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         {
             TVector<TCandidate> expected = {
                 {PragmaName, "yson.CastToString"}};
+            auto completion = engine->CompleteAsync({"PRAGMA ys"}).GetValueSync();
+            UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "ys");
+        }
+        {
+            TVector<TCandidate> expected = {
+                {PragmaName, "yson.CastToString"}};
             auto completion = engine->CompleteAsync({"PRAGMA yson"}).GetValueSync();
             UNIT_ASSERT_VALUES_EQUAL(completion.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(completion.CompletedToken.Content, "yson");


### PR DESCRIPTION
Essentially we need the `UnionNameService` to integrate dynamic name services into the `sql/v1/complete`. This decorator queries multiple name services and merges their responses. We will use it to union static `NameServices` and the `SchemaNameService` (and the `ClusterNameService`, and so on).

It does not deal with exceptions and fails the whole request on some subtask failed. Client should prepare robust children (later `SwallowingNameService` will be added to return an empty `NameResponse` on errors to provide best-effort dynamic object loading).

`StaticNameService` was split into micro-`NameService`s :)

`NameConstraints` are extracted to provide name qualification via `Qualified` and `Unqualified` methods. This is needed because depending on a context `NameService` can return unqualified names (for example, on `PRAGMA yt.#`). As internal indexes for scanning and ranking are built on a sorted list of, then `Ranking` actually needs an ability to get fully-qualified names, so now it via the `NameConstraints`. 

Also this design potentially let us to improve internal indexes by using partitioning by a namespace. Other option was to make `PragmaName` and `FunctionName` more structured via adding a separate field for a namespace, but it seems to me that it will force to do more parsing from indexes results to a `Name`. Anyway this is an internal component so it can be changed if needed.  I still doubt this decision because structured `PragmaName { Namespace, Identifier }` seems to be cleaner and there should be no noticeable overhead because of COW strings.
