### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/contrib/restricted/http-parser/http_parser.c
+++ b/contrib/restricted/http-parser/http_parser.c
@@ -1342,6 +1342,12 @@ reexecute:
               } else if (parser->index == sizeof(TRANSFER_ENCODING)-2) {
                 parser->header_state = h_transfer_encoding;
                 parser->extra_flags |= F_TRANSFER_ENCODING >> 8;
+                /* Multiple `Transfer-Encoding` headers should be treated as
+                 * one, but with values separate by a comma.
+                 *
+                 * See: https://tools.ietf.org/html/rfc7230#section-3.2.2
+                 */
+                parser->flags &= ~F_CHUNKED;
               }
               break;
 


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: contrib/restricted/http-parser/http_parser.c


Hi there,

I identified another vulnerability in a  clone function http_parser_execute() in `contrib/restricted/http-parser/http_parser.c` sourced from [nodejs/node](https://github.com/nodejs/node). This issue, originally reported in [CVE-2020-8287](https://nvd.nist.gov/vuln/detail/cve-2020-8287), was resolved in the repository via this commit https://github.com/nodejs/node/commit/fc70ce08f5818a286fb5899a1bc3aff5965a745e.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!
