### PR TITLE
yt/async_slru_cache: check inserted key consistency in debug build

### DIFF
--- a/yt/yt/core/misc/async_slru_cache-inl.h
+++ b/yt/yt/core/misc/async_slru_cache-inl.h
@@ -773,6 +773,7 @@ void TAsyncSlruCacheBase<TKey, TValue, THash>::EndInsert(const TInsertCookie& in
 {
     YT_VERIFY(value);
     const auto& key = value->GetKey();
+    YT_ASSERT(insertCookie.GetKey() == key);
 
     auto* shard = GetShardByKey(key);
 

--- a/yt/yt/core/misc/unittests/async_slru_cache_ut.cpp
+++ b/yt/yt/core/misc/unittests/async_slru_cache_ut.cpp
@@ -529,7 +529,7 @@ TEST(TAsyncSlruCacheTest, AddRemoveStressTest)
             cookies.emplace_back(std::move(cookie));
         }
 
-        for (int i = 0; i < valueCount; ++i) {
+        for (int i = valueCount-1; i >= 0; --i) {
             cookies.back().EndInsert(values[i]);
             cookies.pop_back();
         }


### PR DESCRIPTION
Whole structure goes nuts if cookie and value keys does not match.
That's funny, but there is one test which already does exactly that.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
