### PR TITLE
Do not umount slot location directory in TSimpleJobDirectoryManager

### DIFF
--- a/yt/yt/server/node/exec_node/job_directory_manager.cpp
+++ b/yt/yt/server/node/exec_node/job_directory_manager.cpp
@@ -186,7 +186,7 @@ public:
         for (int attempt = 0; attempt < TmpfsRemoveAttemptCount; ++attempt) {
             auto mountPoints = NFS::GetMountPoints("/proc/mounts");
             for (const auto& mountPoint : mountPoints) {
-                if (mountPoint.Path == Path_ || mountPoint.Path.StartsWith(Path_ + "/")) {
+                if (mountPoint.Path.StartsWith(Path_ + "/")) {
                     Directories_.insert(mountPoint.Path);
                 }
             }


### PR DESCRIPTION
Slot location directory itself should not be managed and umounted.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
