### PR TITLE
YQL-19747: Fix TSimpleSchema path mutation

### DIFF
--- a/yql/essentials/sql/v1/complete/name/object/simple/schema.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/simple/schema.cpp
@@ -54,13 +54,7 @@ namespace NSQLComplete {
 
             NThreading::TFuture<TListResponse> List(const TListRequest& request) const override {
                 auto [path, name] = Simple_->Split(request.Path);
-
-                TString pathStr(path);
-                if (!pathStr.StartsWith('/')) {
-                    pathStr.prepend('/');
-                }
-
-                return Simple_->List(std::move(pathStr))
+                return Simple_->List(TString(path))
                     .Apply(FilterByName(TString(name)))
                     .Apply(FilterByTypes(std::move(request.Filter.Types)))
                     .Apply(Crop(request.Limit))

--- a/yql/essentials/sql/v1/complete/name/object/simple/static/schema.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/simple/static/schema.cpp
@@ -27,6 +27,10 @@ namespace NSQLComplete {
             }
 
             NThreading::TFuture<TVector<TFolderEntry>> List(TString folder) const override {
+                if (!folder.StartsWith('/')) {
+                    folder.prepend('/');
+                }
+
                 TVector<TFolderEntry> entries;
                 if (const auto* data = Data_.FindPtr(folder)) {
                     entries = *data;


### PR DESCRIPTION
`TSimpleSchema` implementation was incorrect at least as it does not know anything about the path structure and therefore have no right to modify path with `/` symbols.

---

- Related to `YQL-19747`
- Related to https://github.com/vityaman/ydb/issues/34
- Related to https://github.com/ydb-platform/ydb/pull/18146
