### PR TITLE
YQL-19747: Ignore type_id completions and table_key

### DIFF
--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -495,18 +495,6 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {ClusterName, "example"},
                 {ClusterName, "yt:saurus"},
                 {Keyword, "ANY"},
-                {Keyword, "CALLABLE"},
-                {Keyword, "DICT"},
-                {Keyword, "ENUM"},
-                {Keyword, "FLOW"},
-                {Keyword, "LIST"},
-                {Keyword, "OPTIONAL"},
-                {Keyword, "RESOURCE"},
-                {Keyword, "SET"},
-                {Keyword, "STRUCT"},
-                {Keyword, "TAGGED"},
-                {Keyword, "TUPLE"},
-                {Keyword, "VARIANT"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM "), expected);
         }
@@ -590,18 +578,6 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         {
             TVector<TCandidate> expected = {
                 {TableName, "`maxim`"},
-                {Keyword, "CALLABLE"},
-                {Keyword, "DICT"},
-                {Keyword, "ENUM"},
-                {Keyword, "FLOW"},
-                {Keyword, "LIST"},
-                {Keyword, "OPTIONAL"},
-                {Keyword, "RESOURCE"},
-                {Keyword, "SET"},
-                {Keyword, "STRUCT"},
-                {Keyword, "TAGGED"},
-                {Keyword, "TUPLE"},
-                {Keyword, "VARIANT"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM yt:saurus."), expected);
         }

--- a/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/parser_call_stack.cpp
@@ -24,6 +24,8 @@ namespace NSQLComplete {
         RULE(Keyword_hint_uncompat),
         RULE(Keyword_as_compat),
         RULE(Keyword_compat),
+        RULE(Type_id),
+
         RULE(An_id_or_type),
         RULE(An_id),
         RULE(Id_expr),


### PR DESCRIPTION
---

- Related to `YQL-19747`
- Related to https://github.com/ydb-platform/ydb/issues/9056
