### PR TITLE
YQL-19616: Fix TRegexLexer performance

### DIFF
--- a/yql/essentials/sql/v1/highlight/sql_highlight.cpp
+++ b/yql/essentials/sql/v1/highlight/sql_highlight.cpp
@@ -12,6 +12,7 @@
 
 namespace NSQLHighlight {
 
+    using NSQLTranslationV1::Merged;
     using NSQLTranslationV1::TRegexPattern;
 
     struct Syntax {

--- a/yql/essentials/sql/v1/highlight/sql_highlight.cpp
+++ b/yql/essentials/sql/v1/highlight/sql_highlight.cpp
@@ -14,33 +14,6 @@ namespace NSQLHighlight {
 
     using NSQLTranslationV1::TRegexPattern;
 
-    TRegexPattern Merged(TVector<TRegexPattern> patterns) {
-        Y_ENSURE(!patterns.empty());
-
-        const TRegexPattern& sample = patterns.back();
-        Y_ENSURE(AllOf(patterns, [&](const TRegexPattern& pattern) {
-            return std::tie(pattern.After, pattern.IsCaseInsensitive) ==
-                   std::tie(sample.After, sample.IsCaseInsensitive);
-        }));
-
-        Sort(patterns, [](const TRegexPattern& lhs, const TRegexPattern& rhs) {
-            return lhs.Body.length() > rhs.Body.length();
-        });
-
-        TStringBuilder body;
-        for (const auto& pattern : patterns) {
-            body << "(" << pattern.Body << ")|";
-        }
-        Y_ENSURE(body.back() == '|');
-        body.pop_back();
-
-        return TRegexPattern{
-            .Body = std::move(body),
-            .After = sample.After,
-            .IsCaseInsensitive = sample.IsCaseInsensitive,
-        };
-    }
-
     struct Syntax {
         const NSQLReflect::TLexerGrammar* Grammar;
         THashMap<TString, TString> RegexesDefault;
@@ -81,7 +54,7 @@ namespace NSQLHighlight {
 
         TUnit unit = {.Kind = EUnitKind::Keyword};
         for (const auto& keyword : s.Grammar->KeywordNames) {
-            const TStringBuf content = TLexerGrammar::KeywordBlock(keyword);
+            const TStringBuf content = TLexerGrammar::KeywordBlockByName(keyword);
             unit.Patterns.push_back(CaseInsensitive(content));
         }
 

--- a/yql/essentials/sql/v1/highlight/sql_highlighter.cpp
+++ b/yql/essentials/sql/v1/highlight/sql_highlighter.cpp
@@ -13,7 +13,6 @@ namespace NSQLHighlight {
     using NSQLTranslationV1::IGenericLexer;
     using NSQLTranslationV1::TGenericLexerGrammar;
     using NSQLTranslationV1::TGenericToken;
-    using NSQLTranslationV1::TTokenRule;
 
     THashMap<EUnitKind, TString> NamesByUnitKind = [] {
         THashMap<EUnitKind, TString> names;
@@ -51,20 +50,16 @@ namespace NSQLHighlight {
                 patterns = unit.PatternsANSI.Get();
             }
 
+            const auto& name = NamesByUnitKind.at(unit.Kind);
+
             if (unit.Kind == EUnitKind::Comment && ansi) {
                 Y_ENSURE(unit.Patterns.size() == 1);
-                const auto& pattern = unit.Patterns[0];
-                grammar.emplace_back(TTokenRule{
-                    .TokenName = NamesByUnitKind.at(unit.Kind),
-                    .Match = ANSICommentMatcher(Compile(pattern)),
-                });
+                auto matcher = Compile(name, unit.Patterns[0]);
+                grammar.emplace_back(ANSICommentMatcher(name, std::move(matcher)));
             }
 
             for (const auto& pattern : *patterns) {
-                grammar.emplace_back(TTokenRule{
-                    .TokenName = NamesByUnitKind.at(unit.Kind),
-                    .Match = Compile(pattern),
-                });
+                grammar.emplace_back(Compile(name, pattern));
             }
         }
         return grammar;

--- a/yql/essentials/sql/v1/lexer/regex/generic.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/generic.cpp
@@ -2,6 +2,8 @@
 
 #include <contrib/libs/re2/re2/re2.h>
 
+#include <util/string/builder.h>
+
 namespace NSQLTranslationV1 {
 
     namespace {
@@ -110,6 +112,33 @@ namespace NSQLTranslationV1 {
                 };
             }
             return Nothing();
+        };
+    }
+
+    TRegexPattern Merged(TVector<TRegexPattern> patterns) {
+        Y_ENSURE(!patterns.empty());
+
+        const TRegexPattern& sample = patterns.back();
+        Y_ENSURE(AllOf(patterns, [&](const TRegexPattern& pattern) {
+            return std::tie(pattern.After, pattern.IsCaseInsensitive) ==
+                   std::tie(sample.After, sample.IsCaseInsensitive);
+        }));
+
+        Sort(patterns, [](const TRegexPattern& lhs, const TRegexPattern& rhs) {
+            return lhs.Body.length() > rhs.Body.length();
+        });
+
+        TStringBuilder body;
+        for (const auto& pattern : patterns) {
+            body << "(" << pattern.Body << ")|";
+        }
+        Y_ENSURE(body.back() == '|');
+        body.pop_back();
+
+        return TRegexPattern{
+            .Body = std::move(body),
+            .After = sample.After,
+            .IsCaseInsensitive = sample.IsCaseInsensitive,
         };
     }
 

--- a/yql/essentials/sql/v1/lexer/regex/generic.h
+++ b/yql/essentials/sql/v1/lexer/regex/generic.h
@@ -43,6 +43,7 @@ namespace NSQLTranslationV1 {
     };
 
     TTokenMatcher Compile(TString name, const TRegexPattern& regex);
+    TRegexPattern Merged(TVector<TRegexPattern> patterns);
 
     IGenericLexer::TPtr MakeGenericLexer(TGenericLexerGrammar grammar);
 

--- a/yql/essentials/sql/v1/lexer/regex/generic.h
+++ b/yql/essentials/sql/v1/lexer/regex/generic.h
@@ -13,7 +13,7 @@ namespace NSQLTranslationV1 {
     struct TGenericToken {
         static constexpr const char* Error = "<ERROR>";
 
-        TStringBuf Name;
+        TString Name;
         TStringBuf Content;
         size_t Begin = 0; // In bytes
     };

--- a/yql/essentials/sql/v1/lexer/regex/generic.h
+++ b/yql/essentials/sql/v1/lexer/regex/generic.h
@@ -32,14 +32,9 @@ namespace NSQLTranslationV1 {
             size_t maxErrors = IGenericLexer::MaxErrorsLimit) const = 0;
     };
 
-    using TTokenMatcher = std::function<TMaybe<TStringBuf>(TStringBuf prefix)>;
+    using TTokenMatcher = std::function<TMaybe<TGenericToken>(TStringBuf prefix)>;
 
-    struct TTokenRule {
-        TString TokenName;
-        TTokenMatcher Match;
-    };
-
-    using TGenericLexerGrammar = TVector<TTokenRule>;
+    using TGenericLexerGrammar = TVector<TTokenMatcher>;
 
     struct TRegexPattern {
         TString Body;
@@ -47,7 +42,7 @@ namespace NSQLTranslationV1 {
         bool IsCaseInsensitive = false;
     };
 
-    TTokenMatcher Compile(const TRegexPattern& regex);
+    TTokenMatcher Compile(TString name, const TRegexPattern& regex);
 
     IGenericLexer::TPtr MakeGenericLexer(TGenericLexerGrammar grammar);
 

--- a/yql/essentials/sql/v1/lexer/regex/lexer.cpp
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.cpp
@@ -23,8 +23,8 @@ namespace NSQLTranslationV1 {
 
     size_t MatchANSIMultilineComment(TStringBuf remaining);
 
-    TTokenMatcher ANSICommentMatcher(TTokenMatcher defaultComment) {
-        return [defaultComment](TStringBuf prefix) -> TMaybe<TGenericToken> {
+    TTokenMatcher ANSICommentMatcher(TString name, TTokenMatcher defaultComment) {
+        return [defaultComment, name = std::move(name)](TStringBuf prefix) -> TMaybe<TGenericToken> {
             const auto basic = defaultComment(prefix);
             if (basic.Empty()) {
                 return Nothing();
@@ -43,7 +43,7 @@ namespace NSQLTranslationV1 {
             }
 
             return TGenericToken{
-                .Name = "COMMENT",
+                .Name = name,
                 .Content = ll1Content,
             };
         };
@@ -162,7 +162,7 @@ namespace NSQLTranslationV1 {
         for (const auto& [name, regex] : regexByOtherName) {
             generic.emplace_back(Compile(name, {regex}));
             if (name == "COMMENT" && ansi) {
-                generic.back() = ANSICommentMatcher(std::move(generic.back()));
+                generic.back() = ANSICommentMatcher(name, std::move(generic.back()));
             }
         }
 

--- a/yql/essentials/sql/v1/lexer/regex/lexer.h
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.h
@@ -3,10 +3,13 @@
 #include "generic.h"
 
 #include <yql/essentials/parser/lexer_common/lexer.h>
+#include <yql/essentials/sql/v1/reflect/sql_reflect.h>
 
 namespace NSQLTranslationV1 {
 
     TTokenMatcher ANSICommentMatcher(TTokenMatcher defaultComment);
+
+    TRegexPattern KeywordPattern(const NSQLReflect::TLexerGrammar& grammar);
 
     NSQLTranslation::TLexerFactoryPtr MakeRegexLexerFactory(bool ansi);
 

--- a/yql/essentials/sql/v1/lexer/regex/lexer.h
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.h
@@ -7,7 +7,7 @@
 
 namespace NSQLTranslationV1 {
 
-    TTokenMatcher ANSICommentMatcher(TTokenMatcher defaultComment);
+    TTokenMatcher ANSICommentMatcher(TString name, TTokenMatcher defaultComment);
 
     TRegexPattern KeywordPattern(const NSQLReflect::TLexerGrammar& grammar);
 

--- a/yql/essentials/sql/v1/lexer/regex/lexer.h
+++ b/yql/essentials/sql/v1/lexer/regex/lexer.h
@@ -11,6 +11,8 @@ namespace NSQLTranslationV1 {
 
     TRegexPattern KeywordPattern(const NSQLReflect::TLexerGrammar& grammar);
 
+    TRegexPattern PuntuationPattern(const NSQLReflect::TLexerGrammar& grammar);
+
     NSQLTranslation::TLexerFactoryPtr MakeRegexLexerFactory(bool ansi);
 
 } // namespace NSQLTranslationV1

--- a/yql/essentials/sql/v1/lexer/regex/ya.make
+++ b/yql/essentials/sql/v1/lexer/regex/ya.make
@@ -2,6 +2,7 @@ LIBRARY()
 
 PEERDIR(
     contrib/libs/re2
+    
     yql/essentials/public/issue
     yql/essentials/parser/lexer_common
     yql/essentials/sql/settings

--- a/yql/essentials/sql/v1/reflect/sql_reflect.cpp
+++ b/yql/essentials/sql/v1/reflect/sql_reflect.cpp
@@ -5,6 +5,7 @@
 
 #include <util/string/split.h>
 #include <util/string/strip.h>
+#include <util/charset/utf8.h>
 
 namespace NSQLReflect {
 
@@ -23,11 +24,11 @@ namespace NSQLReflect {
         return name;
     }
 
-    const TStringBuf TLexerGrammar::KeywordNameByBlock(const TStringBuf block Y_LIFETIME_BOUND) {
+    const TString TLexerGrammar::KeywordNameByBlock(const TStringBuf block) {
         if (TCaseInsensitiveStringBuf(block) == "SKIP") {
             return "TSKIP";
         }
-        return block;
+        return ToUpperUTF8(block);
     }
 
     TVector<TString> GetResourceLines(const TStringBuf key) {

--- a/yql/essentials/sql/v1/reflect/sql_reflect.cpp
+++ b/yql/essentials/sql/v1/reflect/sql_reflect.cpp
@@ -1,6 +1,7 @@
 #include "sql_reflect.h"
 
 #include <library/cpp/resource/resource.h>
+#include <library/cpp/case_insensitive_string/case_insensitive_string.h>
 
 #include <util/string/split.h>
 #include <util/string/strip.h>
@@ -15,11 +16,18 @@ namespace NSQLReflect {
     const TStringBuf SectionOther = "//! section:other";
     const TStringBuf FragmentPrefix = "fragment ";
 
-    const TStringBuf TLexerGrammar::KeywordBlock(const TStringBuf name) {
+    const TStringBuf TLexerGrammar::KeywordBlockByName(const TStringBuf name Y_LIFETIME_BOUND) {
         if (name == "TSKIP") {
             return "SKIP";
         }
         return name;
+    }
+
+    const TStringBuf TLexerGrammar::KeywordNameByBlock(const TStringBuf block Y_LIFETIME_BOUND) {
+        if (TCaseInsensitiveStringBuf(block) == "SKIP") {
+            return "TSKIP";
+        }
+        return block;
     }
 
     TVector<TString> GetResourceLines(const TStringBuf key) {
@@ -133,7 +141,7 @@ namespace NSQLReflect {
         SubstGlobal(block, "'", "");
         SubstGlobal(block, " ", "");
 
-        Y_ENSURE(name == block || (name == "TSKIP" && block == TLexerGrammar::KeywordBlock("TSKIP")));
+        Y_ENSURE(name == block || (name == "TSKIP" && block == TLexerGrammar::KeywordBlockByName("TSKIP")));
         grammar.KeywordNames.emplace(std::move(name));
     }
 

--- a/yql/essentials/sql/v1/reflect/sql_reflect.h
+++ b/yql/essentials/sql/v1/reflect/sql_reflect.h
@@ -14,7 +14,7 @@ namespace NSQLReflect {
         THashMap<TString, TString> BlockByName;
 
         static const TStringBuf KeywordBlockByName(const TStringBuf name);
-        static const TStringBuf KeywordNameByBlock(const TStringBuf block);
+        static const TString KeywordNameByBlock(const TStringBuf block);
     };
 
     TLexerGrammar LoadLexerGrammar();

--- a/yql/essentials/sql/v1/reflect/sql_reflect.h
+++ b/yql/essentials/sql/v1/reflect/sql_reflect.h
@@ -13,7 +13,8 @@ namespace NSQLReflect {
         TVector<TString> OtherNames;
         THashMap<TString, TString> BlockByName;
 
-        static const TStringBuf KeywordBlock(const TStringBuf name);
+        static const TStringBuf KeywordBlockByName(const TStringBuf name);
+        static const TStringBuf KeywordNameByBlock(const TStringBuf block);
     };
 
     TLexerGrammar LoadLexerGrammar();

--- a/yql/essentials/sql/v1/reflect/ya.make
+++ b/yql/essentials/sql/v1/reflect/ya.make
@@ -4,6 +4,10 @@ SRCS(
     sql_reflect.cpp
 )
 
+PEERDIR(
+    library/cpp/case_insensitive_string
+)
+
 RESOURCE(DONT_PARSE yql/essentials/sql/v1/SQLv1Antlr4.g.in SQLv1Antlr4.g.in)
 
 END()


### PR DESCRIPTION
Fix `TRegexLexer` performance. Now it is just 2 times slower than a reference ANTLR implementation on Release mode, so merged regexes are 3 times better than scan&compare.

![image](https://github.com/user-attachments/assets/4e0cb27a-491d-4dbd-b10a-5725ffa6d902)

---

- Related to `YQL-19616`
- Related to https://github.com/ydb-platform/ydb/issues/15129
- Related to https://github.com/vityaman/ydb/issues/42
