### PR TITLE
YQL-19747: Fix unquoted object path completion

### DIFF
--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -170,14 +170,14 @@ namespace NSQLComplete {
 
                 if constexpr (std::is_base_of_v<TFolderName, T>) {
                     name.Indentifier.append('/');
-                    if (!context.Object->IsEnclosed) {
+                    if (!context.Object->IsQuoted) {
                         name.Indentifier = Quoted(std::move(name.Indentifier));
                     }
                     return {ECandidateKind::FolderName, std::move(name.Indentifier)};
                 }
 
                 if constexpr (std::is_base_of_v<TTableName, T>) {
-                    if (!context.Object->IsEnclosed) {
+                    if (!context.Object->IsQuoted) {
                         name.Indentifier = Quoted(std::move(name.Indentifier));
                     }
                     return {ECandidateKind::TableName, std::move(name.Indentifier)};

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -511,6 +511,15 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM "), expected);
         }
         {
+            TString input = "SELECT * FROM pr";
+            TVector<TCandidate> expected = {
+                {FolderName, "`prod/`"},
+            };
+            TCompletion actual = engine->Complete(SharpedInput(input));
+            UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
+            UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, "pr");
+        }
+        {
             TVector<TCandidate> expected = {};
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM `#"), expected);
         }

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -234,7 +234,11 @@ namespace NSQLComplete {
 
             if (auto path = ObjectPath(context)) {
                 object.Path = *path;
-                object.IsEnclosed = true;
+            }
+
+            if (auto enclosing = context.Enclosing();
+                enclosing.Defined() && enclosing->Base->Name == "ID_QUOTED") {
+                object.IsQuoted = true;
             }
 
             return object;
@@ -245,8 +249,9 @@ namespace NSQLComplete {
                 TString path = enclosing->Base->Content;
                 if (enclosing->Base->Name == "ID_QUOTED") {
                     path = Unquoted(std::move(path));
+                    enclosing->Position += 1;
                 }
-                path.resize(context.Cursor.Position - enclosing->Position - 1);
+                path.resize(context.Cursor.Position - enclosing->Position);
                 return path;
             }
             return Nothing();

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -41,7 +41,7 @@ namespace NSQLComplete {
             TString Cluster;
             TString Path;
             THashSet<EObjectKind> Kinds;
-            bool IsEnclosed = false;
+            bool IsQuoted = false;
         };
 
         TKeywords Keywords;


### PR DESCRIPTION
On `SELECT * FROM pn` it completed to `SELECT * FROM ppnv1`, but expected ``` SELECT * FROM `pnv1` ```.

---

- Related to `YQL-19747`
- Related to https://github.com/ydb-platform/ydb/issues/9056
- Related to https://github.com/vityaman/ydb/issues/44
- Related to https://github.com/ydb-platform/ydb/pull/18146
