### PR TITLE
yt/cri-api: tune ya.make to generate headers

### DIFF
--- a/yt/yt/contrib/cri-api/ya.make
+++ b/yt/yt/contrib/cri-api/ya.make
@@ -2,6 +2,8 @@ PROTO_LIBRARY()
 
 LICENSE(Apache-2.0)
 
+SET(PROTOC_TRANSITIVE_HEADERS "no")
+
 PROTO_NAMESPACE(
     yt/yt/contrib/cri-api
 )


### PR DESCRIPTION
Some tools are stumble on missing api.deps.pb.h in generated headers.