### PR TITLE
fix go-sdk: allow empty json object in yson2json module

### DIFF
--- a/yt/go/yson/yson2json/raw_message.go
+++ b/yt/go/yson/yson2json/raw_message.go
@@ -119,6 +119,7 @@ func (m RawMessage) MarshalYSON(w *yson.Writer) error {
 			if maybeValueWithAttributes {
 				if v == valueKey || v == attributesKey {
 					inMap = inMap[:len(inMap)-1]
+					mapKey = false
 					valueWithAttrs, err := parseValueWithAttributes(d, v)
 					if err != nil {
 						return fmt.Errorf("failed to parse value with attributes: %w", err)

--- a/yt/go/yson/yson2json/raw_message.go
+++ b/yt/go/yson/yson2json/raw_message.go
@@ -48,6 +48,7 @@ func (m RawMessage) MarshalYSON(w *yson.Writer) error {
 
 	var mapKey bool
 	var inMap []bool
+	var maybeValueWithAttributes bool
 
 	isInMap := func() bool {
 		return len(inMap) != 0 && inMap[len(inMap)-1]
@@ -101,12 +102,24 @@ func (m RawMessage) MarshalYSON(w *yson.Writer) error {
 				w.EndList()
 				inMap = inMap[:len(inMap)-1]
 			case '{':
-				key, err := parseStringToken(d)
-				if err != nil {
-					return fmt.Errorf("failed to parse map key: %w", err)
+				maybeValueWithAttributes = true
+				inMap = append(inMap, true)
+			case '}':
+				if maybeValueWithAttributes {
+					maybeValueWithAttributes = false
+					w.BeginMap()
 				}
-				if key == valueKey || key == attributesKey {
-					valueWithAttrs, err := parseValueWithAttributes(d, key)
+				w.EndMap()
+				inMap = inMap[:len(inMap)-1]
+			default:
+				panic("invalid delim")
+			}
+
+		case string:
+			if maybeValueWithAttributes {
+				if v == valueKey || v == attributesKey {
+					inMap = inMap[:len(inMap)-1]
+					valueWithAttrs, err := parseValueWithAttributes(d, v)
 					if err != nil {
 						return fmt.Errorf("failed to parse value with attributes: %w", err)
 					}
@@ -118,19 +131,12 @@ func (m RawMessage) MarshalYSON(w *yson.Writer) error {
 					}
 				} else {
 					w.BeginMap()
-					inMap = append(inMap, true)
 					mapKey = true
-					w.MapKeyString(key)
+					w.MapKeyString(v)
 				}
-			case '}':
-				w.EndMap()
-				inMap = inMap[:len(inMap)-1]
-			default:
-				panic("invalid delim")
-			}
 
-		case string:
-			if mapKey {
+				maybeValueWithAttributes = false
+			} else if mapKey {
 				w.MapKeyString(v)
 			} else {
 				w.String(v)

--- a/yt/go/yson/yson2json/raw_message_test.go
+++ b/yt/go/yson/yson2json/raw_message_test.go
@@ -78,6 +78,10 @@ func TestRawMessage_MarshalYSON(t *testing.T) {
 			Input:  `{}`,
 			Output: `{}`,
 		},
+		{
+			Input:  `{"one":{"$value": {"x": "y"}, "$attributes": {"attr": 10}}, "two": {"$value": {"x": "y"}, "$attributes": {"attr2": 10}}}`,
+			Output: `{one=<attr=10.000000;>{x=y;};two=<attr=10.000000;>{x=y;};}`,
+		},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			m := RawMessage{

--- a/yt/go/yson/yson2json/raw_message_test.go
+++ b/yt/go/yson/yson2json/raw_message_test.go
@@ -80,7 +80,7 @@ func TestRawMessage_MarshalYSON(t *testing.T) {
 		},
 		{
 			Input:  `{"one":{"$value": {"x": "y"}, "$attributes": {"attr": 10}}, "two": {"$value": {"x": "y"}, "$attributes": {"attr2": 10}}}`,
-			Output: `{one=<attr=10.000000;>{x=y;};two=<attr=10.000000;>{x=y;};}`,
+			Output: `{one=<attr=10.000000;>{x=y;};two=<attr2=10.000000;>{x=y;};}`,
 		},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {

--- a/yt/go/yson/yson2json/raw_message_test.go
+++ b/yt/go/yson/yson2json/raw_message_test.go
@@ -74,6 +74,10 @@ func TestRawMessage_MarshalYSON(t *testing.T) {
 }}`,
 			Output: `{schema=<strict=%true;>[{name=id;"type_v3"=int64;};{name=val;"type_v3"=utf8;};];}`,
 		},
+		{
+			Input:  `{}`,
+			Output: `{}`,
+		},
 	} {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			m := RawMessage{


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: go-sdk

Fixed a bug in go yson2json module, which led to inability to parse an empty json object