### PR TITLE
Fix parsing INDEX GLOBAL (SYNC|ASYNC)

### DIFF
--- a/yql/essentials/sql/v1/sql_translation.cpp
+++ b/yql/essentials/sql/v1/sql_translation.cpp
@@ -661,23 +661,29 @@ bool TSqlTranslation::CreateTableIndex(const TRule_table_index& node, TVector<TI
             if (globalIndex.HasBlock2()) {
                 uniqIndex = true;
             }
+            bool sync = true;
             if (globalIndex.HasBlock3()) {
                 const TString token = to_lower(Ctx.Token(globalIndex.GetBlock3().GetToken1()));
                 if (token == "sync") {
-                    if (uniqIndex) {
-                        indexes.back().Type = TIndexDescription::EType::GlobalSyncUnique;
-                    } else {
-                        indexes.back().Type = TIndexDescription::EType::GlobalSync;
-                    }
+                    sync = true;
                 } else if (token == "async") {
-                    if (uniqIndex) {
-                        AltNotImplemented("unique", indexType);
-                        return false;
-                    }
-                    indexes.back().Type = TIndexDescription::EType::GlobalAsync;
+                    sync = false;
                 } else {
                     Y_ABORT("You should change implementation according to grammar changes");
                 }
+            }
+            if (sync) {
+                if (uniqIndex) {
+                    indexes.back().Type = TIndexDescription::EType::GlobalSyncUnique;
+                } else {
+                    indexes.back().Type = TIndexDescription::EType::GlobalSync;
+                }
+            } else {
+                if (uniqIndex) {
+                    AltNotImplemented("unique", indexType);
+                    return false;
+                }
+                indexes.back().Type = TIndexDescription::EType::GlobalAsync;
             }
         }
         break;


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: yql

Fix parsing unique index type. There was an error that, if not specified explicitly (SYNC or ASYNC), index type remained with the default value GLOBAL SYNC, despite that it was explicitly specified as UNIQUE in query.
https://github.com/ydb-platform/ydb/issues/17885