### PR TITLE
yt/core/bus: always send TLS handshake response for incompatible modes

### DIFF
--- a/yt/yt/core/bus/tcp/connection.cpp
+++ b/yt/yt/core/bus/tcp/connection.cpp
@@ -1310,6 +1310,11 @@ bool TTcpConnection::OnHandshakePacketReceived()
 
     if (EncryptionMode_ == EEncryptionMode::Required || otherEncryptionMode == EEncryptionMode::Required) {
         if (EncryptionMode_ == EEncryptionMode::Disabled || otherEncryptionMode == EEncryptionMode::Disabled) {
+            if (ConnectionType_ == EConnectionType::Server) {
+                // Send handshake response before abort to let client deduce reason.
+                ProcessQueuedMessages();
+                OnSocketWrite();
+            }
             Abort(TError(NBus::EErrorCode::SslError, "TLS/SSL client/server encryption mode compatibility error")
                 << TErrorAttribute("mode", EncryptionMode_)
                 << TErrorAttribute("other_mode", otherEncryptionMode));

--- a/yt/yt/core/bus/unittests/ssl_ut.cpp
+++ b/yt/yt/core/bus/unittests/ssl_ut.cpp
@@ -450,7 +450,9 @@ TEST_F(TSslTest, RequiredAndDisabledEncryptionMode)
     auto client = CreateBusClient(clientConfig);
 
     auto bus = client->CreateBus(New<TEmptyBusHandler>());
-    EXPECT_FALSE(bus->GetReadyFuture().Get().IsOK());
+    auto error = bus->GetReadyFuture().Get();
+    EXPECT_FALSE(error.IsOK());
+    EXPECT_EQ(error.GetCode(), EErrorCode::SslError);
 
     server->Stop()
         .Get()
@@ -469,7 +471,9 @@ TEST_F(TSslTest, DisabledAndRequiredEncryptionMode)
     auto client = CreateBusClient(clientConfig);
 
     auto bus = client->CreateBus(New<TEmptyBusHandler>());
-    EXPECT_FALSE(bus->GetReadyFuture().Get().IsOK());
+    auto error = bus->GetReadyFuture().Get();
+    EXPECT_FALSE(error.IsOK());
+    EXPECT_EQ(error.GetCode(), EErrorCode::SslError);
 
     server->Stop()
         .Get()
@@ -545,7 +549,9 @@ TEST_F(TSslTest, CAVerificationModeFailure)
     auto client = CreateBusClient(clientConfig);
 
     auto bus = client->CreateBus(New<TEmptyBusHandler>());
-    EXPECT_FALSE(bus->GetReadyFuture().Get().IsOK());
+    auto error = bus->GetReadyFuture().Get();
+    EXPECT_FALSE(error.IsOK());
+    EXPECT_EQ(error.GetCode(), EErrorCode::SslError);
 
     server->Stop()
         .Get()
@@ -771,7 +777,9 @@ TEST_F(TSslTest, DifferentCipherLists)
     auto client = CreateBusClient(clientConfig);
 
     auto bus = client->CreateBus(New<TEmptyBusHandler>());
-    EXPECT_FALSE(bus->GetReadyFuture().Get().IsOK());
+    auto error = bus->GetReadyFuture().Get();
+    EXPECT_FALSE(error.IsOK());
+    EXPECT_EQ(error.GetCode(), EErrorCode::SslError);
 
     server->Stop()
         .Get()


### PR DESCRIPTION
When TLS modes are incompatible server should try to send handshake
response, to let client deduce reason why this connection is failed.

Socket is likely to have buffer for sending single packet right now,
so we don't need whole data transfer machinery here.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: fix
Component: BUS RPC

Always send BUS RPC handshake response to let client deduce TLS error.
