### PR TITLE
YQL-19747: Fix cluster expression syntax

### DIFF
--- a/yql/essentials/sql/v1/complete/name/service/schema/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/schema/name_service.cpp
@@ -32,12 +32,7 @@ namespace NSQLComplete {
             }
 
             static TString ClusterName(const TObjectNameConstraints& constraints) {
-                TString name = constraints.Cluster;
-                if (!constraints.Provider.empty()) {
-                    name.prepend(":");
-                    name.prepend(constraints.Provider);
-                }
-                return name;
+                return constraints.Cluster;
             }
 
             static TListFilter ToListFilter(const TNameConstraints& constraints) {

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -119,7 +119,7 @@ namespace NSQLComplete {
 
             if (context.Cluster) {
                 TClusterName::TConstraints constraints;
-                constraints.Namespace = context.Cluster->Provider;
+                constraints.Namespace = ""; // TODO(YQL-19747): filter by provider
                 request.Constraints.Cluster = std::move(constraints);
             }
 

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -95,7 +95,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
              {{"/", {{"Table", "people"},
                      {"Folder", "yql"}}},
               {"/yql/", {{"Table", "tutorial"}}}}},
-            {"yt:saurus",
+            {"saurus",
              {{"/", {{"Table", "maxim"}}}}},
         };
 
@@ -190,7 +190,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     Y_UNIT_TEST(Use) {
         TVector<TCandidate> expected = {
             {ClusterName, "example"},
-            {ClusterName, "yt:saurus"},
+            {ClusterName, "saurus"},
         };
         auto engine = MakeSqlCompletionEngineUT();
         UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "USE "), expected);
@@ -202,7 +202,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {TableName, "`maxim`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(
@@ -219,7 +219,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {FolderName, "`prod/`"},
                 {FolderName, "`test/`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(
@@ -284,7 +284,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {FolderName, "`prod/`"},
                 {FolderName, "`test/`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "IF NOT EXISTS"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "CREATE TABLE #"), expected);
@@ -333,7 +333,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             {FolderName, "`prod/`"},
             {FolderName, "`test/`"},
             {ClusterName, "example"},
-            {ClusterName, "yt:saurus"},
+            {ClusterName, "saurus"},
             {Keyword, "IF EXISTS"},
         };
         auto engine = MakeSqlCompletionEngineUT();
@@ -529,7 +529,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {FolderName, "`prod/`"},
                 {FolderName, "`test/`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM "), expected);
@@ -629,12 +629,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
         auto engine = MakeSqlCompletionEngineUT();
         {
             TVector<TCandidate> expected = {
-                {ClusterName, "yt:saurus"},
-            };
-            UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM yt#"), expected);
-        }
-        {
-            TVector<TCandidate> expected = {
+                {ClusterName, "example"},
                 {ClusterName, "saurus"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "SELECT * FROM yt:"), expected);
@@ -671,7 +666,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {TableName, "`maxim`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "USE yt:saurus; SELECT * FROM "), expected);
@@ -687,7 +682,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {TableName, "`maxim`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "USE example; USE yt:saurus; SELECT * FROM "), expected);
@@ -696,7 +691,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {TableName, "`maxim`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, R"(
@@ -712,7 +707,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {TableName, "`people`"},
                 {FolderName, "`yql/`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
                 {Keyword, "ANY"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, R"(
@@ -786,7 +781,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {FolderName, "`prod/`"},
                 {FolderName, "`test/`"},
                 {ClusterName, "example"},
-                {ClusterName, "yt:saurus"},
+                {ClusterName, "saurus"},
             };
             UNIT_ASSERT_VALUES_EQUAL(Complete(engine, "UPSERT INTO "), expected);
         }


### PR DESCRIPTION
There was a mistake thinking that provider is a part of a cluster name. Actually `yt:saurus` and `saurus` are same clusters and provider (`yt`) serves only as a hint for translation expressions such as `yt:$cluster_name`.

---

- Related to `YQL-19747`
- Related to https://github.com/vityaman/ydb/issues/54
- Related to https://github.com/ydb-platform/ydb/issues/9056
