### PR TITLE
YQL-19747: Fix some TODOs and Clang Tidy checks

### DIFF
--- a/yql/essentials/sql/v1/complete/antlr4/c3i.h
+++ b/yql/essentials/sql/v1/complete/antlr4/c3i.h
@@ -39,8 +39,8 @@ namespace NSQLComplete {
             std::unordered_set<TRuleId> IgnoredRules;
         };
 
-        virtual TC3Candidates Complete(TStringBuf text, size_t caretTokenIndex) = 0;
         virtual ~IC3Engine() = default;
+        virtual TC3Candidates Complete(TStringBuf text, size_t caretTokenIndex) = 0;
     };
 
 } // namespace NSQLComplete

--- a/yql/essentials/sql/v1/complete/name/cluster/discovery.h
+++ b/yql/essentials/sql/v1/complete/name/cluster/discovery.h
@@ -12,7 +12,7 @@ namespace NSQLComplete {
     public:
         using TPtr = TIntrusivePtr<IClusterDiscovery>;
 
-        virtual ~IClusterDiscovery() = default;
+        ~IClusterDiscovery() override = default;
         virtual NThreading::TFuture<TClusterList> Query() const = 0;
     };
 

--- a/yql/essentials/sql/v1/complete/name/object/schema.cpp
+++ b/yql/essentials/sql/v1/complete/name/object/schema.cpp
@@ -1,6 +1,6 @@
 #include "schema.h"
 
 template <>
-void Out<NSQLComplete::TFolderEntry>(IOutputStream& out, const NSQLComplete::TFolderEntry& entry) {
-    out << "{" << entry.Type << ", " << entry.Name << "}";
+void Out<NSQLComplete::TFolderEntry>(IOutputStream& out, const NSQLComplete::TFolderEntry& value) {
+    out << "{" << value.Type << ", " << value.Name << "}";
 }

--- a/yql/essentials/sql/v1/complete/name/object/schema.h
+++ b/yql/essentials/sql/v1/complete/name/object/schema.h
@@ -45,7 +45,7 @@ namespace NSQLComplete {
     public:
         using TPtr = TIntrusivePtr<ISchema>;
 
-        virtual ~ISchema() = default;
+        ~ISchema() override = default;
         virtual NThreading::TFuture<TListResponse> List(const TListRequest& request) const = 0;
     };
 

--- a/yql/essentials/sql/v1/complete/name/object/simple/schema.h
+++ b/yql/essentials/sql/v1/complete/name/object/simple/schema.h
@@ -13,7 +13,7 @@ namespace NSQLComplete {
     public:
         using TPtr = TIntrusivePtr<ISimpleSchema>;
 
-        virtual ~ISimpleSchema() = default;
+        ~ISimpleSchema() override = default;
 
         virtual TSplittedPath Split(TStringBuf path) const = 0;
 

--- a/yql/essentials/sql/v1/complete/name/service/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.cpp
@@ -8,7 +8,7 @@ namespace NSQLComplete {
 
     namespace {
 
-        void SetPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
+        void SetPrefix(TString& name, TStringBuf delimeter, const TNamespaced& namespaced) {
             if (namespaced.Namespace.empty()) {
                 return;
             }
@@ -17,7 +17,7 @@ namespace NSQLComplete {
             name.prepend(namespaced.Namespace);
         }
 
-        void FixPrefix(TString& name, const TStringBuf delimeter, const TNamespaced& namespaced) {
+        void FixPrefix(TString& name, TStringBuf delimeter, const TNamespaced& namespaced) {
             if (namespaced.Namespace.empty()) {
                 return;
             }

--- a/yql/essentials/sql/v1/complete/name/service/name_service.h
+++ b/yql/essentials/sql/v1/complete/name/service/name_service.h
@@ -118,8 +118,8 @@ namespace NSQLComplete {
     public:
         using TPtr = TIntrusivePtr<INameService>;
 
+        ~INameService() override = default;
         virtual NThreading::TFuture<TNameResponse> Lookup(TNameRequest request) const = 0;
-        virtual ~INameService() = default;
     };
 
     TString NormalizeName(TStringBuf name);

--- a/yql/essentials/sql/v1/complete/name/service/ranking/frequency.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/frequency.cpp
@@ -50,7 +50,7 @@ namespace NSQLComplete {
             return items;
         }
 
-        static TVector<TFrequencyItem> ParseListFromJsonText(const TStringBuf text) {
+        static TVector<TFrequencyItem> ParseListFromJsonText(TStringBuf text) {
             NJson::TJsonValue json = NJson::ReadJsonFastTree(text);
             return ParseListFromJsonArray(json.GetArraySafe());
         }
@@ -104,7 +104,7 @@ namespace NSQLComplete {
         });
     }
 
-    TFrequencyData ParseJsonFrequencyData(const TStringBuf text) {
+    TFrequencyData ParseJsonFrequencyData(TStringBuf text) {
         return Collect(TFrequencyItem::ParseListFromJsonText(text));
     }
 

--- a/yql/essentials/sql/v1/complete/name/service/ranking/frequency.h
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/frequency.h
@@ -15,7 +15,7 @@ namespace NSQLComplete {
 
     TFrequencyData Pruned(const TFrequencyData& data);
 
-    TFrequencyData ParseJsonFrequencyData(const TStringBuf text);
+    TFrequencyData ParseJsonFrequencyData(TStringBuf text);
 
     TFrequencyData LoadFrequencyData();
 

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
@@ -108,7 +108,7 @@ namespace NSQLComplete {
             return std::numeric_limits<size_t>::max() - weight;
         }
 
-        const TStringBuf ContentView(const TGenericName& name Y_LIFETIME_BOUND) const {
+        TStringBuf ContentView(const TGenericName& name Y_LIFETIME_BOUND) const {
             return std::visit([](const auto& name) -> TStringBuf {
                 using T = std::decay_t<decltype(name)>;
                 if constexpr (std::is_base_of_v<TKeyword, T>) {

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.cpp
@@ -15,7 +15,7 @@ namespace NSQLComplete {
 
     public:
         explicit TRanking(TFrequencyData frequency)
-            : Frequency_(frequency)
+            : Frequency_(std::move(frequency))
         {
         }
 

--- a/yql/essentials/sql/v1/complete/name/service/ranking/ranking.h
+++ b/yql/essentials/sql/v1/complete/name/service/ranking/ranking.h
@@ -11,11 +11,11 @@ namespace NSQLComplete {
     public:
         using TPtr = TIntrusivePtr<IRanking>;
 
+        ~IRanking() override = default;
         virtual void CropToSortedPrefix(
             TVector<TGenericName>& names,
             const TNameConstraints& constraints,
             size_t limit) const = 0;
-        virtual ~IRanking() = default;
     };
 
     // TODO(YQL-19747): Migrate YDB CLI to MakeDefaultRanking(...)

--- a/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_service.cpp
@@ -103,7 +103,7 @@ namespace NSQLComplete {
 
     class TPragmaNameService: public IRankingNameService {
     public:
-        explicit TPragmaNameService(IRanking::TPtr ranking, TVector<TString> pragmas)
+        TPragmaNameService(IRanking::TPtr ranking, TVector<TString> pragmas)
             : IRankingNameService(std::move(ranking))
             , Pragmas_(BuildNameIndex(std::move(pragmas), NormalizeName))
         {
@@ -127,7 +127,7 @@ namespace NSQLComplete {
 
     class TTypeNameService: public IRankingNameService {
     public:
-        explicit TTypeNameService(IRanking::TPtr ranking, TVector<TString> types)
+        TTypeNameService(IRanking::TPtr ranking, TVector<TString> types)
             : IRankingNameService(std::move(ranking))
             , Types_(BuildNameIndex(std::move(types), NormalizeName))
         {
@@ -151,7 +151,7 @@ namespace NSQLComplete {
 
     class TFunctionNameService: public IRankingNameService {
     public:
-        explicit TFunctionNameService(IRanking::TPtr ranking, TVector<TString> functions)
+        TFunctionNameService(IRanking::TPtr ranking, TVector<TString> functions)
             : IRankingNameService(std::move(ranking))
             , Functions_(BuildNameIndex(std::move(functions), NormalizeName))
         {
@@ -175,7 +175,7 @@ namespace NSQLComplete {
 
     class THintNameService: public IRankingNameService {
     public:
-        explicit THintNameService(
+        THintNameService(
             IRanking::TPtr ranking,
             THashMap<EStatementKind, TVector<TString>> hints)
             : IRankingNameService(std::move(ranking))

--- a/yql/essentials/sql/v1/complete/name/service/static/name_set.h
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_set.h
@@ -16,9 +16,6 @@ namespace NSQLComplete {
         THashMap<EStatementKind, TVector<TString>> Hints;
     };
 
-    // TODO(YQL-19747): Migrate YDB CLI to TNameSet
-    using NameSet = TNameSet;
-
     TNameSet Pruned(TNameSet names, const TFrequencyData& frequency);
 
     TNameSet LoadDefaultNameSet();

--- a/yql/essentials/sql/v1/complete/name/service/static/name_set_json.cpp
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_set_json.cpp
@@ -10,7 +10,7 @@
 
 namespace NSQLComplete {
 
-    NJson::TJsonValue LoadJsonResource(const TStringBuf filename) {
+    NJson::TJsonValue LoadJsonResource(TStringBuf filename) {
         TString text;
         Y_ENSURE(NResource::FindExact(filename, &text));
         return NJson::ReadJsonFastTree(text);

--- a/yql/essentials/sql/v1/complete/name/service/static/name_set_json.h
+++ b/yql/essentials/sql/v1/complete/name/service/static/name_set_json.h
@@ -10,7 +10,7 @@
 
 namespace NSQLComplete {
 
-    NJson::TJsonValue LoadJsonResource(const TStringBuf filename);
+    NJson::TJsonValue LoadJsonResource(TStringBuf filename);
 
     template <class T, class U>
     T Merge(T lhs, U rhs) {

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -265,8 +265,8 @@ namespace NSQLComplete {
 } // namespace NSQLComplete
 
 template <>
-void Out<NSQLComplete::ECandidateKind>(IOutputStream& out, NSQLComplete::ECandidateKind kind) {
-    switch (kind) {
+void Out<NSQLComplete::ECandidateKind>(IOutputStream& out, NSQLComplete::ECandidateKind value) {
+    switch (value) {
         case NSQLComplete::ECandidateKind::Keyword:
             out << "Keyword";
             break;
@@ -298,6 +298,6 @@ void Out<NSQLComplete::ECandidateKind>(IOutputStream& out, NSQLComplete::ECandid
 }
 
 template <>
-void Out<NSQLComplete::TCandidate>(IOutputStream& out, const NSQLComplete::TCandidate& candidate) {
-    out << "{" << candidate.Kind << ", \"" << candidate.Content << "\"}";
+void Out<NSQLComplete::TCandidate>(IOutputStream& out, const NSQLComplete::TCandidate& value) {
+    out << "{" << value.Kind << ", \"" << value.Content << "\"}";
 }

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -25,11 +25,12 @@ namespace NSQLComplete {
         {
         }
 
-        TCompletion Complete(TCompletionInput input) override {
-            return CompleteAsync(std::move(input), {}).ExtractValueSync();
+        NThreading::TFuture<TCompletion>
+        Complete(TCompletionInput input, TEnvironment env = {}) override {
+            return CompleteAsync(input, env);
         }
 
-        virtual NThreading::TFuture<TCompletion> CompleteAsync(TCompletionInput input, TEnvironment env) override {
+        NThreading::TFuture<TCompletion> CompleteAsync(TCompletionInput input, TEnvironment env) override {
             if (
                 input.CursorPosition < input.Text.length() &&
                     IsUTF8ContinuationByte(input.Text.at(input.CursorPosition)) ||

--- a/yql/essentials/sql/v1/complete/sql_complete.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete.cpp
@@ -14,7 +14,7 @@ namespace NSQLComplete {
 
     class TSqlCompletionEngine: public ISqlCompletionEngine {
     public:
-        explicit TSqlCompletionEngine(
+        TSqlCompletionEngine(
             TLexerSupplier lexer,
             INameService::TPtr names,
             ISqlCompletionEngine::TConfiguration configuration)

--- a/yql/essentials/sql/v1/complete/sql_complete.h
+++ b/yql/essentials/sql/v1/complete/sql_complete.h
@@ -53,8 +53,9 @@ namespace NSQLComplete {
         };
 
         virtual ~ISqlCompletionEngine() = default;
-        virtual TCompletion Complete(TCompletionInput input) = 0; // TODO(YQL-19747): migrate YDB CLI to CompleteAsync
         virtual NThreading::TFuture<TCompletion>
+        Complete(TCompletionInput input, TEnvironment env = {}) = 0;
+        virtual NThreading::TFuture<TCompletion> // TODO(YQL-19747): Migrate YDB CLI to `Complete` method
         CompleteAsync(TCompletionInput input, TEnvironment env = {}) = 0;
     };
 

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -529,7 +529,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {FolderName, "`prod/"},
             };
-            TCompletion actual = engine->Complete(SharpedInput(input));
+            TCompletion actual = engine->Complete(SharpedInput(input)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, "pr");
         }
@@ -550,7 +550,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {FolderName, "prod/"},
                 {FolderName, "test/"},
             };
-            TCompletion actual = engine->Complete(SharpedInput(input));
+            TCompletion actual = engine->Complete(SharpedInput(input)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, "");
         }
@@ -561,7 +561,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {TableName, "account"},
                 {TableName, "example"},
             };
-            TCompletion actual = engine->Complete(SharpedInput(input));
+            TCompletion actual = engine->Complete(SharpedInput(input)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, "");
         }
@@ -571,7 +571,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
                 {TableName, "abacaba"},
                 {TableName, "account"},
             };
-            TCompletion actual = engine->Complete(SharpedInput(input));
+            TCompletion actual = engine->Complete(SharpedInput(input)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, "a");
         }
@@ -580,7 +580,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {FolderName, ".sys/"},
             };
-            TCompletion actual = engine->Complete(SharpedInput(input));
+            TCompletion actual = engine->Complete(SharpedInput(input)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, ".sy");
         }
@@ -589,7 +589,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
             TVector<TCandidate> expected = {
                 {FolderName, "service/"},
             };
-            TCompletion actual = engine->Complete(SharpedInput(input));
+            TCompletion actual = engine->Complete(SharpedInput(input)).ExtractValueSync();
             UNIT_ASSERT_VALUES_EQUAL(actual.Candidates, expected);
             UNIT_ASSERT_VALUES_EQUAL(actual.CompletedToken.Content, "ser");
         }

--- a/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
+++ b/yql/essentials/sql/v1/complete/sql_complete_ut.cpp
@@ -122,7 +122,7 @@ Y_UNIT_TEST_SUITE(SqlCompleteTests) {
     }
 
     TVector<TCandidate> CompleteTop(size_t limit, ISqlCompletionEngine::TPtr& engine, TString sharped) {
-        auto candidates = Complete(engine, sharped);
+        auto candidates = Complete(engine, std::move(sharped));
         candidates.crop(limit);
         return candidates;
     }

--- a/yql/essentials/sql/v1/complete/syntax/format.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/format.cpp
@@ -11,7 +11,7 @@ namespace NSQLComplete {
 
     namespace {
 
-        static const THashSet<std::string> Keywords = [] {
+        const THashSet<std::string> Keywords = [] {
             const auto& grammar = GetSqlGrammar();
             const auto& vocabulary = grammar.GetVocabulary();
 
@@ -22,7 +22,7 @@ namespace NSQLComplete {
             return keywords;
         }();
 
-        static const THashSet<TString> TypeConstructors = {
+        const THashSet<TString> TypeConstructors = {
             "DECIMAL",
             "OPTIONAL",
             "TUPLE",

--- a/yql/essentials/sql/v1/complete/syntax/grammar.h
+++ b/yql/essentials/sql/v1/complete/syntax/grammar.h
@@ -19,6 +19,7 @@ namespace NSQLComplete {
 
     class ISqlGrammar {
     public:
+        virtual ~ISqlGrammar() = default;
         virtual const antlr4::dfa::Vocabulary& GetVocabulary() const = 0;
         virtual const std::string& SymbolizedRule(TRuleId rule) const = 0;
         virtual TRuleId GetRuleId(std::string_view symbolized) const = 0;
@@ -26,7 +27,6 @@ namespace NSQLComplete {
         virtual const std::unordered_set<TTokenId>& GetAllTokens() const = 0;
         virtual const std::unordered_set<TTokenId>& GetKeywordTokens() const = 0;
         virtual const std::unordered_set<TTokenId>& GetPunctuationTokens() const = 0;
-        virtual ~ISqlGrammar() = default;
     };
 
     const ISqlGrammar& GetSqlGrammar();

--- a/yql/essentials/sql/v1/complete/syntax/grammar.h
+++ b/yql/essentials/sql/v1/complete/syntax/grammar.h
@@ -13,8 +13,7 @@
 #endif
 #include <yql/essentials/parser/antlr_ast/gen/v1_antlr4/SQLv1Antlr4Parser.h>
 
-#define RULE_(mode, name) NALA##mode##Antlr4::SQLv1Antlr4Parser::Rule##name
-#define RULE(name) RULE_(Default, name)
+#define RULE(name) NALADefaultAntlr4::SQLv1Antlr4Parser::Rule##name
 
 namespace NSQLComplete {
 

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -88,7 +88,9 @@ namespace NSQLComplete {
             if (auto enclosing = context.Enclosing()) {
                 if (enclosing->IsLiteral()) {
                     return result;
-                } else if (enclosing->Base->Name == "ID_QUOTED") {
+                }
+
+                if (enclosing->Base->Name == "ID_QUOTED") {
                     result.Object = ObjectMatch(context, candidates);
                     return result;
                 }

--- a/yql/essentials/sql/v1/complete/syntax/local.cpp
+++ b/yql/essentials/sql/v1/complete/syntax/local.cpp
@@ -49,7 +49,7 @@ namespace NSQLComplete {
             TDefaultYQLGrammar>;
 
     public:
-        explicit TSpecializedLocalSyntaxAnalysis(
+        TSpecializedLocalSyntaxAnalysis(
             TLexerSupplier lexer, const THashSet<TString>& IgnoredRules)
             : Grammar_(&GetSqlGrammar())
             , Lexer_(lexer(/* ansi = */ IsAnsiLexer))
@@ -324,7 +324,7 @@ namespace NSQLComplete {
 
     class TLocalSyntaxAnalysis: public ILocalSyntaxAnalysis {
     public:
-        explicit TLocalSyntaxAnalysis(
+        TLocalSyntaxAnalysis(
             TLexerSupplier lexer, const THashSet<TString>& IgnoredRules)
             : DefaultEngine_(lexer, IgnoredRules)
             , AnsiEngine_(lexer, IgnoredRules)

--- a/yql/essentials/sql/v1/complete/syntax/local.h
+++ b/yql/essentials/sql/v1/complete/syntax/local.h
@@ -62,8 +62,8 @@ namespace NSQLComplete {
     public:
         using TPtr = THolder<ILocalSyntaxAnalysis>;
 
-        virtual TLocalSyntaxContext Analyze(TCompletionInput input) = 0;
         virtual ~ILocalSyntaxAnalysis() = default;
+        virtual TLocalSyntaxContext Analyze(TCompletionInput input) = 0;
     };
 
     ILocalSyntaxAnalysis::TPtr MakeLocalSyntaxAnalysis(

--- a/yql/essentials/sql/v1/complete/ya.make
+++ b/yql/essentials/sql/v1/complete/ya.make
@@ -12,8 +12,6 @@ PEERDIR(
     yql/essentials/sql/v1/complete/syntax
     yql/essentials/sql/v1/complete/analysis/global
     yql/essentials/sql/v1/complete/text
-    # TODO(YQL-19747): add it to YDB CLI PEERDIR
-    yql/essentials/sql/v1/complete/name/service/static
 )
 
 END()


### PR DESCRIPTION
```bash
ya dump compile-commands > /tmp/cc/compile_commands.json
find . -type f \( -name "*.cpp" -o -name "*.h" \) -exec clang-tidy {} -p /tmp/cc {} -checks="misc-*" \;
```

---

- Related to `YQL-19747`
- Related to https://github.com/ydb-platform/ydb/issues/9056
