### PR TITLE
Re-enable Clang Tidy bugprone-use-after-move check

### DIFF
--- a/build/config/tests/clang_tidy/config.yaml
+++ b/build/config/tests/clang_tidy/config.yaml
@@ -2,14 +2,7 @@ Checks: >
   -*,
   arcadia-typeid-name-restriction,
   arcadia-ascii-compare-ignorecase,
-  # bugprone-use-after-move is disabled as it does not treat . as a synchornization point, as guaranteed by C++17
-  # See the discussion in
-  # https://github.com/llvm/llvm-project/issues/57758
-  # and
-  # https://stackoverflow.com/questions/73729536/is-clang-tidy-version-14-right-with-bugprone-use-after-move-error-on-this-co
-  #
-  # This check should be re-enabled, once the upstream issue is solved.
-  # bugprone-use-after-move,
+  bugprone-use-after-move,
   performance-implicit-conversion-in-loop,
   readability-identifier-naming,
 CheckOptions:


### PR DESCRIPTION
Seems that the issue https://github.com/llvm/llvm-project/issues/57758 is resolved.