### PR TITLE
yt/core/bus: fail connection if client TLS certificate is required but not provided

### DIFF
--- a/yt/yt/core/bus/tcp/connection.cpp
+++ b/yt/yt/core/bus/tcp/connection.cpp
@@ -1318,6 +1318,16 @@ bool TTcpConnection::OnHandshakePacketReceived()
                 << TErrorAttribute("mode", EncryptionMode_)
                 << TErrorAttribute("other_mode", otherEncryptionMode));
         } else {
+            if (ConnectionType_ == EConnectionType::Client &&
+                handshake.has_verification_mode() &&
+                handshake.verification_mode() != static_cast<int>(EVerificationMode::None) &&
+                !Config_->CertificateChain)
+            {
+                // Fail connection earlier to avoid wasting time on TLS handshake.
+                Abort(TError(NBus::EErrorCode::SslError, "Server requested TLS/SSL client certificate for connection"));
+                return true;
+            }
+
             EstablishSslSession_ = true;
             // Expect ssl ack from the other side.
             RemainingSslAckPacketBytes_ = GetSslAckPacketSize();
@@ -2029,6 +2039,14 @@ bool TTcpConnection::DoSslHandshake()
     switch (SSL_get_error(Ssl_.get(), result)) {
         case SSL_ERROR_NONE:
             YT_LOG_DEBUG("TLS/SSL connection has been established by SSL_do_handshake");
+            if (VerificationMode_ != EVerificationMode::None) {
+                NCrypto::TX509Ptr peerCertificate(SSL_get_peer_certificate(Ssl_.get()));
+                if (!peerCertificate) {
+                    Abort(TError(NBus::EErrorCode::SslError, "TLS/SSL peer certificate is not available"));
+                }
+                YT_LOG_DEBUG("TLS/SSL peer certificate (FingerprintSHA256: %v)",
+                    NCrypto::GetFingerprintSHA256(peerCertificate));
+            }
             MaxFragmentsPerWrite_ = 1;
             SslState_ = ESslState::Established;
             ReadyPromise_.TrySet();
@@ -2166,8 +2184,8 @@ void TTcpConnection::TryEstablishSslSession()
             }
             [[fallthrough]];
         case EVerificationMode::Ca: {
-            // Enable verification of the peer's certificate with the CA.
-            SSL_set_verify(Ssl_.get(), SSL_VERIFY_PEER, /*callback*/ nullptr);
+            // Request and verify peer certificate, terminate connection if certificate is not provided.
+            SSL_set_verify(Ssl_.get(), SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, /*callback*/ nullptr);
             break;
         }
         case EVerificationMode::None:

--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -19,6 +19,8 @@
 
 #include <library/cpp/openssl/io/stream.h>
 
+#include <util/string/hex.h>
+
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -88,6 +90,19 @@ void TSslDeleter::operator()(SSL_CTX* ctx) const noexcept
 void TSslDeleter::operator()(SSL* ssl) const noexcept
 {
     SSL_free(ssl);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TString GetFingerprintSHA256(const TX509Ptr& certificate)
+{
+    auto md_type = EVP_sha256();
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int md_len = 0;
+    if (!X509_digest(certificate.get(), md_type, md, &md_len)) {
+        THROW_ERROR GetLastSslError("X509_digest() failed");
+    }
+    return HexEncode(md, md_len);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/crypto/tls.h
+++ b/yt/yt/core/crypto/tls.h
@@ -35,6 +35,10 @@ using TSslPtr = std::unique_ptr<SSL, TSslDeleter>;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TString GetFingerprintSHA256(const TX509Ptr& certificate);
+
+////////////////////////////////////////////////////////////////////////////////
+
 DECLARE_REFCOUNTED_STRUCT(TSslContextImpl)
 
 using TCertificatePathResolver = std::function<TString(const TString&)>;


### PR DESCRIPTION
SSL flag "SSL_VERIFY_PEER" indeed requests and verifies client certificate.
But it does _nothing_ if client have not provided any TLS certificate.
Safe behaviour needs also flag "SSL_VERIFY_FAIL_IF_NO_PEER_CERT".

* fail client certificate verification without client certificate
* add additional check that certificate is available after TLS handshake
* log peer certificate fingerprint to track connectivity
* add early failure on client side to avoid wasting time on TLS handshake
* add test cases for mutual TLS certificate verification

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: fix
Component: misc-server

Fix mTLS in bus RPC
