### PR TITLE
Fix pool validation in strawberry

### DIFF
--- a/yt/chyt/controller/internal/api/api.go
+++ b/yt/chyt/controller/internal/api/api.go
@@ -211,7 +211,7 @@ func (a *API) validatePoolOption(ctx context.Context, poolValue any, poolTreesVa
 				fmt.Sprintf("pool_trees option has unexpected value type %v", typeName),
 				yterrors.Attr("type", typeName))
 		}
-		poolTrees = make([]string, len(poolTreeValues))
+		poolTrees = make([]string, 0, len(poolTreeValues))
 		for _, poolTreeValue := range poolTreeValues {
 			poolTree, ok := poolTreeValue.(string)
 			if !ok {


### PR DESCRIPTION

* Changelog entry
Type: fix
Component: strawberry

Fixed pool validation: due to incorrect slice init there was an empty value in the list of available pool trees

