### PR TITLE
strawberry/chyt: add options for mTLS

### DIFF
--- a/yt/chyt/controller/internal/chyt/configs.go
+++ b/yt/chyt/controller/internal/chyt/configs.go
@@ -420,6 +420,9 @@ func (c *Controller) appendConfigs(ctx context.Context, oplet *strawberry.Oplet,
 	if c.config.AddressResolver != nil {
 		ytServerClickHouseConfig["address_resolver"] = c.config.AddressResolver
 	}
+	if c.config.BusServer != nil {
+		ytServerClickHouseConfig["bus_server"] = c.config.BusServer
+	}
 	ytServerClickHouseConfigPath, err := c.uploadConfig(ctx, oplet.Alias(), "config.yson", ytServerClickHouseConfig)
 	if err != nil {
 		return err

--- a/yt/chyt/controller/internal/chyt/controller.go
+++ b/yt/chyt/controller/internal/chyt/controller.go
@@ -30,6 +30,7 @@ type Config struct {
 	LocalBinariesDir          *string              `yson:"local_binaries_dir"`
 	LogRotationMode           *LogRotationModeType `yson:"log_rotation_mode"`
 	AddressResolver           map[string]any       `yson:"address_resolver"`
+	BusServer                 map[string]any       `yson:"bus_server"`
 	EnableYandexSpecificLinks *bool                `yson:"enable_yandex_specific_links"`
 	ExportSystemLogTables     *bool                `yson:"export_system_log_tables"`
 	EnableGeodata             *bool                `yson:"enable_geodata"`

--- a/yt/chyt/controller/internal/chyt/controller.go
+++ b/yt/chyt/controller/internal/chyt/controller.go
@@ -34,6 +34,7 @@ type Config struct {
 	ExportSystemLogTables     *bool                `yson:"export_system_log_tables"`
 	EnableGeodata             *bool                `yson:"enable_geodata"`
 	EnableRuntimeData         *bool                `yson:"enable_runtime_data"`
+	SecureVaultFiles          map[string]string    `yson:"secure_vault_files"`
 }
 
 const (
@@ -230,9 +231,15 @@ func (c *Controller) Prepare(ctx context.Context, oplet *strawberry.Oplet) (
 	}
 
 	if c.tvmSecret != "" {
-		spec["secure_vault"] = map[string]any{
-			"TVM_SECRET": c.tvmSecret,
+		oplet.SetSecret("TVM_SECRET", c.tvmSecret)
+	}
+
+	for secret, name := range c.config.SecureVaultFiles {
+		var value []byte
+		if value, err = os.ReadFile(name); err != nil {
+			return
 		}
+		oplet.SetSecret(secret, value)
 	}
 
 	// Prepare runtime stuff if need: stderr/core-table, etc.

--- a/yt/chyt/controller/internal/strawberry/oplet.go
+++ b/yt/chyt/controller/internal/strawberry/oplet.go
@@ -266,6 +266,13 @@ func (oplet *Oplet) Secrets() map[string]any {
 	return oplet.secrets
 }
 
+func (oplet *Oplet) SetSecret(secret string, value any) {
+	if oplet.secrets == nil {
+		oplet.secrets = make(map[string]any)
+	}
+	oplet.secrets[secret] = value
+}
+
 type OpletState string
 
 const (


### PR DESCRIPTION
- strawberry/chyt: add opiton to pass secrets into secure vault
  "secure_vault_files" = {
      "secret_name" = "file_path";
  }
  
  add into operation spec:
  
  "secure_fault" = {
      "secret_name" = "file_content";
  }
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- strawberry/chyt: add option to pass bus_server config
  Required for BUS server mTLS setup.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
---

* Changelog entry
Type: feature
Component: strawberry

mTLS support
