### PR TITLE
mTLS: use cluster connection bus config for discovery connections

### DIFF
--- a/yt/chyt/server/host.cpp
+++ b/yt/chyt/server/host.cpp
@@ -733,7 +733,7 @@ private:
         NApi::NNative::TConnectionOptions connectionOptions;
         connectionOptions.RetryRequestQueueSizeLimitExceeded = true;
 
-        ChannelFactory_ = CreateCachingChannelFactory(CreateTcpBusChannelFactory(New<NBus::TBusConfig>()));
+        ChannelFactory_ = CreateCachingChannelFactory(CreateTcpBusChannelFactory(ConnectionConfig_->Dynamic->BusClient));
 
         Connection_ = NApi::NNative::CreateConnection(
             ConnectionConfig_,

--- a/yt/chyt/tests/server/base.py
+++ b/yt/chyt/tests/server/base.py
@@ -828,6 +828,8 @@ class ClickHouseTestBase(YTEnvSetup):
         Clique.base_config["clickhouse"] = Clique.base_config["engine"]
         del Clique.base_config["engine"]
         Clique.base_config["cluster_connection"] = copy.deepcopy(cls.Env.configs["driver"])
+        if "bus_server" in cls.Env.configs["node"][0]:
+            Clique.base_config["bus_server"] = copy.deepcopy(cls.Env.configs["node"][0]["bus_server"])
         if "tvm_service" in Clique.base_config["cluster_connection"]:
             Clique.base_config["native_authentication_manager"] = {
                 "tvm_service": Clique.base_config["cluster_connection"].pop("tvm_service"),

--- a/yt/yt/server/http_proxy/clickhouse/handler.cpp
+++ b/yt/yt/server/http_proxy/clickhouse/handler.cpp
@@ -119,7 +119,7 @@ public:
         , IsLegacyQueryHandler_(!bootstrap->IsChytApiServerAddress(req->GetRemoteAddress()) && req->GetUrl().Path.StartsWith("/query"))
         , AllowGetRequests_(!IsLegacyQueryHandler_) // In case of the non-legacy handler GET-requests are allowed by default.
         , Handler_(handler)
-        , ChannelFactory_(CreateTcpBusChannelFactory(New<NBus::TBusConfig>()))
+        , ChannelFactory_(CreateTcpBusChannelFactory(Bootstrap_->GetConfig()->ClusterConnection->Dynamic->BusClient))
     {
         if (auto* traceParent = req->GetHeaders()->Find("traceparent")) {
             YT_LOG_INFO("Request contains traceparent header (Traceparent: %v)", traceParent);

--- a/yt/yt/server/query_tracker/chyt_engine.cpp
+++ b/yt/yt/server/query_tracker/chyt_engine.cpp
@@ -400,11 +400,11 @@ class TChytEngine
     : public IQueryEngine
 {
 public:
-    TChytEngine(IClientPtr stateClient, TYPath stateRoot)
+    TChytEngine(NNative::IClientPtr stateClient, TYPath stateRoot)
         : StateClient_(std::move(stateClient))
         , StateRoot_(std::move(stateRoot))
         , ControlQueue_(New<TActionQueue>("MockEngineControl"))
-        , ClusterDirectory_(DynamicPointerCast<NNative::IConnection>(StateClient_->GetConnection())->GetClusterDirectory())
+        , ClusterDirectory_(StateClient_->GetNativeConnection()->GetClusterDirectory())
         , ChannelFactory_(CreateCachingChannelFactory(CreateTcpBusChannelFactory(New<NYT::NBus::TBusConfig>())))
     { }
 
@@ -419,7 +419,7 @@ public:
     }
 
 private:
-    const IClientPtr StateClient_;
+    const NNative::IClientPtr StateClient_;
     const TYPath StateRoot_;
     const TActionQueuePtr ControlQueue_;
     TChytEngineConfigPtr ChytConfig_;
@@ -429,7 +429,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IQueryEnginePtr CreateChytEngine(const IClientPtr& stateClient, const TYPath& stateRoot)
+IQueryEnginePtr CreateChytEngine(const NNative::IClientPtr& stateClient, const TYPath& stateRoot)
 {
     return New<TChytEngine>(stateClient, stateRoot);
 }

--- a/yt/yt/server/query_tracker/chyt_engine.cpp
+++ b/yt/yt/server/query_tracker/chyt_engine.cpp
@@ -15,6 +15,7 @@
 #include <yt/yt/library/clickhouse_discovery/helpers.h>
 
 #include <yt/yt/ytlib/api/native/client.h>
+#include <yt/yt/ytlib/api/native/config.h>
 
 #include <yt/yt/ytlib/hive/cluster_directory.h>
 
@@ -405,7 +406,8 @@ public:
         , StateRoot_(std::move(stateRoot))
         , ControlQueue_(New<TActionQueue>("MockEngineControl"))
         , ClusterDirectory_(StateClient_->GetNativeConnection()->GetClusterDirectory())
-        , ChannelFactory_(CreateCachingChannelFactory(CreateTcpBusChannelFactory(New<NYT::NBus::TBusConfig>())))
+        , ChannelFactory_(CreateCachingChannelFactory(CreateTcpBusChannelFactory(
+            StateClient_->GetNativeConnection()->GetConfig()->BusClient)))
     { }
 
     IQueryHandlerPtr StartOrAttachQuery(NRecords::TActiveQuery activeQuery) override

--- a/yt/yt/server/query_tracker/chyt_engine.h
+++ b/yt/yt/server/query_tracker/chyt_engine.h
@@ -2,7 +2,7 @@
 
 #include "private.h"
 
-#include <yt/yt/client/api/public.h>
+#include <yt/yt/ytlib/api/native/public.h>
 
 #include <yt/yt/core/ypath/public.h>
 
@@ -10,7 +10,7 @@ namespace NYT::NQueryTracker {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-IQueryEnginePtr CreateChytEngine(const NApi::IClientPtr& stateClient, const NYPath::TYPath& stateRoot);
+IQueryEnginePtr CreateChytEngine(const NApi::NNative::IClientPtr& stateClient, const NYPath::TYPath& stateRoot);
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
- yt/chyt/tests: copy bus server tls config from node
- yt/http_proxy: use cluster connection bus client config for discovery client
- yt/query_tracker: pass native client to ChytEngine constructor
- yt/query_tracker: use cluster connection bus client config for discovery client
- yt/chyt: use cluster connection bus client config for discovery client
  
---

* Changelog entry
Type: fix
Component: discovery client

Use cluster connection bus client config for discovery client connections
