### PR TITLE
mTLS: job proxy connectivity

### DIFF
--- a/yt/yt/server/lib/exec_node/config.cpp
+++ b/yt/yt/server/lib/exec_node/config.cpp
@@ -768,6 +768,9 @@ void TJobProxyConfig::Register(TRegistrar registrar)
     registrar.Parameter("core_watcher", &TThis::CoreWatcher)
         .DefaultNew();
 
+    registrar.Parameter("supervisor_connection", &TThis::SupervisorConnection)
+        .Default();
+
     registrar.Parameter("supervisor_rpc_timeout", &TThis::SupervisorRpcTimeout)
         .Default(TDuration::Seconds(30));
 

--- a/yt/yt/server/lib/exec_node/config.cpp
+++ b/yt/yt/server/lib/exec_node/config.cpp
@@ -768,6 +768,9 @@ void TJobProxyConfig::Register(TRegistrar registrar)
     registrar.Parameter("core_watcher", &TThis::CoreWatcher)
         .DefaultNew();
 
+    registrar.Parameter("cluster_connection", &TThis::ClusterConnection)
+        .Default();
+
     registrar.Parameter("supervisor_connection", &TThis::SupervisorConnection)
         .Default();
 

--- a/yt/yt/server/lib/exec_node/config.h
+++ b/yt/yt/server/lib/exec_node/config.h
@@ -682,6 +682,8 @@ struct TJobProxyConfig
 
     NJobProxy::TCoreWatcherConfigPtr CoreWatcher;
 
+    NBus::TBusClientConfigPtr SupervisorConnection;
+
     TDuration SupervisorRpcTimeout;
 
     TDuration JobProxyHeartbeatPeriod;

--- a/yt/yt/server/lib/exec_node/config.h
+++ b/yt/yt/server/lib/exec_node/config.h
@@ -682,6 +682,8 @@ struct TJobProxyConfig
 
     NJobProxy::TCoreWatcherConfigPtr CoreWatcher;
 
+    NApi::NNative::TConnectionCompoundConfigPtr ClusterConnection;
+
     NBus::TBusClientConfigPtr SupervisorConnection;
 
     TDuration SupervisorRpcTimeout;

--- a/yt/yt/server/node/exec_node/bootstrap.cpp
+++ b/yt/yt/server/node/exec_node/bootstrap.cpp
@@ -520,8 +520,12 @@ private:
 
         newJobProxyConfigTemplate->AuthenticationManager = GetConfig()->ExecNode->JobProxy->JobProxyAuthenticationManager;
 
-        newJobProxyConfigTemplate->SupervisorConnection = New<NYT::NBus::TBusClientConfig>();
-        newJobProxyConfigTemplate->SupervisorConnection->Address = localAddress;
+        if (const auto& supervisorConnection = GetConfig()->ExecNode->JobProxy->SupervisorConnection) {
+            newJobProxyConfigTemplate->SupervisorConnection = CloneYsonStruct(supervisorConnection);
+        } else {
+            newJobProxyConfigTemplate->SupervisorConnection = New<NYT::NBus::TBusClientConfig>();
+            newJobProxyConfigTemplate->SupervisorConnection->Address = localAddress;
+        }
 
         newJobProxyConfigTemplate->SupervisorRpcTimeout = GetConfig()->ExecNode->JobProxy->SupervisorRpcTimeout;
 

--- a/yt/yt/server/node/exec_node/bootstrap.cpp
+++ b/yt/yt/server/node/exec_node/bootstrap.cpp
@@ -496,7 +496,11 @@ private:
         newJobProxyConfigTemplate->SetSingletonConfig(GetConfig()->ExecNode->JobProxy->JobProxyLogging->LogManagerTemplate);
         newJobProxyConfigTemplate->SetSingletonConfig(GetConfig()->ExecNode->JobProxy->JobProxyJaeger);
 
-        newJobProxyConfigTemplate->OriginalClusterConnection = GetConfig()->ClusterConnection->Clone();
+        if (const auto& clusterConnection = GetConfig()->ExecNode->JobProxy->ClusterConnection) {
+            newJobProxyConfigTemplate->OriginalClusterConnection = clusterConnection->Clone();
+        } else {
+            newJobProxyConfigTemplate->OriginalClusterConnection = GetConfig()->ClusterConnection->Clone();
+        }
 
         // We could probably replace addresses for known cells here as well, but
         // changing addresses of a known cell is cursed anyway, so I'm not

--- a/yt/yt/tests/integration/node/test_job_proxy.py
+++ b/yt/yt/tests/integration/node/test_job_proxy.py
@@ -606,3 +606,20 @@ class TestJobProxySignatures(YTEnvSetup):
         new_config["validation"]["cypress_key_reader"]["path"] = new_path
         update_nodes_dynamic_config(path="exec_node/signature_components", value=new_config)
         wait(lambda: ls(new_path))
+
+
+@authors("khlebnikov")
+class TestJobProxyTls(YTEnvSetup):
+    NUM_MASTERS = 1
+    NUM_NODES = 1
+    NUM_SCHEDULERS = 1
+
+    ENABLE_TLS = True
+
+    def test_smoke(self):
+        run_test_vanilla("true", track=True)
+
+
+@authors("khlebnikov")
+class TestJobProxyTlsCri(TestJobProxyTls):
+    JOB_ENVIRONMENT_TYPE = "cri"


### PR DESCRIPTION
- Add job-proxy supervisor connection into exec node config
  Job proxy needs client certificate for connection with exec node.
    
- Add separate job proxy cluster connection config
  Job proxy need special configuration for TLS certificates.
    
- Add job-proxy test with TLS

---

* Changelog entry
Type: feature
Component: map-reduce

Support mTLS for job proxy connectivity