### PR TITLE
yt/environment: enable mutual TLS for cluster connection

### DIFF
--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -79,6 +79,8 @@ class LocalYtConfig(object):
     ca_cert_key = attr.ib(None)
     rpc_cert = attr.ib(None)
     rpc_cert_key = attr.ib(None)
+    rpc_client_cert = attr.ib(None)
+    rpc_client_cert_key = attr.ib(None)
     https_cert = attr.ib(None)
     https_cert_key = attr.ib(None)
 

--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -446,6 +446,8 @@ def _build_master_configs(yt_config,
 
             config["cluster_connection"] = cluster_connection_config
 
+            config["bus_client"] = _build_native_bus_config(yt_config)
+
             multidaemon_config_output["daemons"][f"master_{cell_index}_{master_index}"] = {
                 "type": "master",
                 "config": config,
@@ -521,6 +523,8 @@ def _build_clock_configs(yt_config, multidaemon_config_output, clock_dirs, clock
 
         config["rpc_port"], config["monitoring_port"] = ports[clock_index]
 
+        config["bus_client"] = _build_native_bus_config(yt_config)
+
         config["clock_cell"] = connection_config
 
         # COMPAT(aleksandra-zh)
@@ -583,6 +587,8 @@ def _build_discovery_server_configs(yt_config, multidaemon_config_output, ports_
 
         config["rpc_port"], config["monitoring_port"] = ports[index]
 
+        config["bus_client"] = _build_native_bus_config(yt_config)
+
         multidaemon_config_output["daemons"][f"discovery_{index}"] = {
             "type": "discovery_server",
             "config": config,
@@ -633,6 +639,8 @@ def _build_queue_agent_configs(multidaemon_config_output,
 
         config["rpc_port"] = rpc_ports[index]
         config["monitoring_port"] = next(ports_generator)
+
+        config["bus_client"] = _build_native_bus_config(yt_config)
 
         set_at(config, "queue_agent/stage", "production")
 
@@ -734,6 +742,8 @@ def _build_timestamp_provider_configs(yt_config,
 
         config["rpc_port"] = next(ports_generator)
         config["monitoring_port"] = next(ports_generator)
+
+        config["bus_client"] = _build_native_bus_config(yt_config)
 
         multidaemon_config_output["daemons"][f"timestamp_provider_{index}"] = {
             "type": "timestamp_provider",
@@ -1060,13 +1070,22 @@ def _build_node_configs(multidaemon_config_output,
             # Forward variables set in docker image into user job environment.
             set_at(config, "exec_node/job_proxy/forward_all_environment_variables", True)
 
-            # Job proxy needs CA certificate to validate incoming connections.
-            if yt_config.ca_cert is not None:
-                get_at(config, "exec_node/slot_manager/job_environment/job_proxy_bind_mounts").append({
-                    "internal_path": yt_config.ca_cert,
-                    "external_path": yt_config.ca_cert,
-                    "read_only": True,
-                })
+            # Job proxy needs TLS certificates for bus connections in both directions.
+            bus_certs = [
+                yt_config.ca_cert,
+                yt_config.rpc_cert,
+                yt_config.rpc_cert_key,
+                yt_config.rpc_client_cert,
+                yt_config.rpc_client_cert_key,
+            ]
+
+            for cert in bus_certs:
+                if cert is not None:
+                    get_at(config, "exec_node/slot_manager/job_environment/job_proxy_bind_mounts").append({
+                        "internal_path": cert,
+                        "external_path": cert,
+                        "read_only": True,
+                    })
 
         if yt_config.use_slot_user_id:
             start_uid = 10000 + config["rpc_port"]
@@ -1607,6 +1626,29 @@ def _build_rpc_proxy_configs(multidaemon_config_output,
     return configs
 
 
+def _build_native_bus_config(yt_config, is_server=False):
+    if not yt_config.enable_tls:
+        return {
+            "encryption_mode": "disabled",
+            "verification_mode": "none",
+        }
+
+    return {
+        "ca": {
+            "file_name": yt_config.ca_cert,
+        },
+        "cert_chain": {
+            "file_name": yt_config.rpc_cert if is_server else yt_config.rpc_client_cert,
+        },
+        "private_key": {
+            "file_name": yt_config.rpc_cert_key if is_server else yt_config.rpc_client_cert_key,
+        },
+        "encryption_mode": "required",
+        "verification_mode": "full",
+        "peer_alternative_host_name": yt_config.cluster_name,
+    }
+
+
 def _build_cluster_connection_config(yt_config,
                                      master_connection_configs,
                                      clock_connection_config,
@@ -1801,15 +1843,8 @@ def _build_cluster_connection_config(yt_config,
             "refresh_time": 0
         }
 
-    if yt_config.ca_cert is not None:
-        set_at(cluster_connection, "bus_client", {
-            "ca": {
-                "file_name": yt_config.ca_cert,
-            },
-            "encryption_mode": "required",
-            "verification_mode": "full",
-            "peer_alternative_host_name": yt_config.cluster_name,
-        })
+
+    set_at(cluster_connection, "bus_client", _build_native_bus_config(yt_config))
 
     if yt_config.delta_global_cluster_connection_config:
         cluster_connection = update(cluster_connection, yt_config.delta_global_cluster_connection_config)
@@ -2185,16 +2220,7 @@ def init_singletons(config, yt_config):
             },
             "enable_validation": True,
         })
-    if yt_config.rpc_cert is not None:
-        set_at(config, "bus_server", {
-            "encryption_mode": "optional",
-            "cert_chain": {
-                "file_name": yt_config.rpc_cert,
-            },
-            "private_key": {
-                "file_name": yt_config.rpc_cert_key,
-            },
-        })
+    set_at(config, "bus_server", _build_native_bus_config(yt_config, is_server=True))
 
 
 def init_jaeger_collector(config, name, process_tags):

--- a/yt/python/yt/environment/yt_env.py
+++ b/yt/python/yt/environment/yt_env.py
@@ -430,7 +430,19 @@ class YTInstance(object):
                 ca_cert_key=self.yt_config.ca_cert_key,
                 cert=self.yt_config.rpc_cert,
                 cert_key=self.yt_config.rpc_cert_key,
-                names=names
+                names=names,
+            )
+
+        if self.yt_config.rpc_client_cert is None:
+            self.yt_config.rpc_client_cert = os.path.join(self.path, "rpc_client.crt")
+            self.yt_config.rpc_client_cert_key = os.path.join(self.path, "rpc_client.key")
+            create_certificate(
+                ca_cert=self.yt_config.ca_cert,
+                ca_cert_key=self.yt_config.ca_cert_key,
+                cert=self.yt_config.rpc_client_cert,
+                cert_key=self.yt_config.rpc_client_cert_key,
+                names=names,
+                extended_key_usage="clientAuth",
             )
 
         if self.yt_config.https_cert is None and self.yt_config.http_proxy_count > 0:

--- a/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
+++ b/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
@@ -64,6 +64,7 @@ ENDIF()
 DEPENDS(
     yt/yt/packages/tests_package
     yt/yt/tools/yt_sudo_fixup
+    contrib/libs/openssl/apps
 )
 
 IF (NOT OPENSOURCE)

--- a/yt/yt/tests/integration/YaMakeDependsBoilerplate.txt
+++ b/yt/yt/tests/integration/YaMakeDependsBoilerplate.txt
@@ -14,7 +14,6 @@ DEPENDS(
 #proxies
 DEPENDS(
     yt/yt/tests/integration/fake_blackbox
-    contrib/libs/openssl/apps
 )
 
 IF (NOT OPENSOURCE)

--- a/yt/yt/tests/library/yt_env_setup.py
+++ b/yt/yt/tests/library/yt_env_setup.py
@@ -325,7 +325,7 @@ class YTEnvSetup(object):
     ENABLE_STATIC_DROP_COLUMN = True
     ENABLE_DYNAMIC_DROP_COLUMN = True
     ENABLE_ALLOW_SECONDARY_INDICES = True
-    ENABLE_TLS = False
+    ENABLE_TLS = None
 
     JOB_PROXY_LOGGING = {"mode": "per_job_directory"}
 
@@ -603,6 +603,10 @@ class YTEnvSetup(object):
         if os.environ.get("YT_DISABLE_MULTIDAEMON"):
             enable_multidaemon = False
 
+        enable_tls = cls.ENABLE_TLS
+        if enable_tls is None:
+            enable_tls = bool(os.environ.get("YT_ENABLE_TLS"))
+
         job_proxy_logging = cls.get_param("JOB_PROXY_LOGGING", index)
         # COMPAT(pogorelov): drop after migrating compat tests in 25.1
         if "node" in cls.ARTIFACT_COMPONENTS.get("24_2", []):
@@ -693,7 +697,7 @@ class YTEnvSetup(object):
             enable_resource_tracking=cls.get_param("ENABLE_RESOURCE_TRACKING", index),
             enable_tvm_only_proxies=cls.get_param("ENABLE_TVM_ONLY_PROXIES", index),
             mock_tvm_id=(1000 + index if use_native_auth else None),
-            enable_tls=cls.ENABLE_TLS,
+            enable_tls=enable_tls,
             enable_legacy_logging_scheme=enable_legacy_logging_scheme,
             wait_for_dynamic_config=cls.WAIT_FOR_DYNAMIC_CONFIG,
             enable_chyt_http_proxies=cls.get_param("ENABLE_CHYT_HTTP_PROXIES", index),


### PR DESCRIPTION
Mutual TLS is a simple way to secure internal RPC.
Environment "YT_ENABLE_TLS=1" activates TLS in all integration tests.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>