### PR TITLE
operation_id should be optional in get_job

### DIFF
--- a/yt/yt/client/driver/scheduler_commands.cpp
+++ b/yt/yt/client/driver/scheduler_commands.cpp
@@ -164,6 +164,11 @@ bool TGetJobStderrCommand::HasResponseParameters() const
     return true;
 }
 
+NScheduler::TJobId TGetJobStderrCommand::GetJobId() const
+{
+    return JobId;
+}
+
 void TGetJobStderrCommand::DoExecute(ICommandContextPtr context)
 {
     auto result = WaitFor(context->GetClient()->GetJobStderr(OperationIdOrAlias, JobId, Options))
@@ -240,6 +245,11 @@ void TGetJobFailContextCommand::DoExecute(ICommandContextPtr context)
     auto output = context->Request().OutputStream;
     WaitFor(output->Write(result))
         .ThrowOnError();
+}
+
+NScheduler::TJobId TGetJobFailContextCommand::GetJobId() const
+{
+    return JobId;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -681,6 +691,11 @@ void TGetJobCommand::DoExecute(ICommandContextPtr context)
         .ValueOrThrow();
 
     context->ProduceOutputValue(result);
+}
+
+NScheduler::TJobId TGetJobCommand::GetJobId() const
+{
+    return JobId;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/driver/scheduler_commands.h
+++ b/yt/yt/client/driver/scheduler_commands.h
@@ -30,7 +30,7 @@ public:
         registrar.Postprocessor([] (TThis* command) {
             auto operationId = command->OperationId;
             if (operationId && command->OperationAlias.has_value() ||
-                !operationId && !command->OperationAlias.has_value())
+                !operationId && !command->OperationAlias.has_value() && !command->GetJobId())
             {
                 THROW_ERROR_EXCEPTION("Exactly one of \"operation_id\" and \"operation_alias\" should be set")
                     << TErrorAttribute("operation_id", command->OperationId)
@@ -39,7 +39,7 @@ public:
 
             if (command->OperationId) {
                 command->OperationIdOrAlias = command->OperationId;
-            } else {
+            } else if (command->OperationAlias) {
                 command->OperationIdOrAlias = *command->OperationAlias;
             }
         });
@@ -48,6 +48,10 @@ public:
 protected:
     // Is calculated by OperationId and OperationAlias.
     NScheduler::TOperationIdOrAlias OperationIdOrAlias;
+
+    virtual NScheduler::TJobId GetJobId() const {
+        return {};
+    }
 
 private:
     NScheduler::TOperationId OperationId;
@@ -134,6 +138,7 @@ private:
 
     void DoExecute(ICommandContextPtr context) override;
     bool HasResponseParameters() const override;
+    NScheduler::TJobId GetJobId() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -164,6 +169,7 @@ private:
     NJobTrackerClient::TJobId JobId;
 
     void DoExecute(ICommandContextPtr context) override;
+    NScheduler::TJobId GetJobId() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -226,6 +232,7 @@ private:
     NJobTrackerClient::TJobId JobId;
 
     void DoExecute(ICommandContextPtr context) override;
+    NScheduler::TJobId GetJobId() const override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/scheduler/operation_id_or_alias-inl.h
+++ b/yt/yt/client/scheduler/operation_id_or_alias-inl.h
@@ -33,7 +33,8 @@ void FromProto(TOperationIdOrAlias* operationIdOrAlias, const TProtoClass& enclo
             break;
         }
         case TProtoClass::OperationIdOrAliasCase::OPERATION_ID_OR_ALIAS_NOT_SET: {
-            THROW_ERROR_EXCEPTION("None of operation id and operation alias is set in oneof OperationIdOrAlias proto");
+            operationIdOrAlias->Payload = {};
+            break;
         }
     }
 }
@@ -45,7 +46,9 @@ void ToProto(TProtoClassPtr enclosingProtoMessage, const TOperationIdOrAlias& op
 
     Visit(operationIdOrAlias.Payload,
         [&] (const TOperationId& operationId) {
-            ToProto(enclosingProtoMessage->mutable_operation_id(), operationId);
+            if (operationId) {
+                ToProto(enclosingProtoMessage->mutable_operation_id(), operationId);
+            }
         },
         [&] (const TString& alias) {
             enclosingProtoMessage->set_operation_alias(alias);

--- a/yt/yt/tests/integration/scheduler/test_get_job.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job.py
@@ -18,7 +18,7 @@ from yt_operations_archive_helpers import (
 
 import yt.environment.init_operations_archive as init_operations_archive
 
-from yt.common import date_string_to_datetime, uuid_to_parts, parts_to_uuid, update, date_string_to_timestamp_mcs
+from yt.common import date_string_to_datetime, uuid_to_parts, parts_to_uuid, update, date_string_to_timestamp_mcs, YtError
 
 from flaky import flaky
 
@@ -164,6 +164,7 @@ class _TestGetJobCommon(_TestGetJobBase):
 
         self._check_get_job(op.id, job_id, before_start_time, state="running", has_spec=None,
                             pool="my_pool", pool_tree="default")
+        assert get_job(None, job_id)["operation_id"] == op.id
 
         @wait_no_assert
         def correct_stderr_size():
@@ -175,6 +176,8 @@ class _TestGetJobCommon(_TestGetJobBase):
 
         self._check_get_job(op.id, job_id, before_start_time, state="failed", has_spec=True,
                             pool="my_pool", pool_tree="default")
+        with pytest.raises(YtError, match="Allocation .* not found"):
+            assert get_job(None, job_id)
 
         job_info = retry(lambda: get_job(op.id, job_id))
         assert job_info["fail_context_size"] > 0

--- a/yt/yt/tests/integration/scheduler/test_get_job.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job.py
@@ -176,14 +176,13 @@ class _TestGetJobCommon(_TestGetJobBase):
 
         self._check_get_job(op.id, job_id, before_start_time, state="failed", has_spec=True,
                             pool="my_pool", pool_tree="default")
-        with pytest.raises(YtError, match="Allocation .* not found"):
-            assert get_job(None, job_id)
 
         job_info = retry(lambda: get_job(op.id, job_id))
         assert job_info["fail_context_size"] > 0
         events = job_info["events"]
         assert len(events) > 0
         assert all(field in events[0] for field in ["phase", "state", "time"])
+        assert retry(lambda: get_job(None, job_id))["operation_id"] == op.id
 
         delete_job_from_archive(op.id, job_id)
 

--- a/yt/yt/tests/integration/scheduler/test_get_job.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job.py
@@ -18,7 +18,7 @@ from yt_operations_archive_helpers import (
 
 import yt.environment.init_operations_archive as init_operations_archive
 
-from yt.common import date_string_to_datetime, uuid_to_parts, parts_to_uuid, update, date_string_to_timestamp_mcs, YtError
+from yt.common import date_string_to_datetime, uuid_to_parts, parts_to_uuid, update, date_string_to_timestamp_mcs
 
 from flaky import flaky
 

--- a/yt/yt/tests/integration/scheduler/test_get_job_artifacts.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job_artifacts.py
@@ -6,7 +6,7 @@ from yt_commands import (
     set, remove, exists, create_tmpdir, create_user, make_ace, insert_rows, select_rows, lookup_rows,
     read_table, write_table, map, reduce, map_reduce,
     sort, list_jobs, get_job_input,
-    get_job_stderr, get_job_stderr_paged, get_job_spec, get_job_input_paths,
+    get_job, get_job_stderr, get_job_stderr_paged, get_job_spec, get_job_input_paths,
     clean_operations, sync_create_cells, update_op_parameters, raises_yt_error,
     gc_collect, run_test_vanilla, wait_no_assert)
 
@@ -645,10 +645,13 @@ class TestGetJobStderr(YTEnvSetup):
         job_id = wait_breakpoint()[0]
 
         wait(lambda: retry(lambda: get_job_stderr(op.id, job_id)) == b"STDERR-OUTPUT\n")
+        assert get_job_stderr(None, job_id) == b"STDERR-OUTPUT\n"
         release_breakpoint()
         op.track()
         res = get_job_stderr(op.id, job_id)
         assert res == b"STDERR-OUTPUT\n"
+        with pytest.raises(YtError, match="Allocation .* not found"):
+            get_job_stderr(None, job_id)
 
         clean_operations()
 

--- a/yt/yt/tests/integration/scheduler/test_get_job_artifacts.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job_artifacts.py
@@ -650,12 +650,11 @@ class TestGetJobStderr(YTEnvSetup):
         op.track()
         res = get_job_stderr(op.id, job_id)
         assert res == b"STDERR-OUTPUT\n"
-        with pytest.raises(YtError, match="Allocation .* not found"):
-            get_job_stderr(None, job_id)
 
         clean_operations()
 
         wait(lambda: get_job_stderr(op.id, job_id) == b"STDERR-OUTPUT\n")
+        wait(lambda: get_job_stderr(None, job_id) == b"STDERR-OUTPUT\n")
 
     @authors("ignat")
     def test_get_job_stderr(self):

--- a/yt/yt/tests/integration/scheduler/test_get_job_artifacts.py
+++ b/yt/yt/tests/integration/scheduler/test_get_job_artifacts.py
@@ -6,7 +6,7 @@ from yt_commands import (
     set, remove, exists, create_tmpdir, create_user, make_ace, insert_rows, select_rows, lookup_rows,
     read_table, write_table, map, reduce, map_reduce,
     sort, list_jobs, get_job_input,
-    get_job, get_job_stderr, get_job_stderr_paged, get_job_spec, get_job_input_paths,
+    get_job_stderr, get_job_stderr_paged, get_job_spec, get_job_input_paths,
     clean_operations, sync_create_cells, update_op_parameters, raises_yt_error,
     gc_collect, run_test_vanilla, wait_no_assert)
 

--- a/yt/yt/tests/integration/scheduler/test_scheduler_common.py
+++ b/yt/yt/tests/integration/scheduler/test_scheduler_common.py
@@ -17,7 +17,7 @@ from yt_commands import (
     raises_yt_error, update_scheduler_config, update_controller_agent_config,
     assert_statistics, sorted_dicts,
     set_node_banned, disable_scheduler_jobs_on_node, enable_scheduler_jobs_on_node,
-    update_nodes_dynamic_config)
+    sync_create_cells, update_nodes_dynamic_config)
 
 import yt_error_codes
 
@@ -79,14 +79,6 @@ class TestSchedulerCommon(YTEnvSetup):
         }
     }
     USE_PORTO = False
-
-    def setup_method(self, method):
-        super(TestSchedulerCommon, self).setup_method(method)
-        sync_create_cells(1)
-        init_operations_archive.create_tables_latest_version(
-            self.Env.create_native_client(),
-            override_tablet_cell_bundle="default",
-        )
 
     @authors("ignat")
     def test_failed_jobs_twice(self):
@@ -199,6 +191,12 @@ class TestSchedulerCommon(YTEnvSetup):
 
     @authors("ignat")
     def test_fail_context(self):
+        sync_create_cells(1)
+        init_operations_archive.create_tables_latest_version(
+            self.Env.create_native_client(),
+            override_tablet_cell_bundle="default",
+        )
+
         create("table", "//tmp/t1")
         create("table", "//tmp/t2")
         write_table("//tmp/t1", {"foo": "bar"})

--- a/yt/yt/tests/library/yt_commands.py
+++ b/yt/yt/tests/library/yt_commands.py
@@ -624,7 +624,8 @@ def partition_tables(paths, **kwargs):
 
 
 def get_job_stderr(operation_id, job_id, **kwargs):
-    kwargs["operation_id"] = operation_id
+    if operation_id:
+        kwargs["operation_id"] = operation_id
     kwargs["job_id"] = job_id
     return execute_command("get_job_stderr", kwargs)
 
@@ -635,7 +636,8 @@ def get_job_trace(operation_id, **kwargs):
 
 
 def get_job_stderr_paged(operation_id, job_id, **kwargs):
-    kwargs["operation_id"] = operation_id
+    if operation_id:
+        kwargs["operation_id"] = operation_id
     kwargs["job_id"] = job_id
     output_stream = BytesIO()
     rsp = execute_command("get_job_stderr", kwargs, return_response=True, output_stream=output_stream)
@@ -646,7 +648,8 @@ def get_job_stderr_paged(operation_id, job_id, **kwargs):
 
 
 def get_job_fail_context(operation_id, job_id, **kwargs):
-    kwargs["operation_id"] = operation_id
+    if operation_id:
+        kwargs["operation_id"] = operation_id
     kwargs["job_id"] = job_id
     return execute_command("get_job_fail_context", kwargs)
 
@@ -744,7 +747,8 @@ def get(path, is_raw=False, **kwargs):
 
 
 def get_job(operation_id, job_id, **kwargs):
-    kwargs["operation_id"] = operation_id
+    if operation_id:
+        kwargs["operation_id"] = operation_id
     kwargs["job_id"] = job_id
     return execute_command("get_job", kwargs, parse_yson=True)
 

--- a/yt/yt/ytlib/api/native/client_impl.h
+++ b/yt/yt/ytlib/api/native/client_impl.h
@@ -1066,7 +1066,7 @@ private:
     NRpc::IChannelPtr WrapChannel(NRpc::IChannelPtr channel) const;
     NRpc::IChannelFactoryPtr WrapChannelFactory(NRpc::IChannelFactoryPtr factory) const;
 
-    NControllerAgent::TOperationId GetJobOperation(NControllerAgent::TJobId jobId) const;
+    NControllerAgent::TOperationId GetJobOperation(NControllerAgent::TJobId jobId);
 
     const IClientPtr& GetOperationsArchiveClient();
 

--- a/yt/yt/ytlib/api/native/client_impl.h
+++ b/yt/yt/ytlib/api/native/client_impl.h
@@ -1066,6 +1066,8 @@ private:
     NRpc::IChannelPtr WrapChannel(NRpc::IChannelPtr channel) const;
     NRpc::IChannelFactoryPtr WrapChannelFactory(NRpc::IChannelFactoryPtr factory) const;
 
+    NControllerAgent::TOperationId GetJobOperation(NControllerAgent::TJobId jobId) const;
+
     const IClientPtr& GetOperationsArchiveClient();
 
     template <class T>

--- a/yt/yt/ytlib/api/native/client_job_info_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_job_info_impl.cpp
@@ -1120,6 +1120,9 @@ TGetJobStderrResponse TClient::DoGetJobStderr(
         [&] (const TString& alias) {
             operationId = ResolveOperationAlias(alias, options, deadline);
         });
+    if (!operationId) {
+        operationId = GetJobOperation(jobId);
+    }
 
     ValidateOperationAccess(operationId, jobId, EPermissionSet(EPermission::Read));
 
@@ -1361,6 +1364,9 @@ TSharedRef TClient::DoGetJobFailContext(
         [&] (const TString& alias) {
             operationId = ResolveOperationAlias(alias, options, deadline);
         });
+    if (!operationId) {
+        operationId = GetJobOperation(jobId);
+    }
 
     ValidateOperationAccess(operationId, jobId, EPermissionSet(EPermission::Read));
 
@@ -2714,6 +2720,9 @@ TYsonString TClient::DoGetJob(
         [&] (const TString& alias) {
             operationId = ResolveOperationAlias(alias, options, deadline);
         });
+    if (!operationId) {
+        operationId = GetJobOperation(jobId);
+    }
 
     if (Connection_->GetConfig()->StrictOperationInfoAccessValidation) {
         ValidateOperationAccess(operationId, jobId, EPermissionSet(EPermission::Read));


### PR DESCRIPTION
In our installations of YTsaurus users don't have direct network access to the exec nodes. This makes it harder to expose Web UI of services running in Vanilla operations, like Spark.

For that, we've developed a proxy, which accepts HTTP traffic, checks YT authentication/authorization and forwards the traffic to exec nodes.

This proxy needs to somehow know where to route the traffic (job and its port from `port_count`).

Right now this is done by prefixing the URL path with exec node address and physical port, though it could be `operation_id` + `job_id` instead of the exec node address.

But prefixing paths is not totally safe because of browser isolation (CORS, cookies, probably something else).
Also initially I've thought that it would not be possible to adapt the Spark application inside job to the URLs with prefixed paths, but this has managed to be not a problem after all.

A better solution would be to use wildcard-hosts, something like `*.proxy.yt...`. This way those hosts would be more isolated from each other.

The problem is that the wildcard max length is 63 characters, so it can't fit both `operation_id` and `job_id`. If the traffic would be http, we could've used multiple wildcards, but with https we can't sign an SSL certificate for such a host.
So, if it would be possible to skip `operation_id` from those requests, then the wildcard host could fit just `job_id` and port ID.
Still, it is possible to only put `operation_id` in the wildcard for the isolation and put the rest needed for resolving (`job_id`, port) inside the path prefix, though a single `job_id` would be more convenient to use.

So, this pull request is about giving a way to resolve running jobs by their id without the `operation_id`, so the proxy could proxy the traffic to those.
That's why I only care about running jobs.

We can live without this feature, so if it is too hard to resolve completed jobs, then I won't pursue it.