### PR TITLE
Introduce `directory` as an alias to `map_node` type

### DIFF
--- a/yt/yt/client/driver/cypress_commands.cpp
+++ b/yt/yt/client/driver/cypress_commands.cpp
@@ -285,6 +285,13 @@ void TCreateNodeCommand::Register(TRegistrar registrar)
             return command->Options.IgnoreTypeMismatch;
         })
         .Optional(/*init*/ false);
+
+    registrar.Postprocessor([] (TThis* command) {
+        if (command->Type == EObjectType::Directory) {
+            // Directory as a Type argument is an alias to MapNode.
+            command->Type = EObjectType::MapNode;
+        }
+    });
 }
 
 void TCreateNodeCommand::DoExecute(ICommandContextPtr context)

--- a/yt/yt/client/object_client/helpers.cpp
+++ b/yt/yt/client/object_client/helpers.cpp
@@ -38,6 +38,7 @@ bool IsVersionedType(EObjectType type)
         type == EObjectType::DoubleNode ||
         type == EObjectType::BooleanNode ||
         type == EObjectType::MapNode ||
+        type == EObjectType::Directory ||
         type == EObjectType::ListNode ||
         type == EObjectType::File ||
         type == EObjectType::Table ||

--- a/yt/yt/client/object_client/public.h
+++ b/yt/yt/client/object_client/public.h
@@ -220,6 +220,9 @@ DEFINE_ENUM(EObjectType,
     ((ListNode)                                     (304))
     ((BooleanNode)                                  (305))
 
+    // Alias to MapNode
+    ((Directory)                                    (308))
+
     // Dynamic nodes
     ((File)                                         (400))
     ((Table)                                        (401))

--- a/yt/yt/tests/integration/cypress/test_cypress.py
+++ b/yt/yt/tests/integration/cypress/test_cypress.py
@@ -1338,6 +1338,13 @@ class TestCypress(YTEnvSetup):
     def test_create(self):
         create("map_node", "//tmp/some_node")
 
+    @authors("pavel-bash")
+    @not_implemented_in_sequoia
+    def test_directory_alias(self):
+        # Directory should be an alias to map_node.
+        create("directory", "//tmp/some_node")
+        assert get("//tmp/some_node/@type") == "map_node"
+
     @authors("babenko")
     def test_create_recursive_fail(self):
         create("map_node", "//tmp/some_node")


### PR DESCRIPTION
# Description

Now, to create a directory, the user writes something like `yt create map_node...`. That corresponds to what the type actually is, but can be misleading, especially to the new users.

That's why this PR introduces an alias to `map_node` -> `directory`. Now, it'll be possible to write `yt create directory...`.