### PR TITLE
yt/core/crypto: handle several certificate sources

### DIFF
--- a/yt/yt/core/crypto/config.h
+++ b/yt/yt/core/crypto/config.h
@@ -8,7 +8,8 @@ namespace NYT::NCrypto {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-//! Either an inlined value, environment variable, or a file reference.
+//! Environment variable and/or a file reference or inlined value.
+//! Environment variable have priority if specified and defined.
 struct TPemBlobConfig
     : public NYTree::TYsonStruct
 {
@@ -16,7 +17,7 @@ struct TPemBlobConfig
     std::optional<TString> FileName;
     std::optional<TString> Value;
 
-    TString LoadBlob() const;
+    TString LoadBlob(TCertificatePathResolver pathResolver = nullptr) const;
 
     static TPemBlobConfigPtr CreateFileReference(const TString& fileName);
 

--- a/yt/yt/core/crypto/public.h
+++ b/yt/yt/core/crypto/public.h
@@ -8,6 +8,10 @@ namespace NYT::NCrypto {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+using TCertificatePathResolver = std::function<TString(const TString&)>;
+
+////////////////////////////////////////////////////////////////////////////////
+
 DECLARE_REFCOUNTED_STRUCT(TPemBlobConfig)
 DECLARE_REFCOUNTED_STRUCT(TSslContextCommand)
 DECLARE_REFCOUNTED_STRUCT(TSslContextConfig)

--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -882,48 +882,28 @@ void TSslContext::AddPrivateKey(const TString& privateKey)
 void TSslContext::AddCertificateAuthority(const TPemBlobConfigPtr& pem, TCertificatePathResolver resolver)
 {
     if (pem) {
-        if (pem->FileName) {
-            auto filePath = resolver ? resolver(*pem->FileName) : *pem->FileName;
-            AddCertificateAuthorityFromFile(filePath);
-        } else {
-            AddCertificateAuthority(pem->LoadBlob());
-        }
+        AddCertificateAuthority(pem->LoadBlob(resolver));
     }
 }
 
 void TSslContext::AddCertificate(const TPemBlobConfigPtr& pem, TCertificatePathResolver resolver)
 {
     if (pem) {
-        if (pem->FileName) {
-            auto filePath = resolver ? resolver(*pem->FileName) : *pem->FileName;
-            AddCertificateFromFile(filePath);
-        } else {
-            AddCertificate(pem->LoadBlob());
-        }
+        AddCertificate(pem->LoadBlob(resolver));
     }
 }
 
 void TSslContext::AddCertificateChain(const TPemBlobConfigPtr& pem, TCertificatePathResolver resolver)
 {
     if (pem) {
-        if (pem->FileName) {
-            auto filePath = resolver ? resolver(*pem->FileName) : *pem->FileName;
-            AddCertificateChainFromFile(filePath);
-        } else {
-            AddCertificateChain(pem->LoadBlob());
-        }
+        AddCertificateChain(pem->LoadBlob(resolver));
     }
 }
 
 void TSslContext::AddPrivateKey(const TPemBlobConfigPtr& pem, TCertificatePathResolver resolver)
 {
     if (pem) {
-        if (pem->FileName) {
-            auto filePath = resolver ? resolver(*pem->FileName) : *pem->FileName;
-            AddPrivateKeyFromFile(filePath);
-        } else {
-            AddPrivateKey(pem->LoadBlob());
-        }
+        AddPrivateKey(pem->LoadBlob(resolver));
     }
 }
 

--- a/yt/yt/core/crypto/tls.h
+++ b/yt/yt/core/crypto/tls.h
@@ -41,8 +41,6 @@ TString GetFingerprintSHA256(const TX509Ptr& certificate);
 
 DECLARE_REFCOUNTED_STRUCT(TSslContextImpl)
 
-using TCertificatePathResolver = std::function<TString(const TString&)>;
-
 class TSslContext
     : public TRefCounted
 {


### PR DESCRIPTION
Allow specifying both environment variable and file as certificate source.

This allows to use single "//sys/@cluster_connection" and "//sys/clusters" bus
configs for server instances and jobs like chyt: servers will use certificates
from secret files, operations - from secure vault environment variables.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>


