### PR TITLE
mTLS: add public rpc server to rpc proxies

### DIFF
--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -83,6 +83,8 @@ class LocalYtConfig(object):
     rpc_cert_key = attr.ib(None)
     https_cert = attr.ib(None)
     https_cert_key = attr.ib(None)
+    public_rpc_cert = attr.ib(None)
+    piblic_rpc_cert_key = attr.ib(None)
 
     """Native authentication settings"""
     mock_tvm_id = attr.ib(None)

--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -75,8 +75,10 @@ class LocalYtConfig(object):
 
     """TLS settings"""
     enable_tls = attr.ib(False)
-    ca_cert = attr.ib(None)
-    ca_cert_key = attr.ib(None)
+    internal_ca_cert = attr.ib(None)
+    internal_ca_cert_key = attr.ib(None)
+    public_ca_cert = attr.ib(None)
+    public_ca_cert_key = attr.ib(None)
     rpc_cert = attr.ib(None)
     rpc_cert_key = attr.ib(None)
     https_cert = attr.ib(None)

--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -1061,10 +1061,10 @@ def _build_node_configs(multidaemon_config_output,
             set_at(config, "exec_node/job_proxy/forward_all_environment_variables", True)
 
             # Job proxy needs CA certificate to validate incoming connections.
-            if yt_config.ca_cert is not None:
+            if yt_config.internal_ca_cert is not None:
                 get_at(config, "exec_node/slot_manager/job_environment/job_proxy_bind_mounts").append({
-                    "internal_path": yt_config.ca_cert,
-                    "external_path": yt_config.ca_cert,
+                    "internal_path": yt_config.internal_ca_cert,
+                    "external_path": yt_config.internal_ca_cert,
                     "read_only": True,
                 })
 
@@ -1801,10 +1801,10 @@ def _build_cluster_connection_config(yt_config,
             "refresh_time": 0
         }
 
-    if yt_config.ca_cert is not None:
+    if yt_config.internal_ca_cert is not None:
         set_at(cluster_connection, "bus_client", {
             "ca": {
-                "file_name": yt_config.ca_cert,
+                "file_name": yt_config.internal_ca_cert,
             },
             "encryption_mode": "required",
             "verification_mode": "full",

--- a/yt/python/yt/environment/yt_env.py
+++ b/yt/python/yt/environment/yt_env.py
@@ -417,17 +417,30 @@ class YTInstance(object):
     def _prepare_certificates(self):
         names = [self.yt_config.fqdn, self.yt_config.cluster_name]
 
-        if self.yt_config.ca_cert is None:
-            self.yt_config.ca_cert = os.path.join(self.path, "ca.crt")
-            self.yt_config.ca_cert_key = os.path.join(self.path, "ca.key")
-            create_ca(ca_cert=self.yt_config.ca_cert, ca_cert_key=self.yt_config.ca_cert_key)
+        if self.yt_config.internal_ca_cert is None:
+            self.yt_config.internal_ca_cert = os.path.join(self.path, "internal_ca.crt")
+            self.yt_config.internal_ca_cert_key = os.path.join(self.path, "internal_ca.key")
+            create_ca(
+                ca_cert=self.yt_config.internal_ca_cert,
+                ca_cert_key=self.yt_config.internal_ca_cert_key,
+                subj="/O={}/OU={}".format(self.id, "YT Internal CA"),
+            )
+
+        if self.yt_config.public_ca_cert is None:
+            self.yt_config.public_ca_cert = os.path.join(self.path, "public_ca.crt")
+            self.yt_config.public_ca_cert_key = os.path.join(self.path, "public_ca.key")
+            create_ca(
+                ca_cert=self.yt_config.public_ca_cert,
+                ca_cert_key=self.yt_config.public_ca_cert_key,
+                subj="/O={}/OU={}".format(self.id, "YT Public CA"),
+            )
 
         if self.yt_config.rpc_cert is None:
             self.yt_config.rpc_cert = os.path.join(self.path, "rpc.crt")
             self.yt_config.rpc_cert_key = os.path.join(self.path, "rpc.key")
             create_certificate(
-                ca_cert=self.yt_config.ca_cert,
-                ca_cert_key=self.yt_config.ca_cert_key,
+                ca_cert=self.yt_config.internal_ca_cert,
+                ca_cert_key=self.yt_config.internal_ca_cert_key,
                 cert=self.yt_config.rpc_cert,
                 cert_key=self.yt_config.rpc_cert_key,
                 names=names
@@ -437,8 +450,8 @@ class YTInstance(object):
             self.yt_config.https_cert = os.path.join(self.path, "https.crt")
             self.yt_config.https_cert_key = os.path.join(self.path, "https.key")
             create_certificate(
-                ca_cert=self.yt_config.ca_cert,
-                ca_cert_key=self.yt_config.ca_cert_key,
+                ca_cert=self.yt_config.public_ca_cert,
+                ca_cert_key=self.yt_config.public_ca_cert_key,
                 cert=self.yt_config.https_cert,
                 cert_key=self.yt_config.https_cert_key,
                 names=names

--- a/yt/python/yt/environment/yt_env.py
+++ b/yt/python/yt/environment/yt_env.py
@@ -457,6 +457,17 @@ class YTInstance(object):
                 names=names
             )
 
+        if self.yt_config.public_rpc_cert is None and self.yt_config.rpc_proxy_count > 0:
+            self.yt_config.public_rpc_cert = os.path.join(self.path, "public_rpc.crt")
+            self.yt_config.public_rpc_cert_key = os.path.join(self.path, "public_rpc.key")
+            create_certificate(
+                ca_cert=self.yt_config.public_ca_cert,
+                ca_cert_key=self.yt_config.public_ca_cert_key,
+                cert=self.yt_config.public_rpc_cert,
+                cert_key=self.yt_config.public_rpc_cert_key,
+                names=names
+            )
+
     def _prepare_builtin_environment(self, ports_generator, modify_configs_func, modify_driver_logging_config_func):
         service_infos = [
             ("ytserver-clock", "clocks", self.yt_config.clock_count),
@@ -871,23 +882,27 @@ class YTInstance(object):
         return ["{0}:{1}".format(self.yt_config.fqdn, get_value_from_config(config, "port", "kafkaproxy"))
                 for config in self.configs["kafka_proxy"]]
 
-    def get_rpc_proxy_address(self, tvm_only=False):
-        return self.get_rpc_proxy_addresses(tvm_only=tvm_only)[0]
+    def get_rpc_proxy_address(self, address_type=None, tvm_only=False):
+        return self.get_rpc_proxy_addresses(address_type=address_type, tvm_only=tvm_only)[0]
 
-    def get_rpc_proxy_addresses(self, tvm_only=False):
+    def get_rpc_proxy_addresses(self, address_type=None, tvm_only=False):
         if self.yt_config.rpc_proxy_count == 0:
             raise YtError("Rpc proxies are not started")
-        if tvm_only:
-            return ["{0}:{1}".format(self.yt_config.fqdn, get_value_from_config(config, "tvm_only_rpc_port", "rpc_proxy"))
-                    for config in self.configs["rpc_proxy"]]
-        return ["{0}:{1}".format(self.yt_config.fqdn, get_value_from_config(config, "rpc_port", "rpcproxy"))
+
+        if address_type == "tvm_only_internal_rpc" or tvm_only:
+            port_field = "tvm_only_rpc_port"
+        elif address_type == "public_rpc":
+            port_field = "public_rpc_port"
+        elif address_type == "monitoring_http":
+            port_field = "monitoring_port"
+        else:
+            port_field = "rpc_port"
+
+        return ["{0}:{1}".format(self.yt_config.fqdn, get_value_from_config(config, port_field, "rpc_proxy"))
                 for config in self.configs["rpc_proxy"]]
 
     def get_rpc_proxy_monitoring_addresses(self):
-        if self.yt_config.rpc_proxy_count == 0:
-            raise YtError("Rpc proxies are not started")
-        return ["{0}:{1}".format(self.yt_config.fqdn, get_value_from_config(config, "monitoring_port", "rpcproxy"))
-                for config in self.configs["rpc_proxy"]]
+        return self.get_rpc_proxy_addresses(address_type="monitoring_http")
 
     def get_http_proxy_monitoring_addresses(self):
         if self.yt_config.http_proxy_count == 0:
@@ -1986,6 +2001,17 @@ class YTInstance(object):
             return YtClient(token=token, proxy=self.get_http_proxy_address(), config=self._default_client_config)
         return self.create_native_client()
 
+    def create_rpc_client(self, driver_name="rpc_driver"):
+        token = DEFAULT_ADMIN_TOKEN if self.yt_config.enable_auth else None
+        config = update(
+            self._default_client_config,
+            {
+                "backend": "rpc",
+                "driver_config": self.configs[driver_name],
+            }
+        )
+        return YtClient(token=token, config=config)
+
     def create_native_client(self, driver_name="driver"):
         driver_config_path = self.config_paths[driver_name]
 
@@ -2151,12 +2177,12 @@ class YTInstance(object):
             self.config_paths["rpc_proxy"].append(config_path)
             self._service_processes["rpc_proxy"].append(None)
 
-            rpc_client_config_path = os.path.join(self.configs_path, "rpc-client.yson")
-            if self._load_existing_environment:
-                if not os.path.isfile(rpc_client_config_path):
-                    raise YtError("Rpc client config {0} not found".format(rpc_client_config_path))
-            else:
-                write_config(rpc_client_config, rpc_client_config_path)
+        rpc_client_config_path = os.path.join(self.configs_path, "rpc-client.yson")
+        if self._load_existing_environment:
+            if not os.path.isfile(rpc_client_config_path):
+                raise YtError("Rpc client config {0} not found".format(rpc_client_config_path))
+        else:
+            write_config(rpc_client_config, rpc_client_config_path)
 
     def start_multi(self):
         name = "multi"

--- a/yt/yt/client/api/rpc_proxy/public.h
+++ b/yt/yt/client/api/rpc_proxy/public.h
@@ -40,6 +40,7 @@ DEFINE_ENUM(EAddressType,
     ((Https)              (4))
     ((TvmOnlyHttp)        (5))
     ((TvmOnlyHttps)       (6))
+    ((PublicRpc)          (7))
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/driver/config.cpp
+++ b/yt/yt/client/driver/config.cpp
@@ -55,6 +55,9 @@ void TDriverConfig::Register(TRegistrar registrar)
     registrar.Parameter("proxy_discovery_cache", &TThis::ProxyDiscoveryCache)
         .DefaultNew();
 
+    registrar.Parameter("default_rpc_proxy_address_type", &TThis::DefaultRpcProxyAddressType)
+        .Default(NApi::NRpcProxy::EAddressType::InternalRpc);
+
     registrar.Parameter("enable_internal_commands", &TThis::EnableInternalCommands)
         .Default(false);
 

--- a/yt/yt/client/driver/config.h
+++ b/yt/yt/client/driver/config.h
@@ -4,6 +4,8 @@
 
 #include <yt/yt/client/api/public.h>
 
+#include <yt/yt/client/api/rpc_proxy/public.h>
+
 #include <yt/yt/client/table_client/public.h>
 
 #include <yt/yt/client/chunk_client/public.h>
@@ -42,6 +44,8 @@ struct TDriverConfig
     std::optional<std::string> MultiproxyTargetCluster;
 
     TAsyncExpiringCacheConfigPtr ProxyDiscoveryCache;
+
+    NApi::NRpcProxy::EAddressType DefaultRpcProxyAddressType;
 
     bool EnableInternalCommands;
 

--- a/yt/yt/server/rpc_proxy/bootstrap.h
+++ b/yt/yt/server/rpc_proxy/bootstrap.h
@@ -63,12 +63,14 @@ private:
 
     NMonitoring::IMonitoringManagerPtr MonitoringManager_;
     NBus::IBusServerPtr BusServer_;
+    NBus::IBusServerPtr PublicBusServer_;
     NBus::IBusServerPtr TvmOnlyBusServer_;
     IApiServicePtr ApiService_;
     IApiServicePtr TvmOnlyApiService_;
     NRpc::IServicePtr DiscoveryService_;
     NRpc::IServicePtr ShuffleService_;
     NRpc::IServerPtr RpcServer_;
+    NRpc::IServerPtr PublicRpcServer_;
     NRpc::IServerPtr TvmOnlyRpcServer_;
     NRpc::IServerPtr GrpcServer_;
     NHttp::IServerPtr HttpServer_;

--- a/yt/yt/server/rpc_proxy/config.h
+++ b/yt/yt/server/rpc_proxy/config.h
@@ -127,6 +127,10 @@ struct TProxyBootstrapConfig
 
     TAccessCheckerConfigPtr AccessChecker;
 
+    int PublicRpcPort;
+
+    NBus::TBusServerConfigPtr PublicBusServer;
+
     //! GRPC server configuration.
     NRpc::NGrpc::TServerConfigPtr GrpcServer;
 

--- a/yt/yt/server/rpc_proxy/discovery_service.cpp
+++ b/yt/yt/server/rpc_proxy/discovery_service.cpp
@@ -211,6 +211,7 @@ private:
     {
         auto proxyAddressMap = TProxyAddressMap{
             {EAddressType::InternalRpc, GetLocalAddresses(Config_->Addresses, Config_->RpcPort)},
+            {EAddressType::PublicRpc, GetLocalAddresses(Config_->Addresses, Config_->PublicRpcPort ? Config_->PublicRpcPort : Config_->RpcPort)},
             {EAddressType::MonitoringHttp, GetLocalAddresses(Config_->Addresses, Config_->MonitoringPort)}
         };
 

--- a/yt/yt/tests/integration/proxies/test_http_proxy.py
+++ b/yt/yt/tests/integration/proxies/test_http_proxy.py
@@ -95,8 +95,8 @@ class HttpProxyTestBase(YTEnvSetup):
     def _get_https_proxy_address(self):
         return self.Env.get_http_proxy_address(https=True)
 
-    def _get_ca_cert(self):
-        return self.Env.yt_config.ca_cert
+    def _get_https_ca_cert(self):
+        return self.Env.yt_config.public_ca_cert
 
     def _get_proxy_cert_path(self, index=0):
         proxy_config = self.Env.configs["http_proxy"][index]
@@ -1947,7 +1947,7 @@ class TestHttpsProxy(HttpProxyTestBase):
 
     @authors("khlebnikov")
     def test_ping_verify_ca(self):
-        rsp = requests.get(self._get_https_proxy_url() + "/ping", verify=self._get_ca_cert())
+        rsp = requests.get(self._get_https_proxy_url() + "/ping", verify=self._get_https_ca_cert())
         rsp.raise_for_status()
 
     @authors("khlebnikov")
@@ -1963,8 +1963,8 @@ class TestHttpsProxy(HttpProxyTestBase):
         assert current_fingerprint() == old_fingerprint
 
         create_certificate(
-            ca_cert=self._get_ca_cert(),
-            ca_cert_key=self.Env.yt_config.ca_cert_key,
+            ca_cert=self.Env.yt_config.public_ca_cert,
+            ca_cert_key=self.Env.yt_config.public_ca_cert_key,
             cert=proxy_cert,
             cert_key=proxy_cert_key,
             names=[self.Env.yt_config.fqdn, self.Env.yt_config.cluster_name],
@@ -1977,7 +1977,7 @@ class TestHttpsProxy(HttpProxyTestBase):
 
         wait(lambda: current_fingerprint() == new_fingerprint)
 
-        rsp = requests.get(self._get_https_proxy_url() + "/ping", verify=self._get_ca_cert())
+        rsp = requests.get(self._get_https_proxy_url() + "/ping", verify=self._get_https_ca_cert())
         rsp.raise_for_status()
 
 


### PR DESCRIPTION
- **yt/rpc-proxy: add dedicated bus server for public use**
- **yt/driver: add option for rpc-proxy default address type**
- **yt/environment: separate internal and public CA**
- **yt/environment: prefer https for rpc proxy discovery**
- **yt/test: use rpc proxy public rpc port for tls setup**

---

* Changelog entry
Type: feature
Component: misc-server

Add public RPC server for RPC proxies with own TLS certificate.

