### PR TITLE
YT-13159: Remove enable_graceful_abort compats

### DIFF
--- a/yt/yt/server/controller_agent/config.cpp
+++ b/yt/yt/server/controller_agent/config.cpp
@@ -608,7 +608,7 @@ void TJobTrackerConfig::Register(TRegistrar registrar)
         .Default(TDuration::Seconds(5));
     // TODO(arkady-e1ppa): remove this when all nodes are 24.1.
     registrar.Parameter("enable_graceful_abort", &TThis::EnableGracefulAbort)
-        .Default(false);
+        .Default(true);
     registrar.Parameter("check_node_heartbeat_sequence_number", &TThis::CheckNodeHeartbeatSequenceNumber)
         .Default(false);
     registrar.Parameter("heavy_invoker_thread_count", &TThis::HeavyInvokerThreadCount)


### PR DESCRIPTION
commit_hash:b45823089c05888cf313202451df9dd8ce22d460

* Changelog entry
Type: feature
Component: controller-agent

Enable graceful abort by default in 24.2.

