### PR TITLE
Add internal_registry_regex to controller agents config

### DIFF
--- a/yt/yt/server/controller_agent/config.cpp
+++ b/yt/yt/server/controller_agent/config.cpp
@@ -754,6 +754,8 @@ void TDockerRegistryConfig::Register(TRegistrar registrar)
         .Default();
     registrar.Parameter("internal_registry_alternative_addresses", &TThis::InternalRegistryAlternativeAddresses)
         .Default();
+    registrar.Parameter("internal_registry_regex", &TThis::InternalRegistryRegex)
+        .Default();
     registrar.Parameter("use_yt_token_for_internal_registry", &TThis::UseYtTokenForInternalRegistry)
         .Default(false);
     registrar.Parameter("forward_internal_images_to_job_specs", &TThis::ForwardInternalImagesToJobSpecs)

--- a/yt/yt/server/controller_agent/config.h
+++ b/yt/yt/server/controller_agent/config.h
@@ -788,6 +788,9 @@ struct TDockerRegistryConfig
     //! Alternative addresses for internal docker registry.
     std::vector<std::string> InternalRegistryAlternativeAddresses;
 
+    //! Regex of trusted docker registries which accept cluster yt token for authentication.
+    NRe2::TRe2Ptr InternalRegistryRegex;
+
     bool UseYtTokenForInternalRegistry = false;
 
     bool ForwardInternalImagesToJobSpecs = false;

--- a/yt/yt/server/controller_agent/controllers/helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/helpers.cpp
@@ -25,6 +25,8 @@
 #include <yt/yt/client/table_client/row_buffer.h>
 #include <yt/yt/client/table_client/timestamped_schema_helpers.h>
 
+#include <yt/yt/library/re2/re2.h>
+
 #include <util/string/builder.h>
 #include <util/string/split.h>
 
@@ -310,6 +312,8 @@ TDockerImageSpec::TDockerImageSpec(const TString& dockerImage, const TDockerRegi
         IsInternal = true;
         imageRef = dockerImage;
     } else if (std::ranges::find(internalRegistries, Registry) != internalRegistries.end()) {
+        IsInternal = true;
+    } else if (config->InternalRegistryRegex && NRe2::TRe2::FullMatch(Registry, *config->InternalRegistryRegex)) {
         IsInternal = true;
     }
 


### PR DESCRIPTION
Sometimes, `internal_registry_alternative_addresses` are not enough, and a custom regex is required