### PR TITLE
Add family prefix to yt op alias

### DIFF
--- a/yt/chyt/controller/internal/agent/agent.go
+++ b/yt/chyt/controller/internal/agent/agent.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -127,6 +128,9 @@ func (a *Agent) processRunningOperations(runningOps []yt.OperationStatus) error 
 			continue
 		}
 		alias := opAlias.(string)[1:]
+
+		// So that oplets are found even after switching use_family_prefix_in_op_alias -> false.
+		alias = strings.TrimPrefix(alias, family+strawberry.OpAliasFamilyDelimiter)
 
 		oplet, ok := a.aliasToOp[alias]
 		if !ok {
@@ -466,15 +470,16 @@ func (a *Agent) GetAgentInfo() strawberry.AgentInfo {
 	}
 
 	return strawberry.AgentInfo{
-		StrawberryRoot:        a.root,
-		Hostname:              a.hostname,
-		Stage:                 a.config.Stage,
-		Proxy:                 a.proxy,
-		Family:                a.family,
-		OperationNamespace:    a.OperationNamespace(),
-		RobotUsername:         a.config.RobotUsername,
-		DefaultNetworkProject: a.config.DefaultNetworkProject,
-		ClusterURL:            strawberry.ExecuteTemplate(a.config.ClusterURLTemplate, clusterURLTemplateData),
+		StrawberryRoot:           a.root,
+		Hostname:                 a.hostname,
+		Stage:                    a.config.Stage,
+		Proxy:                    a.proxy,
+		Family:                   a.family,
+		OperationNamespace:       a.OperationNamespace(),
+		RobotUsername:            a.config.RobotUsername,
+		DefaultNetworkProject:    a.config.DefaultNetworkProject,
+		ClusterURL:               strawberry.ExecuteTemplate(a.config.ClusterURLTemplate, clusterURLTemplateData),
+		UseFamilyPrefixInOpAlias: a.config.UseFamilyPrefixInOpAlias,
 	}
 }
 

--- a/yt/chyt/controller/internal/agent/config.go
+++ b/yt/chyt/controller/internal/agent/config.go
@@ -58,6 +58,8 @@ type Config struct {
 	ScaleWorkerNumber *int `yson:"scale_worker_number"`
 	// ScalePeriod defines how often agent runs oplet scaling task.
 	ScalePeriod *yson.Duration `yson:"scale_period"`
+
+	UseFamilyPrefixInOpAlias bool `yson:"use_family_prefix_in_op_alias"`
 }
 
 const (

--- a/yt/chyt/controller/internal/strawberry/helpers.go
+++ b/yt/chyt/controller/internal/strawberry/helpers.go
@@ -22,7 +22,10 @@ var (
 	prerequisiteCheckFailedRE = regexp.MustCompile("[Pp]rerequisite check failed")
 )
 
-const AccessControlNamespacesPath = ypath.Path("//sys/access_control_object_namespaces")
+const (
+	AccessControlNamespacesPath = ypath.Path("//sys/access_control_object_namespaces")
+	OpAliasFamilyDelimiter      = "::"
+)
 
 func toOperationACL(acl []yt.ACE) []yt.ACE {
 	if acl == nil {

--- a/yt/chyt/controller/internal/strawberry/oplet.go
+++ b/yt/chyt/controller/internal/strawberry/oplet.go
@@ -23,9 +23,10 @@ type AgentInfo struct {
 	// RobotUsername is needed for a temporary workaround to add the robot to the operation acl.
 	//
 	// TODO(dakovalkov): remove after YT-17557
-	RobotUsername         string
-	DefaultNetworkProject *string
-	ClusterURL            string
+	RobotUsername            string
+	DefaultNetworkProject    *string
+	ClusterURL               string
+	UseFamilyPrefixInOpAlias bool
 }
 
 func DescribeOptions(a AgentInfo, speclet Speclet) []OptionGroupDescriptor {
@@ -906,7 +907,13 @@ func (oplet *Oplet) restartOp(ctx context.Context, reason string) error {
 	// TODO(gudqeit): move speclet patching to a separate method.
 	spec["annotations"] = annotations
 	spec["description"] = description
-	spec["alias"] = "*" + oplet.alias
+
+	if oplet.agentInfo.UseFamilyPrefixInOpAlias {
+		spec["alias"] = "*" + oplet.c.Family() + OpAliasFamilyDelimiter + oplet.alias
+	} else {
+		spec["alias"] = "*" + oplet.alias
+	}
+
 	if oplet.strawberrySpeclet.Pool != nil {
 		spec["pool"] = *oplet.strawberrySpeclet.Pool
 	}


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: strawberry

For now it is impossible to have, for example, chyt clique and jupyt instance with the same alias since this alias is used as the yt operation's alias that must be unique. This PR introduces an option that adds prefixes with the family name to yt op aliases, leaving strawberry aliases as is

