### PR TITLE
Convert several CRI structures into YSON structures

### DIFF
--- a/yt/yt/library/containers/cri/config.cpp
+++ b/yt/yt/library/containers/cri/config.cpp
@@ -100,4 +100,57 @@ void TCriImageCacheConfig::Register(TRegistrar registrar)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TCriPodDescriptorPtr TCriPodDescriptor::Create(TString name, TString id)
+{
+    auto descriptor = New<TCriPodDescriptor>();
+    descriptor->Name = std::move(name);
+    descriptor->Id = std::move(id);
+    return descriptor;
+}
+
+void TCriPodDescriptor::Register(TRegistrar registrar)
+{
+    registrar.Parameter("name", &TThis::Name)
+        .NonEmpty();
+
+    registrar.Parameter("id", &TThis::Id)
+        .NonEmpty();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TCriContainerResources::Register(TRegistrar registrar)
+{
+    registrar.Parameter("cpu_limit", &TThis::CpuLimit)
+        .Optional();
+
+    registrar.Parameter("cpu_request", &TThis::CpuRequest)
+        .Optional();
+
+    registrar.Parameter("memory_limit", &TThis::MemoryLimit)
+        .Optional();
+
+    registrar.Parameter("memory_request", &TThis::MemoryRequest)
+        .Optional();
+
+    registrar.Parameter("memory_oom_group", &TThis::MemoryOomGroup)
+        .Optional();
+
+    registrar.Parameter("cpuset_cpus", &TThis::CpusetCpus)
+        .Optional();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void TCriPodSpec::Register(TRegistrar registrar)
+{
+    registrar.Parameter("name", &TThis::Name)
+        .NonEmpty();
+
+    registrar.Parameter("resources", &TThis::Resources)
+        .DefaultNew();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NContainers::NCri

--- a/yt/yt/library/containers/cri/config.cpp
+++ b/yt/yt/library/containers/cri/config.cpp
@@ -100,7 +100,7 @@ void TCriImageCacheConfig::Register(TRegistrar registrar)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TCriPodDescriptorPtr TCriPodDescriptor::Create(TString name, TString id)
+TCriPodDescriptorPtr TCriPodDescriptor::Create(std::string name, std::string id)
 {
     auto descriptor = New<TCriPodDescriptor>();
     descriptor->Name = std::move(name);
@@ -148,7 +148,7 @@ void TCriPodSpec::Register(TRegistrar registrar)
         .NonEmpty();
 
     registrar.Parameter("resources", &TThis::Resources)
-        .DefaultNew();
+        .Default();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/library/containers/cri/config.h
+++ b/yt/yt/library/containers/cri/config.h
@@ -115,4 +115,58 @@ DEFINE_REFCOUNTED_TYPE(TCriImageCacheConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TCriPodDescriptor
+    : public NYTree::TYsonStruct
+{
+    TString Name;
+    TString Id;
+
+    static TCriPodDescriptorPtr Create(TString name, TString id);
+
+    REGISTER_YSON_STRUCT(TCriPodDescriptor);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TCriPodDescriptor)
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCriContainerResources
+    : public NYTree::TYsonStruct
+{
+    std::optional<double> CpuLimit;
+    std::optional<double> CpuRequest;
+    std::optional<i64> MemoryLimit;
+    std::optional<i64> MemoryRequest;
+
+    //! At OOM kill all tasks at once.
+    std::optional<bool> MemoryOomGroup;
+
+    std::optional<TString> CpusetCpus;
+
+    REGISTER_YSON_STRUCT(TCriContainerResources);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TCriContainerResources)
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TCriPodSpec
+    : public NYTree::TYsonStruct
+{
+    TString Name;
+    TCriContainerResourcesPtr Resources;
+
+    REGISTER_YSON_STRUCT(TCriPodSpec);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TCriPodSpec)
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NContainers::NCri

--- a/yt/yt/library/containers/cri/config.h
+++ b/yt/yt/library/containers/cri/config.h
@@ -118,10 +118,10 @@ DEFINE_REFCOUNTED_TYPE(TCriImageCacheConfig)
 struct TCriPodDescriptor
     : public NYTree::TYsonStruct
 {
-    TString Name;
-    TString Id;
+    std::string Name;
+    std::string Id;
 
-    static TCriPodDescriptorPtr Create(TString name, TString id);
+    static TCriPodDescriptorPtr Create(std::string name, std::string id);
 
     REGISTER_YSON_STRUCT(TCriPodDescriptor);
 
@@ -133,7 +133,7 @@ DEFINE_REFCOUNTED_TYPE(TCriPodDescriptor)
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TCriContainerResources
-    : public NYTree::TYsonStruct
+    : public NYTree::TYsonStructLite
 {
     std::optional<double> CpuLimit;
     std::optional<double> CpuRequest;
@@ -143,22 +143,20 @@ struct TCriContainerResources
     //! At OOM kill all tasks at once.
     std::optional<bool> MemoryOomGroup;
 
-    std::optional<TString> CpusetCpus;
+    std::optional<std::string> CpusetCpus;
 
-    REGISTER_YSON_STRUCT(TCriContainerResources);
+    REGISTER_YSON_STRUCT_LITE(TCriContainerResources);
 
     static void Register(TRegistrar registrar);
 };
-
-DEFINE_REFCOUNTED_TYPE(TCriContainerResources)
 
 ////////////////////////////////////////////////////////////////////////////////
 
 struct TCriPodSpec
     : public NYTree::TYsonStruct
 {
-    TString Name;
-    TCriContainerResourcesPtr Resources;
+    std::string Name;
+    TCriContainerResources Resources;
 
     REGISTER_YSON_STRUCT(TCriPodSpec);
 

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -87,7 +87,7 @@ public:
         const TString& path,
         ICriExecutorPtr executor,
         TCriContainerSpecPtr containerSpec,
-        const TCriPodDescriptor& podDescriptor,
+        TCriPodDescriptorPtr podDescriptor,
         TCriPodSpecPtr podSpec,
         TDuration pollPeriod = TDuration::MilliSeconds(100))
         : TProcessBase(path)
@@ -135,7 +135,7 @@ public:
 private:
     const ICriExecutorPtr Executor_;
     const TCriContainerSpecPtr ContainerSpec_;
-    const TCriPodDescriptor PodDescriptor_;
+    const TCriPodDescriptorPtr PodDescriptor_;
     const TCriPodSpecPtr PodSpec_;
     const TDuration PollPeriod_;
 
@@ -160,7 +160,7 @@ private:
             }
         }
 
-        Logger.AddTag("Pod: %v", PodDescriptor_);
+        Logger.AddTag("Pod: %v", *PodDescriptor_);
 
         YT_LOG_DEBUG("Creating container (Container: %v)",
             ContainerSpec_->Name);
@@ -207,8 +207,8 @@ private:
             auto error = TError("Cannot get container status")
                 << TErrorAttribute("container_name", ContainerDescriptor_.Name)
                 << TErrorAttribute("container_id", ContainerDescriptor_.Id)
-                << TErrorAttribute("pod_name", PodDescriptor_.Name)
-                << TErrorAttribute("pod_id", PodDescriptor_.Id)
+                << TErrorAttribute("pod_name", PodDescriptor_->Name)
+                << TErrorAttribute("pod_id", PodDescriptor_->Id)
                 << responseOrError;
             YT_LOG_ERROR(error, "Process is lost");
             YT_UNUSED_FUTURE(AsyncWaitExecutor_->Stop());
@@ -324,13 +324,12 @@ public:
     }
 
     TFuture<void> ForEachPodSandbox(
-        const TCallback<void(const TCriPodDescriptor&, const NProto::PodSandbox&)>& callback,
+        const TCallback<void(TCriPodDescriptorPtr, const NProto::PodSandbox&)>& callback,
         std::function<void(NProto::PodSandboxFilter&)> initFilter) override
     {
         return ListPodSandbox(initFilter).Apply(BIND([=] (const TCriRuntimeApi::TRspListPodSandboxPtr& rsp) {
             for (const auto& pod : rsp->items()) {
-                TCriPodDescriptor descriptor{.Name=pod.metadata().name(), .Id=pod.id()};
-                callback(descriptor, pod);
+                callback(TCriPodDescriptor::Create(pod.metadata().name(), pod.id()), pod);
             }
         }));
     }
@@ -348,10 +347,10 @@ public:
     }
 
     TFuture<TCriRuntimeApi::TRspPodSandboxStatusPtr> GetPodSandboxStatus(
-        const TCriPodDescriptor& podDescriptor, bool verbose = false) override
+        TCriPodDescriptorPtr podDescriptor, bool verbose = false) override
     {
         auto req = RuntimeApi_.PodSandboxStatus();
-        req->set_pod_sandbox_id(podDescriptor.Id);
+        req->set_pod_sandbox_id(podDescriptor->Id);
         req->set_verbose(verbose);
         return req->Invoke();
     }
@@ -365,7 +364,7 @@ public:
         return req->Invoke();
     }
 
-    TFuture<TCriPodDescriptor> RunPodSandbox(TCriPodSpecPtr podSpec) override
+    TFuture<TCriPodDescriptorPtr> RunPodSandbox(TCriPodSpecPtr podSpec) override
     {
         auto req = RuntimeApi_.RunPodSandbox();
 
@@ -375,39 +374,39 @@ public:
             req->set_runtime_handler(Config_->RuntimeHandler);
         }
 
-        return req->Invoke().Apply(BIND([name = podSpec->Name] (const TCriRuntimeApi::TRspRunPodSandboxPtr& rsp) -> TCriPodDescriptor {
-            return TCriPodDescriptor{.Name = name, .Id = rsp->pod_sandbox_id()};
+        return req->Invoke().Apply(BIND([name = podSpec->Name] (const TCriRuntimeApi::TRspRunPodSandboxPtr& rsp) -> TCriPodDescriptorPtr {
+            return TCriPodDescriptor::Create(name, rsp->pod_sandbox_id());
         }));
     }
 
-    TFuture<void> StopPodSandbox(const TCriPodDescriptor& podDescriptor) override
+    TFuture<void> StopPodSandbox(TCriPodDescriptorPtr podDescriptor) override
     {
         auto req = RuntimeApi_.StopPodSandbox();
-        req->set_pod_sandbox_id(podDescriptor.Id);
+        req->set_pod_sandbox_id(podDescriptor->Id);
         return req->Invoke().AsVoid();
     }
 
-    TFuture<void> RemovePodSandbox(const TCriPodDescriptor& podDescriptor) override
+    TFuture<void> RemovePodSandbox(TCriPodDescriptorPtr podDescriptor) override
     {
         auto req = RuntimeApi_.RemovePodSandbox();
-        req->set_pod_sandbox_id(podDescriptor.Id);
+        req->set_pod_sandbox_id(podDescriptor->Id);
         return req->Invoke().AsVoid();
     }
 
     TFuture<void> UpdatePodResources(
-        const TCriPodDescriptor& /*pod*/,
-        const TCriContainerResources& /*resources*/) override
+        TCriPodDescriptorPtr /*pod*/,
+        TCriContainerResourcesPtr /*resources*/) override
     {
         return MakeFuture(TError("Not implemented"));
     }
 
     TFuture<TCriDescriptor> CreateContainer(
         TCriContainerSpecPtr containerSpec,
-        const TCriPodDescriptor& podDescriptor,
+        TCriPodDescriptorPtr podDescriptor,
         TCriPodSpecPtr podSpec) override
     {
         auto req = RuntimeApi_.CreateContainer();
-        req->set_pod_sandbox_id(podDescriptor.Id);
+        req->set_pod_sandbox_id(podDescriptor->Id);
 
         auto* config = req->mutable_config();
 
@@ -528,7 +527,7 @@ public:
         return req->Invoke().AsVoid();
     }
 
-    TFuture<void> UpdateContainerResources(const TCriDescriptor& descriptor, const TCriContainerResources& resources) override
+    TFuture<void> UpdateContainerResources(const TCriDescriptor& descriptor, TCriContainerResourcesPtr resources) override
     {
         auto req = RuntimeApi_.UpdateContainerResources();
         req->set_container_id(descriptor.Id);
@@ -546,8 +545,8 @@ public:
             std::vector<TFuture<void>> futures;
             futures.reserve(pods->items_size());
             for (const auto& pod : pods->items()) {
-                TCriPodDescriptor podDescriptor{.Name = pod.metadata().name(), .Id = pod.id() };
-                futures.push_back(StopPodSandbox(podDescriptor));
+                auto podDescriptor = TCriPodDescriptor::Create(pod.metadata().name(), pod.id());
+                futures.push_back(StopPodSandbox(std::move(podDescriptor)));
             }
             WaitFor(AllSucceeded(std::move(futures)))
                 .ThrowOnError();
@@ -557,18 +556,18 @@ public:
             std::vector<TFuture<void>> futures;
             futures.reserve(pods->items_size());
             for (const auto& pod : pods->items()) {
-                TCriPodDescriptor podDescriptor{.Name = pod.metadata().name(), .Id = pod.id()};
-                futures.push_back(RemovePodSandbox(podDescriptor));
+                auto podDescriptor = TCriPodDescriptor::Create(pod.metadata().name(), pod.id());
+                futures.push_back(RemovePodSandbox(std::move(podDescriptor)));
             }
             WaitFor(AllSucceeded(std::move(futures)))
                 .ThrowOnError();
         }
     }
 
-    void CleanPodSandbox(const TCriPodDescriptor& podDescriptor) override
+    void CleanPodSandbox(TCriPodDescriptorPtr podDescriptor) override
     {
         auto containers = WaitFor(ListContainers([=] (NProto::ContainerFilter& filter) {
-                filter.set_pod_sandbox_id(podDescriptor.Id);
+                filter.set_pod_sandbox_id(podDescriptor->Id);
             }))
             .ValueOrThrow();
 
@@ -641,10 +640,10 @@ public:
     TProcessBasePtr CreateProcess(
         const TString& path,
         TCriContainerSpecPtr containerSpec,
-        const TCriPodDescriptor& podDescriptor,
+        TCriPodDescriptorPtr podDescriptor,
         TCriPodSpecPtr podSpec) override
     {
-        return New<TCriProcess>(path, this, std::move(containerSpec), podDescriptor, std::move(podSpec));
+        return New<TCriProcess>(path, this, std::move(containerSpec), std::move(podDescriptor), std::move(podSpec));
     }
 
 private:
@@ -654,31 +653,31 @@ private:
 
     std::atomic<ui32> Attempt_;
 
-    void FillLinuxContainerResources(NProto::LinuxContainerResources* resources, const TCriContainerResources& spec)
+    void FillLinuxContainerResources(NProto::LinuxContainerResources* resources, TCriContainerResourcesPtr spec)
     {
         auto* unified = resources->mutable_unified();
 
-        if (spec.CpuLimit) {
+        if (spec->CpuLimit) {
             i64 period = Config_->CpuPeriod.MicroSeconds();
-            i64 quota = period * *spec.CpuLimit;
+            i64 quota = period * *spec->CpuLimit;
 
             resources->set_cpu_period(period);
             resources->set_cpu_quota(quota);
         }
 
-        if (spec.MemoryLimit) {
-            resources->set_memory_limit_in_bytes(*spec.MemoryLimit);
+        if (spec->MemoryLimit) {
+            resources->set_memory_limit_in_bytes(*spec->MemoryLimit);
         }
 
-        if (spec.MemoryRequest) {
-            (*unified)["memory.low"] = ToString(*spec.MemoryRequest);
+        if (spec->MemoryRequest) {
+            (*unified)["memory.low"] = ToString(*spec->MemoryRequest);
         }
 
-        if (spec.MemoryOomGroup.value_or(Config_->MemoryOomGroup)) {
+        if (spec->MemoryOomGroup.value_or(Config_->MemoryOomGroup)) {
             (*unified)["memory.oom.group"] = "1";
         }
 
-        if (const auto& cpusetCpus = spec.CpusetCpus) {
+        if (const auto& cpusetCpus = spec->CpusetCpus) {
             resources->set_cpuset_cpus(*cpusetCpus);
         }
     }

--- a/yt/yt/library/containers/cri/cri_executor.cpp
+++ b/yt/yt/library/containers/cri/cri_executor.cpp
@@ -546,7 +546,7 @@ public:
             futures.reserve(pods->items_size());
             for (const auto& pod : pods->items()) {
                 auto podDescriptor = TCriPodDescriptor::Create(pod.metadata().name(), pod.id());
-                futures.push_back(StopPodSandbox(std::move(podDescriptor)));
+                futures.push_back(StopPodSandbox(podDescriptor));
             }
             WaitFor(AllSucceeded(std::move(futures)))
                 .ThrowOnError();
@@ -557,7 +557,7 @@ public:
             futures.reserve(pods->items_size());
             for (const auto& pod : pods->items()) {
                 auto podDescriptor = TCriPodDescriptor::Create(pod.metadata().name(), pod.id());
-                futures.push_back(RemovePodSandbox(std::move(podDescriptor)));
+                futures.push_back(RemovePodSandbox(podDescriptor));
             }
             WaitFor(AllSucceeded(std::move(futures)))
                 .ThrowOnError();

--- a/yt/yt/library/containers/cri/cri_executor.h
+++ b/yt/yt/library/containers/cri/cri_executor.h
@@ -75,7 +75,7 @@ struct TCriContainerSpec
 
     TCriCredentials Credentials;
 
-    TCriContainerResourcesPtr Resources;
+    TCriContainerResources Resources;
 
     //! Command to execute (i.e., entrypoint for docker).
     std::vector<TString> Command;
@@ -129,7 +129,7 @@ struct ICriExecutor
     //! Returns status of the pod.
     //! @param verbose fill field "info" with runtime-specific debug.
     virtual TFuture<TCriRuntimeApi::TRspPodSandboxStatusPtr> GetPodSandboxStatus(
-        TCriPodDescriptorPtr pod, bool verbose = false) = 0;
+        const TCriPodDescriptorPtr& pod, bool verbose = false) = 0;
 
     //! Returns status of the container.
     //! @param verbose fill "info" with runtime-specific debug information.
@@ -137,21 +137,21 @@ struct ICriExecutor
         const TCriDescriptor& ct, bool verbose = false) = 0;
 
     virtual TFuture<TCriPodDescriptorPtr> RunPodSandbox(TCriPodSpecPtr podSpec) = 0;
-    virtual TFuture<void> StopPodSandbox(TCriPodDescriptorPtr pod) = 0;
-    virtual TFuture<void> RemovePodSandbox(TCriPodDescriptorPtr pod) = 0;
+    virtual TFuture<void> StopPodSandbox(const TCriPodDescriptorPtr& pod) = 0;
+    virtual TFuture<void> RemovePodSandbox(const TCriPodDescriptorPtr& pod) = 0;
     virtual TFuture<void> UpdatePodResources(
-        TCriPodDescriptorPtr pod,
-        TCriContainerResourcesPtr resources) = 0;
+        const TCriPodDescriptorPtr& pod,
+        const TCriContainerResources& resources) = 0;
 
     //! Remove all pods and containers in namespace managed by executor.
     virtual void CleanNamespace() = 0;
 
     //! Remove all containers in one pod.
-    virtual void CleanPodSandbox(TCriPodDescriptorPtr pod) = 0;
+    virtual void CleanPodSandbox(const TCriPodDescriptorPtr& pod) = 0;
 
     virtual TFuture<TCriDescriptor> CreateContainer(
         TCriContainerSpecPtr containerSpec,
-        TCriPodDescriptorPtr pod,
+        const TCriPodDescriptorPtr& pod,
         TCriPodSpecPtr podSpec) = 0;
 
     virtual TFuture<void> StartContainer(const TCriDescriptor& ct) = 0;
@@ -166,7 +166,7 @@ struct ICriExecutor
 
     virtual TFuture<void> UpdateContainerResources(
         const TCriDescriptor& ct,
-        TCriContainerResourcesPtr resources) = 0;
+        const TCriContainerResources& resources) = 0;
 
     virtual TFuture<TCriImageApi::TRspListImagesPtr> ListImages(
         std::function<void(NProto::ImageFilter&)> initFilter = nullptr) = 0;

--- a/yt/yt/library/containers/cri/cri_executor.h
+++ b/yt/yt/library/containers/cri/cri_executor.h
@@ -18,12 +18,6 @@ struct TCriDescriptor
     TString Id;
 };
 
-struct TCriPodDescriptor
-{
-    TString Name;
-    TString Id;
-};
-
 struct TCriImageDescriptor
 {
     TString Image;
@@ -35,28 +29,6 @@ void FormatValue(TStringBuilderBase* builder, const TCriPodDescriptor& descripto
 void FormatValue(TStringBuilderBase* builder, const TCriImageDescriptor& descriptor, TStringBuf spec);
 
 ////////////////////////////////////////////////////////////////////////////////
-
-struct TCriContainerResources
-{
-    std::optional<double> CpuLimit;
-    std::optional<double> CpuRequest;
-    std::optional<i64> MemoryLimit;
-    std::optional<i64> MemoryRequest;
-
-    //! At OOM kill all tasks at once.
-    std::optional<bool> MemoryOomGroup;
-
-    std::optional<TString> CpusetCpus;
-};
-
-struct TCriPodSpec
-    : public TRefCounted
-{
-    TString Name;
-    TCriContainerResources Resources;
-};
-
-DEFINE_REFCOUNTED_TYPE(TCriPodSpec)
 
 struct TCriBindMount
 {
@@ -103,7 +75,7 @@ struct TCriContainerSpec
 
     TCriCredentials Credentials;
 
-    TCriContainerResources Resources;
+    TCriContainerResourcesPtr Resources;
 
     //! Command to execute (i.e., entrypoint for docker).
     std::vector<TString> Command;
@@ -147,7 +119,7 @@ struct ICriExecutor
         std::function<void(NProto::ContainerFilter&)> initFilter = nullptr) = 0;
 
     virtual TFuture<void> ForEachPodSandbox(
-        const TCallback<void(const TCriPodDescriptor&, const NProto::PodSandbox&)>& callback,
+        const TCallback<void(TCriPodDescriptorPtr, const NProto::PodSandbox&)>& callback,
         std::function<void(NProto::PodSandboxFilter&)> initFilter = nullptr) = 0;
 
     virtual TFuture<void> ForEachContainer(
@@ -157,29 +129,29 @@ struct ICriExecutor
     //! Returns status of the pod.
     //! @param verbose fill field "info" with runtime-specific debug.
     virtual TFuture<TCriRuntimeApi::TRspPodSandboxStatusPtr> GetPodSandboxStatus(
-        const TCriPodDescriptor& pod, bool verbose = false) = 0;
+        TCriPodDescriptorPtr pod, bool verbose = false) = 0;
 
     //! Returns status of the container.
     //! @param verbose fill "info" with runtime-specific debug information.
     virtual TFuture<TCriRuntimeApi::TRspContainerStatusPtr> GetContainerStatus(
         const TCriDescriptor& ct, bool verbose = false) = 0;
 
-    virtual TFuture<TCriPodDescriptor> RunPodSandbox(TCriPodSpecPtr podSpec) = 0;
-    virtual TFuture<void> StopPodSandbox(const TCriPodDescriptor& pod) = 0;
-    virtual TFuture<void> RemovePodSandbox(const TCriPodDescriptor& pod) = 0;
+    virtual TFuture<TCriPodDescriptorPtr> RunPodSandbox(TCriPodSpecPtr podSpec) = 0;
+    virtual TFuture<void> StopPodSandbox(TCriPodDescriptorPtr pod) = 0;
+    virtual TFuture<void> RemovePodSandbox(TCriPodDescriptorPtr pod) = 0;
     virtual TFuture<void> UpdatePodResources(
-        const TCriPodDescriptor& pod,
-        const TCriContainerResources& resources) = 0;
+        TCriPodDescriptorPtr pod,
+        TCriContainerResourcesPtr resources) = 0;
 
     //! Remove all pods and containers in namespace managed by executor.
     virtual void CleanNamespace() = 0;
 
     //! Remove all containers in one pod.
-    virtual void CleanPodSandbox(const TCriPodDescriptor& pod) = 0;
+    virtual void CleanPodSandbox(TCriPodDescriptorPtr pod) = 0;
 
     virtual TFuture<TCriDescriptor> CreateContainer(
         TCriContainerSpecPtr containerSpec,
-        const TCriPodDescriptor& pod,
+        TCriPodDescriptorPtr pod,
         TCriPodSpecPtr podSpec) = 0;
 
     virtual TFuture<void> StartContainer(const TCriDescriptor& ct) = 0;
@@ -194,7 +166,7 @@ struct ICriExecutor
 
     virtual TFuture<void> UpdateContainerResources(
         const TCriDescriptor& ct,
-        const TCriContainerResources& resources) = 0;
+        TCriContainerResourcesPtr resources) = 0;
 
     virtual TFuture<TCriImageApi::TRspListImagesPtr> ListImages(
         std::function<void(NProto::ImageFilter&)> initFilter = nullptr) = 0;
@@ -216,7 +188,7 @@ struct ICriExecutor
     virtual TProcessBasePtr CreateProcess(
         const TString& path,
         TCriContainerSpecPtr containerSpec,
-        const TCriPodDescriptor& pod,
+        TCriPodDescriptorPtr pod,
         TCriPodSpecPtr podSpec) = 0;
 };
 

--- a/yt/yt/library/containers/cri/public.h
+++ b/yt/yt/library/containers/cri/public.h
@@ -15,6 +15,9 @@ DECLARE_REFCOUNTED_STRUCT(ICriExecutor)
 DECLARE_REFCOUNTED_STRUCT(TCriImageCacheConfig)
 DECLARE_REFCOUNTED_CLASS(TCriImageCacheEntry)
 DECLARE_REFCOUNTED_STRUCT(ICriImageCache)
+DECLARE_REFCOUNTED_STRUCT(TCriPodDescriptor)
+DECLARE_REFCOUNTED_STRUCT(TCriContainerResources)
+DECLARE_REFCOUNTED_STRUCT(TCriPodSpec)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/library/containers/cri/public.h
+++ b/yt/yt/library/containers/cri/public.h
@@ -16,7 +16,6 @@ DECLARE_REFCOUNTED_STRUCT(TCriImageCacheConfig)
 DECLARE_REFCOUNTED_CLASS(TCriImageCacheEntry)
 DECLARE_REFCOUNTED_STRUCT(ICriImageCache)
 DECLARE_REFCOUNTED_STRUCT(TCriPodDescriptor)
-DECLARE_REFCOUNTED_STRUCT(TCriContainerResources)
 DECLARE_REFCOUNTED_STRUCT(TCriPodSpec)
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1045,7 +1045,7 @@ public:
 
         auto podSpec = New<NCri::TCriPodSpec>();
         podSpec->Name = Format("%v%v", SlotPodPrefix, slotIndex);
-        podSpec->Resources->CpuLimit = CpuLimit_;
+        podSpec->Resources.CpuLimit = CpuLimit_;
         PodSpecs_[slotIndex] = podSpec;
         SlotCpusetCpus_[slotIndex] = EmptyCpuSet;
 
@@ -1135,7 +1135,6 @@ public:
         YT_VERIFY(slotType == ESlotType::Common);
 
         auto spec = New<NCri::TCriContainerSpec>();
-        spec->Resources = New<NCri::TCriContainerResources>();
 
         // Run setup using default docker image for job workspace.
         spec->Image.Image = ConcreteConfig_->JobProxyImage;
@@ -1159,7 +1158,7 @@ public:
 
         const auto& cpusetCpu = SlotCpusetCpus_[slotIndex];
         if (cpusetCpu != EmptyCpuSet) {
-            spec->Resources->CpusetCpus = cpusetCpu;
+            spec->Resources.CpusetCpus = cpusetCpu;
         }
 
         std::vector<TFuture<void>> results;
@@ -1220,7 +1219,6 @@ private:
         YT_VERIFY(slotType == ESlotType::Common);
 
         auto spec = New<NCri::TCriContainerSpec>();
-        spec->Resources = New<NCri::TCriContainerResources>();
 
         spec->Name = "job-proxy";
 
@@ -1335,12 +1333,12 @@ private:
             });
         }
 
-        spec->Resources->CpuLimit = config->ContainerCpuLimit;
-        spec->Resources->MemoryLimit = config->SlotContainerMemoryLimit;
+        spec->Resources.CpuLimit = config->ContainerCpuLimit;
+        spec->Resources.MemoryLimit = config->SlotContainerMemoryLimit;
 
         const auto& cpusetCpu = SlotCpusetCpus_[slotIndex];
         if (cpusetCpu != EmptyCpuSet) {
-            spec->Resources->CpusetCpus = cpusetCpu;
+            spec->Resources.CpusetCpus = cpusetCpu;
         }
 
         // Allow strace in job shell.

--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1045,13 +1045,13 @@ public:
 
         auto podSpec = New<NCri::TCriPodSpec>();
         podSpec->Name = Format("%v%v", SlotPodPrefix, slotIndex);
-        podSpec->Resources.CpuLimit = CpuLimit_;
+        podSpec->Resources->CpuLimit = CpuLimit_;
         PodSpecs_[slotIndex] = podSpec;
         SlotCpusetCpus_[slotIndex] = EmptyCpuSet;
 
         auto slotInitFuture = Executor_->RunPodSandbox(podSpec);
         slotInitFuture
-            .Subscribe(BIND([this, this_ = MakeStrong(this), slotIndex] (const TErrorOr<TCriPodDescriptor>& result){
+            .Subscribe(BIND([this, this_ = MakeStrong(this), slotIndex] (const TErrorOr<TCriPodDescriptorPtr>& result){
                 YT_ASSERT_THREAD_AFFINITY(JobThread);
 
                 if (result.IsOK()) {
@@ -1135,6 +1135,7 @@ public:
         YT_VERIFY(slotType == ESlotType::Common);
 
         auto spec = New<NCri::TCriContainerSpec>();
+        spec->Resources = New<NCri::TCriContainerResources>();
 
         // Run setup using default docker image for job workspace.
         spec->Image.Image = ConcreteConfig_->JobProxyImage;
@@ -1158,7 +1159,7 @@ public:
 
         const auto& cpusetCpu = SlotCpusetCpus_[slotIndex];
         if (cpusetCpu != EmptyCpuSet) {
-            spec->Resources.CpusetCpus = cpusetCpu;
+            spec->Resources->CpusetCpus = cpusetCpu;
         }
 
         std::vector<TFuture<void>> results;
@@ -1201,7 +1202,7 @@ private:
     const ICriExecutorPtr Executor_;
     const ICriImageCachePtr ImageCache_;
 
-    std::vector<TCriPodDescriptor> PodDescriptors_;
+    std::vector<TCriPodDescriptorPtr> PodDescriptors_;
     std::vector<TCriPodSpecPtr> PodSpecs_;
     std::vector<TString> SlotCpusetCpus_;
     double CpuLimit_ = 0;
@@ -1219,6 +1220,7 @@ private:
         YT_VERIFY(slotType == ESlotType::Common);
 
         auto spec = New<NCri::TCriContainerSpec>();
+        spec->Resources = New<NCri::TCriContainerResources>();
 
         spec->Name = "job-proxy";
 
@@ -1333,12 +1335,12 @@ private:
             });
         }
 
-        spec->Resources.CpuLimit = config->ContainerCpuLimit;
-        spec->Resources.MemoryLimit = config->SlotContainerMemoryLimit;
+        spec->Resources->CpuLimit = config->ContainerCpuLimit;
+        spec->Resources->MemoryLimit = config->SlotContainerMemoryLimit;
 
         const auto& cpusetCpu = SlotCpusetCpus_[slotIndex];
         if (cpusetCpu != EmptyCpuSet) {
-            spec->Resources.CpusetCpus = cpusetCpu;
+            spec->Resources->CpusetCpus = cpusetCpu;
         }
 
         // Allow strace in job shell.


### PR DESCRIPTION
# Description

This is part of the bigger sidecars work: https://github.com/ytsaurus/ytsaurus/pull/1326#discussion_r2172756401. Several CRI structures (`TCriPodDescriptor`, `TCriContainerResources` and `TCriPodSpec`) were converted into YSON structures, and all the related code was changed. This change is required for the sidecars feature.