### PR TITLE
Add require_administer_for_password_set option

### DIFF
--- a/yt/yt/client/driver/config.cpp
+++ b/yt/yt/client/driver/config.cpp
@@ -67,6 +67,9 @@ void TDriverConfig::Register(TRegistrar registrar)
     registrar.Parameter("require_password_in_authentication_commands", &TThis::RequirePasswordInAuthenticationCommands)
         .Default(true);
 
+    registrar.Parameter("require_administer_for_password_set", &TThis::RequireAdministerForPasswordSet)
+        .Default(false);
+
     registrar.Preprocessor([] (TThis* config) {
         config->ClientCache->Capacity = 1024_KB;
         config->ProxyDiscoveryCache->RefreshTime = TDuration::Seconds(15);

--- a/yt/yt/client/driver/config.h
+++ b/yt/yt/client/driver/config.h
@@ -54,6 +54,9 @@ struct TDriverConfig
     //! Controls whether authentication commands (SetUserPassword, IssueToken, ListUserTokens, etc.) require a correct password to be used.
     bool RequirePasswordInAuthenticationCommands;
 
+    //! If true, forces the `administer` permission requirement for setting a user’s password.
+    bool RequireAdministerForPasswordSet;
+
     REGISTER_YSON_STRUCT(TDriverConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/client/driver/driver.cpp
+++ b/yt/yt/client/driver/driver.cpp
@@ -455,6 +455,7 @@ public:
 
         auto options = TClientOptions::FromAuthenticationIdentity(identity);
         options.RequirePasswordInAuthenticationCommands = Config_->RequirePasswordInAuthenticationCommands;
+        options.RequireAdministerForPasswordSet = Config_->RequireAdministerForPasswordSet;
         options.Token = request.UserToken;
         options.ServiceTicketAuth = request.ServiceTicket
             ? std::make_optional(New<NAuth::TServiceTicketFixedAuth>(*request.ServiceTicket))

--- a/yt/yt/library/auth/authentication_options.h
+++ b/yt/yt/library/auth/authentication_options.h
@@ -35,6 +35,9 @@ struct TAuthenticationOptions
 
     //! Controls whether authentication commands (SetUserPassword, IssueToken, ListUserTokens, etc.) require a correct password to be used.
     bool RequirePasswordInAuthenticationCommands = true;
+
+    //! If true, forces the `administer` permission requirement for setting a user’s password.
+    bool RequireAdministerForPasswordSet = false;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/api/native/client_impl.h
+++ b/yt/yt/ytlib/api/native/client_impl.h
@@ -1510,7 +1510,8 @@ private:
         TStringBuf action,
         const std::string& user,
         const TString& passwordSha256,
-        const TTimeoutOptions& options);
+        const TTimeoutOptions& options,
+        bool requireAdminister);
 
     //
     // Flow


### PR DESCRIPTION
Useful for restricting usage of passwords by non-admins/in non-special circumstances in favor of SSO authentication.

* Changelog entry
Type: feature
Component: proxy

Add `require_administer_for_password_set` option to allow forcing the `administer` permission requirement for running `set-user-password`.

