### PR TITLE
Fix master chunk spec fetcher usage for ordered dynamic tables in CHYT; pre 25.1

### DIFF
--- a/yt/chyt/server/subquery.cpp
+++ b/yt/chyt/server/subquery.cpp
@@ -664,7 +664,8 @@ private:
             MasterChunkSpecFetcher_->Add(
                 table->ObjectId,
                 table->ExternalCellTag,
-                table->ChunkCount,
+                // XXX(achulkov2, babenko): YT-11825
+                table->IsOrderedDynamic() ? -1 : table->ChunkCount,
                 tableIndex,
                 table->Path.GetNewRanges(table->Comparator));
         }

--- a/yt/chyt/server/table.cpp
+++ b/yt/chyt/server/table.cpp
@@ -53,6 +53,11 @@ bool TTable::IsSortedDynamic() const
     return Dynamic && Schema->IsSorted();
 }
 
+bool TTable::IsOrderedDynamic() const
+{
+    return Dynamic && !Schema->IsSorted();
+}
+
 void FormatValue(TStringBuilderBase* builder, const TTablePtr& table, TStringBuf spec)
 {
     FormatValue(builder, table->Path, spec);

--- a/yt/chyt/server/table.h
+++ b/yt/chyt/server/table.h
@@ -41,6 +41,7 @@ struct TTable
     TTable(NYPath::TRichYPath path, const NYTree::IAttributeDictionaryPtr& attributes);
 
     bool IsSortedDynamic() const;
+    bool IsOrderedDynamic() const;
 };
 
 void FormatValue(TStringBuilderBase* builder, const TTablePtr& table, TStringBuf spec);

--- a/yt/yt/ytlib/table_client/table_columnar_statistics_cache.h
+++ b/yt/yt/ytlib/table_client/table_columnar_statistics_cache.h
@@ -14,6 +14,10 @@ namespace NYT::NTableClient {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// NB(achulkov2): Due to YT-11825 this cache does not work with ordered dynamic tables properly iff master version is less than 25.1.
+// Since this cache is currently only used by CHYT for static tables AND 25.1 release/deployment in open-source is visible on the horizon,
+// we do not spend effort to use the pre-25.1 chunkCount = -1 hack for ordered dynamic tables, as it would require propagating the value
+// of the `dynamic` attribute to the cache key.
 class TTableColumnarStatisticsCache
     : public TRefCounted
 {


### PR DESCRIPTION
We have been living with the evil YT-11825 for quite a while, until it was finally been fixed by the hero @ifsmirnov (and maybe others). However, when adding ordered dynamic table support for CHYT, I forgot to use the applicable `chunkCount = -1` hack in the master chunk spec fetcher path, so for CHYT + pre-25.1 masters + ordered dynamic tables you could receive incorrect query results. Let's cherry-pick this into appropriate CHYT branches, cc: @buyval01.

The added test passed in trunk both before and after the changes, since the underlying issue has been fixed.

However, since we haven't really removed the hack from other places, I suggest merging this, cherry-picking to necessary CHYT branches, and then removing the hacks one by one in later commits.

Alternatively, we can just merge this only into the CHYT branches that are compatible with versions until 24.2 inclusive, I leave it up to @buyval01.

* Changelog entry
Type: fix
Component: chyt

Fix usage of master chunk spec fetcher for ordered dynamic tables. Applicable for CHYT over YT server versions up to 24.2, inclusive.

