### PR TITLE
Do not log empty user_tag fields

### DIFF
--- a/yt/yt/server/master/security_server/access_log.cpp
+++ b/yt/yt/server/master/security_server/access_log.cpp
@@ -76,7 +76,7 @@ TOneShotFluentLogEvent LogStructuredEventFluently(ELogLevel level)
     const auto& identity = NRpc::GetCurrentAuthenticationIdentity();
     return NLogging::LogStructuredEventFluently(AccessLogger(), level)
         .Item("user").Value(identity.User)
-        .DoIf(identity.UserTag != identity.User && identity.UserTag != "", [&] (auto fluent) {
+        .DoIf(identity.UserTag != identity.User && !identity.UserTag.empty(), [&] (auto fluent) {
             fluent
                 .Item("user_tag").Value(identity.UserTag);
         });

--- a/yt/yt/server/master/security_server/access_log.cpp
+++ b/yt/yt/server/master/security_server/access_log.cpp
@@ -76,7 +76,7 @@ TOneShotFluentLogEvent LogStructuredEventFluently(ELogLevel level)
     const auto& identity = NRpc::GetCurrentAuthenticationIdentity();
     return NLogging::LogStructuredEventFluently(AccessLogger(), level)
         .Item("user").Value(identity.User)
-        .DoIf(identity.UserTag != identity.User, [&] (auto fluent) {
+        .DoIf(identity.UserTag != identity.User && identity.UserTag != "", [&] (auto fluent) {
             fluent
                 .Item("user_tag").Value(identity.UserTag);
         });


### PR DESCRIPTION
`user_tag` is pretty much always (or almost always) empty, let's log only non-empty values to reduce amount of noice in master access logs.
