### PR TITLE
yt/rpc_proxy: do not announce PublicRpc address fallback to InternalRpc

### DIFF
--- a/yt/yt/server/rpc_proxy/discovery_service.cpp
+++ b/yt/yt/server/rpc_proxy/discovery_service.cpp
@@ -211,9 +211,12 @@ private:
     {
         auto proxyAddressMap = TProxyAddressMap{
             {EAddressType::InternalRpc, GetLocalAddresses(Config_->Addresses, Config_->RpcPort)},
-            {EAddressType::PublicRpc, GetLocalAddresses(Config_->Addresses, Config_->PublicRpcPort ? Config_->PublicRpcPort : Config_->RpcPort)},
             {EAddressType::MonitoringHttp, GetLocalAddresses(Config_->Addresses, Config_->MonitoringPort)}
         };
+
+        if (Config_->PublicRpcPort) {
+            proxyAddressMap.emplace(EAddressType::PublicRpc, GetLocalAddresses(Config_->Addresses, Config_->PublicRpcPort));
+        }
 
         if (Config_->TvmOnlyAuth && Config_->TvmOnlyRpcPort) {
             auto addresses = GetLocalAddresses(Config_->Addresses, Config_->TvmOnlyRpcPort);


### PR DESCRIPTION
Old client are confused by new enum value in proxy discovery response.
Hide RPC proxy PublicRpc address unless we really have separate port.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: fix
Component: rpc-proxy

Remove RPC proxy PublicRpc address fallback to InternalRpc
