### PR TITLE
yt/cli: fix "yt execute" for commands with input data

### DIFF
--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -1966,7 +1966,7 @@ def add_remove_member_parser(add_parser):
 def execute(**kwargs):
     if "output_format" not in kwargs["execute_params"]:
         kwargs["execute_params"]["output_format"] = yt.create_format(output_format)
-    data = chunk_iter_stream(sys.stdin, 16 * MB) if "input_format" in kwargs["execute_params"] else None
+    data = chunk_iter_stream(get_binary_std_stream(sys.stdin), 16 * MB) if "input_format" in kwargs["execute_params"] else None
     result = yt.driver.make_request(kwargs["command_name"], kwargs["execute_params"], data=data)
     if result is not None:
         print_to_output(result, eoln=False)

--- a/yt/python/yt/wrapper/tests/test_yt_cli.py
+++ b/yt/python/yt/wrapper/tests/test_yt_cli.py
@@ -536,6 +536,17 @@ class TestYtBinary(object):
         response = yt_cli.check_output(["yt", "execute", "exists", "{path=\"" + table_path + "\";output_format=json}"])
         assert not json.loads(response)["value"]
 
+    @authors("khlebnikov")
+    def test_execute_binary_stdin(self, yt_cli: YtCli):
+        file_path = "//home/wrapper_test/binary_file"
+        data = b"\x00\xff\x7f"
+        process = yt_cli.run_in_background([
+            "yt", "execute", "write_file", "{path=\\\"" + file_path + "\\\";input_format=binary}"
+        ])
+        stdout, stderr = process.communicate(input=data)
+        assert process.returncode == 0
+        assert yt_cli.check_output(["yt", "read-file", file_path]) == data
+
     @authors("ilyaibraev")
     def test_brotli_write(self, yt_cli: YtCli):
         table_path = "//home/wrapper_test/test_table"


### PR DESCRIPTION
For example:
echo '{}' | yt execute set '{path="...";input_format=yson}'

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
