### PR TITLE
yt/yt/core/https: make secure by default

### DIFF
--- a/yt/yt/core/crypto/config.cpp
+++ b/yt/yt/core/crypto/config.cpp
@@ -78,7 +78,7 @@ void TSslContextConfig::Register(TRegistrar registrar)
     registrar.Parameter("ssl_configuration_commands", &TThis::SslConfigurationCommands)
         .Optional();
     registrar.Parameter("insecure_skip_verify", &TThis::InsecureSkipVerify)
-        .Default(DefaultInsecureSkipVerify);
+        .Default(false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/crypto/config.h
+++ b/yt/yt/core/crypto/config.h
@@ -30,9 +30,6 @@ DEFINE_REFCOUNTED_TYPE(TPemBlobConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-//! FIXME: Enabled during migration, because this code has always been broken.
-constexpr bool DefaultInsecureSkipVerify = true;
-
 struct TSslContextCommand
     : public NYTree::TYsonStruct
 {

--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -184,7 +184,7 @@ struct TSslContextImpl
         return SSL_get_SSL_CTX(ssl) == ActiveContext_.get();
     }
 
-    DEFINE_BYVAL_RW_BOOLEAN_PROPERTY(InsecureSkipVerify, DefaultInsecureSkipVerify);
+    DEFINE_BYVAL_RW_BOOLEAN_PROPERTY(InsecureSkipVerify, false);
 
 private:
     YT_DECLARE_SPIN_LOCK(NThreading::TReaderWriterSpinLock, Lock_);

--- a/yt/yt/core/http/unittests/http_ut.cpp
+++ b/yt/yt/core/http/unittests/http_ut.cpp
@@ -650,7 +650,6 @@ private:
 
             auto clientConfig = New<NHttps::TClientConfig>();
             clientConfig->Credentials = New<NHttps::TClientCredentialsConfig>();
-            clientConfig->Credentials->InsecureSkipVerify = false;
             clientConfig->Credentials->CertificateAuthority = CreateTestKeyBlob("ca.pem");
             SetupClient(clientConfig);
             Client = NHttps::CreateClient(clientConfig, Poller);
@@ -685,7 +684,6 @@ TEST_P(THttpServerTest, CertificateValidation)
 
     auto clientConfig = New<NHttps::TClientConfig>();
     clientConfig->Credentials = New<NHttps::TClientCredentialsConfig>();
-    clientConfig->Credentials->InsecureSkipVerify = false;
     auto client = NHttps::CreateClient(clientConfig, Poller);
 
     auto result = WaitFor(client->Get(TestUrl + "/ok"));


### PR DESCRIPTION
Let's make HTTPS secure by default. Like it always supposed to be.

Link: https://github.com/ytsaurus/ytsaurus/pull/1357
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: Fix
Component: core

Make HTTPS client secure by default.
