### PR TITLE
yt/environment: enable mutual TLS for cluster connection

### DIFF
--- a/yt/python/yt/environment/api/__init__.py
+++ b/yt/python/yt/environment/api/__init__.py
@@ -81,6 +81,8 @@ class LocalYtConfig(object):
     public_ca_cert_key = attr.ib(None)
     rpc_cert = attr.ib(None)
     rpc_cert_key = attr.ib(None)
+    rpc_client_cert = attr.ib(None)
+    rpc_client_cert_key = attr.ib(None)
     https_cert = attr.ib(None)
     https_cert_key = attr.ib(None)
     public_rpc_cert = attr.ib(None)

--- a/yt/python/yt/environment/configs_provider.py
+++ b/yt/python/yt/environment/configs_provider.py
@@ -454,6 +454,8 @@ def _build_master_configs(yt_config,
 
             config["cluster_connection"] = cluster_connection_config
 
+            config["bus_client"] = _build_native_bus_config(yt_config)
+
             multidaemon_config_output["daemons"][f"master_{cell_index}_{master_index}"] = {
                 "type": "master",
                 "config": config,
@@ -529,6 +531,8 @@ def _build_clock_configs(yt_config, multidaemon_config_output, clock_dirs, clock
 
         config["rpc_port"], config["monitoring_port"] = ports[clock_index]
 
+        config["bus_client"] = _build_native_bus_config(yt_config)
+
         config["clock_cell"] = connection_config
 
         # COMPAT(aleksandra-zh)
@@ -591,6 +595,8 @@ def _build_discovery_server_configs(yt_config, multidaemon_config_output, ports_
 
         config["rpc_port"], config["monitoring_port"] = ports[index]
 
+        config["bus_client"] = _build_native_bus_config(yt_config)
+
         multidaemon_config_output["daemons"][f"discovery_{index}"] = {
             "type": "discovery_server",
             "config": config,
@@ -641,6 +647,8 @@ def _build_queue_agent_configs(multidaemon_config_output,
 
         config["rpc_port"] = rpc_ports[index]
         config["monitoring_port"] = next(ports_generator)
+
+        config["bus_client"] = _build_native_bus_config(yt_config)
 
         set_at(config, "queue_agent/stage", "production")
 
@@ -742,6 +750,8 @@ def _build_timestamp_provider_configs(yt_config,
 
         config["rpc_port"] = next(ports_generator)
         config["monitoring_port"] = next(ports_generator)
+
+        config["bus_client"] = _build_native_bus_config(yt_config)
 
         multidaemon_config_output["daemons"][f"timestamp_provider_{index}"] = {
             "type": "timestamp_provider",
@@ -1064,17 +1074,30 @@ def _build_node_configs(multidaemon_config_output,
                 _get_node_job_environment_config(yt_config, index, logs_dir)
             )
 
+        if yt_config.enable_tls:
+            set_at(config, "exec_node/job_proxy/supervisor_connection", _build_native_bus_config(yt_config))
+            set_at(config, "exec_node/job_proxy/supervisor_connection/address", "{0}:{1}".format("127.0.0.1", config["rpc_port"]))
+
         if yt_config.jobs_environment_type == "cri":
             # Forward variables set in docker image into user job environment.
             set_at(config, "exec_node/job_proxy/forward_all_environment_variables", True)
 
-            # Job proxy needs CA certificate to validate incoming connections.
-            if yt_config.internal_ca_cert is not None:
-                get_at(config, "exec_node/slot_manager/job_environment/job_proxy_bind_mounts").append({
-                    "internal_path": yt_config.internal_ca_cert,
-                    "external_path": yt_config.internal_ca_cert,
-                    "read_only": True,
-                })
+            # Job proxy needs TLS certificates for bus connections in both directions.
+            bus_certs = (
+                yt_config.internal_ca_cert,
+                yt_config.rpc_cert,
+                yt_config.rpc_cert_key,
+                yt_config.rpc_client_cert,
+                yt_config.rpc_client_cert_key,
+            )
+
+            for cert in bus_certs:
+                if cert is not None:
+                    get_at(config, "exec_node/slot_manager/job_environment/job_proxy_bind_mounts").append({
+                        "internal_path": cert,
+                        "external_path": cert,
+                        "read_only": True,
+                    })
 
         if yt_config.use_slot_user_id:
             start_uid = 10000 + config["rpc_port"]
@@ -1478,6 +1501,8 @@ def _build_native_driver_configs(master_connection_configs,
                 }
             }
 
+            cell_connection_config["bus_client"] = _build_native_bus_config(yt_config)
+
             if yt_config.mock_tvm_id is not None:
                 cell_connection_config["tvm_id"] = yt_config.mock_tvm_id
 
@@ -1657,6 +1682,29 @@ def _build_rpc_proxy_configs(multidaemon_config_output,
     return configs
 
 
+def _build_native_bus_config(yt_config, is_server=False):
+    if not yt_config.enable_tls:
+        return {
+            "encryption_mode": "disabled",
+            "verification_mode": "none",
+        }
+
+    return {
+        "ca": {
+            "file_name": yt_config.internal_ca_cert,
+        },
+        "cert_chain": {
+            "file_name": yt_config.rpc_cert if is_server else yt_config.rpc_client_cert,
+        },
+        "private_key": {
+            "file_name": yt_config.rpc_cert_key if is_server else yt_config.rpc_client_cert_key,
+        },
+        "encryption_mode": "required",
+        "verification_mode": "full",
+        "peer_alternative_host_name": yt_config.cluster_name,
+    }
+
+
 def _build_cluster_connection_config(yt_config,
                                      master_connection_configs,
                                      clock_connection_config,
@@ -1782,6 +1830,8 @@ def _build_cluster_connection_config(yt_config,
         update_inplace(cluster_connection["cypress_proxy"], _get_balancing_channel_config())
         cluster_connection["cypress_proxy"]["addresses"] = cypress_proxy_addresses
 
+    cluster_connection["bus_client"] = _build_native_bus_config(yt_config)
+
     if yt_config.mock_tvm_id is not None:
         cluster_connection["tvm_id"] = yt_config.mock_tvm_id
 
@@ -1857,16 +1907,6 @@ def _build_cluster_connection_config(yt_config,
             "refresh_time": 0,
             "expiration_period": 0,
         }
-
-    if yt_config.internal_ca_cert is not None:
-        set_at(cluster_connection, "bus_client", {
-            "ca": {
-                "file_name": yt_config.internal_ca_cert,
-            },
-            "encryption_mode": "required",
-            "verification_mode": "full",
-            "peer_alternative_host_name": yt_config.cluster_name,
-        })
 
     if yt_config.delta_global_cluster_connection_config:
         cluster_connection = update(cluster_connection, yt_config.delta_global_cluster_connection_config)
@@ -2242,16 +2282,7 @@ def init_singletons(config, yt_config):
             },
             "enable_validation": True,
         })
-    if yt_config.rpc_cert is not None:
-        set_at(config, "bus_server", {
-            "encryption_mode": "optional",
-            "cert_chain": {
-                "file_name": yt_config.rpc_cert,
-            },
-            "private_key": {
-                "file_name": yt_config.rpc_cert_key,
-            },
-        })
+    set_at(config, "bus_server", _build_native_bus_config(yt_config, is_server=True))
 
 
 def init_jaeger_collector(config, name, process_tags):

--- a/yt/python/yt/environment/tls_helpers.py
+++ b/yt/python/yt/environment/tls_helpers.py
@@ -1,3 +1,4 @@
+from itertools import chain
 import subprocess
 import tempfile
 
@@ -22,12 +23,21 @@ def create_ca(ca_cert, ca_cert_key, subj="/CN=Fake CA", key_type="rsa:2048"):
             "-sha512", "-nodes", "-newkey", key_type,
             "-days", "30", "-subj", subj,
             "-keyout", ca_cert_key, "-out", ca_cert,
+            "-addext", "basicConstraints=critical,CA:TRUE,pathlen:0",
+            "-addext", "keyUsage=critical,keyCertSign",
         ], stderr=subprocess.DEVNULL)
 
 
-def create_certificate(cert, cert_key, ca_cert, ca_cert_key, names, key_type="rsa:2048"):
-    subj = "/CN=" + names[0]
-    addext = "subjectAltName = " + ",".join(["DNS:" + n for n in names])
+def create_certificate(cert, cert_key, ca_cert, ca_cert_key, names, subj=None, extended_key_usage="serverAuth", key_type="rsa:2048"):
+    if subj is None:
+        subj = "/CN=" + names[0]
+    addext = [
+        "subjectAltName = " + ",".join(["DNS:" + n for n in names]),
+        "basicConstraints = critical,CA:FALSE",
+        "keyUsage = critical,digitalSignature,keyEncipherment",
+        "extendedKeyUsage = critical," + extended_key_usage,
+    ]
+    addext_args = list(chain(*[["-addext", ext] for ext in addext]))
 
     # works for openssl 3.x
     # run([openssl_binary(), "req",  "-batch", "-x509", "-nodes", "-sha512",
@@ -43,14 +53,14 @@ def create_certificate(cert, cert_key, ca_cert, ca_cert_key, names, key_type="rs
         cfg.write("[req]\ndistinguished_name = req\n")
         cfg.flush()
 
-        ext.write("[ext]\n{}\n".format(addext))
+        ext.write("[ext]\n{}\n".format("\n".join(addext)))
         ext.flush()
 
         subprocess.check_call([
             openssl_binary(), "req", "-new", "-batch", "-config", cfg.name,
-            "-nodes", "-newkey", key_type, "-subj", subj, "-addext", addext,
+            "-nodes", "-newkey", key_type, "-subj", subj,
             "-keyout", cert_key, "-out", cert_req.name,
-        ], stderr=subprocess.DEVNULL)
+        ] + addext_args, stderr=subprocess.DEVNULL)
 
         subprocess.check_call([
             openssl_binary(), "x509", "-req", "-sha512", "-days", "30",

--- a/yt/python/yt/environment/yt_env.py
+++ b/yt/python/yt/environment/yt_env.py
@@ -423,7 +423,7 @@ class YTInstance(object):
             create_ca(
                 ca_cert=self.yt_config.internal_ca_cert,
                 ca_cert_key=self.yt_config.internal_ca_cert_key,
-                subj="/O={}/OU={}".format(self.id, "YT Internal CA"),
+                subj=f"/O={self.id}/OU=YT Internal CA",
             )
 
         if self.yt_config.public_ca_cert is None:
@@ -432,7 +432,7 @@ class YTInstance(object):
             create_ca(
                 ca_cert=self.yt_config.public_ca_cert,
                 ca_cert_key=self.yt_config.public_ca_cert_key,
-                subj="/O={}/OU={}".format(self.id, "YT Public CA"),
+                subj=f"/O={self.id}/OU=YT Public CA",
             )
 
         if self.yt_config.rpc_cert is None:
@@ -443,7 +443,22 @@ class YTInstance(object):
                 ca_cert_key=self.yt_config.internal_ca_cert_key,
                 cert=self.yt_config.rpc_cert,
                 cert_key=self.yt_config.rpc_cert_key,
-                names=names
+                names=names,
+                extended_key_usage="serverAuth",
+                subj=f"/O={self.id}/OU=YT Native RPC Server",
+            )
+
+        if self.yt_config.rpc_client_cert is None:
+            self.yt_config.rpc_client_cert = os.path.join(self.path, "rpc_client.crt")
+            self.yt_config.rpc_client_cert_key = os.path.join(self.path, "rpc_client.key")
+            create_certificate(
+                ca_cert=self.yt_config.internal_ca_cert,
+                ca_cert_key=self.yt_config.internal_ca_cert_key,
+                cert=self.yt_config.rpc_client_cert,
+                cert_key=self.yt_config.rpc_client_cert_key,
+                names=names,
+                extended_key_usage="clientAuth",
+                subj=f"/O={self.id}/OU=YT Native RPC Client",
             )
 
         if self.yt_config.https_cert is None and self.yt_config.http_proxy_count > 0:
@@ -454,7 +469,8 @@ class YTInstance(object):
                 ca_cert_key=self.yt_config.public_ca_cert_key,
                 cert=self.yt_config.https_cert,
                 cert_key=self.yt_config.https_cert_key,
-                names=names
+                names=names,
+                subj=f"/O={self.id}/OU=YT HTTPS Server",
             )
 
         if self.yt_config.public_rpc_cert is None and self.yt_config.rpc_proxy_count > 0:
@@ -465,7 +481,8 @@ class YTInstance(object):
                 ca_cert_key=self.yt_config.public_ca_cert_key,
                 cert=self.yt_config.public_rpc_cert,
                 cert_key=self.yt_config.public_rpc_cert_key,
-                names=names
+                names=names,
+                subj=f"/O={self.id}/OU=YT Public RPC Server",
             )
 
     def _prepare_builtin_environment(self, ports_generator, modify_configs_func, modify_driver_logging_config_func):

--- a/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
+++ b/yt/yt/tests/integration/YaMakeBoilerplateForTests.txt
@@ -64,6 +64,7 @@ ENDIF()
 DEPENDS(
     yt/yt/packages/tests_package
     yt/yt/tools/yt_sudo_fixup
+    contrib/libs/openssl/apps
 )
 
 IF (NOT OPENSOURCE)

--- a/yt/yt/tests/integration/YaMakeDependsBoilerplate.txt
+++ b/yt/yt/tests/integration/YaMakeDependsBoilerplate.txt
@@ -14,7 +14,6 @@ DEPENDS(
 #proxies
 DEPENDS(
     yt/yt/tests/integration/fake_blackbox
-    contrib/libs/openssl/apps
 )
 
 IF (NOT OPENSOURCE)

--- a/yt/yt/tests/library/yt_env_setup.py
+++ b/yt/yt/tests/library/yt_env_setup.py
@@ -324,7 +324,7 @@ class YTEnvSetup(object):
     ENABLE_DYNAMIC_TABLE_COLUMN_RENAMES = True
     ENABLE_STATIC_DROP_COLUMN = True
     ENABLE_DYNAMIC_DROP_COLUMN = True
-    ENABLE_TLS = False
+    ENABLE_TLS = None
 
     JOB_PROXY_LOGGING = {"mode": "per_job_directory"}
 
@@ -616,6 +616,10 @@ class YTEnvSetup(object):
         if os.environ.get("YT_DISABLE_MULTIDAEMON"):
             enable_multidaemon = False
 
+        enable_tls = cls.ENABLE_TLS
+        if enable_tls is None and bool(os.environ.get("YT_ENABLE_TLS")):
+            enable_tls = True
+
         job_proxy_logging = cls.get_param("JOB_PROXY_LOGGING", index)
         # COMPAT(pogorelov): drop after migrating compat tests in 25.1
         if "node" in cls.ARTIFACT_COMPONENTS.get("24_2", []):
@@ -719,7 +723,7 @@ class YTEnvSetup(object):
             enable_resource_tracking=cls.get_param("ENABLE_RESOURCE_TRACKING", index),
             enable_tvm_only_proxies=cls.get_param("ENABLE_TVM_ONLY_PROXIES", index),
             mock_tvm_id=(1000 + index if use_native_auth else None),
-            enable_tls=cls.ENABLE_TLS,
+            enable_tls=enable_tls,
             enable_legacy_logging_scheme=enable_legacy_logging_scheme,
             wait_for_dynamic_config=cls.WAIT_FOR_DYNAMIC_CONFIG,
             enable_chyt_http_proxies=cls.get_param("ENABLE_CHYT_HTTP_PROXIES", index),


### PR DESCRIPTION
Mutual TLS is a simple way to secure internal RPC once and for all.
If it is working there is no much reason to use it partially
(i.e. only HTTPS or RPC proxy BUS TLS without internal RPC mTLS).

Environment "YT_ENABLE_TLS=1" activates mTLS for all integration tests.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
