### PR TITLE
Increase MaxMediumCount from 120 to 64'000

### DIFF
--- a/library/cpp/yt/compact_containers/compact_map-inl.h
+++ b/library/cpp/yt/compact_containers/compact_map-inl.h
@@ -1,0 +1,634 @@
+#ifndef COMPACT_MAP_INL_H_
+#error "Direct inclusion of this file is not allowed, include compact_map.h"
+#include "compact_map.h"
+#endif
+
+namespace NYT {
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <bool IsConst>
+class TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TIteratorBase
+{
+private:
+    friend class TCompactMap<TKey, TValue, N, TCompare, TAllocator>;
+    friend class TIteratorBase<!IsConst>;
+    friend class iterator;
+    friend class const_iterator;
+
+    using TVecIter = std::conditional_t<IsConst, TVectorConstIterator, TVectorIterator>;
+    using TMapIter = std::conditional_t<IsConst, TMapConstIterator, TMapIterator>;
+    using TValueType = typename TCompactMap::value_type;
+    using TVectorValue = typename TCompactMap::TVectorValue;
+    using TSmallValue = std::conditional_t<IsConst, const TVectorValue, TVectorValue>;
+    using TSmallPointer = std::conditional_t<IsConst, const TVectorValue*, TVectorValue*>;
+    using TReference = std::conditional_t<IsConst, const TValueType&, TValueType&>;
+    using TPointer = std::conditional_t<IsConst, const TValueType*, TValueType*>;
+
+    static_assert(
+        sizeof(TVectorValue) == sizeof(TValueType),
+        "TCompactMap relies on identical layout of internal and public pair types");
+    static_assert(
+        alignof(TVectorValue) == alignof(TValueType),
+        "TCompactMap relies on identical layout of internal and public pair types");
+
+    static TReference VectorRef(TSmallValue& value)
+    {
+        // Technically, this violates strict aliasing rules, and is, therefore, undefined behavior.
+        // In practice, see the comment regarding value_type in the class header. It is defined
+        // with `may_alias` attribute to suppress optimizations based on type-based alias analysis.
+        return reinterpret_cast<TReference>(value);
+    }
+
+    static TPointer VectorPtr(TSmallPointer ptr)
+    {
+        // Technically, this violates strict aliasing rules, and is, therefore, undefined behavior.
+        // In practice, see the comment regarding value_type in the class header. It is defined
+        // with `may_alias` attribute to suppress optimizations based on type-based alias analysis.
+        return reinterpret_cast<TPointer>(ptr);
+    }
+
+    union
+    {
+        TVecIter VIter;
+        TMapIter MIter;
+    };
+    bool Small_;
+
+    explicit TIteratorBase(TVecIter it)
+        : VIter(it)
+        , Small_(true)
+    { }
+
+    explicit TIteratorBase(TMapIter it)
+        : MIter(it)
+        , Small_(false)
+    { }
+
+    // Conversion constructor for const_iterator from iterator.
+    template <bool WasConst, typename = std::enable_if_t<IsConst && !WasConst>>
+    TIteratorBase(const TIteratorBase<WasConst>& other)
+        : Small_(other.Small_)
+    {
+        if (Small_) {
+            VIter = other.VIter;
+        } else {
+            MIter = other.MIter;
+        }
+    }
+
+public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = TValueType;
+    using reference = TReference;
+    using pointer = TPointer;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    reference operator*() const
+    {
+        if (Small_) {
+            return VectorRef(*VIter);
+        }
+        return *MIter;
+    }
+
+    pointer operator->() const
+    {
+        if (Small_) {
+            return VectorPtr(&*VIter);
+        }
+        return &*MIter;
+    }
+
+    TIteratorBase& operator++()
+    {
+        if (Small_) {
+            ++VIter;
+        } else {
+            ++MIter;
+        }
+        return *this;
+    }
+
+    TIteratorBase operator++(int)
+    {
+        TIteratorBase tmp = *this;
+        ++*this;
+        return tmp;
+    }
+
+    TIteratorBase& operator--()
+    {
+        if (Small_) {
+            --VIter;
+        } else {
+            --MIter;
+        }
+        return *this;
+    }
+
+    TIteratorBase operator--(int)
+    {
+        TIteratorBase tmp = *this;
+        --*this;
+        return tmp;
+    }
+
+    bool operator==(const TIteratorBase& other) const
+    {
+        if (Small_ != other.Small_) {
+            return false;
+        }
+        return Small_ ? VIter == other.VIter : MIter == other.MIter;
+    }
+
+    bool operator!=(const TIteratorBase& other) const
+    {
+        return !(*this == other);
+    }
+};
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+class TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator
+    : public TCompactMap<TKey, TValue, N, TCompare, TAllocator>::template TIteratorBase<false>
+{
+public:
+    iterator() = default;
+
+private:
+    friend class TCompactMap<TKey, TValue, N, TCompare, TAllocator>;
+    friend class const_iterator;
+    using TBase = typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::template TIteratorBase<false>;
+
+    explicit iterator(TVectorIterator it)
+        : TBase(it)
+    { }
+
+    explicit iterator(TMapIterator it)
+        : TBase(it)
+    { }
+};
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+class TCompactMap<TKey, TValue, N, TCompare, TAllocator>::const_iterator
+    : public TCompactMap<TKey, TValue, N, TCompare, TAllocator>::template TIteratorBase<true>
+{
+public:
+    const_iterator() = default;
+    
+    // Allow implicit conversion from iterator to const_iterator.
+    const_iterator(const iterator& other)
+        : TBase(other.Small_ ? TBase(other.VIter) : TBase(other.MIter))
+    { }
+
+private:
+    friend class TCompactMap<TKey, TValue, N, TCompare, TAllocator>;
+    using TBase = typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::template TIteratorBase<true>;
+
+    explicit const_iterator(TVectorConstIterator it)
+        : TBase(it)
+    { }
+
+    explicit const_iterator(TMapConstIterator it)
+        : TBase(it)
+    { }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TCompactMap(const allocator_type& alloc)
+    : Alloc_(alloc)
+    , Map_(key_compare{}, alloc)
+{ }
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TIt>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TCompactMap(TIt first, TIt last)
+{
+    insert(first, last);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TCompactMap(std::initializer_list<value_type> init)
+{
+    insert(init.begin(), init.end());
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+bool TCompactMap<TKey, TValue, N, TCompare, TAllocator>::empty() const
+{
+    return IsSmall() ? Vector_.empty() : Map_.empty();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::size_type
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::size() const
+{
+    return IsSmall() ? Vector_.size() : Map_.size();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+void TCompactMap<TKey, TValue, N, TCompare, TAllocator>::clear()
+{
+    Vector_.clear();
+    Map_.clear();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::begin() -> iterator
+{
+    return BeginImpl(this);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::begin() const -> const_iterator
+{
+    return BeginImpl(this);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::cbegin() const -> const_iterator
+{
+    return begin();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::end() -> iterator
+{
+    return EndImpl(this);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::end() const -> const_iterator
+{
+    return EndImpl(this);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::cend() const -> const_iterator
+{
+    return end();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+bool TCompactMap<TKey, TValue, N, TCompare, TAllocator>::IsSmall() const
+{
+    return Map_.empty();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+void TCompactMap<TKey, TValue, N, TCompare, TAllocator>::UpgradeToMap()
+{
+    if (!IsSmall()) {
+        return;
+    }
+
+    Map_ = TMap(Compare_, Alloc_);
+    for (auto& item : Vector_) {
+        Map_.emplace(item.first, item.second);
+    }
+
+    Vector_.clear();
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TVectorConstIterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::VectorLowerBound(const key_type& key) const
+{
+    return VectorLowerBoundImpl(Vector_.begin(), Vector_.end(), key, Compare_);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TVectorIterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::VectorLowerBound(const key_type& key)
+{
+    return VectorLowerBoundImpl(Vector_.begin(), Vector_.end(), key, Compare_);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class... TArgs>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::EmplaceSmall(TVectorConstIterator pos, TArgs&&... args) -> TVectorIterator
+{
+    return Vector_.emplace(pos, std::forward<TArgs>(args)...);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TVectorIteratorType>
+std::pair<TVectorIteratorType, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::VectorLowerBoundImpl(
+    TVectorIteratorType begin,
+    TVectorIteratorType end,
+    const key_type& key,
+    const key_compare& compare)
+{
+    auto comp = [&compare] (const auto& pair, const key_type& k) {
+        return compare(pair.first, k);
+    };
+
+    auto it = std::lower_bound(begin, end, key, comp);
+    bool found = (it != end && !compare(key, it->first));
+    return {it, found};
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TKeyParam>
+typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::mapped_type&
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::Subscript(TKeyParam&& key)
+{
+    if (IsSmall()) {
+        auto [vectorIt, found] = VectorLowerBound(key);
+
+        if (found) {
+            return vectorIt->second;
+        }
+
+        if (Vector_.size() < N) {
+            auto inserted = EmplaceSmall(vectorIt, std::forward<TKeyParam>(key), mapped_type());
+            return inserted->second;
+        }
+
+        UpgradeToMap();
+    }
+
+    return Map_[std::forward<TKeyParam>(key)];
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TSelf>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::BeginImpl(TSelf* self)
+    -> std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>
+{
+    using TResult = std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>;
+    if (self->IsSmall()) {
+        return TResult(self->Vector_.begin());
+    }
+    return TResult(self->Map_.begin());
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TSelf>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::EndImpl(TSelf* self)
+    -> std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>
+{
+    using TResult = std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>;
+    if (self->IsSmall()) {
+        return TResult(self->Vector_.end());
+    }
+    return TResult(self->Map_.end());
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TSelf>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::FindImpl(TSelf* self, const key_type& key)
+    -> std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>
+{
+    using TResult = std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>;
+    if (self->IsSmall()) {
+        auto [it, found] = self->VectorLowerBound(key);
+        return found ? TResult(it) : TResult(self->Vector_.end());
+    }
+    return TResult(self->Map_.find(key));
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TSelf>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::AtImpl(TSelf* self, const key_type& key)
+    -> std::conditional_t<std::is_const_v<TSelf>, const mapped_type&, mapped_type&>
+{
+    auto it = FindImpl(self, key);
+    if (it == EndImpl(self)) {
+        throw std::out_of_range("TCompactMap::at");
+    }
+    return it->second;
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::size_type
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::count(const key_type& key) const
+{
+    return FindImpl(this, key) == EndImpl(this) ? 0 : 1;
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+bool TCompactMap<TKey, TValue, N, TCompare, TAllocator>::contains(const key_type& key) const
+{
+    return FindImpl(this, key) != EndImpl(this);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::find(const key_type& key) -> iterator
+{
+    return FindImpl(this, key);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::find(const key_type& key) const -> const_iterator
+{
+    return FindImpl(this, key);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::insert(const value_type& v)
+{
+    if (IsSmall()) {
+        auto [vectorIt, found] = VectorLowerBound(v.first);
+
+        if (found) {
+            return {iterator(vectorIt), false};
+        }
+
+        if (Vector_.size() < N) {
+            auto inserted = EmplaceSmall(vectorIt, v.first, v.second);
+            return {iterator(inserted), true};
+        }
+
+        UpgradeToMap();
+    }
+
+    auto [mapIt, inserted] = Map_.emplace(v.first, v.second);
+    return {iterator(mapIt), inserted};
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class... TArgs>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::emplace(TArgs&&... args)
+{
+    if (IsSmall()) {
+        TVectorValue value(std::forward<TArgs>(args)...);
+        auto [vectorIt, found] = VectorLowerBound(value.first);
+
+        if (found) {
+            return {iterator(vectorIt), false};
+        }
+
+        if (Vector_.size() < N) {
+            auto inserted = EmplaceSmall(vectorIt, std::move(value));
+            return {iterator(inserted), true};
+        }
+
+        UpgradeToMap();
+
+        // We already constructed the value above, so we cannot forward args again below.
+        auto [mapIt, inserted] = Map_.emplace(std::move(value));
+        return {iterator(mapIt), inserted};
+    }
+
+    auto [mapIt, inserted] = Map_.emplace(std::forward<TArgs>(args)...);
+    return {iterator(mapIt), inserted};
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class... TArgs>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::try_emplace(const key_type& key, TArgs&&... args)
+{
+    return TryEmplaceImpl(key, std::forward<TArgs>(args)...);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class... TArgs>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::try_emplace(key_type&& key, TArgs&&... args)
+{
+    return TryEmplaceImpl(std::move(key), std::forward<TArgs>(args)...);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TIt>
+void TCompactMap<TKey, TValue, N, TCompare, TAllocator>::insert(TIt first, TIt last)
+{
+    for (; first != last; ++first) {
+        insert(*first);
+    }
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class M>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator, bool> TCompactMap<TKey, TValue, N, TCompare, TAllocator>::insert_or_assign(const key_type& key, M&& obj)
+{
+    if (IsSmall()) {
+        auto [vectorIt, found] = VectorLowerBound(key);
+        
+        if (found) {
+            vectorIt->second = std::forward<M>(obj);
+            return {iterator(vectorIt), false};
+        }
+
+        if (Vector_.size() < N) {
+            auto inserted = EmplaceSmall(vectorIt, key, std::forward<M>(obj));
+            return {iterator(inserted), true};
+        }
+
+        UpgradeToMap();
+    }
+
+    auto [mapIt, inserted] = Map_.insert_or_assign(key, std::forward<M>(obj));
+    return {iterator(mapIt), inserted};
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+template <class TKeyParam, class... TArgs>
+std::pair<typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::iterator, bool>
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::TryEmplaceImpl(TKeyParam&& key, TArgs&&... args)
+{
+    if (IsSmall()) {
+        auto [vectorIt, found] = VectorLowerBound(key);
+
+        if (found) {
+            return {iterator(vectorIt), false};
+        }
+
+        if (Vector_.size() < N) {
+            auto inserted = EmplaceSmall(
+                vectorIt,
+                std::piecewise_construct,
+                std::forward_as_tuple(std::forward<TKeyParam>(key)),
+                std::forward_as_tuple(std::forward<TArgs>(args)...));
+            return {iterator(inserted), true};
+        }
+
+        UpgradeToMap();
+    }
+
+    auto [mapIt, inserted] = Map_.try_emplace(std::forward<TKeyParam>(key), std::forward<TArgs>(args)...);
+    return {iterator(mapIt), inserted};
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::erase(const key_type& key) -> size_type
+{
+    if (IsSmall()) {
+        auto [vectorIt, found] = VectorLowerBound(key);
+
+        if (!found) {
+            return 0;
+        }
+
+        Vector_.erase(vectorIt);
+        return 1;
+    }
+
+    return Map_.erase(key);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::erase(iterator pos) -> iterator
+{
+    return erase(const_iterator(pos));
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::erase(const_iterator pos) -> iterator
+{
+    if (IsSmall()) {
+        return iterator(Vector_.erase(pos.VIter));
+    }
+
+    return iterator(Map_.erase(pos.MIter));
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+auto TCompactMap<TKey, TValue, N, TCompare, TAllocator>::erase(const_iterator first, const_iterator last) -> iterator
+{
+    if (IsSmall()) {
+        return iterator(Vector_.erase(first.VIter, last.VIter));
+    }
+
+    return iterator(Map_.erase(first.MIter, last.MIter));
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::mapped_type&
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::operator[](const key_type& key)
+{
+    return Subscript(key);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::mapped_type&
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::operator[](key_type&& key)
+{
+    return Subscript(std::move(key));
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::mapped_type&
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::at(const key_type& key)
+{
+    return AtImpl(this, key);
+}
+
+template <class TKey, class TValue, size_t N, class TCompare, class TAllocator>
+const typename TCompactMap<TKey, TValue, N, TCompare, TAllocator>::mapped_type&
+TCompactMap<TKey, TValue, N, TCompare, TAllocator>::at(const key_type& key) const
+{
+    return AtImpl(this, key);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT

--- a/library/cpp/yt/compact_containers/compact_map-inl.h
+++ b/library/cpp/yt/compact_containers/compact_map-inl.h
@@ -1,5 +1,6 @@
 #ifndef COMPACT_MAP_INL_H_
 #error "Direct inclusion of this file is not allowed, include compact_map.h"
+// For the sake of sane code completion.
 #include "compact_map.h"
 #endif
 

--- a/library/cpp/yt/compact_containers/compact_map.h
+++ b/library/cpp/yt/compact_containers/compact_map.h
@@ -14,8 +14,10 @@ namespace NYT {
 ///////////////////////////////////////////////////////////////////////////////
 
 //! A flat map that keeps up to N elements inline in a sorted TCompactVector,
-//! then transparently upgrades to std::map for larger sizes.
-//! Any modifying operation may invalidate all iterators.
+//! like TCompactFlatMap, but, unlike TCompactFlatMap, transparently falls back
+//! to std::map storage when the size exceeds N.
+//!
+//! Be very careful, any modifying operation may invalidate all iterators.
 template <
     class TKey,
     class TValue,

--- a/library/cpp/yt/compact_containers/compact_map.h
+++ b/library/cpp/yt/compact_containers/compact_map.h
@@ -1,0 +1,167 @@
+#pragma once
+
+#include "compact_vector.h"
+
+#include <map>
+#include <initializer_list>
+#include <tuple>
+#include <utility>
+#include <algorithm>
+#include <type_traits>
+
+namespace NYT {
+
+///////////////////////////////////////////////////////////////////////////////
+
+//! A flat map that keeps up to N elements inline in a sorted TCompactVector,
+//! then transparently upgrades to std::map for larger sizes.
+//! Any modifying operation may invalidate all iterators.
+template <
+    class TKey,
+    class TValue,
+    size_t N,
+    class TCompare = std::less<TKey>,
+    class TAllocator = std::allocator<std::pair<const TKey, TValue>>>
+class TCompactMap
+{
+public:
+    using key_type = TKey;
+    using mapped_type = TValue;
+    // We store std::pair<TKey, TValue> in TCompactVector because of its copy-assignability requirement.
+    // The underlying storage type of std::map is, obviosly, std::pair<const TKey, TValue>.
+    // To provide a single iterator interface, we use reinterpret_cast to convert between pointers
+    // to values of these types, which should have the same layout on all sane compilers.
+    // However, this is still technically undefined behavior and a strict aliasing violation.
+    // Annotating it with may_alias should stop optimizations based on type-based alias analysis.
+    using value_type = std::pair<const TKey, TValue> alias_hack;
+    using key_compare = TCompare;
+    using allocator_type = TAllocator;
+    using size_type = std::size_t;
+
+    class iterator;
+    class const_iterator;
+
+    TCompactMap() = default;
+    explicit TCompactMap(const allocator_type& alloc);
+
+    template <class TIt>
+    TCompactMap(TIt first, TIt last);
+
+    TCompactMap(std::initializer_list<value_type> init);
+
+    bool empty() const;
+    size_type size() const;
+
+    void clear();
+
+    iterator begin();
+    const_iterator begin() const;
+    const_iterator cbegin() const;
+
+    iterator end();
+    const_iterator end() const;
+    const_iterator cend() const;
+
+    size_type count(const key_type& key) const;
+
+    iterator find(const key_type& key);
+    const_iterator find(const key_type& key) const;
+
+    bool contains(const key_type& key) const;
+
+    std::pair<iterator, bool> insert(const value_type& v);
+
+    template <class... TArgs>
+    std::pair<iterator, bool> emplace(TArgs&&... args);
+
+    template <class... TArgs>
+    std::pair<iterator, bool> try_emplace(const key_type& key, TArgs&&... args);
+
+    template <class... TArgs>
+    std::pair<iterator, bool> try_emplace(key_type&& key, TArgs&&... args);
+
+    template <class TIt>
+    void insert(TIt first, TIt last);
+
+    template <class TMapped>
+    std::pair<iterator, bool> insert_or_assign(const key_type& key, TMapped&& obj);
+
+    size_type erase(const key_type& key);
+    iterator erase(iterator pos);
+    iterator erase(const_iterator pos);
+    iterator erase(const_iterator first, const_iterator last);
+
+    mapped_type& operator[](const key_type& key);
+    mapped_type& operator[](key_type&& key);
+
+    mapped_type& at(const key_type& key);
+    const mapped_type& at(const key_type& key) const;
+
+private:
+    template <bool IsConst>
+    class TIteratorBase;
+
+    // Inline vector stores pairs without const-qualified key, because its values have to be copy-assignable.
+    using TVector = TCompactVector<std::pair<TKey, TValue>, N>;
+    using TVectorValue = typename TVector::value_type;
+    using TMap = std::map<key_type, mapped_type, key_compare, allocator_type>;
+    using TVectorIterator = typename TVector::iterator;
+    using TVectorConstIterator = typename TVector::const_iterator;
+    using TMapIterator = typename TMap::iterator;
+    using TMapConstIterator = typename TMap::const_iterator;
+
+    TVector Vector_;
+    TMap Map_;
+    key_compare Compare_{};
+    allocator_type Alloc_{};
+
+    // Returns if map part is empty (i.e. we are still using inline vector).
+    bool IsSmall() const;
+    // Moves data from inline vector to map.
+    void UpgradeToMap();
+
+    // Performs binary search in inline vector. Returns iterator and found flag.
+    std::pair<TVectorConstIterator, bool> VectorLowerBound(const key_type& key) const;
+    std::pair<TVectorIterator, bool> VectorLowerBound(const key_type& key);
+
+    template <class... TArgs>
+    TVectorIterator EmplaceSmall(TVectorConstIterator pos, TArgs&&... args);
+
+    template <class TVectorIteratorType>
+    static std::pair<TVectorIteratorType, bool> VectorLowerBoundImpl(
+        TVectorIteratorType begin,
+        TVectorIteratorType end,
+        const key_type& key,
+        const key_compare& compare);
+
+    template <class TKeyParam>
+    mapped_type& Subscript(TKeyParam&& key);
+
+    template <class TSelf>
+    static auto BeginImpl(TSelf* self)
+        -> std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>;
+
+    template <class TSelf>
+    static auto EndImpl(TSelf* self)
+        -> std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>;
+
+    template <class TSelf>
+    static auto FindImpl(TSelf* self, const key_type& key)
+        -> std::conditional_t<std::is_const_v<TSelf>, const_iterator, iterator>;
+
+    template <class TSelf>
+    static auto AtImpl(TSelf* self, const key_type& key)
+        -> std::conditional_t<std::is_const_v<TSelf>, const mapped_type&, mapped_type&>;
+
+    template <class TKeyParam, class... TArgs>
+    std::pair<iterator, bool> TryEmplaceImpl(TKeyParam&& key, TArgs&&... args);
+
+};
+
+///////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT
+
+#define COMPACT_MAP_INL_H_
+#include "compact_map-inl.h"
+#undef COMPACT_MAP_INL_H_

--- a/library/cpp/yt/compact_containers/unittests/compact_map_ut.cpp
+++ b/library/cpp/yt/compact_containers/unittests/compact_map_ut.cpp
@@ -1,0 +1,875 @@
+#include <library/cpp/yt/compact_containers/compact_map.h>
+
+#include <library/cpp/testing/gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace NYT {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+using TMap = TCompactMap<std::string, std::string, 2>;
+
+TMap CreateMap()
+{
+    std::vector<std::pair<std::string, std::string>> data = {
+        {"I", "met"},
+        {"a", "traveller"},
+        {"from", "an"},
+        {"antique", "land"}
+    };
+    return {data.begin(), data.end()};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Basic operations.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, DefaultEmpty)
+{
+    TMap m;
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.begin(), m.end());
+    EXPECT_EQ(m.size(), 0u);
+}
+
+TEST(TCompactMapTest, Size)
+{
+    auto m = CreateMap();
+
+    EXPECT_EQ(m.size(), 4u);
+
+    m.insert({"Who", "said"});
+
+    EXPECT_EQ(m.size(), 5u);
+
+    m.erase("antique");
+
+    EXPECT_EQ(m.size(), 4u);
+}
+
+TEST(TCompactMapTest, ClearAndEmpty)
+{
+    auto m = CreateMap();
+
+    EXPECT_FALSE(m.empty());
+    EXPECT_NE(m.begin(), m.end());
+
+    m.clear();
+
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.begin(), m.end());
+
+    m.insert({"Who", "said"});
+
+    EXPECT_FALSE(m.empty());
+    EXPECT_NE(m.begin(), m.end());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Small size (inline vector) tests.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, InsertSmall)
+{
+    TCompactMap<int, std::string, 4> m;
+
+    auto [it1, inserted1] = m.insert({1, "one"});
+    EXPECT_TRUE(inserted1);
+    EXPECT_EQ(it1->first, 1);
+    EXPECT_EQ(it1->second, "one");
+    EXPECT_EQ(m.size(), 1u);
+
+    auto [it2, inserted2] = m.insert({2, "two"});
+    EXPECT_TRUE(inserted2);
+    EXPECT_EQ(m.size(), 2u);
+
+    auto [it3, inserted3] = m.insert({1, "uno"});
+    EXPECT_FALSE(inserted3);
+    EXPECT_EQ(it3->second, "one"); // Value not changed
+    EXPECT_EQ(m.size(), 2u);
+}
+
+TEST(TCompactMapTest, FindSmall)
+{
+    TCompactMap<int, std::string, 4> m;
+    m.insert({1, "one"});
+    m.insert({2, "two"});
+    m.insert({3, "three"});
+
+    auto it = m.find(2);
+    EXPECT_NE(it, m.end());
+    EXPECT_EQ(it->first, 2);
+    EXPECT_EQ(it->second, "two");
+
+    auto it2 = m.find(99);
+    EXPECT_EQ(it2, m.end());
+}
+
+TEST(TCompactMapTest, EraseSmall)
+{
+    TCompactMap<int, std::string, 4> m;
+    m.insert({1, "one"});
+    m.insert({2, "two"});
+    m.insert({3, "three"});
+
+    EXPECT_TRUE(m.erase(2));
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_EQ(m.find(2), m.end());
+    EXPECT_NE(m.find(1), m.end());
+    EXPECT_NE(m.find(3), m.end());
+
+    EXPECT_FALSE(m.erase(99));
+    EXPECT_EQ(m.size(), 2u);
+}
+
+TEST(TCompactMapTest, IteratorSmall)
+{
+    TCompactMap<int, std::string, 4> m;
+    m.insert({3, "three"});
+    m.insert({1, "one"});
+    m.insert({2, "two"});
+
+    std::vector<int> keys;
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    std::sort(keys.begin(), keys.end());
+    EXPECT_EQ(keys, std::vector<int>({1, 2, 3}));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Large size (std::map) tests.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, GrowToLarge)
+{
+    TCompactMap<int, std::string, 4> m;
+
+    for (int i = 0; i < 8; i++) {
+        m.insert({i, std::to_string(i)});
+    }
+
+    EXPECT_EQ(m.size(), 8u);
+
+    for (int i = 0; i < 8; i++) {
+        EXPECT_EQ(m.count(i), 1u);
+        EXPECT_EQ(m.find(i)->second, std::to_string(i));
+    }
+
+    EXPECT_EQ(m.count(99), 0u);
+}
+
+TEST(TCompactMapTest, InsertLarge)
+{
+    TCompactMap<int, std::string, 2> m;
+
+    for (int i = 0; i < 5; i++) {
+        auto [it, inserted] = m.insert({i, std::to_string(i)});
+        EXPECT_TRUE(inserted);
+        EXPECT_EQ(it->first, i);
+        EXPECT_EQ(it->second, std::to_string(i));
+    }
+
+    EXPECT_EQ(m.size(), 5u);
+
+    auto [it, inserted] = m.insert({2, "two"});
+    EXPECT_FALSE(inserted);
+    EXPECT_EQ(it->second, "2"); // Value not changed
+    EXPECT_EQ(m.size(), 5u);
+}
+
+TEST(TCompactMapTest, FindLarge)
+{
+    TCompactMap<int, std::string, 2> m;
+
+    for (int i = 0; i < 8; i++) {
+        m.insert({i, std::to_string(i)});
+    }
+
+    for (int i = 0; i < 8; i++) {
+        auto it = m.find(i);
+        EXPECT_NE(it, m.end());
+        EXPECT_EQ(it->first, i);
+        EXPECT_EQ(it->second, std::to_string(i));
+    }
+
+    EXPECT_EQ(m.find(99), m.end());
+}
+
+TEST(TCompactMapTest, EraseLarge)
+{
+    TCompactMap<int, std::string, 2> m;
+
+    for (int i = 0; i < 8; i++) {
+        m.insert({i, std::to_string(i)});
+    }
+
+    for (int i = 0; i < 8; i++) {
+        EXPECT_EQ(m.count(i), 1u);
+        EXPECT_TRUE(m.erase(i));
+        EXPECT_EQ(m.count(i), 0u);
+        EXPECT_EQ(m.size(), 8u - i - 1);
+        
+        for (int j = i + 1; j < 8; j++) {
+            EXPECT_EQ(m.count(j), 1u);
+        }
+    }
+
+    EXPECT_EQ(m.count(99), 0u);
+}
+
+TEST(TCompactMapTest, IteratorLarge)
+{
+    TCompactMap<int, std::string, 2> m;
+
+    for (int i = 0; i < 6; i++) {
+        m.insert({i, std::to_string(i)});
+    }
+
+    std::vector<int> keys;
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    std::sort(keys.begin(), keys.end());
+    std::vector<int> expected = {0, 1, 2, 3, 4, 5};
+    EXPECT_EQ(keys, expected);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Transition from small to large.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, SmallToLargeTransition)
+{
+    TCompactMap<int, std::string, 4> m;
+
+    // Fill small storage
+    for (int i = 0; i < 4; i++) {
+        m.insert({i, std::to_string(i)});
+    }
+
+    EXPECT_EQ(m.size(), 4u);
+
+    // Add one more to trigger transition.
+    m.insert({4, "4"});
+
+    EXPECT_EQ(m.size(), 5u);
+
+    // Check all elements are still there.
+    for (int i = 0; i < 5; i++) {
+        EXPECT_EQ(m.count(i), 1u);
+        EXPECT_EQ(m.find(i)->second, std::to_string(i));
+    }
+}
+
+TEST(TCompactMapTest, GrowShrink)
+{
+    TCompactMap<std::string, std::string, 2> m;
+    m.insert({"Two", "vast"});
+    m.insert({"and", "trunkless"});
+    m.insert({"legs", "of"});
+    m.insert({"stone", "Stand"});
+    m.insert({"in", "the"});
+    m.insert({"desert", "..."});
+
+    EXPECT_EQ(m.size(), 6u);
+
+    m.erase("legs");
+    m.erase("stone");
+    m.erase("in");
+    m.erase("desert");
+
+    EXPECT_EQ(m.size(), 2u);
+
+    // All remaining elements should be accessible.
+    EXPECT_NE(m.find("Two"), m.end());
+    EXPECT_NE(m.find("and"), m.end());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Find operations (mutable and const).
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, FindMutable)
+{
+    auto m = CreateMap();
+    {
+        auto it = m.find("from");
+        EXPECT_NE(it, m.end());
+        EXPECT_EQ(it->second, "an");
+        it->second = "the";
+    }
+    {
+        auto it = m.find("from");
+        EXPECT_NE(it, m.end());
+        EXPECT_EQ(it->second, "the");
+    }
+    {
+        auto it = m.find("Who");
+        EXPECT_EQ(it, m.end());
+    }
+}
+
+TEST(TCompactMapTest, FindConst)
+{
+    const auto& m = CreateMap();
+    {
+        auto it = m.find("from");
+        EXPECT_NE(it, m.end());
+        EXPECT_EQ(it->second, "an");
+    }
+    {
+        auto it = m.find("Who");
+        EXPECT_EQ(it, m.end());
+    }
+}
+
+TEST(TCompactMapTest, Contains)
+{
+    auto m = CreateMap();
+
+    EXPECT_TRUE(m.contains("I"));
+    EXPECT_TRUE(m.contains("from"));
+    EXPECT_FALSE(m.contains("Who"));
+
+    m.erase("I");
+    EXPECT_FALSE(m.contains("I"));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Insert operations.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, Insert)
+{
+    auto m = CreateMap();
+
+    auto [it, inserted] = m.insert({"Who", "said"});
+    EXPECT_TRUE(inserted);
+    EXPECT_EQ(m.size(), 5u);
+    EXPECT_NE(it, m.end());
+    EXPECT_EQ(it, m.find("Who"));
+    EXPECT_EQ(it->second, "said");
+
+    auto [it2, inserted2] = m.insert({"Who", "told"});
+    EXPECT_FALSE(inserted2);
+    EXPECT_EQ(m.size(), 5u);
+    EXPECT_EQ(it2, it);
+    EXPECT_EQ(it->second, "said");
+
+    std::vector<std::pair<std::string, std::string>> data = {
+        {"Two", "vast"},
+        {"and", "trunkless"},
+        {"legs", "of"}
+    };
+    m.insert(data.begin(), data.end());
+    EXPECT_EQ(m.size(), 8u);
+    EXPECT_NE(m.find("and"), m.end());
+    EXPECT_EQ(m.find("and")->second, "trunkless");
+}
+
+TEST(TCompactMapTest, Emplace)
+{
+    TCompactMap<int, std::string, 3> m;
+
+    auto [it1, inserted1] = m.emplace(1, "one");
+    EXPECT_TRUE(inserted1);
+    EXPECT_EQ(it1->second, "one");
+
+    auto [it2, inserted2] = m.emplace(1, "uno");
+    EXPECT_FALSE(inserted2);
+    EXPECT_EQ(it2->second, "one");
+
+    auto [it3, inserted3] = m.emplace(0, "zero");
+    EXPECT_TRUE(inserted3);
+    EXPECT_EQ(it3->first, 0);
+    EXPECT_EQ(m.size(), 2u);
+
+    for (int i = 2; i < 6; ++i) {
+        m.emplace(i, std::to_string(i));
+    }
+
+    EXPECT_EQ(m.size(), 6u);
+    auto [tailIt, tailInserted] = m.emplace(10, "ten");
+    EXPECT_TRUE(tailInserted);
+    EXPECT_EQ(tailIt->first, 10);
+
+    auto [dupIt, dupInserted] = m.emplace(3, "tres");
+    EXPECT_FALSE(dupInserted);
+    EXPECT_EQ(dupIt->second, "3");
+}
+
+TEST(TCompactMapTest, TryEmplace)
+{
+    TCompactMap<int, std::string, 2> m;
+
+    auto [it1, inserted1] = m.try_emplace(1, "one");
+    EXPECT_TRUE(inserted1);
+    EXPECT_EQ(it1->second, "one");
+
+    auto [it2, inserted2] = m.try_emplace(1, "uno");
+    EXPECT_FALSE(inserted2);
+    EXPECT_EQ(it2->second, "one");
+
+    auto [it3, inserted3] = m.try_emplace(0, "zero");
+    EXPECT_TRUE(inserted3);
+    EXPECT_EQ(it3->first, 0);
+
+    auto [it4, inserted4] = m.try_emplace(5, "five");
+    EXPECT_TRUE(inserted4);
+
+    // Grow to std::map backed mode.
+    for (int i = 6; i < 9; ++i) {
+        m.try_emplace(i, std::to_string(i));
+    }
+
+    auto [it5, inserted5] = m.try_emplace(9, "nine");
+    EXPECT_TRUE(inserted5);
+
+    auto [it6, inserted6] = m.try_emplace(5, "FIVE");
+    EXPECT_FALSE(inserted6);
+    EXPECT_EQ(it6->second, "five");
+}
+
+TEST(TCompactMapTest, InsertOrAssign)
+{
+    TCompactMap<int, std::string, 4> m;
+
+    auto [it1, inserted1] = m.insert_or_assign(1, "one");
+    EXPECT_TRUE(inserted1);
+    EXPECT_EQ(it1->second, "one");
+    EXPECT_EQ(m.size(), 1u);
+
+    auto [it2, inserted2] = m.insert_or_assign(1, "uno");
+    EXPECT_FALSE(inserted2);
+    EXPECT_EQ(it2->second, "uno");
+    EXPECT_EQ(m.size(), 1u);
+
+    // Test after growing to large.
+    for (int i = 2; i < 6; i++) {
+        m.insert_or_assign(i, std::to_string(i));
+    }
+
+    auto [it3, inserted3] = m.insert_or_assign(3, "three");
+    EXPECT_FALSE(inserted3);
+    EXPECT_EQ(it3->second, "three");
+}
+
+TEST(TCompactMapTest, InitializerList)
+{
+    TCompactMap<int, std::string, 4> m = {
+        {1, "one"},
+        {2, "two"},
+        {3, "three"}
+    };
+
+    EXPECT_EQ(m.size(), 3u);
+    EXPECT_EQ(m.find(1)->second, "one");
+    EXPECT_EQ(m.find(2)->second, "two");
+    EXPECT_EQ(m.find(3)->second, "three");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Subscript operator
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, SubscriptSmall)
+{
+    TCompactMap<std::string, std::string, 4> m;
+
+    m["key1"] = "value1";
+    EXPECT_EQ(m["key1"], "value1");
+    EXPECT_EQ(m.size(), 1u);
+
+    m["key2"] = "value2";
+    EXPECT_EQ(m.size(), 2u);
+
+    EXPECT_EQ(m["key3"], "");
+    EXPECT_EQ(m.size(), 3u);
+}
+
+TEST(TCompactMapTest, SubscriptLarge)
+{
+    TCompactMap<std::string, std::string, 2> m;
+
+    for (int i = 0; i < 5; i++) {
+        m["key" + std::to_string(i)] = "value" + std::to_string(i);
+    }
+
+    EXPECT_EQ(m.size(), 5u);
+    EXPECT_EQ(m["key3"], "value3");
+
+    m["key3"] = "new_value";
+    EXPECT_EQ(m["key3"], "new_value");
+}
+
+TEST(TCompactMapTest, SubscriptRvalue)
+{
+    TCompactMap<std::string, std::string, 4> m;
+
+    std::string key = "temp";
+    m[std::move(key)] = "value";
+    EXPECT_EQ(m["temp"], "value");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// At operations.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, At)
+{
+    TCompactMap<int, std::string, 4> m;
+    m[1] = "one";
+    m[2] = "two";
+
+    EXPECT_EQ(m.at(1), "one");
+    EXPECT_EQ(m.at(2), "two");
+
+    EXPECT_THROW(m.at(99), std::out_of_range);
+
+    m.at(1) = "uno";
+    EXPECT_EQ(m.at(1), "uno");
+}
+
+TEST(TCompactMapTest, AtConst)
+{
+    TCompactMap<int, std::string, 4> m;
+    m[1] = "one";
+    m[2] = "two";
+
+    const auto& cm = m;
+
+    EXPECT_EQ(cm.at(1), "one");
+    EXPECT_EQ(cm.at(2), "two");
+
+    EXPECT_THROW(cm.at(99), std::out_of_range);
+}
+
+TEST(TCompactMapTest, AtLarge)
+{
+    TCompactMap<int, std::string, 2> m;
+    for (int i = 0; i < 6; i++) {
+        m[i] = std::to_string(i);
+    }
+
+    EXPECT_EQ(m.at(3), "3");
+    EXPECT_THROW(m.at(99), std::out_of_range);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Iterator tests.
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, IteratorModification)
+{
+    TCompactMap<int, std::string, 4> m;
+    m[1] = "one";
+    m[2] = "two";
+    m[3] = "three";
+
+    for (auto it = m.begin(); it != m.end(); ++it) {
+        it->second += "_modified";
+    }
+
+    EXPECT_EQ(m[1], "one_modified");
+    EXPECT_EQ(m[2], "two_modified");
+    EXPECT_EQ(m[3], "three_modified");
+}
+
+TEST(TCompactMapTest, IteratorString)
+{
+    TCompactMap<std::string, std::string, 2> m;
+
+    m["str1"] = "val1";
+    m["str2"] = "val2";
+
+    std::vector<std::string> keys;
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    std::sort(keys.begin(), keys.end());
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_EQ(keys[0], "str1");
+    EXPECT_EQ(keys[1], "str2");
+
+    // Add more to grow.
+    m["str4"] = "val4";
+    m["str0"] = "val0";
+
+    keys.clear();
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    std::sort(keys.begin(), keys.end());
+    EXPECT_EQ(m.size(), 4u);
+    EXPECT_EQ(keys[0], "str0");
+    EXPECT_EQ(keys[1], "str1");
+    EXPECT_EQ(keys[2], "str2");
+    EXPECT_EQ(keys[3], "str4");
+}
+
+TEST(TCompactMapTest, IteratorConversion)
+{
+    TCompactMap<int, std::string, 4> m;
+    m[1] = "one";
+    m[2] = "two";
+
+    auto it = m.begin();
+    TCompactMap<int, std::string, 4>::const_iterator cit = it;
+
+    EXPECT_EQ(*it, *cit);
+}
+
+TEST(TCompactMapTest, IteratorTypeProperties)
+{
+    using TMap = TCompactMap<int, std::string, 4>;
+    using TIter = TMap::iterator;
+    using TCIter = TMap::const_iterator;
+
+    // Key type cannot be modified via any iterator.
+    static_assert(!std::is_assignable_v<decltype((std::declval<TIter>()->first)), std::string>);
+    static_assert(!std::is_assignable_v<decltype((std::declval<TCIter>()->first)), std::string>);
+
+    // Mapped type can only be modified via non-const iterator.
+    static_assert(std::is_assignable_v<decltype((std::declval<TIter>()->second)), std::string>);
+    static_assert(!std::is_assignable_v<decltype((std::declval<TCIter>()->second)), std::string>);
+}
+
+TEST(TCompactMapTest, IteratorDecrementSmallAndLarge)
+{
+    {
+        TCompactMap<int, std::string, 4> m;
+        m[1] = "one";
+        m[2] = "two";
+        m[3] = "three";
+
+        auto it = m.end();
+        --it;
+        EXPECT_EQ(it->first, 3);
+        EXPECT_EQ((it--)->first, 3);
+        EXPECT_EQ(it->first, 2);
+        --it;
+        EXPECT_EQ(it->first, 1);
+        EXPECT_EQ(it, m.begin());
+    }
+
+    {
+        TCompactMap<int, std::string, 2> m;
+        for (int i = 0; i < 5; ++i) {
+            m[i] = std::to_string(i);
+        }
+
+        auto it = m.end();
+        --it;
+        EXPECT_EQ(it->first, 4);
+        EXPECT_EQ((it--)->first, 4);
+        EXPECT_EQ(it->first, 3);
+        --it;
+        EXPECT_EQ(it->first, 2);
+        --it;
+        EXPECT_EQ(it->first, 1);
+        --it;
+        EXPECT_EQ(it->first, 0);
+        EXPECT_EQ(it, m.begin());
+    }
+}
+
+TEST(TCompactMapTest, EraseByIteratorSmallAndLarge)
+{
+    {
+        TCompactMap<int, std::string, 4> m;
+        m[1] = "one";
+        m[2] = "two";
+        m[3] = "three";
+
+        auto middle = m.find(2);
+        ASSERT_NE(middle, m.end());
+        auto next = m.erase(middle);
+        EXPECT_EQ(next->first, 3);
+        EXPECT_EQ(m.count(2), 0u);
+
+        auto rangeBegin = m.begin();
+        auto rangeEnd = m.end();
+        // Removing the tail via iterator range should leave the container empty.
+        auto afterRange = m.erase(rangeBegin, rangeEnd);
+        EXPECT_EQ(afterRange, m.end());
+        EXPECT_TRUE(m.empty());
+    }
+
+    {
+        TCompactMap<int, std::string, 2> m;
+        for (int i = 0; i < 5; ++i) {
+            m[i] = std::to_string(i);
+        }
+
+        auto it = m.find(2);
+        ASSERT_NE(it, m.end());
+        auto next = m.erase(it);
+        EXPECT_EQ(next->first, 3);
+        EXPECT_EQ(m.count(2), 0u);
+
+        auto first = m.find(0);
+        auto last = m.find(3);
+        ASSERT_NE(first, m.end());
+        ASSERT_NE(last, m.end());
+        auto afterRange = m.erase(first, last);
+        EXPECT_EQ(afterRange->first, 3);
+        std::vector<int> remaining;
+        for (const auto& [k, v] : m) {
+            remaining.push_back(k);
+        }
+        EXPECT_EQ(remaining, std::vector<int>({3, 4}));
+    }
+}
+
+TEST(TCompactMapTest, StructuredBindingModifySmallAndLarge)
+{
+    // Small-mode: everything stays in the inline storage.
+    {
+        TCompactMap<int, std::string, 4> m;
+        m[1] = "one";
+        m[2] = "two";
+        m[3] = "three";
+
+        for (auto&& [k, v] : m) {
+            v += "_x";
+        }
+
+        EXPECT_EQ(m[1], "one_x");
+        EXPECT_EQ(m[2], "two_x");
+        EXPECT_EQ(m[3], "three_x");
+    }
+
+    // Large-mode: container has switched to std::map storage.
+    {
+        TCompactMap<int, std::string, 2> m;
+        m[1] = "one";
+        m[2] = "two";
+        m[3] = "three";
+        // Triggers growth to large mode.
+        m[4] = "four";
+
+        for (auto&& [k, v] : m) {
+            v += "_y";
+        }
+
+        EXPECT_EQ(m[1], "one_y");
+        EXPECT_EQ(m[2], "two_y");
+        EXPECT_EQ(m[3], "three_y");
+        EXPECT_EQ(m[4], "four_y");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Edge cases
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TCompactMapTest, EmptyAfterClear)
+{
+    TCompactMap<int, std::string, 4> m;
+
+    for (int i = 0; i < 8; i++) {
+        m[i] = std::to_string(i);
+    }
+
+    m.clear();
+
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0u);
+    EXPECT_EQ(m.begin(), m.end());
+}
+
+TEST(TCompactMapTest, CountZeroOrOne)
+{
+    TCompactMap<int, std::string, 4> m;
+
+    EXPECT_EQ(m.count(1), 0u);
+
+    m[1] = "one";
+    EXPECT_EQ(m.count(1), 1u);
+
+    m.erase(1);
+    EXPECT_EQ(m.count(1), 0u);
+}
+
+TEST(TCompactMapTest, SortedOrder)
+{
+    TCompactMap<int, std::string, 4> m;
+    m[5] = "five";
+    m[1] = "one";
+    m[3] = "three";
+    m[2] = "two";
+
+    std::vector<int> keys;
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    EXPECT_EQ(keys, std::vector<int>({1, 2, 3, 5}));
+}
+
+TEST(TCompactMapTest, CustomComparator)
+{
+    TCompactMap<int, std::string, 4, std::greater<int>> m;
+    m[1] = "one";
+    m[2] = "two";
+    m[3] = "three";
+
+    std::vector<int> keys;
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    EXPECT_EQ(keys, std::vector<int>({3, 2, 1}));
+}
+
+TEST(TCompactMapTest, CustomComparatorAfterUpgrade)
+{
+    TCompactMap<int, std::string, 2, std::greater<int>> m;
+    for (int i = 0; i < 5; ++i) {
+        m[i] = std::to_string(i);
+    }
+
+    std::vector<int> keys;
+    for (const auto& [k, v] : m) {
+        keys.push_back(k);
+    }
+
+    EXPECT_EQ(keys, std::vector<int>({4, 3, 2, 1, 0}));
+}
+
+TEST(TCompactMapTest, ZeroInlineCapacityBehavesLikeMap)
+{
+    TCompactMap<int, std::string, 0> m;
+    EXPECT_TRUE(m.empty());
+
+    m[7] = "seven";
+    EXPECT_EQ(m.size(), 1u);
+    EXPECT_EQ(m.at(7), "seven");
+
+    auto [it, inserted] = m.insert_or_assign(7, "SEVEN");
+    EXPECT_FALSE(inserted);
+    EXPECT_EQ(it->second, "SEVEN");
+
+    auto [it2, inserted2] = m.insert_or_assign(4, "four");
+    EXPECT_TRUE(inserted2);
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_EQ(m.at(4), "four");
+
+    EXPECT_EQ(m.erase(7), 1u);
+    EXPECT_EQ(m.erase(7), 0u);
+    EXPECT_FALSE(m.contains(7));
+    EXPECT_EQ(m.begin()->first, 4);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace
+} // namespace NYT

--- a/library/cpp/yt/compact_containers/unittests/ya.make
+++ b/library/cpp/yt/compact_containers/unittests/ya.make
@@ -5,6 +5,7 @@ INCLUDE(${ARCADIA_ROOT}/library/cpp/yt/ya_cpp.make.inc)
 SRCS(
     compact_flat_map_ut.cpp
     compact_heap_ut.cpp
+    compact_map_ut.cpp
     compact_set_ut.cpp
     compact_vector_ut.cpp
     compact_queue_ut.cpp

--- a/yt/yt/client/chunk_client/chunk_replica-inl.h
+++ b/yt/yt/client/chunk_client/chunk_replica-inl.h
@@ -18,8 +18,8 @@ static_assert(
     ChunkReplicaIndexBound <= (1LL << 5),
     "Replica index must fit into 5 bits.");
 static_assert(
-    MediumIndexBound <= (1LL << 7),
-    "Medium index must fit into 7 bits.");
+    MediumIndexBound <= (1LL << 16),
+    "Medium index must fit into 16 bits.");
 
 Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium()
     : Value_(NNodeTrackerClient::InvalidNodeId.Underlying())

--- a/yt/yt/client/chunk_client/chunk_replica.h
+++ b/yt/yt/client/chunk_client/chunk_replica.h
@@ -50,7 +50,7 @@ private:
      *  Bits:
      *   0-23: node id (24 bits)
      *  24-28: replica index (5 bits)
-     *  29-37: medium index (7 bits)
+     *  29-44: medium index (16 bits)
      */
     ui64 Value_;
 

--- a/yt/yt/client/chunk_client/public-inl.h
+++ b/yt/yt/client/chunk_client/public-inl.h
@@ -1,0 +1,32 @@
+﻿#ifndef PUBLIC_INL_H_
+#error "Direct inclusion of this file is not allowed, include public.h"
+// For the sake of sane code completion.
+#include "public.h"
+#endif
+
+#include <array>
+#include <span>
+
+namespace NYT::NChunkClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+inline constexpr auto SentinelMediumIndexesStorage = [] {
+    std::array<int, 2 + (MediumIndexBound - RealMediumIndexBound)> sentinels{
+        GenericMediumIndex,
+        AllMediaIndex,
+    };
+    for (int index = RealMediumIndexBound; index < MediumIndexBound; ++index) {
+        sentinels[2 + (index - RealMediumIndexBound)] = index;
+    }
+    return sentinels;
+}();
+
+constexpr std::span<const int> GetSentinelMediumIndexes()
+{
+    return std::span<const int>(SentinelMediumIndexesStorage);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/public.cpp
+++ b/yt/yt/client/chunk_client/public.cpp
@@ -20,4 +20,21 @@ const std::string DefaultSlotsMediumName("default");
 
 ////////////////////////////////////////////////////////////////////////////////
 
+static_assert(TypicalMediumCount <= MaxMediumCount, "Typical medium count exceeds max medium count");
+static_assert(MaxMediumCount <= RealMediumIndexBound, "Max medium count exceeds bound on real medium indexes");
+static_assert(RealMediumIndexBound <= MediumIndexBound, "Real medium index bound exceeds medium index bound");
+
+bool IsSentinelMediumIndex(int mediumIndex)
+{
+    return mediumIndex == GenericMediumIndex || mediumIndex == AllMediaIndex || (MediumIndexBound <= mediumIndex && mediumIndex < MediumIndexBound);
+}
+
+bool IsValidRealMediumIndex(int mediumIndex)
+{
+    return mediumIndex >= 0 && mediumIndex < RealMediumIndexBound &&
+        mediumIndex != GenericMediumIndex && mediumIndex != AllMediaIndex;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/public.cpp
+++ b/yt/yt/client/chunk_client/public.cpp
@@ -24,9 +24,14 @@ static_assert(TypicalMediumCount <= MaxMediumCount, "Typical medium count exceed
 static_assert(MaxMediumCount <= RealMediumIndexBound, "Max medium count exceeds bound on real medium indexes");
 static_assert(RealMediumIndexBound <= MediumIndexBound, "Real medium index bound exceeds medium index bound");
 
-bool IsSentinelMediumIndex(int mediumIndex)
+std::vector<int> GetSentinelMediumIndexes()
 {
-    return mediumIndex == GenericMediumIndex || mediumIndex == AllMediaIndex || (MediumIndexBound <= mediumIndex && mediumIndex < MediumIndexBound);
+    std::vector<int> sentinels = {GenericMediumIndex, AllMediaIndex};
+    sentinels.reserve(sentinels.size() + (MediumIndexBound - RealMediumIndexBound));
+    for (int index = RealMediumIndexBound; index < MediumIndexBound; ++index) {
+        sentinels.push_back(index);
+    }
+    return sentinels;
 }
 
 bool IsValidRealMediumIndex(int mediumIndex)

--- a/yt/yt/client/chunk_client/public.cpp
+++ b/yt/yt/client/chunk_client/public.cpp
@@ -24,16 +24,6 @@ static_assert(TypicalMediumCount <= MaxMediumCount, "Typical medium count exceed
 static_assert(MaxMediumCount <= RealMediumIndexBound, "Max medium count exceeds bound on real medium indexes");
 static_assert(RealMediumIndexBound <= MediumIndexBound, "Real medium index bound exceeds medium index bound");
 
-std::vector<int> GetSentinelMediumIndexes()
-{
-    std::vector<int> sentinels = {GenericMediumIndex, AllMediaIndex};
-    sentinels.reserve(sentinels.size() + (MediumIndexBound - RealMediumIndexBound));
-    for (int index = RealMediumIndexBound; index < MediumIndexBound; ++index) {
-        sentinels.push_back(index);
-    }
-    return sentinels;
-}
-
 bool IsValidRealMediumIndex(int mediumIndex)
 {
     return mediumIndex >= 0 && mediumIndex < RealMediumIndexBound &&

--- a/yt/yt/client/chunk_client/public.h
+++ b/yt/yt/client/chunk_client/public.h
@@ -10,6 +10,8 @@
 #include <library/cpp/yt/compact_containers/compact_vector.h>
 #include <library/cpp/yt/compact_containers/compact_map.h>
 
+#include <span>
+
 namespace NYT::NChunkClient {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -133,10 +135,12 @@ constexpr int DefaultIntermediateDataReplicationFactor = 2;
  *                              ^^
  *                              Legacy sentinels embedded into the real range for compatibility
  *
- * “Real” media correspond to actual master medium objects. Sentinels are special indexes
+ * "Real" media correspond to actual master medium objects. Sentinels are special indexes
  * that do not have associated medium objects and are used for special purposes across APIs.
  * Because GenericMediumIndex/AllMediaIndex sit inside the real range, |RealMediumIndexBound|
  * exceeds the plain count limit by 2, to keep room for |MaxMediumCount| real media.
+ * One must also avoid using comparison for checking the real-ness of a medium and must
+ * use |IsValidRealMediumIndex| instead.
  */
 //! Maximum allowed number of real (non-sentinel) media objects on a cluster.
 //! NB: The bound on medium *indexes* for associated master media objects is *not* equal to this value.
@@ -154,7 +158,7 @@ constexpr int MediumIndexBound = MaxMediumCount + 100;
 
 //! Returns a list of all sentinel medium indexes: |GenericMediumIndex|, |AllMediaIndex| and
 //! every reserved slot in |[RealMediumIndexBound, MediumIndexBound)|.
-std::vector<int> GetSentinelMediumIndexes();
+constexpr std::span<const int> GetSentinelMediumIndexes();
 //! Returns true if |mediumIndex| is a valid medium index for a master medium object,
 //! i.e. it falls in range |[0, RealMediumIndexBound)| and is not equal to any of the
 //! reserved sentinel values (see |IsSentinelMediumIndex|).
@@ -263,3 +267,7 @@ DEFINE_ENUM_WITH_UNDERLYING_TYPE(EChunkFormat, i8,
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NYT::NChunkClient
+
+#define PUBLIC_INL_H_
+#include "public-inl.h"
+#undef PUBLIC_INL_H_

--- a/yt/yt/client/chunk_client/public.h
+++ b/yt/yt/client/chunk_client/public.h
@@ -135,9 +135,8 @@ constexpr int RealMediumIndexBound = MaxMediumCount + 2;
 //! A small amount of room is reserved for sentinels.
 constexpr int MediumIndexBound = MaxMediumCount + 100;
 
-//! Returns true if |mediumIndex| falls within the sentinel range:
-//!   |{GenericMediumIndex=126} + {AllMediaIndex=127} + [RealMediumIndexBound, MediumIndexBound)|.
-bool IsSentinelMediumIndex(int mediumIndex);
+//! Returns a list of all sentinel medium indexes: |GenericMediumIndex|, |AllMediaIndex| and |[RealMediumIndexBound, MediumIndexBound)|.
+std::vector<int> GetSentinelMediumIndexes();
 //! Returns true if |mediumIndex| is a valid medium index: in range |[0, RealMediumIndexBound)|
 //! and not equal to any of the reserved sentinel values (see |IsSentinelMediumIndex|).
 bool IsValidRealMediumIndex(int mediumIndex);

--- a/yt/yt/client/chunk_client/used_medium_index_set.cpp
+++ b/yt/yt/client/chunk_client/used_medium_index_set.cpp
@@ -1,0 +1,30 @@
+#include "used_medium_index_set.h"
+
+#include "public.h"
+
+namespace NYT::NChunkClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TUsedMediumIndexSet::TUsedMediumIndexSet()
+    : TMexIntSet()
+{
+    FillSentinels();
+}
+
+void TUsedMediumIndexSet::Clear()
+{
+    TMexIntSet::Clear();
+    FillSentinels();
+}
+
+void TUsedMediumIndexSet::FillSentinels()
+{
+    for (auto mediumIndex : GetSentinelMediumIndexes()) {
+        Insert(mediumIndex);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/used_medium_index_set.h
+++ b/yt/yt/client/chunk_client/used_medium_index_set.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <yt/yt/core/misc/mex_set.h>
+
+namespace NYT::NChunkClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Initializes itself with all sentinels. Useful because history has left us with
+//! sentinels inside the valid medium index range.
+class TUsedMediumIndexSet
+    : public TMexIntSet
+{
+public:
+    TUsedMediumIndexSet();
+    void Clear();
+
+private:
+    void FillSentinels();
+};
+    
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkClient

--- a/yt/yt/client/ya.make
+++ b/yt/yt/client/ya.make
@@ -86,6 +86,7 @@ SRCS(
     chunk_client/public.cpp
     chunk_client/read_limit.cpp
     chunk_client/ready_event_reader_base.cpp
+    chunk_client/used_medium_index_set.cpp
 
     file_client/config.cpp
 

--- a/yt/yt/core/misc/mex_set.cpp
+++ b/yt/yt/core/misc/mex_set.cpp
@@ -1,0 +1,136 @@
+#include "mex_set.h"
+
+namespace NYT {
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// This could have been a privavte class helper, but we are fooled by const-ness issues.
+// Patiently waiting for deducing this in C++23 to end this madness.
+template <class TMap>
+auto FindAdjacentIntervals(TMap& intervals, int value) -> std::pair<decltype(intervals.begin()), decltype(intervals.begin())>
+{
+    auto rightIt = intervals.upper_bound(value);
+    auto leftIt = intervals.end();
+
+    if (rightIt != intervals.begin()) {
+        leftIt = std::prev(rightIt);
+    }
+
+    return {leftIt, rightIt};
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+bool TMexSet::Insert(int value)
+{
+    ValidateBounds(value);
+
+    auto [leftIt, rightIt] = FindAdjacentIntervals(Intervals_, value);
+
+    if (leftIt != Intervals_.end() && leftIt->second > value) {
+        // Already present.
+        return false;
+    }
+
+    auto leftAdjacent = leftIt != Intervals_.end() && leftIt->second == value;
+    auto rightAdjacent = rightIt != Intervals_.end() && rightIt->first == value + 1;
+
+    if (value == Mex_) {
+        if (rightAdjacent) {
+            Mex_ = rightIt->second;
+        } else {
+            ++Mex_;
+        }
+    }
+
+    if (leftAdjacent && rightAdjacent) {
+        // Merge both intervals.
+        leftIt->second = rightIt->second;
+        Intervals_.erase(rightIt);
+    } else if (leftAdjacent) {
+        // Extend left interval to the right.
+        leftIt->second += 1;
+    } else if (rightAdjacent) {
+        // Extend right interval to the left.
+        auto newRight = rightIt->second;
+        Intervals_.erase(rightIt);
+        Intervals_[value] = newRight;
+    } else {
+        // Create a new interval.
+        Intervals_[value] = value + 1;
+    }
+
+    return true;
+}
+
+bool TMexSet::Erase(int value)
+{
+    ValidateBounds(value);
+
+    auto [leftIt, rightIt] = FindAdjacentIntervals(Intervals_, value);
+    if (leftIt == Intervals_.end() || leftIt->second <= value) {
+        // Not present.
+        return false;
+    }
+
+    if (leftIt->first == value && leftIt->second == value + 1) {
+        // Remove the interval.
+        Intervals_.erase(leftIt);
+    } else if (leftIt->first == value) {
+        // Shrink the interval from the left.
+        auto newRight = leftIt->second;
+        Intervals_.erase(leftIt);
+        Intervals_[value + 1] = newRight;
+    } else if (leftIt->second == value + 1) {
+        // Shrink the interval from the right.
+        leftIt->second = value;
+    } else {
+        // Split the interval.
+        auto oldRight = leftIt->second;
+        leftIt->second = value;
+        Intervals_[value + 1] = oldRight;
+    }
+
+    if (value < Mex_) {
+        Mex_ = value;
+    }
+
+    return true;
+}
+
+bool TMexSet::Contains(int value) const
+{
+    ValidateBounds(value);
+
+    auto [leftIt, _] = FindAdjacentIntervals(Intervals_, value);
+    return leftIt != Intervals_.end() && leftIt->second > value;
+}
+
+void TMexSet::Clear()
+{
+    Intervals_.clear();
+    Mex_ = 0;
+}
+
+int TMexSet::GetMex() const
+{
+    return Mex_;
+}
+
+void TMexSet::ValidateBounds(int value)
+{
+    YT_VERIFY(value >= 0);
+    YT_VERIFY(value < std::numeric_limits<int>::max());
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT

--- a/yt/yt/core/misc/mex_set.h
+++ b/yt/yt/core/misc/mex_set.h
@@ -2,21 +2,24 @@
 
 #include "public.h"
 
+#include <utility>
+
 namespace NYT {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-//! A simple set of integers supporting fast MEX (minimum excluded value) queries.
+//! A simple set of non-negative integers supporting fast MEX (minimum excluded value) queries.
 //! Implemented as a set of disjoint intervals. See complexities of operations below.
 //! Feel free to extend however needed, or to replace with a more efficient implementation,
-//! there are about a million ways to do MEX with different tradeoffs. This one make sense
+//! there are about a million ways to do MEX with different tradeoffs. This one makes sense
 //! if the set is densely and consecutively populated, e.g. it is often just a few intervals.
-class TMexSet
+//! NB: Value-related methods throw on out of bounds values (negative or equal to INT_MAX).
+class TMexIntSet
 {
 public:
-    TMexSet() = default;
+    TMexIntSet() = default;
 
-    //! Inserts a value into the set.
+    //! Inserts a value into the set. Value must be non-negative.
     //! Returns whether an insertion actually took place.
     //! Complexity: O(log N), where N is the number of disjoint intervals in the set.
     bool Insert(int value);
@@ -44,7 +47,12 @@ private:
     // Current MEX value.
     int Mex_ = 0;
 
+    // NB: Throws if value is out of the [0, INT_MAX) range.
     static void ValidateBounds(int value);
+
+    // Finds iterators to intervals adjacent to the given value.
+    template <class TMap>
+    static auto FindAdjacentIntervals(TMap& intervals, int value) -> std::pair<decltype(intervals.begin()), decltype(intervals.begin())>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/misc/mex_set.h
+++ b/yt/yt/core/misc/mex_set.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "public.h"
+
+namespace NYT {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! A simple set of integers supporting fast MEX (minimum excluded value) queries.
+//! Implemented as a set of disjoint intervals. See complexities of operations below.
+//! Feel free to extend however needed, or to replace with a more efficient implementation,
+//! there are about a million ways to do MEX with different tradeoffs. This one make sense
+//! if the set is densely and consecutively populated, e.g. it is often just a few intervals.
+class TMexSet
+{
+public:
+    TMexSet() = default;
+
+    //! Inserts a value into the set.
+    //! Returns whether an insertion actually took place.
+    //! Complexity: O(log N), where N is the number of disjoint intervals in the set.
+    bool Insert(int value);
+
+    //! Erases a value from the set.
+    //! Returns whether an element was actually erased.
+    //! Complexity: O(log N), where N is the number of disjoint intervals in the set.
+    bool Erase(int value);
+
+    //! Returns whether the set contains the value.
+    //! Complexity: O(log N), where N is the number of disjoint intervals in the set.
+    bool Contains(int value) const;
+
+    //! Clears the set and resets MEX to 0.
+    //! Complexity: O(N), where N is the number of disjoint intervals in the set.
+    void Clear();
+
+    //! Returns the minimum non-negative integer not contained in the set.
+    //! Complexity: O(1).
+    int GetMex() const;
+
+private:
+    // Maps left endpoint (inclusive) of an interval to its right endpoint (exclusive).
+    std::map<int, int> Intervals_;
+    // Current MEX value.
+    int Mex_ = 0;
+
+    static void ValidateBounds(int value);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT

--- a/yt/yt/core/misc/serialize-inl.h
+++ b/yt/yt/core/misc/serialize-inl.h
@@ -13,6 +13,7 @@
 #include <yt/yt/core/yson/string.h>
 
 #include <library/cpp/yt/compact_containers/compact_flat_map.h>
+#include <library/cpp/yt/compact_containers/compact_map.h>
 #include <library/cpp/yt/compact_containers/compact_set.h>
 #include <library/cpp/yt/compact_containers/compact_vector.h>
 
@@ -1145,6 +1146,12 @@ struct TSorterSelector<TCompactFlatMap<K, V, N>, C, TSortedTag>
     using TSorter = TCollectionSorter<TCompactFlatMap<K, V, N>, TKeySorterComparer<C>>;
 };
 
+template <class K, class V, size_t N, class C>
+struct TSorterSelector<TCompactMap<K, V, N>, C, TSortedTag>
+{
+    using TSorter = TCollectionSorter<TCompactMap<K, V, N>, TKeySorterComparer<C>>;
+};
+
 template <class C, class... T>
 struct TSorterSelector<std::unordered_multimap<T...>, C, TSortedTag>
 {
@@ -1984,6 +1991,12 @@ struct TSerializerTraits<THashMap<K, V, Q, A>, C, void>
 
 template <class K, class V, size_t N, class C>
 struct TSerializerTraits<TCompactFlatMap<K, V, N>, C, void>
+{
+    using TSerializer = TMapSerializer<>;
+};
+
+template <class K, class V, size_t N, class C>
+struct TSerializerTraits<TCompactMap<K, V, N>, C, void>
 {
     using TSerializer = TMapSerializer<>;
 };

--- a/yt/yt/core/misc/unittests/mex_set_ut.cpp
+++ b/yt/yt/core/misc/unittests/mex_set_ut.cpp
@@ -1,0 +1,231 @@
+#include <yt/yt/core/test_framework/framework.h>
+
+#include <yt/yt/core/misc/mex_set.h>
+
+#include <random>
+
+namespace NYT {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSlowMexSet
+{
+public:
+    bool Insert(int value)
+    {
+        return Set_.insert(value).second;
+    }
+
+    bool Erase(int value)
+    {
+        return Set_.erase(value) > 0;
+    }
+
+    bool Contains(int value) const
+    {
+        return Set_.contains(value);
+    }
+
+    void Clear()
+    {
+        Set_.clear();
+    }
+
+    int GetMex() const
+    {
+        int mex = 0;
+        while (Set_.contains(mex)) {
+            ++mex;
+        }
+        return mex;
+    }
+
+private:
+    THashSet<int> Set_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TMexSetTest, Stress)
+{
+    TMexSet mexSet;
+    TSlowMexSet slowMexSet;
+
+    std::mt19937 rng(1543);
+    std::uniform_int_distribution<int> val(0, 2000);
+    std::bernoulli_distribution shouldInsert(0.6); 
+
+    for (int step = 0; step < 5000; ++step) {
+        int v = val(rng);
+        if (shouldInsert(rng)) {
+            EXPECT_EQ(mexSet.Insert(v), slowMexSet.Insert(v));
+        } else {
+            EXPECT_EQ(mexSet.Erase(v), slowMexSet.Erase(v));
+        }
+        EXPECT_EQ(mexSet.Contains(v), slowMexSet.Contains(v));
+        EXPECT_EQ(mexSet.GetMex(), slowMexSet.GetMex());
+
+        for (int spotCheckIndex = 0; spotCheckIndex < 20; ++spotCheckIndex) {
+            int checkValue = val(rng);
+            EXPECT_EQ(mexSet.Contains(checkValue), slowMexSet.Contains(checkValue));
+        }
+
+        if (step % 1000 == 0) {
+            mexSet.Clear();
+            slowMexSet.Clear();
+        }
+    }
+}
+
+TEST(TMexSetTest, Empty)
+{
+    TMexSet mexSet;
+
+    EXPECT_EQ(0, mexSet.GetMex());
+    EXPECT_FALSE(mexSet.Contains(0));
+    EXPECT_FALSE(mexSet.Contains(2));
+    EXPECT_FALSE(mexSet.Contains(100500));
+
+    EXPECT_FALSE(mexSet.Erase(0));
+    EXPECT_FALSE(mexSet.Erase(100500));
+}
+
+TEST(TMexSetTest, InsertNonZeroFirstKeepsMexZero) {
+    TMexSet m;
+
+    EXPECT_TRUE(m.Insert(10));
+    EXPECT_EQ(m.GetMex(), 0);
+    EXPECT_TRUE(m.Contains(10));
+    EXPECT_FALSE(m.Insert(10));
+}
+
+TEST(TMexSetTest, MexAdvancementAndLeftIntervalExtension) {
+    TMexSet m;
+
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_TRUE(m.Insert(i));
+        EXPECT_EQ(m.GetMex(), i + 1);
+    }
+}
+
+TEST(TMexSetTest, ExtendLeftIntervalToTheRight) {
+    TMexSet m;
+
+    EXPECT_TRUE(m.Insert(0));
+    EXPECT_EQ(m.GetMex(), 1);
+    EXPECT_TRUE(m.Insert(1));
+    EXPECT_EQ(m.GetMex(), 2);
+    EXPECT_TRUE(m.Insert(2));
+    EXPECT_EQ(m.GetMex(), 3);
+
+    EXPECT_TRUE(m.Insert(5));
+    EXPECT_EQ(m.GetMex(), 3);
+
+    EXPECT_TRUE(m.Insert(3));
+    EXPECT_EQ(m.GetMex(), 4);
+}
+
+TEST(TMexSetTest, MergeBothSides) {
+    TMexSet m;
+
+    // Left interval: [0, 2).
+    EXPECT_TRUE(m.Insert(0));
+    EXPECT_TRUE(m.Insert(1));
+
+    // Right interval: [3, 5).
+    EXPECT_TRUE(m.Insert(3));
+    EXPECT_TRUE(m.Insert(4));
+
+    EXPECT_EQ(m.GetMex(), 2);
+
+    // Now the intervals are merged.
+    EXPECT_TRUE(m.Insert(2));
+    EXPECT_EQ(m.GetMex(), 5);
+}
+
+TEST(TMexSetTest, EraseRightEdge) {
+    TMexSet m;
+
+    EXPECT_TRUE(m.Insert(2));
+    EXPECT_TRUE(m.Insert(3));
+    EXPECT_TRUE(m.Insert(4));
+    EXPECT_EQ(m.GetMex(), 0);
+
+    EXPECT_TRUE(m.Erase(4));
+    EXPECT_TRUE(m.Contains(2));
+    EXPECT_TRUE(m.Contains(3));
+    EXPECT_FALSE(m.Contains(4));
+    EXPECT_EQ(m.GetMex(), 0);
+}
+
+TEST(TMexSetTest, EraseLeftEdge) {
+    TMexSet m;
+
+    EXPECT_TRUE(m.Insert(2));
+    EXPECT_TRUE(m.Insert(3));
+    EXPECT_TRUE(m.Insert(4));
+    EXPECT_EQ(m.GetMex(), 0);
+
+    EXPECT_TRUE(m.Erase(2));
+    EXPECT_TRUE(m.Contains(3));
+    EXPECT_TRUE(m.Contains(4));
+    EXPECT_FALSE(m.Contains(2));
+    EXPECT_EQ(m.GetMex(), 0);
+}
+
+TEST(TMexSetTest, IntervalSplit) {
+    TMexSet m;
+    for (int v = 0; v < 5; ++v) {
+        EXPECT_TRUE(m.Insert(v));
+    }
+
+    EXPECT_EQ(m.GetMex(), 5);
+
+    EXPECT_TRUE(m.Erase(2));
+    EXPECT_EQ(m.GetMex(), 2);
+    EXPECT_TRUE(m.Contains(1));
+    EXPECT_FALSE(m.Contains(2));
+    EXPECT_TRUE(m.Contains(3));
+}
+
+TEST(TMexSetTest, EraseSingleElementInterval) {
+    TMexSet m;
+    m.Insert(5);
+    EXPECT_TRUE(m.Erase(5));
+    EXPECT_FALSE(m.Contains(5));
+    EXPECT_EQ(m.GetMex(), 0);
+}
+
+TEST(TMexSetTest, InsertAboveMex) {
+    TMexSet m;
+
+    for (int v : {0,1,2,4,5}) {
+        EXPECT_TRUE(m.Insert(v));
+    }
+    EXPECT_EQ(m.GetMex(), 3);
+
+    EXPECT_TRUE(m.Insert(10));
+    EXPECT_EQ(m.GetMex(), 3);
+
+    EXPECT_TRUE(m.Insert(3));
+    EXPECT_EQ(m.GetMex(), 6);
+}
+
+TEST(TMexSetTest, Clear) {
+    TMexSet m;
+
+    for (int v = 0; v < 7; ++v) {
+        EXPECT_TRUE(m.Insert(v));
+    }
+    EXPECT_EQ(m.GetMex(), 7);
+
+    m.Clear();
+    EXPECT_EQ(m.GetMex(), 0);
+    EXPECT_FALSE(m.Contains(0));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace
+} // namespace NYT

--- a/yt/yt/core/misc/unittests/mex_set_ut.cpp
+++ b/yt/yt/core/misc/unittests/mex_set_ut.cpp
@@ -47,9 +47,9 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TEST(TMexSetTest, Stress)
+TEST(TMexIntSetTest, Stress)
 {
-    TMexSet mexSet;
+    TMexIntSet mexSet;
     TSlowMexSet slowMexSet;
 
     std::mt19937 rng(1543);
@@ -78,9 +78,9 @@ TEST(TMexSetTest, Stress)
     }
 }
 
-TEST(TMexSetTest, Empty)
+TEST(TMexIntSetTest, Empty)
 {
-    TMexSet mexSet;
+    TMexIntSet mexSet;
 
     EXPECT_EQ(0, mexSet.GetMex());
     EXPECT_FALSE(mexSet.Contains(0));
@@ -91,8 +91,8 @@ TEST(TMexSetTest, Empty)
     EXPECT_FALSE(mexSet.Erase(100500));
 }
 
-TEST(TMexSetTest, InsertNonZeroFirstKeepsMexZero) {
-    TMexSet m;
+TEST(TMexIntSetTest, InsertNonZeroFirstKeepsMexZero) {
+    TMexIntSet m;
 
     EXPECT_TRUE(m.Insert(10));
     EXPECT_EQ(m.GetMex(), 0);
@@ -100,8 +100,8 @@ TEST(TMexSetTest, InsertNonZeroFirstKeepsMexZero) {
     EXPECT_FALSE(m.Insert(10));
 }
 
-TEST(TMexSetTest, MexAdvancementAndLeftIntervalExtension) {
-    TMexSet m;
+TEST(TMexIntSetTest, MexAdvancementAndLeftIntervalExtension) {
+    TMexIntSet m;
 
     for (int i = 0; i < 10; ++i) {
         EXPECT_TRUE(m.Insert(i));
@@ -109,8 +109,8 @@ TEST(TMexSetTest, MexAdvancementAndLeftIntervalExtension) {
     }
 }
 
-TEST(TMexSetTest, ExtendLeftIntervalToTheRight) {
-    TMexSet m;
+TEST(TMexIntSetTest, ExtendLeftIntervalToTheRight) {
+    TMexIntSet m;
 
     EXPECT_TRUE(m.Insert(0));
     EXPECT_EQ(m.GetMex(), 1);
@@ -126,8 +126,8 @@ TEST(TMexSetTest, ExtendLeftIntervalToTheRight) {
     EXPECT_EQ(m.GetMex(), 4);
 }
 
-TEST(TMexSetTest, MergeBothSides) {
-    TMexSet m;
+TEST(TMexIntSetTest, MergeBothSides) {
+    TMexIntSet m;
 
     // Left interval: [0, 2).
     EXPECT_TRUE(m.Insert(0));
@@ -144,8 +144,8 @@ TEST(TMexSetTest, MergeBothSides) {
     EXPECT_EQ(m.GetMex(), 5);
 }
 
-TEST(TMexSetTest, EraseRightEdge) {
-    TMexSet m;
+TEST(TMexIntSetTest, EraseRightEdge) {
+    TMexIntSet m;
 
     EXPECT_TRUE(m.Insert(2));
     EXPECT_TRUE(m.Insert(3));
@@ -159,8 +159,8 @@ TEST(TMexSetTest, EraseRightEdge) {
     EXPECT_EQ(m.GetMex(), 0);
 }
 
-TEST(TMexSetTest, EraseLeftEdge) {
-    TMexSet m;
+TEST(TMexIntSetTest, EraseLeftEdge) {
+    TMexIntSet m;
 
     EXPECT_TRUE(m.Insert(2));
     EXPECT_TRUE(m.Insert(3));
@@ -174,8 +174,8 @@ TEST(TMexSetTest, EraseLeftEdge) {
     EXPECT_EQ(m.GetMex(), 0);
 }
 
-TEST(TMexSetTest, IntervalSplit) {
-    TMexSet m;
+TEST(TMexIntSetTest, IntervalSplit) {
+    TMexIntSet m;
     for (int v = 0; v < 5; ++v) {
         EXPECT_TRUE(m.Insert(v));
     }
@@ -189,16 +189,16 @@ TEST(TMexSetTest, IntervalSplit) {
     EXPECT_TRUE(m.Contains(3));
 }
 
-TEST(TMexSetTest, EraseSingleElementInterval) {
-    TMexSet m;
+TEST(TMexIntSetTest, EraseSingleElementInterval) {
+    TMexIntSet m;
     m.Insert(5);
     EXPECT_TRUE(m.Erase(5));
     EXPECT_FALSE(m.Contains(5));
     EXPECT_EQ(m.GetMex(), 0);
 }
 
-TEST(TMexSetTest, InsertAboveMex) {
-    TMexSet m;
+TEST(TMexIntSetTest, InsertAboveMex) {
+    TMexIntSet m;
 
     for (int v : {0,1,2,4,5}) {
         EXPECT_TRUE(m.Insert(v));
@@ -212,8 +212,8 @@ TEST(TMexSetTest, InsertAboveMex) {
     EXPECT_EQ(m.GetMex(), 6);
 }
 
-TEST(TMexSetTest, Clear) {
-    TMexSet m;
+TEST(TMexIntSetTest, Clear) {
+    TMexIntSet m;
 
     for (int v = 0; v < 7; ++v) {
         EXPECT_TRUE(m.Insert(v));

--- a/yt/yt/core/misc/unittests/ya.make
+++ b/yt/yt/core/misc/unittests/ya.make
@@ -46,6 +46,7 @@ SRCS(
     lock_free_hash_table_ut.cpp
     lru_cache_ut.cpp
     maybe_inf_ut.cpp
+    mex_set_ut.cpp
     moving_average_ut.cpp
     mpl_ut.cpp
     mpsc_fair_share_queue_ut.cpp

--- a/yt/yt/core/ya.make
+++ b/yt/yt/core/ya.make
@@ -143,6 +143,7 @@ SRCS(
     misc/inotify.cpp
     misc/fair_share_hierarchical_queue.cpp
     misc/linear_probe.cpp
+    misc/mex_set.cpp
     misc/relaxed_mpsc_queue.cpp
     misc/parser_helpers.cpp
     misc/pattern_formatter.cpp

--- a/yt/yt/server/lib/misc/max_min_balancer-inl.h
+++ b/yt/yt/server/lib/misc/max_min_balancer-inl.h
@@ -9,14 +9,6 @@ namespace NYT::NServer {
 ////////////////////////////////////////////////////////////////////////////////
 
 template <typename T, typename W>
-TDecayingMaxMinBalancer<T, W>::TWeighedContender::TWeighedContender(T contender, W weight)
-    : Contender(contender)
-    , Weight(weight)
-{ }
-
-////////////////////////////////////////////////////////////////////////////////
-
-template <typename T, typename W>
 TDecayingMaxMinBalancer<T, W>::TDecayingMaxMinBalancer(
     W decayFactor,
     TDuration decayInterval)
@@ -28,41 +20,62 @@ TDecayingMaxMinBalancer<T, W>::TDecayingMaxMinBalancer(
 template <typename T, typename W>
 void TDecayingMaxMinBalancer<T, W>::AddContender(T contender, W initialWeight)
 {
-    YT_ASSERT(FindContender(contender) == Contenders_.end());
-    Contenders_.emplace_back(contender, initialWeight);
+    YT_ASSERT(ContenderToWeight_.emplace(contender, initialWeight).second);
 }
 
 template <typename T, typename W>
-std::optional<T> TDecayingMaxMinBalancer<T, W>::TakeWinner()
+std::optional<T> TDecayingMaxMinBalancer<T, W>::ChooseWinner()
 {
-    if (Contenders_.empty()) {
+    if (ContenderToWeight_.empty()) {
         return std::nullopt;
     } else {
-        auto it = std::min_element(Contenders_.begin(), Contenders_.end());
-        return it->Contender;
+        auto it = std::min_element(
+            ContenderToWeight_.begin(),
+            ContenderToWeight_.end(),
+            [] (const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
+        return it->first;
     }
 }
 
 template <typename T, typename W>
 template <typename P>
-std::optional<T> TDecayingMaxMinBalancer<T, W>::TakeWinnerIf(P pred)
+std::optional<T> TDecayingMaxMinBalancer<T, W>::ChooseWinnerIf(P pred)
 {
     auto resultIt = std::find_if(
-        Contenders_.begin(),
-        Contenders_.end(),
-        [&] (const TWeighedContender& w) { return pred(w.Contender); });
+        ContenderToWeight_.begin(),
+        ContenderToWeight_.end(),
+        [&] (const auto& w) { return pred(w.first); });
 
-    for (auto it = resultIt; it != Contenders_.end(); ++it) {
-        if (pred(it->Contender) && it->Weight < resultIt->Weight) {
+    for (auto it = resultIt; it != ContenderToWeight_.end(); ++it) {
+        if (pred(it->first) && it->second < resultIt->second) {
             resultIt = it;
         }
     }
 
-    if (resultIt == Contenders_.end()) {
+    if (resultIt == ContenderToWeight_.end()) {
         return std::nullopt;
     } else {
-        return resultIt->Contender;
+        return resultIt->first;
     }
+}
+
+template <typename T, typename W>
+template <typename C>
+std::optional<T> TDecayingMaxMinBalancer<T, W>::ChooseRangeWinner(C subset, W defaultWeight)
+{
+    std::optional<T> result;
+    std::optional<W> resultWeight;
+    for (auto contender : subset) {
+        auto it = ContenderToWeight_.find(contender);
+        auto contenderWeight = it == ContenderToWeight_.end() ? defaultWeight : it->second;
+
+        if (!result || contenderWeight < resultWeight) {
+            result = contender;
+            resultWeight = contenderWeight;
+        }
+    }
+
+    return result;
 }
 
 template <typename T, typename W>
@@ -70,17 +83,31 @@ void TDecayingMaxMinBalancer<T, W>::AddWeight(T winner, W extraWeight)
 {
     MaybeDecay();
 
-    auto it = FindContender(winner);
-    YT_VERIFY(it != Contenders_.end());
+    auto it = ContenderToWeight_.find(winner);
+    YT_VERIFY(it != ContenderToWeight_.end());
 
-    it->Weight += extraWeight;
+    it->second += extraWeight;
+}
+
+template <typename T, typename W>
+void TDecayingMaxMinBalancer<T, W>::AddWeightWithDefault(T winner, W extraWeight, W defaultWeight)
+{
+    MaybeDecay();
+
+    auto it = ContenderToWeight_.find(winner);
+    if (it == ContenderToWeight_.end()) {
+        it = ContenderToWeight_.emplace(winner, defaultWeight).first;
+    }
+    YT_VERIFY(it != ContenderToWeight_.end());
+
+    it->second += extraWeight;
 }
 
 template <typename T, typename W>
 void TDecayingMaxMinBalancer<T, W>::ResetWeights()
 {
-    for (auto& contender : Contenders_) {
-        contender.Weight = W();
+    for (auto& contender : ContenderToWeight_) {
+        contender.second = W();
     }
 }
 
@@ -88,20 +115,10 @@ template <typename T, typename W>
 void TDecayingMaxMinBalancer<T, W>::MaybeDecay()
 {
     for (auto now = NProfiling::GetCpuInstant(); NextDecayInstant_ <= now; NextDecayInstant_ += DecayInterval_) {
-        for (auto& contender : Contenders_) {
-            contender.Weight *= DecayFactor_;
+        for (auto& contender : ContenderToWeight_) {
+            contender.second *= DecayFactor_;
         }
     }
-}
-
-template <typename T, typename W>
-typename std::vector<typename TDecayingMaxMinBalancer<T, W>::TWeighedContender>::iterator
-TDecayingMaxMinBalancer<T, W>::FindContender(T contender)
-{
-    return std::find_if(
-        Contenders_.begin(),
-        Contenders_.end(),
-        [&] (const TWeighedContender& w) { return w.Contender == contender; });
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/misc/max_min_balancer-inl.h
+++ b/yt/yt/server/lib/misc/max_min_balancer-inl.h
@@ -20,7 +20,7 @@ TDecayingMaxMinBalancer<T, W>::TDecayingMaxMinBalancer(
 template <typename T, typename W>
 void TDecayingMaxMinBalancer<T, W>::AddContender(T contender, W initialWeight)
 {
-    YT_ASSERT(ContenderToWeight_.emplace(contender, initialWeight).second);
+    YT_ASSERT(TryAddContender(contender, initialWeight));
 }
 
 template <typename T, typename W>

--- a/yt/yt/server/lib/misc/max_min_balancer-inl.h
+++ b/yt/yt/server/lib/misc/max_min_balancer-inl.h
@@ -24,6 +24,12 @@ void TDecayingMaxMinBalancer<T, W>::AddContender(T contender, W initialWeight)
 }
 
 template <typename T, typename W>
+bool TDecayingMaxMinBalancer<T, W>::TryAddContender(T contender, W initialWeight)
+{
+    return ContenderToWeight_.emplace(contender, initialWeight).second;
+}
+
+template <typename T, typename W>
 std::optional<T> TDecayingMaxMinBalancer<T, W>::ChooseWinner()
 {
     if (ContenderToWeight_.empty()) {
@@ -84,20 +90,6 @@ void TDecayingMaxMinBalancer<T, W>::AddWeight(T winner, W extraWeight)
     MaybeDecay();
 
     auto it = ContenderToWeight_.find(winner);
-    YT_VERIFY(it != ContenderToWeight_.end());
-
-    it->second += extraWeight;
-}
-
-template <typename T, typename W>
-void TDecayingMaxMinBalancer<T, W>::AddWeightWithDefault(T winner, W extraWeight, W defaultWeight)
-{
-    MaybeDecay();
-
-    auto it = ContenderToWeight_.find(winner);
-    if (it == ContenderToWeight_.end()) {
-        it = ContenderToWeight_.emplace(winner, defaultWeight).first;
-    }
     YT_VERIFY(it != ContenderToWeight_.end());
 
     it->second += extraWeight;

--- a/yt/yt/server/lib/misc/max_min_balancer.h
+++ b/yt/yt/server/lib/misc/max_min_balancer.h
@@ -32,9 +32,9 @@ namespace NYT::NServer {
  *  over the weight type, #ChooseRangeWinner can be used to choose among a range
  *  of potential contenders possibly not added to the balancer.
  *
- *  To increase the contender's weight, use #AddWeight() for elements known to exist
- *  and #AddWeightWithDefault() otherwise. Same restrictions on #defaultWeight apply to
- *  the latter method.
+ *  To increase the contender's weight, use #AddWeight() for elements known to exist.
+ *  #TryAddContender() may be used to initialalize contenders before increasing their weight.
+ *  This is useful in a lazy initialization setting.
  *
  *  Not thread safe.
  */
@@ -45,6 +45,7 @@ public:
     TDecayingMaxMinBalancer(W decayFactor, TDuration decayInterval);
 
     void AddContender(T contender, W initialWeight = W());
+    bool TryAddContender(T contender, W initialWeight = W());
 
     //! Selects winner between added contenders.
     //! Returns null if there aren't any contenders.
@@ -69,10 +70,6 @@ public:
 
     //! Increase weight of existing contender.
     void AddWeight(T winner, W extraWeight);
-    //! If contender is not present, it is initialized with #defaultWeight before
-    //! performing the requested increment.
-    //! NB: Same note about #defaultWeight applies as for #ChooseRangeWinner().
-    void AddWeightWithDefault(T winner, W extraWeight, W defaultWeight = W());
 
     void ResetWeights();
 

--- a/yt/yt/server/lib/misc/max_min_balancer.h
+++ b/yt/yt/server/lib/misc/max_min_balancer.h
@@ -44,7 +44,11 @@ class TDecayingMaxMinBalancer
 public:
     TDecayingMaxMinBalancer(W decayFactor, TDuration decayInterval);
 
+    //! Adds a contender with an initial weight.
+    //! Contender must not be already added.
     void AddContender(T contender, W initialWeight = W());
+    //! Tries to add a contender with an initial weight.
+    //! Returns true if the contender was added, false if it was already present.
     bool TryAddContender(T contender, W initialWeight = W());
 
     //! Selects winner between added contenders.

--- a/yt/yt/server/lib/misc/max_min_balancer.h
+++ b/yt/yt/server/lib/misc/max_min_balancer.h
@@ -24,11 +24,17 @@ namespace NYT::NServer {
  *       shouldn't be called twice with equal arguments.)
  *  Indexes, pointers and iterators make ideal contenders.
  *
- *  The contender with the minimum weight is chosen via #TakeWinner().
- *  #TakeWinnerIf() may be used to find, among contenders matching given
+ *  The contender with the minimum weight is chosen via #ChooseWinner().
+ *  #ChooseWinnerIf() may be used to find, among contenders matching given
  *  predicate, the one with the minimum weight.
  *
- *  To increase the contender's weight, use #AddWeight().
+ *  If the initial value for all contenders is the neutral element for multiplication
+ *  over the weight type, #ChooseRangeWinner can be used to choose among a range
+ *  of potential contenders possibly not added to the balancer.
+ *
+ *  To increase the contender's weight, use #AddWeight() for elements known to exist
+ *  and #AddWeightWithDefault() otherwise. Same restrictions on #defaultWeight apply to
+ *  the latter method.
  *
  *  Not thread safe.
  */
@@ -40,38 +46,45 @@ public:
 
     void AddContender(T contender, W initialWeight = W());
 
-    // Returns null if there're no contenders.
-    std::optional<T> TakeWinner();
+    //! Selects winner between added contenders.
+    //! Returns null if there aren't any contenders.
+    //! Complexity: linear in the number of stored contenders.
+    std::optional<T> ChooseWinner();
 
-    // Returns null if there're no contenders or no contender satisfies #pred.
+    //! Selects winner between added contenders that satisfy #pred.
+    //! Returns null if there are no contenders or no contender satisfies #pred.
+    //! Complexity: linear in the number of stored contenders.
     template <typename P>
-    std::optional<T> TakeWinnerIf(P pred);
+    std::optional<T> ChooseWinnerIf(P pred);
 
+    //! Selects winner between potential contenders in the provided range.
+    //! If a contender was not added to the balancer, #defaultWeight will be used as its weight.
+    //! Complexity: linear in the size of the range.
+    //! NB: Results may be unexpected if #defaultWeight is not equal to both the initial weight
+    //! for all previously added contenders, as well as the neutral element for the multiplication
+    //! operation over the weight type. This holds true for most usecases, allowing to populate
+    //! contenders lazily.
+    template <typename R>
+    std::optional<T> ChooseRangeWinner(R range, W defaultWeight = W());
+
+    //! Increase weight of existing contender.
     void AddWeight(T winner, W extraWeight);
+    //! If contender is not present, it is initialized with #defaultWeight before
+    //! performing the requested increment.
+    //! NB: Same note about #defaultWeight applies as for #ChooseRangeWinner().
+    void AddWeightWithDefault(T winner, W extraWeight, W defaultWeight = W());
 
     void ResetWeights();
 
 private:
-    struct TWeighedContender
-    {
-        T Contender;
-        W Weight;
-
-        TWeighedContender(T contender, W weight);
-
-        bool operator<(const TWeighedContender& rhs) const { return Weight < rhs.Weight; }
-    };
-
     void MaybeDecay();
-
-    typename std::vector<TWeighedContender>::iterator FindContender(T contender);
 
     W DecayFactor_;
     NProfiling::TCpuDuration DecayInterval_;
     NProfiling::TCpuInstant NextDecayInstant_;
 
 protected: // for testing
-    std::vector<TWeighedContender> Contenders_;
+    THashMap<T, W> ContenderToWeight_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/misc/unittests/max_min_balancer_ut.cpp
+++ b/yt/yt/server/lib/misc/unittests/max_min_balancer_ut.cpp
@@ -67,31 +67,36 @@ std::vector<int> ShuffleWithDefaults(TTestBalancer& balancer, std::vector<int> c
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
         *winner = 0;
-        balancer.AddWeightWithDefault(*winner, 100);
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 100);
     }
     {
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
         *winner = 1;
-        balancer.AddWeightWithDefault(*winner, 80);
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 80);
     }
     {
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
         *winner = 2;
-        balancer.AddWeightWithDefault(*winner, 90);
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 90);
     }
     {
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
         *winner = 3;
-        balancer.AddWeightWithDefault(*winner, 60);
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 60);
     }
     {
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
         *winner = 4;
-        balancer.AddWeightWithDefault(*winner, 70);
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 70);
     }
 
     // Now the picture should be the following:
@@ -149,7 +154,8 @@ TEST(TMaxMinBalancerTest, Lazy)
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
         EXPECT_EQ(e, *winner);
-        balancer.AddWeightWithDefault(*winner, 1000); // Just to shift to the back of the queue.
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 1000); // Just to shift to the back of the queue.
     }
 
     Sleep(sleepInterval);
@@ -157,7 +163,8 @@ TEST(TMaxMinBalancerTest, Lazy)
     {
         auto winner = balancer.ChooseRangeWinner(contenderRange);
         EXPECT_TRUE(winner);
-        balancer.AddWeightWithDefault(*winner, 10);
+        balancer.TryAddContender(*winner);
+        balancer.AddWeight(*winner, 10);
     }
 
     auto& contenders = balancer.PeekContenders();

--- a/yt/yt/server/lib/misc/unittests/max_min_balancer_ut.cpp
+++ b/yt/yt/server/lib/misc/unittests/max_min_balancer_ut.cpp
@@ -1,5 +1,7 @@
 #include <yt/yt/core/test_framework/framework.h>
 
+#include <yt/yt/core/misc/collection_helpers.h>
+
 #include <yt/yt/server/lib/misc/max_min_balancer.h>
 
 namespace NYT::NServer {
@@ -15,9 +17,9 @@ public:
 
     using TBase::TBase;
 
-    auto PeekContenders() -> decltype(Contenders_)&
+    auto PeekContenders() -> decltype(ContenderToWeight_)&
     {
-        return Contenders_;
+        return ContenderToWeight_;
     }
 };
 
@@ -25,34 +27,71 @@ public:
 std::vector<int> Shuffle(TTestBalancer& balancer)
 {
     {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         *winner = 0;
         balancer.AddWeight(*winner, 100);
     }
     {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         *winner = 1;
         balancer.AddWeight(*winner, 80);
     }
     {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         *winner = 2;
         balancer.AddWeight(*winner, 90);
     }
     {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         *winner = 3;
         balancer.AddWeight(*winner, 60);
     }
     {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         *winner = 4;
         balancer.AddWeight(*winner, 70);
+    }
+
+    // Now the picture should be the following:
+    return {3 /*60*/, 4 /*70*/, 1 /*80*/, 2 /*90*/, 0 /*100*/};
+}
+
+std::vector<int> ShuffleWithDefaults(TTestBalancer& balancer, std::vector<int> contenderRange)
+{
+    {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        *winner = 0;
+        balancer.AddWeightWithDefault(*winner, 100);
+    }
+    {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        *winner = 1;
+        balancer.AddWeightWithDefault(*winner, 80);
+    }
+    {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        *winner = 2;
+        balancer.AddWeightWithDefault(*winner, 90);
+    }
+    {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        *winner = 3;
+        balancer.AddWeightWithDefault(*winner, 60);
+    }
+    {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        *winner = 4;
+        balancer.AddWeightWithDefault(*winner, 70);
     }
 
     // Now the picture should be the following:
@@ -72,7 +111,7 @@ TEST(TMaxMinBalancerTest, Basic)
     auto expected = Shuffle(balancer);
 
     for (const auto& e : expected) {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         EXPECT_EQ(e, *winner);
         balancer.AddWeight(*winner, 1000); // Just to shift to the back of the queue.
@@ -81,21 +120,56 @@ TEST(TMaxMinBalancerTest, Basic)
     Sleep(sleepInterval);
 
     {
-        auto winner = balancer.TakeWinner();
+        auto winner = balancer.ChooseWinner();
         EXPECT_TRUE(winner);
         balancer.AddWeight(*winner, 10);
     }
 
     auto& contenders = balancer.PeekContenders();
-    std::sort(contenders.begin(), contenders.end());
-    EXPECT_EQ(107, contenders[0].Weight); // (70 + 1000) * 0.1
-    EXPECT_EQ(108, contenders[1].Weight); // ditto
-    EXPECT_EQ(109, contenders[2].Weight);
-    EXPECT_EQ(110, contenders[3].Weight);
-    EXPECT_EQ(116, contenders[4].Weight); // (60 + 1000) * 0.1 + 10
+    EXPECT_THAT(GetValues(contenders), testing::UnorderedElementsAre(
+        107, // (70 + 1000) * 0.1
+        108, // ditto
+        109,
+        110,
+        116)); // (60 + 1000) * 0.1 + 10
 }
 
-TEST(TMaxMinBalancerTest, TakeWinnerIf)
+TEST(TMaxMinBalancerTest, Lazy)
+{
+    auto decayInterval = TDuration::MilliSeconds(200);
+    auto sleepInterval = TDuration::MilliSeconds(300);
+
+    TTestBalancer balancer(0.1, decayInterval);
+
+    std::vector<int> contenderRange = {0, 1, 2, 3, 4};
+
+    auto expected = ShuffleWithDefaults(balancer, contenderRange);
+
+    for (const auto& e : expected) {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        EXPECT_EQ(e, *winner);
+        balancer.AddWeightWithDefault(*winner, 1000); // Just to shift to the back of the queue.
+    }
+
+    Sleep(sleepInterval);
+
+    {
+        auto winner = balancer.ChooseRangeWinner(contenderRange);
+        EXPECT_TRUE(winner);
+        balancer.AddWeightWithDefault(*winner, 10);
+    }
+
+    auto& contenders = balancer.PeekContenders();
+    EXPECT_THAT(GetValues(contenders), testing::UnorderedElementsAre(
+        107, // (70 + 1000) * 0.1
+        108, // ditto
+        109,
+        110,
+        116)); // (60 + 1000) * 0.1 + 10
+}
+
+TEST(TMaxMinBalancerTest, ChooseWinnerIf)
 {
     TTestBalancer balancer(0.1, TDuration::Seconds(1));
     for (int i = 0; i < 5; ++i) {
@@ -107,7 +181,7 @@ TEST(TMaxMinBalancerTest, TakeWinnerIf)
     std::vector<int> toSkip(expected.begin(), expected.begin() + 2);
 
     {
-        auto winner = balancer.TakeWinnerIf(
+        auto winner = balancer.ChooseWinnerIf(
             [&] (int i) {
                 return std::find(toSkip.begin(), toSkip.end(), i) == toSkip.end();
             });
@@ -117,7 +191,7 @@ TEST(TMaxMinBalancerTest, TakeWinnerIf)
     }
 
     {
-        auto winner = balancer.TakeWinnerIf(
+        auto winner = balancer.ChooseWinnerIf(
             [&] (int i) {
                 return std::find(expected.begin(), expected.end(), i) == toSkip.end();
             });

--- a/yt/yt/server/master/cell_master/serialize.h
+++ b/yt/yt/server/master/cell_master/serialize.h
@@ -178,6 +178,7 @@ DEFINE_ENUM(EMasterReign,
     ((FixStatisticsAccountingUponHunkJournalChunkSeal)              (3128))  // akozhikhov
     ((AddStrongerTxAccessValidationCheck)                           (3129))  // h0pless
     ((StructFieldRenamingAndRemoval)                                (3130))  // s-berdnikov
+    ((MaxMediumCountIncrease)                                       (3131))  // achulkov2
 );
 
 static_assert(TEnumTraits<EMasterReign>::IsMonotonic, "Master reign enum is not monotonic");

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -2120,7 +2120,7 @@ public:
         return chunkList;
     }
 
-    void CreateMediumPrologue(const std::string& name)
+    void CreateMediumPrologue(const std::string& name, std::optional<int> hintIndex)
     {
         ValidateMediumName(name);
 
@@ -2135,6 +2135,18 @@ public:
             THROW_ERROR_EXCEPTION("Medium count limit %v is reached",
                 MaxMediumCount);
         }
+
+        if (hintIndex && !IsValidRealMediumIndex(*hintIndex)) {
+            THROW_ERROR_EXCEPTION("Requested medium index %v is not allowed for actual media objects",
+                *hintIndex);
+        }
+
+        if (hintIndex && FindMediumByIndex(*hintIndex)) {
+            THROW_ERROR_EXCEPTION(
+                NYTree::EErrorCode::AlreadyExists,
+                "Medium with requested index %v already exists",
+                *hintIndex);
+        }
     }
 
     TDomesticMedium* CreateDomesticMedium(
@@ -2144,7 +2156,7 @@ public:
         std::optional<int> hintIndex,
         TObjectId hintId) override
     {
-        CreateMediumPrologue(name);
+        CreateMediumPrologue(name, hintIndex);
 
         auto objectManager = Bootstrap_->GetObjectManager();
         auto id = objectManager->GenerateId(EObjectType::DomesticMedium, hintId);
@@ -2164,7 +2176,7 @@ public:
         std::optional<int> hintIndex,
         TObjectId hintId) override
     {
-        CreateMediumPrologue(name);
+        CreateMediumPrologue(name, hintIndex);
 
         auto objectManager = Bootstrap_->GetObjectManager();
         auto id = objectManager->GenerateId(EObjectType::S3Medium, hintId);
@@ -2267,9 +2279,7 @@ public:
 
     TMedium* FindMediumByIndex(int index) const override
     {
-        return index >= 0 && index < MaxMediumCount
-            ? IndexToMediumMap_[index]
-            : nullptr;
+        return GetOrDefault(IndexToMediumMap_, index, nullptr);
     }
 
     TMedium* GetMediumByIndexOrThrow(int index) const override
@@ -2584,8 +2594,7 @@ private:
 
     NHydra::TEntityMap<TMedium, TEntityMapTypeTraits<TMedium>> MediumMap_;
     THashMap<std::string, TMedium*> NameToMediumMap_;
-    std::vector<TMedium*> IndexToMediumMap_;
-    TMediumSet UsedMediumIndexes_;
+    TMediumMap<TMedium*> IndexToMediumMap_;
 
     TMediumId DefaultStoreMediumId_;
     TMedium* DefaultStoreMedium_ = nullptr;
@@ -5200,8 +5209,7 @@ private:
 
         MediumMap_.Clear();
         NameToMediumMap_.clear();
-        IndexToMediumMap_ = std::vector<TMedium*>(MaxMediumCount, nullptr);
-        UsedMediumIndexes_.reset();
+        IndexToMediumMap_.clear();
 
         ChunksCreated_ = 0;
         ChunksDestroyed_ = 0;
@@ -6394,12 +6402,16 @@ private:
 
     int GetFreeMediumIndex()
     {
-        for (int index = 0; index < MaxMediumCount; ++index) {
-            if (!UsedMediumIndexes_[index]) {
-                return index;
-            }
+        YT_VERIFY(IndexToMediumMap_.size() < MaxMediumCount);
+
+        int candidate = 0;
+        while (IndexToMediumMap_.contains(candidate) || IsSentinelMediumIndex(candidate)) {
+            ++candidate;
         }
-        YT_ABORT();
+
+        YT_VERIFY(candidate < RealMediumIndexBound);
+
+        return candidate;
     }
 
     TDomesticMedium* DoCreateDomesticMedium(
@@ -6462,11 +6474,8 @@ private:
         EmplaceOrCrash(NameToMediumMap_, medium->GetName(), medium);
 
         auto mediumIndex = medium->GetIndex();
-        YT_VERIFY(!UsedMediumIndexes_[mediumIndex]);
-        UsedMediumIndexes_.set(mediumIndex);
 
-        YT_VERIFY(!IndexToMediumMap_[mediumIndex]);
-        IndexToMediumMap_[mediumIndex] = medium;
+        EmplaceOrCrash(IndexToMediumMap_, mediumIndex, medium);
     }
 
     void UnregisterMedium(TMedium* medium)
@@ -6474,11 +6483,9 @@ private:
         EraseOrCrash(NameToMediumMap_, medium->GetName());
 
         auto mediumIndex = medium->GetIndex();
-        YT_VERIFY(UsedMediumIndexes_[mediumIndex]);
-        UsedMediumIndexes_.reset(mediumIndex);
 
-        YT_VERIFY(IndexToMediumMap_[mediumIndex] == medium);
-        IndexToMediumMap_[mediumIndex] = nullptr;
+        YT_VERIFY(FindMediumByIndex(mediumIndex) == medium);
+        IndexToMediumMap_.erase(mediumIndex);
     }
 
     void InitializeMediumConfig(TDomesticMedium* medium)

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -216,18 +216,18 @@ struct TChunkToLinkedListNode
 //! Initializes itself with all sentinels. Required because history has left us with
 //! sentinels inside the valid medium index range.
 class TUsedMediumIndexSet
-    : public TMexSet
+    : public TMexIntSet
 {
 public:
     TUsedMediumIndexSet()
-        : TMexSet()
+        : TMexIntSet()
     {
         FillSentinels();
     }
 
     void Clear()
     {
-        TMexSet::Clear();
+        TMexIntSet::Clear();
         FillSentinels();
     }
 
@@ -2168,7 +2168,7 @@ public:
         }
 
         if (hintIndex && !IsValidRealMediumIndex(*hintIndex)) {
-            THROW_ERROR_EXCEPTION("Requested medium index %v is not allowed for actual media objects",
+            THROW_ERROR_EXCEPTION("Requested medium index %v is not allowed for real media objects",
                 *hintIndex);
         }
 

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -126,6 +126,7 @@
 
 #include <yt/yt/client/chunk_client/chunk_replica.h>
 #include <yt/yt/client/chunk_client/data_statistics.h>
+#include <yt/yt/client/chunk_client/used_medium_index_set.h>
 
 #include <yt/yt/client/query_client/query_builder.h>
 
@@ -149,8 +150,6 @@
 #include <yt/yt/core/logging/log.h>
 
 #include <yt/yt/core/yson/string.h>
-
-#include <yt/yt/core/misc/mex_set.h>
 
 #include <library/cpp/iterator/zip.h>
 
@@ -211,34 +210,6 @@ struct TChunkToLinkedListNode
     }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-
-//! Initializes itself with all sentinels. Required because history has left us with
-//! sentinels inside the valid medium index range.
-class TUsedMediumIndexSet
-    : public TMexIntSet
-{
-public:
-    TUsedMediumIndexSet()
-        : TMexIntSet()
-    {
-        FillSentinels();
-    }
-
-    void Clear()
-    {
-        TMexIntSet::Clear();
-        FillSentinels();
-    }
-
-private:
-    void FillSentinels()
-    {
-        for (auto mediumIndex : GetSentinelMediumIndexes()) {
-            Insert(mediumIndex);
-        }
-    }
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/chunk_server/chunk_owner_base.h
+++ b/yt/yt/server/master/chunk_server/chunk_owner_base.h
@@ -158,7 +158,7 @@ private:
 DEFINE_MASTER_OBJECT_TYPE(TChunkOwnerBase)
 
 // Think twice before increasing this.
-YT_STATIC_ASSERT_SIZEOF_SANITY(TChunkOwnerBase, 576);
+YT_STATIC_ASSERT_SIZEOF_SANITY(TChunkOwnerBase, 592);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/chunk_server/chunk_replica-inl.h
+++ b/yt/yt/server/master/chunk_server/chunk_replica-inl.h
@@ -10,10 +10,10 @@
 
 #include <yt/yt/core/misc/serialize.h>
 
-template <class T, bool WithReplicaState, int IndexCount, template <typename> class TAccessor>
-struct THash<NYT::NChunkServer::TAugmentedPtr<T, WithReplicaState, IndexCount, TAccessor>>
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <typename> class TAccessor>
+struct THash<NYT::NChunkServer::TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAccessor>>
 {
-    Y_FORCE_INLINE size_t operator()(NYT::NChunkServer::TAugmentedPtr<T, WithReplicaState, IndexCount, TAccessor> value) const
+    Y_FORCE_INLINE size_t operator()(NYT::NChunkServer::TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAccessor> value) const
     {
         return value.GetHash();
     }
@@ -27,134 +27,191 @@ static_assert(
     NChunkClient::ChunkReplicaIndexBound <= (1LL << 5),
     "Replica index must fit into 5 bits.");
 static_assert(
-    NChunkClient::MediumIndexBound <= (1LL << 7),
-    "Medium index must fit into 7 bits.");
-static_assert(
     static_cast<int>(TEnumTraits<EChunkReplicaState>::GetMaxValue()) < (1LL << 3),
     "Chunk replica state must fit into 2 bits.");
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr()
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr()
     : Value_(0)
+    // ExtraIndex_ is zero-initialized in class declaration.
 { }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(T* ptr, int index)
-    requires (!WithReplicaState && IndexCount == 1)
-    : Value_(reinterpret_cast<uintptr_t>(ptr) | (static_cast<uintptr_t>(index) << 56))
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(T* ptr, int index)
+    requires (!WithReplicaState && TotalIndexCount == 1)
 {
+    Value_ = reinterpret_cast<uintptr_t>(ptr);
+
+    if constexpr (CompactIndexCount >= 1) {
+        Value_ |= (static_cast<uintptr_t>(index) << 56);
+        YT_ASSERT(index >= 0 && index <= 0xff);
+    }
+
+    if constexpr (ExtraIndexCount >= 1) {
+        ExtraIndex1_ = index;
+    }
+
+    // Should be true for all cases in practice, so doesn't hurt to check.
     YT_ASSERT((reinterpret_cast<uintptr_t>(ptr) & 0xff00000000000000LL) == 0);
-    YT_ASSERT(index >= 0 && index <= 0xff);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(
     T* ptr,
     int index,
     EChunkReplicaState state)
-    requires (WithReplicaState && IndexCount == 1)
-    : Value_(
-        reinterpret_cast<uintptr_t>(ptr) |
-        static_cast<uintptr_t>(state) |
-        (static_cast<uintptr_t>(index) << 56))
+    requires (WithReplicaState && TotalIndexCount == 1)
 {
+    Value_ = reinterpret_cast<uintptr_t>(ptr) | static_cast<uintptr_t>(state);
+
+    if constexpr (CompactIndexCount >= 1) {
+        Value_ |= (static_cast<uintptr_t>(index) << 56);
+        YT_ASSERT(index >= 0 && index <= 0xff);
+    }
+
+    if constexpr (ExtraIndexCount >= 1) {
+        ExtraIndex1_ = index;
+    }
+
+    // Should be true for all cases in practice, so doesn't hurt to check.
     YT_ASSERT((reinterpret_cast<uintptr_t>(ptr) & 0xff00000000000003LL) == 0);
-    YT_ASSERT(index >= 0 && index <= 0xff);
     YT_ASSERT(static_cast<uintptr_t>(state) <= 0x3);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(
     T* ptr,
     int firstIndex,
     int secondIndex)
-    requires (!WithReplicaState && IndexCount == 2)
-    : Value_(
-        reinterpret_cast<uintptr_t>(ptr) |
-        (static_cast<uintptr_t>(firstIndex) << 56) |
-        (static_cast<uintptr_t>(secondIndex) << 48))
+    requires (!WithReplicaState && TotalIndexCount == 2)
 {
+    Value_ = reinterpret_cast<uintptr_t>(ptr);
+
+    if constexpr (CompactIndexCount >= 1) {
+        Value_ |= (static_cast<uintptr_t>(firstIndex) << 56);
+        YT_ASSERT(firstIndex >= 0 && firstIndex <= 0xff);
+    }
+
+    if constexpr (CompactIndexCount >= 2) {
+        Value_ |= (static_cast<uintptr_t>(secondIndex) << 48);
+        YT_ASSERT(secondIndex >= 0 && secondIndex <= 0xff);
+    }
+
+    if constexpr (ExtraIndexCount >= 1) {
+        // If extra index is requested, it is always the second index.
+        ExtraIndex1_ = secondIndex;
+    }
+
+    // Should be true for all cases in practice, so doesn't hurt to check.
     YT_ASSERT((reinterpret_cast<uintptr_t>(ptr) & 0xffff000000000000LL) == 0);
-    YT_ASSERT(firstIndex >= 0 && firstIndex <= 0xff);
-    YT_ASSERT(secondIndex >= 0 && secondIndex <= 0xff);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(
     T* ptr,
     int firstIndex,
     int secondIndex,
     EChunkReplicaState state)
-    requires (WithReplicaState && IndexCount == 2)
-    : Value_(
-        reinterpret_cast<uintptr_t>(ptr) |
-        static_cast<uintptr_t>(state) |
-        (static_cast<uintptr_t>(firstIndex) << 56) |
-        (static_cast<uintptr_t>(secondIndex) << 48))
+    requires (WithReplicaState && TotalIndexCount == 2)
 {
+    Value_ = reinterpret_cast<uintptr_t>(ptr) | static_cast<uintptr_t>(state);
+
+    if constexpr (CompactIndexCount >= 1) {
+        Value_ |= (static_cast<uintptr_t>(firstIndex) << 56);
+        YT_ASSERT(firstIndex >= 0 && firstIndex <= 0xff);
+    }
+
+    if constexpr (CompactIndexCount >= 2) {
+        Value_ |= (static_cast<uintptr_t>(secondIndex) << 48);
+        YT_ASSERT(secondIndex >= 0 && secondIndex <= 0xff);
+    }
+
+    if constexpr (ExtraIndexCount >= 1) {
+        // If extra index is requested, it is always the second index.
+        ExtraIndex1_ = secondIndex;
+    }
+
+    // Should be true for all cases in practice, so doesn't hurt to check.
     YT_ASSERT((reinterpret_cast<uintptr_t>(ptr) & 0xffff000000000003LL) == 0);
-    YT_ASSERT(firstIndex >= 0 && firstIndex <= 0xff);
-    YT_ASSERT(secondIndex >= 0 && secondIndex <= 0xff);
     YT_ASSERT(static_cast<uintptr_t>(state) <= 0x3);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(
-    TAugmentedPtr<T, true, IndexCount, TAugmentationAccessor> other)
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(
+    TAugmentedPtr<T, true, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> other)
     requires (!WithReplicaState)
     : Value_(other.ToGenericState().Value_)
+    , ExtraIndex1_(other.ExtraIndex1_)
 { }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(
-    TAugmentedPtr<T, false, IndexCount, TAugmentationAccessor> other)
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(
+    TAugmentedPtr<T, false, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> other)
     requires WithReplicaState
     : Value_(other.Value_)
+    , ExtraIndex1_(other.ExtraIndex1_)
 { }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::TAugmentedPtr(
-    TAugmentedPtr<T, false, IndexCount, TAugmentationAccessor> other,
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::TAugmentedPtr(
+    TAugmentedPtr<T, false, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> other,
     EChunkReplicaState state)
     requires WithReplicaState
     : Value_(other.Value_ | static_cast<uintptr_t>(state))
+    , ExtraIndex1_(other.ExtraIndex1_)
 { }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE T* TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::GetPtr() const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE T* TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::GetPtr() const
 {
     return reinterpret_cast<T*>(Value_ & 0x0000fffffffffffcLL);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
 template <int Index>
-Y_FORCE_INLINE int TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::GetIndex() const
-    requires (Index <= IndexCount)
+Y_FORCE_INLINE int TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::GetIndex() const
+    requires (Index <= TotalIndexCount)
 {
-    return (Value_ >> (64 - 8 * Index)) & 0xff;
+    if constexpr (Index <= CompactIndexCount) {
+        return (Value_ >> (64 - 8 * Index)) & 0xff;
+    }
+
+    if constexpr (Index == CompactIndexCount + 1) {
+        return ExtraIndex1_;
+    }
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE size_t TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::GetHash() const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE size_t TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::GetHash() const
 {
-    return static_cast<size_t>(Value_);
+    auto result = static_cast<size_t>(Value_);
+
+    if constexpr (ExtraIndexCount >= 1) {
+        HashCombine(result, ExtraIndex1_);
+    }
+
+    return result;
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE EChunkReplicaState TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::GetReplicaState() const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE EChunkReplicaState TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::GetReplicaState() const
     requires WithReplicaState
 {
     return static_cast<EChunkReplicaState>(Value_ & 0x3);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::operator==(TAugmentedPtr other) const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::operator==(TAugmentedPtr other) const
 {
-    return Value_ == other.Value_;
+    auto result = Value_ == other.Value_;
+    if constexpr (ExtraIndexCount >= 1) {
+        result &= ExtraIndex1_ == other.ExtraIndex1_;
+    }
+    return result;
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::operator<(TAugmentedPtr other) const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::operator<(TAugmentedPtr other) const
 {
     int thisFirstIndex = GetIndex<1>();
     int otherFirstIndex = other.GetIndex<1>();
@@ -170,7 +227,7 @@ Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentation
         }
     }
 
-    if constexpr (IndexCount == 2) {
+    if constexpr (TotalIndexCount == 2) {
         auto thisSecondIndex = GetIndex<2>();
         auto otherSecondIndex = other.GetIndex<2>();
         if (thisSecondIndex != otherSecondIndex) {
@@ -181,32 +238,33 @@ Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentation
     return GetPtr()->GetId() < other.GetPtr()->GetId();
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::operator>(TAugmentedPtr other) const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::operator>(TAugmentedPtr other) const
 {
     return other < *this;
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::operator<=(TAugmentedPtr other) const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::operator<=(TAugmentedPtr other) const
 {
     return !operator>(other);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::operator>=(TAugmentedPtr other) const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE bool TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::operator>=(TAugmentedPtr other) const
 {
     return !operator<(other);
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
 template <class C>
-Y_FORCE_INLINE void TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::Save(C& context) const
+Y_FORCE_INLINE void TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::Save(C& context) const
+    requires (ExtraIndexCount == 0)
 {
     using NYT::Save;
     SaveWith<NCellMaster::TRawNonversionedObjectPtrSerializer>(context, GetPtr());
     Save<ui8>(context, GetIndex<1>());
-    if constexpr (IndexCount == 2) {
+    if constexpr (TotalIndexCount == 2) {
         Save<ui8>(context, GetIndex<2>());
     }
     if constexpr (WithReplicaState) {
@@ -214,14 +272,15 @@ Y_FORCE_INLINE void TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentation
     }
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
 template <class C>
-Y_FORCE_INLINE void TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::Load(C& context)
+Y_FORCE_INLINE void TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::Load(C& context)
+    requires (ExtraIndexCount == 0)
 {
     using NYT::Load;
     auto* ptr = LoadWith<NCellMaster::TRawNonversionedObjectPtrSerializer, T*>(context);
     int firstIndex = Load<ui8>(context);
-    if constexpr (IndexCount == 2) {
+    if constexpr (TotalIndexCount == 2) {
         int secondIndex = Load<ui8>(context);
         if constexpr (WithReplicaState) {
             auto state = Load<EChunkReplicaState>(context);
@@ -237,16 +296,18 @@ Y_FORCE_INLINE void TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentation
     }
 }
 
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
-Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor> TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>::ToGenericState() const
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
+Y_FORCE_INLINE TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>::ToGenericState() const
     requires WithReplicaState
 {
-    if constexpr (IndexCount == 1) {
+    if constexpr (TotalIndexCount == 1) {
         return TAugmentedPtr(GetPtr(), GetIndex<1>());
     } else {
         return TAugmentedPtr(GetPtr(), GetIndex<1>(), GetIndex<2>());
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////
 
 namespace NDetail {
 

--- a/yt/yt/server/master/chunk_server/chunk_replica.h
+++ b/yt/yt/server/master/chunk_server/chunk_replica.h
@@ -17,38 +17,46 @@ namespace NYT::NChunkServer {
 ////////////////////////////////////////////////////////////////////////////////
 
 //! A compact representation for |(T*, index1, index2, replica_state)|.
-template <class T, bool WithReplicaState, int IndexCount, template <class> class TAugmentationAccessor>
+//! Compact indices are stored in the upper 16 bits of the pointer value.
+//! Extra indices are stored as plain integer fields.
+//! NB: Storing replica state requires T* to be aligned to at least 4 bytes.
+template <class T, bool WithReplicaState, int CompactIndexCount, int ExtraIndexCount, template <class> class TAugmentationAccessor>
 class TAugmentedPtr
-    : public TAugmentationAccessor<TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>>
+    : public TAugmentationAccessor<TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>>
 {
 private:
-    static_assert(1 <= IndexCount && IndexCount <= 2);
-    friend class TAugmentationAccessor<TAugmentedPtr<T, WithReplicaState, IndexCount, TAugmentationAccessor>>;
-    friend class TAugmentedPtr<T, !WithReplicaState, IndexCount, TAugmentationAccessor>;
+    static constexpr int TotalIndexCount = CompactIndexCount + ExtraIndexCount;
+
+    static_assert(0 <= CompactIndexCount && CompactIndexCount <= 2);
+    static_assert(0 <= ExtraIndexCount && ExtraIndexCount <= 1);
+    static_assert(1 <= TotalIndexCount && TotalIndexCount <= 2);
+
+    friend class TAugmentationAccessor<TAugmentedPtr<T, WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>>;
+    friend class TAugmentedPtr<T, !WithReplicaState, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor>;
 
 public:
     TAugmentedPtr();
 
     TAugmentedPtr(T* ptr, int index)
-        requires (!WithReplicaState && IndexCount == 1);
+        requires (!WithReplicaState && TotalIndexCount == 1);
 
     TAugmentedPtr(T* ptr, int index, EChunkReplicaState replicaState = EChunkReplicaState::Generic)
-        requires (WithReplicaState && IndexCount == 1);
+        requires (WithReplicaState && TotalIndexCount == 1);
 
     TAugmentedPtr(T* ptr, int firstIndex, int secondIndex)
-        requires (!WithReplicaState && IndexCount == 2);
+        requires (!WithReplicaState && TotalIndexCount == 2);
 
     TAugmentedPtr(T* ptr, int firstIndex, int secondIndex, EChunkReplicaState = EChunkReplicaState::Generic)
-        requires (WithReplicaState && IndexCount == 2);
+        requires (WithReplicaState && TotalIndexCount == 2);
 
-    explicit TAugmentedPtr(TAugmentedPtr<T, true, IndexCount, TAugmentationAccessor> other)
+    explicit TAugmentedPtr(TAugmentedPtr<T, true, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> other)
         requires (!WithReplicaState);
 
-    explicit TAugmentedPtr(TAugmentedPtr<T, false, IndexCount, TAugmentationAccessor> other)
+    explicit TAugmentedPtr(TAugmentedPtr<T, false, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> other)
         requires WithReplicaState;
 
     TAugmentedPtr(
-        TAugmentedPtr<T, false, IndexCount, TAugmentationAccessor> other,
+        TAugmentedPtr<T, false, CompactIndexCount, ExtraIndexCount, TAugmentationAccessor> other,
         EChunkReplicaState state)
         requires WithReplicaState;
 
@@ -63,10 +71,15 @@ public:
     bool operator> (TAugmentedPtr other) const;
     bool operator>=(TAugmentedPtr other) const;
 
+    // COMPAT(achulkov2): There is nothing wrong with implementing Save/Load for extra indexes, however,
+    // forbidding them helps us double check that is no place where medium index is currently serialized
+    // as part of this class. At some point this limitation should be removed.
     template <class C>
-    void Save(C& context) const;
+    void Save(C& context) const
+        requires (ExtraIndexCount == 0);
     template <class C>
-    void Load(C& context);
+    void Load(C& context)
+        requires (ExtraIndexCount == 0);
 
     TAugmentedPtr ToGenericState() const
         requires WithReplicaState;
@@ -77,12 +90,15 @@ public:
 private:
     static_assert(sizeof(uintptr_t) == 8, "Pointer type must be of size 8.");
 
-    // Use compact 8-byte representation with index occupying the highest 8 bits.
+    //! Uses compact 8-byte representation with indices occupying the highest 16 bits.
     uintptr_t Value_;
+
+    //! Extra full-sized index. Zero-cost if not requested.
+    [[no_unique_address]] std::conditional_t<ExtraIndexCount >= 1, int, std::monostate> ExtraIndex1_{};
 
     template <int Index>
     int GetIndex() const
-        requires (Index <= IndexCount);
+        requires (Index <= TotalIndexCount);
 };
 
 namespace NDetail {
@@ -121,35 +137,40 @@ template <class T>
 using TPtrWithMediumIndex = TAugmentedPtr<
     T,
     /*WithReplicaState*/ false,
-    /*IndexCount*/ 1,
+    /*CompactIndexCount*/ 0,
+    /*ExtraIndexCount*/ 1,
     NDetail::TAugmentedPtrMediumIndexAccessor>;
 
 template <class T>
 using TPtrWithReplicaIndex = TAugmentedPtr<
     T,
     /*WithReplicaState*/ false,
-    /*IndexCount*/ 1,
+    /*CompactIndexCount*/ 1,
+    /*ExtraIndexCount*/ 0,
     NDetail::TAugmentedPtrReplicaIndexAccessor>;
 
 template <class T>
 using TPtrWithReplicaInfo = TAugmentedPtr<
     T,
     /*WithReplicaState*/ true,
-    /*IndexCount*/ 1,
+    /*CompactIndexCount*/ 1,
+    /*ExtraIndexCount*/ 0,
     NDetail::TAugmentedPtrReplicaIndexAccessor>;
 
 template <class T>
 using TPtrWithReplicaAndMediumIndex = TAugmentedPtr<
     T,
     /*WithReplicaState*/ false,
-    /*IndexCount*/ 2,
+    /*CompactIndexCount*/ 1,
+    /*ExtraIndexCount*/ 1,
     NDetail::TAugmentedPtrReplicaAndMediumIndexAccessor>;
 
 template <class T>
 using TPtrWithReplicaInfoAndMediumIndex = TAugmentedPtr<
     T,
     /*WithReplicaState*/ true,
-    /*IndexCount*/ 2,
+    /*CompactIndexCount*/ 1,
+    /*ExtraIndexCount*/ 1,
     NDetail::TAugmentedPtrReplicaAndMediumIndexAccessor>;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -162,8 +183,6 @@ using TNodePtrWithReplicaAndMediumIndex = TPtrWithReplicaAndMediumIndex<NNodeTra
 using TNodePtrWithReplicaAndMediumIndexList = TCompactVector<TNodePtrWithReplicaAndMediumIndex, TypicalReplicaCount>;
 using TNodePtrWithReplicaInfoAndMediumIndex = TPtrWithReplicaInfoAndMediumIndex<NNodeTrackerServer::TNode>;
 using TNodePtrWithReplicaInfoAndMediumIndexList = TCompactVector<TNodePtrWithReplicaInfoAndMediumIndex, TypicalReplicaCount>;
-using TNodePtrWithMediumIndex = TPtrWithMediumIndex<NNodeTrackerServer::TNode>;
-using TNodePtrWithMediumIndexList = TCompactVector<TNodePtrWithMediumIndex, TypicalReplicaCount>;
 
 using TChunkLocationPtrWithReplicaIndex = TPtrWithReplicaIndex<TChunkLocation>;
 using TChunkLocationPtrWithReplicaIndexList = TCompactVector<TChunkLocationPtrWithReplicaIndex, TypicalReplicaCount>;

--- a/yt/yt/server/master/chunk_server/chunk_replication_queue.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_replication_queue.cpp
@@ -16,7 +16,7 @@ void TChunkReplicationQueue::TChunkReplicationQueue::Add(
     if (inserted) {
         RandomIterator_ = it;
     }
-    it->second.set(targetMediumIndex);
+    it->second.insert(targetMediumIndex);
 }
 
 void TChunkReplicationQueue::TChunkReplicationQueue::Erase(
@@ -25,9 +25,9 @@ void TChunkReplicationQueue::TChunkReplicationQueue::Erase(
 {
     auto it = Queue_.find(chunkIdWithIndex);
     YT_VERIFY(it != Queue_.end());
-    it->second.reset(targetMediumIndex);
+    it->second.erase(targetMediumIndex);
 
-    if (it->second.none()) {
+    if (it->second.empty()) {
         Erase(it);
     }
 }

--- a/yt/yt/server/master/chunk_server/chunk_replicator.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.cpp
@@ -511,13 +511,13 @@ void TChunkReplicator::TouchChunk(TChunk* chunk)
     TouchChunkInRepairQueues(chunk);
 }
 
-TMediumMap<EChunkStatus> TChunkReplicator::ComputeChunkStatuses(
+TCompactMediumMap<EChunkStatus> TChunkReplicator::ComputeChunkStatuses(
     TChunk* chunk,
     const TStoredChunkReplicaList& replicas)
 {
     VerifyPersistentStateRead();
 
-    TMediumMap<EChunkStatus> result;
+    TCompactMediumMap<EChunkStatus> result;
 
     auto statistics = ComputeChunkStatistics(chunk, replicas);
 
@@ -574,6 +574,7 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeErasureChunkStatisti
     auto* codec = NErasure::GetCodec(chunk->GetErasureCodec());
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     TCompactMediumMap<std::array<TChunkLocationList, ChunkReplicaIndexBound>> decommissionedReplicas;
     TCompactMediumMap<std::array<ui8, RackIndexBound>> perRackReplicaCounters;
     TCompactMediumMap<THashSet<const THost*>> replicasHosts;
@@ -581,21 +582,29 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeErasureChunkStatisti
     TMediumMap<std::array<TChunkLocationList, ChunkReplicaIndexBound>> decommissionedReplicas;
     TMediumMap<std::array<ui8, RackIndexBound>> perRackReplicaCounters;
 >>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
+=======
+    TCompactMediumMap<std::array<TChunkLocationList, ChunkReplicaIndexBound>> decommissionedReplicas;
+    TCompactMediumMap<std::array<ui8, RackIndexBound>> perRackReplicaCounters;
+>>>>>>> 79614a97641 (address comments)
     // TODO(gritukan): YT-16557.
-    TMediumMap<THashMap<const TDataCenter*, ui8>> perDataCenterReplicaCounters;
+    TCompactMediumMap<THashMap<const TDataCenter*, ui8>> perDataCenterReplicaCounters;
 
     // An arbitrary replica collocated with too may others within a single rack - per medium.
+<<<<<<< HEAD
 <<<<<<< HEAD
     TCompactMediumMap<TAugmentedStoredChunkReplicaPtr> unsafelyPlacedSealedReplicas;
 =======
     TMediumMap<TChunkLocationPtrWithReplicaInfo> unsafelyPlacedSealedReplicas;
 >>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
+=======
+    TCompactMediumMap<TChunkLocationPtrWithReplicaInfo> unsafelyPlacedSealedReplicas;
+>>>>>>> 79614a97641 (address comments)
     // An arbitrary replica that violates consistent placement requirements - per medium.
-    TMediumMap<std::array<TChunkLocation*, ChunkReplicaIndexBound>> inconsistentlyPlacedSealedReplicas;
+    TCompactMediumMap<std::array<TChunkLocation*, ChunkReplicaIndexBound>> inconsistentlyPlacedSealedReplicas;
 
-    TMediumMap<int> replicaCount;
-    TMediumMap<int> decommissionedReplicaCount;
-    TMediumMap<int> temporarilyUnavailableReplicaCount;
+    TCompactMediumMap<int> replicaCount;
+    TCompactMediumMap<int> decommissionedReplicaCount;
+    TCompactMediumMap<int> temporarilyUnavailableReplicaCount;
 
     NErasure::TPartIndexSet replicaIndexes;
 
@@ -691,8 +700,12 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeErasureChunkStatisti
 =======
     bool allMediaTransient = true;
     bool allMediaDataPartsOnly = true;
+<<<<<<< HEAD
     TMediumMap<NErasure::TPartIndexSet> mediumToErasedIndexes;
 >>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
+=======
+    TCompactMediumMap<NErasure::TPartIndexSet> mediumToErasedIndexes;
+>>>>>>> 79614a97641 (address comments)
     TMediumSet activeMedia;
 
     for (const auto& entry : chunkReplication) {
@@ -773,7 +786,7 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeErasureChunkStatisti
     return result;
 }
 
-TMediumMap<TNodeList> TChunkReplicator::GetChunkConsistentPlacementNodes(
+TCompactMediumMap<TNodeList> TChunkReplicator::GetChunkConsistentPlacementNodes(
     const TChunk* chunk,
     const TStoredChunkReplicaList& replicas)
 {
@@ -787,7 +800,7 @@ TMediumMap<TNodeList> TChunkReplicator::GetChunkConsistentPlacementNodes(
 
     const auto& chunkManager = Bootstrap_->GetChunkManager();
 
-    TMediumMap<TNodeList> result;
+    TCompactMediumMap<TNodeList> result;
     auto chunkReplication = GetChunkAggregatedReplication(chunk, replicas);
     for (const auto& entry : chunkReplication) {
         auto mediumPolicy = entry.Policy();
@@ -938,7 +951,7 @@ void TChunkReplicator::ComputeErasureChunkStatisticsCrossMedia(
     NErasure::ICodec* codec,
     bool allMediaTransient,
     bool allMediaDataPartsOnly,
-    const TMediumMap<NErasure::TPartIndexSet>& mediumToErasedIndexes,
+    const TCompactMediumMap<NErasure::TPartIndexSet>& mediumToErasedIndexes,
     const TMediumSet& activeMedia,
     const NErasure::TPartIndexSet& replicaIndexes,
     bool totallySealed)
@@ -1655,14 +1668,13 @@ EMisscheduleReason TChunkReplicator::TryScheduleReplicationJob(
     context->ScheduleJob(job);
 
     YT_LOG_DEBUG("Replication job scheduled "
-        "(JobId: %v, JobEpoch: %v, Address: %v, ChunkId: %v, TargetAddresses: %v, IsPullReplicationJob: %v, TargetMediumIndex: %v, TargetMediumName: %v)",
+        "(JobId: %v, JobEpoch: %v, Address: %v, ChunkId: %v, TargetAddresses: %v, IsPullReplicationJob: %v, TargetMediumName: %v)",
         job->GetJobId(),
         job->GetJobEpoch(),
         sourceNode->GetDefaultAddress(),
         chunkWithIndex,
         MakeFormattableView(targetNodes, TNodePtrAddressFormatter()),
         isPullReplicationJob,
-        targetMediumIndex,
         targetMedium->GetName());
 
     if (targetNode) {
@@ -1854,7 +1866,10 @@ EMisscheduleReason TChunkReplicator::TryScheduleRepairJob(
         repairQueue == EChunkRepairQueue::Decommissioned);
     context->ScheduleJob(job);
 
-    ChunkRepairQueueBalancer(repairQueue).AddWeightWithDefault(
+    auto& chunkRepairQueueBalancer = ChunkRepairQueueBalancer(repairQueue);
+
+    chunkRepairQueueBalancer.TryAddContender(mediumIndex);
+    chunkRepairQueueBalancer.AddWeight(
         mediumIndex,
         job->ResourceUsage().repair_data_size() * job->TargetReplicas().size());
 

--- a/yt/yt/server/master/chunk_server/chunk_replicator.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.cpp
@@ -573,32 +573,14 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeErasureChunkStatisti
 
     auto* codec = NErasure::GetCodec(chunk->GetErasureCodec());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
     TCompactMediumMap<std::array<TChunkLocationList, ChunkReplicaIndexBound>> decommissionedReplicas;
     TCompactMediumMap<std::array<ui8, RackIndexBound>> perRackReplicaCounters;
     TCompactMediumMap<THashSet<const THost*>> replicasHosts;
-=======
-    TMediumMap<std::array<TChunkLocationList, ChunkReplicaIndexBound>> decommissionedReplicas;
-    TMediumMap<std::array<ui8, RackIndexBound>> perRackReplicaCounters;
->>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
-=======
-    TCompactMediumMap<std::array<TChunkLocationList, ChunkReplicaIndexBound>> decommissionedReplicas;
-    TCompactMediumMap<std::array<ui8, RackIndexBound>> perRackReplicaCounters;
->>>>>>> 79614a97641 (address comments)
     // TODO(gritukan): YT-16557.
     TCompactMediumMap<THashMap<const TDataCenter*, ui8>> perDataCenterReplicaCounters;
 
     // An arbitrary replica collocated with too may others within a single rack - per medium.
-<<<<<<< HEAD
-<<<<<<< HEAD
     TCompactMediumMap<TAugmentedStoredChunkReplicaPtr> unsafelyPlacedSealedReplicas;
-=======
-    TMediumMap<TChunkLocationPtrWithReplicaInfo> unsafelyPlacedSealedReplicas;
->>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
-=======
-    TCompactMediumMap<TChunkLocationPtrWithReplicaInfo> unsafelyPlacedSealedReplicas;
->>>>>>> 79614a97641 (address comments)
     // An arbitrary replica that violates consistent placement requirements - per medium.
     TCompactMediumMap<std::array<TChunkLocation*, ChunkReplicaIndexBound>> inconsistentlyPlacedSealedReplicas;
 
@@ -693,19 +675,9 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeErasureChunkStatisti
         }
     }
 
-<<<<<<< HEAD
     auto allMediaTransient = true;
     auto allMediaDataPartsOnly = true;
     TCompactMediumMap<NErasure::TPartIndexSet> mediumToErasedIndexes;
-=======
-    bool allMediaTransient = true;
-    bool allMediaDataPartsOnly = true;
-<<<<<<< HEAD
-    TMediumMap<NErasure::TPartIndexSet> mediumToErasedIndexes;
->>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
-=======
-    TCompactMediumMap<NErasure::TPartIndexSet> mediumToErasedIndexes;
->>>>>>> 79614a97641 (address comments)
     TMediumSet activeMedia;
 
     for (const auto& entry : chunkReplication) {
@@ -1192,21 +1164,12 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeRegularChunkStatisti
         }
     }
 
-<<<<<<< HEAD
     auto precarious = true;
     auto allMediaTransient = true;
-    TCompactVector<int, MaxMediumCount> mediaOnWhichLost;
+    TMediumSet mediaOnWhichLost;
     auto hasMediumOnWhichPresent = false;
     auto hasMediumOnWhichUnderreplicated = false;
     auto hasMediumOnWhichSealedMissing = false;
-=======
-    bool precarious = true;
-    bool allMediaTransient = true;
-    std::vector<int> mediaOnWhichLost;
-    bool hasMediumOnWhichPresent = false;
-    bool hasMediumOnWhichUnderreplicated = false;
-    bool hasMediumOnWhichSealedMissing = false;
->>>>>>> ce7a0627b45 (Increase MaxMediumCount from 120 to 64000)
 
     auto replication = GetChunkAggregatedReplication(chunk, replicas);
     for (auto entry : replication) {
@@ -1270,7 +1233,7 @@ TChunkReplicator::TChunkStatistics TChunkReplicator::ComputeRegularChunkStatisti
         }
 
         if (Any(mediumStatistics.Status & EChunkStatus::Lost)) {
-            mediaOnWhichLost.push_back(mediumIndex);
+            mediaOnWhichLost.insert(mediumIndex);
         } else {
             hasMediumOnWhichPresent = true;
             precarious = precarious && mediumTransient;
@@ -1394,7 +1357,7 @@ void TChunkReplicator::ComputeRegularChunkStatisticsCrossMedia(
     bool hasSealedReplicas,
     bool precarious,
     bool allMediaTransient,
-    const std::vector<int>& mediaOnWhichLost,
+    const TMediumSet& mediaOnWhichLost,
     bool hasMediumOnWhichPresent,
     bool hasMediumOnWhichUnderreplicated,
     bool hasMediumOnWhichSealedMissing)

--- a/yt/yt/server/master/chunk_server/chunk_replicator.h
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.h
@@ -113,7 +113,7 @@ public:
 
     void TouchChunk(TChunk* chunk);
 
-    TMediumMap<EChunkStatus> ComputeChunkStatuses(
+    TCompactMediumMap<EChunkStatus> ComputeChunkStatuses(
         TChunk* chunk,
         const TStoredChunkReplicaList& replicas);
     ECrossMediumChunkStatus ComputeCrossMediumChunkStatus(
@@ -181,7 +181,7 @@ private:
 
     struct TChunkStatistics
     {
-        TMediumMap<TPerMediumChunkStatistics> PerMediumStatistics;
+        TCompactMediumMap<TPerMediumChunkStatistics> PerMediumStatistics;
         ECrossMediumChunkStatus Status = ECrossMediumChunkStatus::None;
     };
 
@@ -348,7 +348,7 @@ private:
         NErasure::ICodec* codec,
         bool allMediaTransient,
         bool allMediaDataPartsOnly,
-        const TMediumMap<NErasure::TPartIndexSet>& mediumToErasedIndexes,
+        const TCompactMediumMap<NErasure::TPartIndexSet>& mediumToErasedIndexes,
         const TMediumSet& activeMedia,
         const NErasure::TPartIndexSet& replicaIndexes,
         bool totallySealed);
@@ -412,7 +412,7 @@ private:
     TMediumMap<TChunkRepairQueue>& ChunkRepairQueues(EChunkRepairQueue queue);
     NServer::TDecayingMaxMinBalancer<int, double>& ChunkRepairQueueBalancer(EChunkRepairQueue queue);
 
-    TMediumMap<TNodeList> GetChunkConsistentPlacementNodes(
+    TCompactMediumMap<TNodeList> GetChunkConsistentPlacementNodes(
         const TChunk* chunk,
         const TStoredChunkReplicaList& replicas);
 

--- a/yt/yt/server/master/chunk_server/chunk_replicator.h
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.h
@@ -325,7 +325,7 @@ private:
         bool hasSealedReplicas,
         bool precarious,
         bool allMediaTransient,
-        const std::vector<int>& mediaOnWhichLost,
+        const TMediumSet& mediaOnWhichLost,
         bool hasMediumOnWhichPresent,
         bool hasMediumOnWhichUnderreplicated,
         bool hasMediumOnWhichSealedMissing);

--- a/yt/yt/server/master/chunk_server/chunk_replicator.h
+++ b/yt/yt/server/master/chunk_server/chunk_replicator.h
@@ -113,7 +113,7 @@ public:
 
     void TouchChunk(TChunk* chunk);
 
-    TCompactMediumMap<EChunkStatus> ComputeChunkStatuses(
+    TMediumMap<EChunkStatus> ComputeChunkStatuses(
         TChunk* chunk,
         const TStoredChunkReplicaList& replicas);
     ECrossMediumChunkStatus ComputeCrossMediumChunkStatus(
@@ -181,7 +181,7 @@ private:
 
     struct TChunkStatistics
     {
-        TCompactMediumMap<TPerMediumChunkStatistics> PerMediumStatistics;
+        TMediumMap<TPerMediumChunkStatistics> PerMediumStatistics;
         ECrossMediumChunkStatus Status = ECrossMediumChunkStatus::None;
     };
 
@@ -235,8 +235,8 @@ private:
     //! In each queue, a single chunk may only appear once.
     // NB: Queues are not modified when a replicator shard is disabled, so one should
     // take care of such a chunks.
-    std::array<TChunkRepairQueue, MaxMediumCount> MissingPartChunkRepairQueues_ = {};
-    std::array<TChunkRepairQueue, MaxMediumCount> DecommissionedPartChunkRepairQueues_ = {};
+    TMediumMap<TChunkRepairQueue> MissingPartChunkRepairQueues_ = {};
+    TMediumMap<TChunkRepairQueue> DecommissionedPartChunkRepairQueues_ = {};
     NServer::TDecayingMaxMinBalancer<int, double> MissingPartChunkRepairQueueBalancer_;
     NServer::TDecayingMaxMinBalancer<int, double> DecommissionedPartChunkRepairQueueBalancer_;
 
@@ -325,7 +325,7 @@ private:
         bool hasSealedReplicas,
         bool precarious,
         bool allMediaTransient,
-        const TCompactVector<int, MaxMediumCount>& mediaOnWhichLost,
+        const std::vector<int>& mediaOnWhichLost,
         bool hasMediumOnWhichPresent,
         bool hasMediumOnWhichUnderreplicated,
         bool hasMediumOnWhichSealedMissing);
@@ -348,7 +348,7 @@ private:
         NErasure::ICodec* codec,
         bool allMediaTransient,
         bool allMediaDataPartsOnly,
-        const TCompactMediumMap<NErasure::TPartIndexSet>& mediumToErasedIndexes,
+        const TMediumMap<NErasure::TPartIndexSet>& mediumToErasedIndexes,
         const TMediumSet& activeMedia,
         const NErasure::TPartIndexSet& replicaIndexes,
         bool totallySealed);
@@ -409,10 +409,10 @@ private:
     const std::unique_ptr<TChunkScanner>& GetChunkRequisitionUpdateScanner(TChunk* chunk) const;
 
     TChunkRepairQueue& ChunkRepairQueue(int mediumIndex, EChunkRepairQueue queue);
-    std::array<TChunkRepairQueue, MaxMediumCount>& ChunkRepairQueues(EChunkRepairQueue queue);
+    TMediumMap<TChunkRepairQueue>& ChunkRepairQueues(EChunkRepairQueue queue);
     NServer::TDecayingMaxMinBalancer<int, double>& ChunkRepairQueueBalancer(EChunkRepairQueue queue);
 
-    TCompactMediumMap<TNodeList> GetChunkConsistentPlacementNodes(
+    TMediumMap<TNodeList> GetChunkConsistentPlacementNodes(
         const TChunk* chunk,
         const TStoredChunkReplicaList& replicas);
 

--- a/yt/yt/server/master/chunk_server/chunk_requisition.h
+++ b/yt/yt/server/master/chunk_server/chunk_requisition.h
@@ -115,8 +115,8 @@ public:
     {
         // Entries are stored sorted by medium index, changing the index would
         // break internal invariants.
-        DEFINE_BYVAL_RO_PROPERTY(ui8, MediumIndex);
-        static_assert(MaxMediumCount <= std::numeric_limits<decltype(MediumIndex_)>::max());
+        DEFINE_BYVAL_RO_PROPERTY(ui16, MediumIndex);
+        static_assert(RealMediumIndexBound <= std::numeric_limits<decltype(MediumIndex_)>::max());
 
         DEFINE_BYREF_RW_PROPERTY(TReplicationPolicy, Policy);
 
@@ -245,7 +245,7 @@ private:
     static auto Find(T& entries, int mediumIndex) -> decltype(entries.begin());
 };
 
-static_assert(sizeof(TChunkReplication) == 16, "TChunkReplication's size is wrong");
+static_assert(sizeof(TChunkReplication) == 24, "TChunkReplication's size is wrong");
 
 bool operator==(const TChunkReplication& lhs, const TChunkReplication& rhs);
 

--- a/yt/yt/server/master/chunk_server/public.h
+++ b/yt/yt/server/master/chunk_server/public.h
@@ -80,6 +80,7 @@ using NChunkClient::MaxMediumPriority;
 using NChunkClient::TDataCenterName;
 using NChunkClient::TChunkLocationUuid;
 using NChunkClient::TMediumMap;
+using NChunkClient::TCompactMediumMap;
 using NChunkClient::TConsistentReplicaPlacementHash;
 using NChunkClient::NullConsistentReplicaPlacementHash;
 using NChunkClient::ChunkReplicaIndexBound;

--- a/yt/yt/server/master/chunk_server/public.h
+++ b/yt/yt/server/master/chunk_server/public.h
@@ -73,13 +73,13 @@ using NChunkClient::EChunkType;
 using NChunkClient::TBlockId;
 using NChunkClient::TypicalReplicaCount;
 using NChunkClient::MaxMediumCount;
+using NChunkClient::RealMediumIndexBound;
 using NChunkClient::MediumIndexBound;
 using NChunkClient::DefaultStoreMediumIndex;
 using NChunkClient::MaxMediumPriority;
 using NChunkClient::TDataCenterName;
 using NChunkClient::TChunkLocationUuid;
 using NChunkClient::TMediumMap;
-using NChunkClient::TCompactMediumMap;
 using NChunkClient::TConsistentReplicaPlacementHash;
 using NChunkClient::NullConsistentReplicaPlacementHash;
 using NChunkClient::ChunkReplicaIndexBound;
@@ -299,7 +299,8 @@ struct TChunkPartLossTimeComparer
 
 using TOldestPartMissingChunkSet = std::set<TChunk*, TChunkPartLossTimeComparer>;
 
-using TMediumSet = std::bitset<MaxMediumCount>;
+// NB: Remember that compact set iterators may be invalidated on any modification!
+using TMediumSet = TCompactSet<int, NChunkClient::TypicalMediumCount>;
 
 constexpr int MediumDefaultPriority = 0;
 

--- a/yt/yt/server/master/node_tracker_server/node.cpp
+++ b/yt/yt/server/master/node_tracker_server/node.cpp
@@ -1093,6 +1093,16 @@ bool TNode::HasMedium(int mediumIndex) const
     return it != locations.end();
 }
 
+TMediumSet TNode::GetMediumSet() const
+{
+    TMediumSet mediumSet;
+    const auto& locations = DataNodeStatistics_.chunk_locations();
+    for (const auto& location : locations) {
+        mediumSet.insert(location.medium_index());
+    }
+    return mediumSet;
+}
+
 std::optional<double> TNode::GetFillFactor(int mediumIndex) const
 {
     return GetOrDefault(FillFactors_, mediumIndex);

--- a/yt/yt/server/master/node_tracker_server/node.h
+++ b/yt/yt/server/master/node_tracker_server/node.h
@@ -383,6 +383,8 @@ public:
     // Returns true iff the node has at least one location belonging to the
     // specified medium.
     bool HasMedium(int mediumIndex) const;
+    //! Returns indexes of all media present on this node.
+    TMediumSet GetMediumSet() const;
 
     int GetHintedSessionCount(int mediumIndex, int chunkHostMasterCellCount) const;
 

--- a/yt/yt/server/master/table_server/table_node.h
+++ b/yt/yt/server/master/table_server/table_node.h
@@ -238,7 +238,7 @@ private:
 
 DEFINE_MASTER_OBJECT_TYPE(TTableNode)
 // Think twice before increasing this.
-YT_STATIC_ASSERT_SIZEOF_SANITY(TTableNode, 680);
+YT_STATIC_ASSERT_SIZEOF_SANITY(TTableNode, 696);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/tablet_server/tablet_owner_base.h
+++ b/yt/yt/server/master/tablet_server/tablet_owner_base.h
@@ -136,7 +136,7 @@ private:
 DEFINE_MASTER_OBJECT_TYPE(TTabletOwnerBase)
 
 // Think twice before increasing this.
-YT_STATIC_ASSERT_SIZEOF_SANITY(TTabletOwnerBase, 592);
+YT_STATIC_ASSERT_SIZEOF_SANITY(TTabletOwnerBase, 608);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/tablet_server/tablet_statistics.h
+++ b/yt/yt/server/master/tablet_server/tablet_statistics.h
@@ -23,7 +23,7 @@ struct TTabletCellStatisticsBase
     i64 HunkCompressedDataSize = 0;
     i64 MemorySize = 0;
     i64 DynamicMemoryPoolSize = 0;
-    NChunkClient::TCompactMediumMap<i64> DiskSpacePerMedium;
+    NChunkClient::TMediumMap<i64> DiskSpacePerMedium;
     int ChunkCount = 0;
     int PartitionCount = 0;
     int StoreCount = 0;

--- a/yt/yt/server/master/tablet_server/tablet_statistics.h
+++ b/yt/yt/server/master/tablet_server/tablet_statistics.h
@@ -23,7 +23,7 @@ struct TTabletCellStatisticsBase
     i64 HunkCompressedDataSize = 0;
     i64 MemorySize = 0;
     i64 DynamicMemoryPoolSize = 0;
-    NChunkClient::TMediumMap<i64> DiskSpacePerMedium;
+    NChunkClient::TCompactMediumMap<i64> DiskSpacePerMedium;
     int ChunkCount = 0;
     int PartitionCount = 0;
     int StoreCount = 0;

--- a/yt/yt/tests/integration/master/test_media.py
+++ b/yt/yt/tests/integration/master/test_media.py
@@ -1,3 +1,4 @@
+from py import builtin
 from yt_env_setup import YTEnvSetup, Restarter, NODES_SERVICE
 
 from yt_commands import (
@@ -5,7 +6,8 @@ from yt_commands import (
     create_domestic_medium, create_s3_medium, write_file,
     read_table, write_table, write_journal, wait_until_sealed,
     get_singular_chunk_id, set_account_disk_space_limit, get_account_disk_space_limit,
-    get_media, set_node_banned, set_all_nodes_banned, create_rack)
+    get_media, set_node_banned, set_all_nodes_banned, create_rack,
+    print_debug, update_nodes_dynamic_config)
 
 from yt.common import YtError
 
@@ -15,12 +17,133 @@ from flaky import flaky
 from copy import deepcopy
 import builtins
 
+import hashlib
 
 ################################################################################
 
+class TestMediaBase(YTEnvSetup):
+    def _check_all_chunks_on_medium(self, tbl, medium):
+        chunk_ids = get("//tmp/{0}/@chunk_ids".format(tbl))
+        for chunk_id in chunk_ids:
+            replicas = get("#" + chunk_id + "/@stored_replicas")
+            for replica in replicas:
+                if replica.attributes["medium"] != medium:
+                    return False
+        return True
+    
+    def _count_chunks_on_medium(self, tbl, medium):
+        chunk_count = 0
+        chunk_ids = get("//tmp/{0}/@chunk_ids".format(tbl))
+        for chunk_id in chunk_ids:
+            replicas = get("#" + chunk_id + "/@stored_replicas")
+            for replica in replicas:
+                if replica.attributes["medium"] == medium:
+                    chunk_count += 1
+
+        return chunk_count
+    
+    def _remove_zeros(self, d):
+        for k in list(d.keys()):
+            if d[k] == 0:
+                del d[k]
+    
+    def _check_account_and_table_usage_equal(self, tbl):
+        account_usage = self._remove_zeros(get("//sys/accounts/tmp/@resource_usage/disk_space_per_medium"))
+        table_usage = self._remove_zeros(get("//tmp/{0}/@resource_usage/disk_space_per_medium".format(tbl)))
+        return account_usage == table_usage
+
+    def _check_chunk_ok(self, ok, chunk_id, media, print_progress=False):
+        available = get("#%s/@available" % chunk_id)
+        replication_status = get("#%s/@replication_status" % chunk_id)
+        lvc = ls("//sys/lost_vital_chunks")
+        media_in_unexpected_state = 0
+        for medium in media:
+            if ok:
+                if (
+                        not available
+                        or medium not in replication_status
+                        or replication_status[medium]["underreplicated"]
+                        or replication_status[medium]["lost"]
+                        or replication_status[medium]["data_missing"]
+                        or replication_status[medium]["parity_missing"]
+                        or len(lvc) != 0
+                ):
+                    media_in_unexpected_state += 1
+            else:
+                if (
+                        available
+                        or medium not in replication_status
+                        or not replication_status[medium]["lost"]
+                        or not replication_status[medium]["data_missing"]
+                        or not replication_status[medium]["parity_missing"]
+                        or len(lvc) == 0
+                ):
+                    media_in_unexpected_state += 1
+        if print_progress and media_in_unexpected_state > 0:
+            print_debug(f"Chunk {chunk_id} is {'not ok' if ok else 'ok'} on {media_in_unexpected_state} media")
+        return media_in_unexpected_state == 0
+
+    def _get_chunk_replica_nodes(self, chunk_id):
+        return builtins.set(str(r) for r in get("#{0}/@stored_replicas".format(chunk_id)))
+
+    def _get_chunk_replica_media(self, chunk_id):
+        return builtins.set(r.attributes["medium"] for r in get("#{0}/@stored_replicas".format(chunk_id)))
+
+    def _ban_nodes(self, nodes):
+        banned = False
+        for node in ls("//sys/cluster_nodes"):
+            if node in nodes:
+                set_node_banned(node, True)
+                banned = True
+        assert banned
+
+    def _get_locations(self, node):
+        return {
+            location["location_uuid"]: location
+            for location in get(node + "/@statistics/locations")
+        }
+
+    def _get_non_existent_location(self, node):
+        locations = self._get_locations(node)
+        for i in range(2**10):
+            location_uuid = "1-1-1-{}".format(hex(i)[2:])
+            if location_uuid not in locations:
+                return location_uuid
+        assert False, "BINGO!!!"
+
+    def _create_domestic_medium(self, medium):
+        if not exists(f"//sys/media/{medium}"):
+            create_domestic_medium(medium)
+
+    def _sync_set_medium_overrides(self, overrides):
+        for location, medium in overrides:
+            path = f"//sys/chunk_locations/{location}/@medium_override"
+            set(path, medium)
+        for location, medium in overrides:
+            wait(lambda: get(f"//sys/chunk_locations/{location}/@statistics/medium_name") == medium)
+
+    def _validate_empty_medium_overrides(self):
+        for location in ls("//sys/chunk_locations"):
+            remove(f"//sys/chunk_locations/{location}/@medium_override")
+
+        def medium_overrides_applied():
+            for location in ls("//sys/chunk_locations"):
+                if get(f"//sys/chunk_locations/{location}/@statistics/medium_name") != "default":
+                    return False
+            return True
+
+        wait(medium_overrides_applied)
+
+    def _set_medium_override_and_wait(self, location, medium):
+        set(f"//sys/chunk_locations/{location}/@medium_override", medium)
+        wait(lambda: get(f"//sys/chunk_locations/{location}/@statistics/medium_name") == medium)
+
+    def _get_chunk_locations(self, chunk_id):
+        return {replica.attributes["location_uuid"] for replica in get(f"#{chunk_id}/@stored_replicas")}
+
 
 @pytest.mark.enabled_multidaemon
-class TestMedia(YTEnvSetup):
+class TestMedia(TestMediaBase):
     ENABLE_MULTIDAEMON = True
     NUM_MASTERS = 1
     NUM_NODES = 10
@@ -69,78 +192,6 @@ class TestMedia(YTEnvSetup):
 
         set("//sys/media/s3/@config", self.S3_MEDIUM_CONFIG)
 
-    def _check_all_chunks_on_medium(self, tbl, medium):
-        chunk_ids = get("//tmp/{0}/@chunk_ids".format(tbl))
-        for chunk_id in chunk_ids:
-            replicas = get("#" + chunk_id + "/@stored_replicas")
-            for replica in replicas:
-                if replica.attributes["medium"] != medium:
-                    return False
-        return True
-
-    def _count_chunks_on_medium(self, tbl, medium):
-        chunk_count = 0
-        chunk_ids = get("//tmp/{0}/@chunk_ids".format(tbl))
-        for chunk_id in chunk_ids:
-            replicas = get("#" + chunk_id + "/@stored_replicas")
-            for replica in replicas:
-                if replica.attributes["medium"] == medium:
-                    chunk_count += 1
-
-        return chunk_count
-
-    def _remove_zeros(self, d):
-        for k in list(d.keys()):
-            if d[k] == 0:
-                del d[k]
-
-    def _check_account_and_table_usage_equal(self, tbl):
-        account_usage = self._remove_zeros(get("//sys/accounts/tmp/@resource_usage/disk_space_per_medium"))
-        table_usage = self._remove_zeros(get("//tmp/{0}/@resource_usage/disk_space_per_medium".format(tbl)))
-        return account_usage == table_usage
-
-    def _check_chunk_ok(self, ok, chunk_id, media):
-        available = get("#%s/@available" % chunk_id)
-        replication_status = get("#%s/@replication_status" % chunk_id)
-        lvc = ls("//sys/lost_vital_chunks")
-        for medium in media:
-            if ok:
-                if (
-                        not available
-                        or medium not in replication_status
-                        or replication_status[medium]["underreplicated"]
-                        or replication_status[medium]["lost"]
-                        or replication_status[medium]["data_missing"]
-                        or replication_status[medium]["parity_missing"]
-                        or len(lvc) != 0
-                ):
-                    return False
-            else:
-                if (
-                        available
-                        or medium not in replication_status
-                        or not replication_status[medium]["lost"]
-                        or not replication_status[medium]["data_missing"]
-                        or not replication_status[medium]["parity_missing"]
-                        or len(lvc) == 0
-                ):
-                    return False
-        return True
-
-    def _get_chunk_replica_nodes(self, chunk_id):
-        return builtins.set(str(r) for r in get("#{0}/@stored_replicas".format(chunk_id)))
-
-    def _get_chunk_replica_media(self, chunk_id):
-        return builtins.set(r.attributes["medium"] for r in get("#{0}/@stored_replicas".format(chunk_id)))
-
-    def _ban_nodes(self, nodes):
-        banned = False
-        for node in ls("//sys/cluster_nodes"):
-            if node in nodes:
-                set_node_banned(node, True)
-                banned = True
-        assert banned
-
     @authors()
     def test_default_store_medium_name(self):
         assert get("//sys/media/default/@name") == "default"
@@ -157,11 +208,6 @@ class TestMedia(YTEnvSetup):
     def test_create_simple(self):
         assert get("//sys/media/hdd4/@name") == "hdd4"
         assert get("//sys/media/hdd4/@index") > 0
-
-    @authors()
-    def test_create_too_many_fails(self):
-        with pytest.raises(YtError):
-            create_domestic_medium("excess_medium")
 
     @authors("aozeritsky", "shakurov")
     def test_rename(self):
@@ -441,7 +487,7 @@ class TestMedia(YTEnvSetup):
     @authors("babenko", "shakurov")
     @pytest.mark.ignore_in_opensource_ci
     def test_chunk_statuses_1_media(self):
-        codec = "reed_solomon_6_3"
+        codec = "isa_reed_solomon_6_3"
         codec_replica_count = 9
 
         create("table", "//tmp/t9")
@@ -464,7 +510,7 @@ class TestMedia(YTEnvSetup):
     @authors("shakurov")
     @pytest.mark.ignore_in_opensource_ci
     def test_chunk_statuses_2_media(self):
-        codec = "reed_solomon_6_3"
+        codec = "isa_reed_solomon_6_3"
         codec_replica_count = 9
 
         create("table", "//tmp/t9")
@@ -719,7 +765,7 @@ class TestMediaMulticell(TestMedia):
 ################################################################################
 
 
-class TestDynamicMedia(YTEnvSetup):
+class TestDynamicMedia(TestMediaBase):
     ENABLE_MULTIDAEMON = False  # There are component restarts.
     NUM_MASTERS = 1
     NUM_NODES = 1
@@ -742,18 +788,6 @@ class TestDynamicMedia(YTEnvSetup):
         }
     }
 
-    def _validate_empty_medium_overrides(self):
-        for location in ls("//sys/chunk_locations"):
-            remove(f"//sys/chunk_locations/{location}/@medium_override")
-
-        def medium_overrides_applied():
-            for location in ls("//sys/chunk_locations"):
-                if get(f"//sys/chunk_locations/{location}/@statistics/medium_name") != "default":
-                    return False
-            return True
-
-        wait(medium_overrides_applied)
-
     def teardown_method(self, method):
         for node in ls("//sys/data_nodes"):
             for location in self._get_locations(f"//sys/data_nodes/{node}"):
@@ -761,41 +795,12 @@ class TestDynamicMedia(YTEnvSetup):
 
         super(TestDynamicMedia, self).teardown_method(method)
 
-    def _set_medium_override_and_wait(self, location, medium):
-        set(f"//sys/chunk_locations/{location}/@medium_override", medium)
-        wait(lambda: get(f"//sys/chunk_locations/{location}/@statistics/medium_name") == medium)
-
     @classmethod
     def modify_node_config(cls, config, cluster_index):
         assert len(config["data_node"]["store_locations"]) == 2
 
         config["data_node"]["store_locations"][0]["medium_name"] = "default"
         config["data_node"]["store_locations"][1]["medium_name"] = "default"
-
-    def _get_locations(self, node):
-        return {
-            location["location_uuid"]: location
-            for location in get(node + "/@statistics/locations")
-        }
-
-    def _get_non_existent_location(self, node):
-        locations = self._get_locations(node)
-        for i in range(2**10):
-            location_uuid = "1-1-1-{}".format(hex(i)[2:])
-            if location_uuid not in locations:
-                return location_uuid
-        assert False, "BINGO!!!"
-
-    def _create_domestic_medium(self, medium):
-        if not exists(f"//sys/media/{medium}"):
-            create_domestic_medium(medium)
-
-    def _sync_set_medium_overrides(self, overrides):
-        for location, medium in overrides:
-            path = f"//sys/chunk_locations/{location}/@medium_override"
-            set(path, medium)
-        for location, medium in overrides:
-            wait(lambda: get(f"//sys/chunk_locations/{location}/@statistics/medium_name") == medium)
 
     @authors("kvk1920")
     def test_medium_change_simple(self):
@@ -965,3 +970,277 @@ class TestDynamicMedia(YTEnvSetup):
         set("//sys/chunk_locations/{}/@medium_override".format(location_uuid), m2)
 
         wait(lambda: get("//sys/chunk_locations/{}/@statistics/chunk_count".format(location_uuid)) == 0)
+
+
+################################################################################
+
+
+# As media cannot be deleted, for now, it is best to use a separate test suite for tests with a significant number of them.
+# NB: Some new media are created during the runtime of the tests, be careful when writing new ones!
+class TestManyMedia(TestMediaBase):
+    NON_DEFAULT_MEDIUM_COUNT = 300
+    NON_DEFAULT_MEDIA = [f"hdd{i}" for i in range(NON_DEFAULT_MEDIUM_COUNT)]
+
+    NUM_MASTERS = 1
+    NUM_NODES = 10
+    # Each non-default medium will have a single location assigned to it.
+    # Default medium will have one location on each node.
+    STORE_LOCATION_COUNT = NON_DEFAULT_MEDIUM_COUNT // NUM_NODES + 1
+
+    # The periods below are set to extremely low values to speed up replication.
+    DELTA_DYNAMIC_MASTER_CONFIG = {
+        "chunk_manager": {
+            "chunk_refresh_period": 2,
+            "chunk_requisition_update_period": 2,
+        },
+    }
+
+    # The periods below are set to extremely low values to speed up replication.
+    DELTA_NODE_CONFIG = {
+        "data_node": {
+            "incremental_heartbeat_period": 2,
+        },
+        "cluster_connection": {
+            "medium_directory_synchronizer": {
+                "sync_period": 10,
+            }
+        },
+    }
+
+    DELTA_DYNAMIC_NODE_CONFIG = {
+        "%true": {
+            "resource_limits": {
+                "overrides": {
+                    "replication_slots": 64,
+                },
+            },
+        },
+    }
+
+    # It is impossible to modify data node configurations non-uniformely, so let's use a sledge-hammer to crack a nut.
+    # TODO(achulkov2): It is better to pass node index to modify_node_config, but that warrants a separate refactoring PR.
+    @classmethod
+    def apply_config_patches(cls, configs, ytserver_version, cluster_index, cluster_path):
+        super(TestManyMedia, cls).apply_config_patches(configs, ytserver_version, cluster_index, cluster_path)
+
+        for node_index, config in enumerate(configs["node"]):
+            locations = config["data_node"]["store_locations"]
+            assert len(locations) == cls.STORE_LOCATION_COUNT
+
+            locations[0]["medium_name"] = "default"
+
+            for i in range(1, cls.STORE_LOCATION_COUNT):
+                medium = cls.NON_DEFAULT_MEDIA[node_index * (cls.STORE_LOCATION_COUNT - 1) + (i - 1)]
+                locations[i]["medium_name"] = medium
+
+    @classmethod
+    def on_masters_started(cls):
+        for medium in cls.NON_DEFAULT_MEDIA:
+            create_domestic_medium(medium)
+
+    @classmethod
+    def setup_class(cls, *args, **kwargs):
+        super(TestManyMedia, cls).setup_class(*args, **kwargs)
+        disk_space_limit = get_account_disk_space_limit("tmp", "default")
+        for medium in cls.NON_DEFAULT_MEDIA:
+            set_account_disk_space_limit("tmp", disk_space_limit, medium)
+
+    # Returns a deterministic sample based on the given seed.
+    @staticmethod
+    def get_deterministic_sample(objects, sample_size, seed):
+        assert sample_size <= len(objects)
+
+        seed_bytes = str(seed).encode("utf-8")
+
+        def key(obj):
+            return hashlib.sha256(seed_bytes + str(obj).encode("utf-8")).digest(), obj
+
+        shuffled = sorted(objects, key=key)
+
+        return shuffled[:sample_size]
+
+    # Returns a deterministic sample of non-default media based on the given seed.
+    @classmethod
+    def get_nondefault_media_sample(cls, sample_size, seed):
+        return cls.get_deterministic_sample(cls.NON_DEFAULT_MEDIA, sample_size, seed)
+    
+    @classmethod
+    def enumerate_nondefault_media_sample(cls, sample_size, seed):
+        indexes = cls.get_deterministic_sample(range(len(cls.NON_DEFAULT_MEDIA)), sample_size, seed)
+        for i in indexes:
+            yield i, cls.NON_DEFAULT_MEDIA[i]
+
+    @classmethod
+    def get_locations_for_nondefault_media(cls, media):
+        medium_to_location = {}
+        for location in ls("//sys/chunk_locations", attributes=["statistics"]):
+            medium = location.attributes["statistics"]["medium_name"]
+            assert medium == "default" or medium not in medium_to_location, f"Non-default medium {medium} has multiple locations"
+            medium_to_location[medium] = str(location)
+        return {medium_to_location[medium] for medium in media}
+
+    @authors("achulkov2")
+    def test_medium_index_assignment(self):
+        assert get("//sys/media/default/@index") == 0
+
+        for i, medium in self.enumerate_nondefault_media_sample(sample_size=30, seed=42):
+            # Indexes 126 and 127 are historical sentinels.
+            expected_medium_index = i + 1 if i + 1 < 126 else i + 3
+            assert get(f"//sys/media/{medium}/@index") == expected_medium_index
+
+        with pytest.raises(YtError):
+            create_domestic_medium("excess_medium_same_index", attributes={"index": 42})
+
+        with pytest.raises(YtError):
+            create_domestic_medium("excess_medium_sentinel_index_126", attributes={"index": 126})
+
+        with pytest.raises(YtError):
+            create_domestic_medium("excess_medium_sentinel_index_127", attributes={"index": 127})
+
+        with pytest.raises(YtError):
+            create_domestic_medium("excess_medium_sentinel_index_64010", attributes={"index": 64010})
+
+        with pytest.raises(YtError):
+            create_domestic_medium("excess_medium_out_of_bounds_index_64103", attributes={"index": 64103})
+
+        create_domestic_medium("excess_medium_666", attributes={"index": 666})
+        assert get("//sys/media/excess_medium_666/@index") == 666
+
+        create_domestic_medium("excess_medium_get_mex")
+        # Default medium + 2 sentinels + 300 non-default media => first free index is 303.
+        assert get("//sys/media/excess_medium_get_mex/@index") == 1 + 2 + 300
+
+    @authors("achulkov2")
+    def test_chunk_movement(self):
+        create("table", "//tmp/t", attributes={"replication_factor": 1})
+        write_table("//tmp/t", [{"a": 1}])
+
+        assert self._check_all_chunks_on_medium("t", "default")
+
+        for medium in self.get_nondefault_media_sample(sample_size=10, seed=1543):
+            print_debug(f"Moving table to medium {medium}")
+            set("//tmp/t/@primary_medium", medium)
+            wait(lambda: self._check_all_chunks_on_medium("t", medium) and self._check_account_and_table_usage_equal("t"))
+
+        set("//tmp/t/@primary_medium", "default")
+        wait(lambda: self._check_all_chunks_on_medium("t", "default") and self._check_account_and_table_usage_equal("t"))
+
+    @authors("achulkov2")
+    def test_many_replicas_with_removal(self):
+        create("table", "//tmp/t", attributes={"replication_factor": 1})
+        write_table("//tmp/t", [{"a": 1}])
+
+        tbl_media = get("//tmp/t/@media")
+
+        # This is a reasonably large number of replicas across newly indexed media,
+        # but small enough for us to check both replication and removal.
+        media_sample = self.get_nondefault_media_sample(sample_size=33, seed=179)
+
+        for medium in media_sample:
+            tbl_media[medium] = {"replication_factor": 1, "data_parts_only": False}
+
+        set("//tmp/t/@media", tbl_media)
+
+        chunk_id = get_singular_chunk_id("//tmp/t")
+        expected_chunk_media = builtin.set(media_sample) | {"default"}
+
+        # This takes around 15 seconds on a local machine, so should be fine.
+        wait(
+            lambda:
+                self._check_chunk_ok(True, chunk_id, media_sample, print_progress=True)
+                and self._get_chunk_replica_media(chunk_id) == expected_chunk_media)
+        
+        chunk_replica_nodes = self._get_chunk_replica_nodes(chunk_id)
+
+        # We stop chunks from being removed to be able to test removal job scheduling.
+        for node in chunk_replica_nodes:
+            set(f"//sys/cluster_nodes/{node}/@resource_limits_overrides/removal_slots", 0)
+
+        remove("//tmp/t")
+
+        # Removal jobs should be scheduled properly.
+        wait(lambda: all(get(f"//sys/cluster_nodes/{node}/@destroyed_chunk_replica_count") > 0 for node in chunk_replica_nodes))
+
+        for node in chunk_replica_nodes:
+            remove(f"//sys/cluster_nodes/{node}/@resource_limits_overrides/removal_slots")
+
+        # We somewhat rely on nothing being removed at the same time as this test is running.
+        # If that turns out not to be the case, there are ways to improve, but let's keep it simple for now.
+        wait(lambda: all(get(f"//sys/cluster_nodes/{node}/@destroyed_chunk_replica_count") == 0 for node in chunk_replica_nodes))
+
+    @authors("achulkov2")
+    @pytest.mark.timeout(300)
+    def test_extreme_replica_count(self):
+        create("table", "//tmp/t", attributes={"replication_factor": 1})
+        write_table("//tmp/t", [{"a": 1}])
+
+        tbl_media = get("//tmp/t/@media")
+
+        # We want to test a number of replicas larger than 8 bits.
+        # This takes a while, as we only schedule one replication job at once,
+        # and there is no easy way (or reason) to change that.
+        media_sample = self.get_nondefault_media_sample(sample_size=257, seed=179)
+
+        for medium in media_sample:
+            tbl_media[medium] = {"replication_factor": 1, "data_parts_only": False}
+
+        set("//tmp/t/@media", tbl_media)
+
+        chunk_id = get_singular_chunk_id("//tmp/t")
+        expected_chunk_media = builtin.set(media_sample) | {"default"}
+
+        # NB: This large wait is impossible to avoid with such number of replicas.
+        # It takes around 130 seconds on local machine, so we give some margin.
+        wait(
+            lambda:
+                self._check_chunk_ok(True, chunk_id, media_sample, print_progress=True)
+                and self._get_chunk_replica_media(chunk_id) == expected_chunk_media,
+            timeout=180)
+        
+    @authors("achulkov2")
+    def test_medium_overrides(self):
+        media_sample = self.get_nondefault_media_sample(sample_size=29, seed=2007)
+
+        create("table", "//tmp/t", attributes={"replication_factor": 1, "primary_medium": media_sample[0]})
+
+        tbl_media = get("//tmp/t/@media")
+        for medium in media_sample[1:]:
+            tbl_media[medium] = {"replication_factor": 1, "data_parts_only": False}
+
+        set("//tmp/t/@media", tbl_media)
+
+        write_table("//tmp/t", [{"a": 1}])
+
+        chunk_id = get_singular_chunk_id("//tmp/t")
+
+        wait(
+            lambda:
+                self._check_chunk_ok(True, chunk_id, media_sample, print_progress=True)
+                and self._get_chunk_replica_media(chunk_id) == builtin.set(media_sample))
+
+        assert self._get_chunk_locations(chunk_id) == self.get_locations_for_nondefault_media(media_sample)
+        
+        medium_overrides = []
+
+        shuffled_nondefault_media = self.get_nondefault_media_sample(sample_size=len(self.NON_DEFAULT_MEDIA), seed=1329)
+        shuffled_index = 0
+
+        for location in ls("//sys/chunk_locations", attributes=["statistics", "medium_override"]):
+            assert "medium_override" not in location.attributes
+
+            medium = get(f"//sys/chunk_locations/{location}/@statistics/medium_name")
+
+            if medium == "default":
+                continue
+
+            new_medium = shuffled_nondefault_media[shuffled_index]
+            shuffled_index += 1
+
+            medium_overrides.append((str(location), new_medium))
+
+        self._sync_set_medium_overrides(medium_overrides)
+
+        wait(lambda:
+            self._check_chunk_ok(True, chunk_id, media_sample, print_progress=True)
+            and self._get_chunk_replica_media(chunk_id) == builtin.set(media_sample)
+            and self._get_chunk_locations(chunk_id) == self.get_locations_for_nondefault_media(media_sample))

--- a/yt/yt/tests/integration/master/test_media.py
+++ b/yt/yt/tests/integration/master/test_media.py
@@ -1,4 +1,3 @@
-from py import builtin
 from yt_env_setup import YTEnvSetup, Restarter, NODES_SERVICE
 
 from yt_commands import (
@@ -1155,7 +1154,7 @@ class TestManyMedia(TestMediaBase):
         set("//tmp/t/@media", tbl_media)
 
         chunk_id = get_singular_chunk_id("//tmp/t")
-        expected_chunk_media = builtin.set(media_sample) | {"default"}
+        expected_chunk_media = builtins.set(media_sample) | {"default"}
 
         # This takes around 15 seconds on a local machine, so should be fine.
         wait(
@@ -1200,7 +1199,7 @@ class TestManyMedia(TestMediaBase):
         set("//tmp/t/@media", tbl_media)
 
         chunk_id = get_singular_chunk_id("//tmp/t")
-        expected_chunk_media = builtin.set(media_sample) | {"default"}
+        expected_chunk_media = builtins.set(media_sample) | {"default"}
 
         # NB: This large wait is impossible to avoid with such number of replicas.
         # It takes around 130 seconds on local machine, so we give some margin.
@@ -1229,7 +1228,7 @@ class TestManyMedia(TestMediaBase):
         wait(
             lambda:
                 self._check_chunk_ok(True, chunk_id, media_sample, print_progress=True)
-                and self._get_chunk_replica_media(chunk_id) == builtin.set(media_sample))
+                and self._get_chunk_replica_media(chunk_id) == builtins.set(media_sample))
 
         assert self._get_chunk_locations(chunk_id) == self._get_locations_for_nondefault_media(media_sample)
 
@@ -1256,7 +1255,7 @@ class TestManyMedia(TestMediaBase):
         wait(
             lambda:
                 self._check_chunk_ok(True, chunk_id, media_sample, print_progress=True)
-                and self._get_chunk_replica_media(chunk_id) == builtin.set(media_sample)
+                and self._get_chunk_replica_media(chunk_id) == builtins.set(media_sample)
                 and self._get_chunk_locations(chunk_id) == self._get_locations_for_nondefault_media(media_sample))
 
 


### PR DESCRIPTION
On the road to S3 media it becomes clear that the current medium count limit of 120 per cluster is not enough once media become more user-facing objects, e.g. a client can configure their own bucket.

Conveniently, this limit is no longer justified by any real physical limitations, and it is relatively safe to increase. Still, it requires a few changes around the place.

From the looks of it we are lucky and no extra actions are required for backwards compatibility of new native clients with old masters before this change. Of course, newer masters with actual media with larger indexes won't work with older native clients, but that has never worked well.

* Changelog entry
Type: feature
Component: master

Increase MaxMediumCount from 120 to 64'000 and medium index size from 8 bits to 16 bits.