### PR TITLE
chyt/controller: detect changes in secrets and cluster connection

### DIFF
--- a/yt/chyt/controller/internal/jupyt/controller.go
+++ b/yt/chyt/controller/internal/jupyt/controller.go
@@ -65,6 +65,10 @@ func (c *Controller) UpdateState() (changed bool, err error) {
 	return false, nil
 }
 
+func (c *Controller) GetControllerSnapshot() (yson.RawValue, error) {
+	return nil, nil
+}
+
 func (c *Controller) buildCommand(speclet *Speclet) (command string, env map[string]string) {
 	cmd := c.config.CommandOrDefault()
 	jupyterEnv := map[string]string{

--- a/yt/chyt/controller/internal/livy/controller.go
+++ b/yt/chyt/controller/internal/livy/controller.go
@@ -34,6 +34,10 @@ func (c *Controller) UpdateState() (changed bool, err error) {
 	return false, nil
 }
 
+func (c *Controller) GetControllerSnapshot() (yson.RawValue, error) {
+	return nil, nil
+}
+
 func getDiscoveryServerAddresses(ctx context.Context, ytc yt.Client) (discoveryAddresses string, err error) {
 	var rawAddresses []string
 	err = ytc.ListNode(ctx, ypath.Path("//sys/discovery_servers"), &rawAddresses, nil)

--- a/yt/chyt/controller/internal/sleep/controller.go
+++ b/yt/chyt/controller/internal/sleep/controller.go
@@ -72,6 +72,10 @@ func (c *Controller) UpdateState() (changed bool, err error) {
 	return false, nil
 }
 
+func (c *Controller) GetControllerSnapshot() (yson.RawValue, error) {
+	return nil, nil
+}
+
 func (c *Controller) DescribeOptions(parsedSpeclet any) []strawberry.OptionGroupDescriptor {
 	speclet := parsedSpeclet.(Speclet)
 

--- a/yt/chyt/controller/internal/strawberry/controller.go
+++ b/yt/chyt/controller/internal/strawberry/controller.go
@@ -34,6 +34,9 @@ type Controller interface {
 	// Returns true if the state has been changed and all oplets should be restarted.
 	UpdateState() (changed bool, err error)
 
+	// GetControllerSnapshot returns snapshot of controller state for tracking oplet coherence.
+	GetControllerSnapshot() (yson.RawValue, error)
+
 	// DescribeOptions returns human-readable descriptors for controller-related speclet options.
 	// Some options can be missing in the result if they are not intended to be visible through user interfaces.
 	//

--- a/yt/chyt/controller/internal/strawberry/speclet.go
+++ b/yt/chyt/controller/internal/strawberry/speclet.go
@@ -17,9 +17,10 @@ type RestartRequiredOptions struct {
 
 type Speclet struct {
 	RestartRequiredOptions
-	Active                 *bool   `yson:"active"`
-	Family                 *string `yson:"family"`
-	RestartOnSpecletChange *bool   `yson:"restart_on_speclet_change"`
+	Active                    *bool   `yson:"active"`
+	Family                    *string `yson:"family"`
+	RestartOnControllerChange *bool   `yson:"restart_on_controller_change"`
+	RestartOnSpecletChange    *bool   `yson:"restart_on_speclet_change"`
 	// MinSpecletRevision is a minimum speclet revision with which an operation does not require a force restart.
 	// If the speclet revision of the running yt operation is less than that,
 	// it will be restarted despite the RestartOnSpecletChange option.
@@ -39,12 +40,13 @@ type Speclet struct {
 }
 
 const (
-	DefaultActive                 = false
-	DefaultFamily                 = "none"
-	DefaultStage                  = "production"
-	DefaultRestartOnSpecletChange = true
-	DefaultMinIncarnationIndex    = -1
-	DefaultEnableCPUReclaim       = false
+	DefaultActive                    = false
+	DefaultFamily                    = "none"
+	DefaultStage                     = "production"
+	DefaultRestartOnControllerChange = true
+	DefaultRestartOnSpecletChange    = true
+	DefaultMinIncarnationIndex       = -1
+	DefaultEnableCPUReclaim          = false
 )
 
 func (speclet *Speclet) ActiveOrDefault() bool {
@@ -66,6 +68,13 @@ func (speclet *Speclet) StageOrDefault() string {
 		return *speclet.Stage
 	}
 	return DefaultStage
+}
+
+func (speclet *Speclet) RestartOnControllerChangeOrDefault() bool {
+	if speclet.RestartOnControllerChange != nil {
+		return *speclet.RestartOnControllerChange
+	}
+	return DefaultRestartOnControllerChange
 }
 
 func (speclet *Speclet) RestartOnSpecletChangeOrDefault() bool {

--- a/yt/chyt/controller/internal/strawberry/state.go
+++ b/yt/chyt/controller/internal/strawberry/state.go
@@ -32,8 +32,10 @@ type PersistentState struct {
 	YTOpPoolTrees []string `yson:"yt_op_pool_trees,omitempty"`
 	// YTOpPool is the last set pool of the current yt operation.
 	YTOpPool *string `yson:"yt_op_pool,omitempty"`
-	// SecretsRevision is a content_revision of the secrets with which current yt operation is started.
+	// YTOpSecretsRevision is a content_revision of the secrets with which current yt operation is started.
 	YTOpSecretsRevision yt.Revision `yson:"yt_op_secrets_revision"`
+	// YTOpControllerSnapshot is a snapshot of controller state when current yt operation was started.
+	YTOpControllerSnapshot yson.RawValue `yson:"yt_op_controller_snapshot,omitempty"`
 
 	// SpecletRevision is a revision of the last seen speclet node.
 	SpecletRevision yt.Revision `yson:"speclet_revision"`


### PR DESCRIPTION
Restart operation when secrets or cluster connection changes.

Present mechanism is unreliable and cannot track changes in secret files.

Add into oplet persistent state controller state snapshot with
hashes for important fields of cluster connection and secrets.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

