### PR TITLE
Remove yt/yql/providers/yt/fmr/recipe from OPENSOURCE

### DIFF
--- a/yt/yql/providers/yt/fmr/ya.make
+++ b/yt/yql/providers/yt/fmr/ya.make
@@ -7,7 +7,6 @@ RECURSE(
     job_launcher
     process
     proto
-    recipe
     request_options
     table_data_service
     tests
@@ -16,6 +15,10 @@ RECURSE(
     worker
     yt_job_service
 )
+
+IF (NOT OPENSOURCE)
+    RECURSE(recipe)
+ENDIF()
 
 RECURSE_FOR_TESTS(
     tests


### PR DESCRIPTION
Without library/recipes/common it breaks ya make recursion.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
