### PR TITLE
added log_once function

### DIFF
--- a/yt/python/yt/wrapper/tests/serverless/test_misc.py
+++ b/yt/python/yt/wrapper/tests/serverless/test_misc.py
@@ -1,7 +1,10 @@
+import yt.logger as yt_logger
 import yt.wrapper as yt
 from typing import get_type_hints
 
 from yt.testlib import authors
+
+from unittest.mock import Mock
 
 
 @authors("denvr")
@@ -14,3 +17,14 @@ def test_config_types():
                 _check_keys(type_hints[param_name], param_value)
 
     _check_keys(yt.default_config.DefaultConfigType, yt.default_config.default_config)
+
+
+def test_log_once():
+    tmp_log = yt_logger.LOGGER.log
+    logger_mock = Mock()
+    yt_logger.LOGGER.log = logger_mock
+    yt_logger.log_once(30, 'test')
+    yt_logger.log_once(30, 'test')
+    yt_logger.log_once(30, 'test')
+    assert logger_mock.call_count == 1
+    yt_logger.LOGGER.log = tmp_log


### PR DESCRIPTION

---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk/cms/excel/cron/microservices (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type:
Component:

Added log_once function that displays a message only once even if multiply called
https://github.com/ytsaurus/ytsaurus/issues/1445

