### PR TITLE
yt/yt/core/misc/isa_crc64/unittests: fix for arm64

### DIFF
--- a/yt/yt/core/misc/isa_crc64/unittests/crc64_reference_test/crc64_reference_test.c
+++ b/yt/yt/core/misc/isa_crc64/unittests/crc64_reference_test/crc64_reference_test.c
@@ -61,10 +61,14 @@ uint64_t crc64_yt_norm_base(
     const unsigned char *buf,
     uint64_t len);
 
+#ifdef __x86_64__
 uint64_t crc64_yt_norm_by8(
     uint64_t init_crc,
     const unsigned char *buf,
     uint64_t len);
+#else
+# define crc64_yt_norm_by8 crc64_yt_norm_base
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Function crc64_yt_norm_by8() is implemented only for x86-64.