### PR TITLE
yt/queue_agent: use native connection bus channel factory for orchid redirects

### DIFF
--- a/yt/yt/server/queue_agent/config.cpp
+++ b/yt/yt/server/queue_agent/config.cpp
@@ -48,8 +48,6 @@ void TCypressSynchronizerDynamicConfig::Register(TRegistrar registrar)
 
 void TQueueAgentConfig::Register(TRegistrar registrar)
 {
-    registrar.Parameter("bus_client", &TThis::BusClient)
-        .DefaultNew();
     registrar.Parameter("stage", &TThis::Stage)
         .NonEmpty();
 }

--- a/yt/yt/server/queue_agent/config.h
+++ b/yt/yt/server/queue_agent/config.h
@@ -81,9 +81,6 @@ DEFINE_REFCOUNTED_TYPE(TCypressSynchronizerDynamicConfig)
 struct TQueueAgentConfig
     : public NYTree::TYsonStruct
 {
-    //! Used to create channels to other queue agents.
-    NBus::TBusConfigPtr BusClient;
-
     //! Identifies a family of queue agents.
     //! Each queue agent only handles queues and consumers with the corresponding attribute set to its own stage.
     std::string Stage;

--- a/yt/yt/server/queue_agent/queue_agent.cpp
+++ b/yt/yt/server/queue_agent/queue_agent.cpp
@@ -30,9 +30,6 @@
 
 #include <yt/yt/core/misc/collection_helpers.h>
 
-#include <yt/yt/core/rpc/bus/channel.h>
-#include <yt/yt/core/rpc/caching_channel_factory.h>
-
 #include <yt/yt/core/ypath/token.h>
 
 #include <yt/yt/core/ytree/fluent.h>
@@ -402,10 +399,7 @@ TQueueAgent::TQueueAgent(
         BIND(&TQueueAgent::Pass, MakeWeak(this)),
         DynamicConfig_->PassPeriod))
     , AgentId_(std::move(agentId))
-    , QueueAgentChannelFactory_(
-        NAuth::CreateNativeAuthenticationInjectingChannelFactory(
-            CreateCachingChannelFactory(CreateTcpBusChannelFactory(Config_->BusClient)),
-            nativeConnection->GetConfig()->TvmId))
+    , QueueAgentChannelFactory_(nativeConnection->GetChannelFactory())
     , QueueExportManager_(CreateQueueExportManager(
         DynamicConfig_->QueueExportManager))
 {


### PR DESCRIPTION
This is completely common interconnect communication.
Special configuration is not required.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
