### PR TITLE
Add empty target to bring contrib/python/boto3 to the project

### DIFF
--- a/yt/yt/tests/local-s3/ya.make
+++ b/yt/yt/tests/local-s3/ya.make
@@ -1,0 +1,11 @@
+PY3_PROGRAM(local_s3_recipe)
+
+SRCDIR(
+    yt/yt/tests/local-s3
+)
+
+PEERDIR(
+    contrib/python/boto3
+)
+
+END()


### PR DESCRIPTION
# Description

In order to properly check #1459, we need to bring the `contrib/python/boto3` to the project. This PR adds an empty target with the specified dependency to fetch it.