### PR TITLE
Add resource_limits to exec_attributes of a job

### DIFF
--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -10380,6 +10380,8 @@ void TOperationControllerBase::InitUserJobSpec(
         joblet->EstimatedResourceUsage.GetJobProxyMemory() * joblet->JobProxyMemoryReserveFactor.value());
 
     if (Options_->SetSlotContainerMemoryLimit) {
+        // Slot container reserve covers everything that lives in the container: user job memory,
+        // the additional job proxy buffers, the static footprint, and the configurable overhead.
         jobSpec->set_slot_container_memory_limit(
             jobSpec->memory_limit() +
             joblet->EstimatedResourceUsage.GetJobProxyMemory() +

--- a/yt/yt/server/lib/misc/job_report.cpp
+++ b/yt/yt/server/lib/misc/job_report.cpp
@@ -140,6 +140,24 @@ void TGpuDevice::Register(TRegistrar registrar)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TJobResourceLimits::Register(TRegistrar registrar)
+{
+    registrar.Parameter("allocation_cpu_limit", &TThis::AllocationCpuLimit)
+        .Optional();
+    registrar.Parameter("allocation_memory_limit", &TThis::AllocationMemoryLimit)
+        .Optional();
+    registrar.Parameter("allocation_gpu_limit", &TThis::AllocationGpuLimit)
+        .Optional();
+    registrar.Parameter("user_job_container_cpu_limit", &TThis::UserJobContainerCpuLimit)
+        .Optional();
+    registrar.Parameter("user_job_slot_container_memory_limit", &TThis::UserJobSlotContainerMemoryLimit)
+        .Optional();
+    registrar.Parameter("user_job_memory_limit", &TThis::UserJobMemoryLimit)
+        .Optional();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TExecAttributes::Register(TRegistrar registrar)
 {
     registrar.Parameter("slot_index", &TThis::SlotIndex)
@@ -154,6 +172,8 @@ void TExecAttributes::Register(TRegistrar registrar)
         .Default();
     registrar.Parameter("gpu_devices", &TThis::GpuDevices)
         .Default();
+    registrar.Parameter("resource_limits", &TThis::ResourceLimits)
+        .Optional();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/misc/job_report.h
+++ b/yt/yt/server/lib/misc/job_report.h
@@ -138,6 +138,23 @@ struct TGpuDevice
 
 DEFINE_REFCOUNTED_TYPE(TGpuDevice);
 
+struct TJobResourceLimits final
+    : public NYTree::TYsonStructLite
+{
+    std::optional<double> AllocationCpuLimit;
+    std::optional<i64> AllocationMemoryLimit;
+    std::optional<i64> AllocationGpuLimit;
+    std::optional<double> UserJobContainerCpuLimit;
+    std::optional<i64> UserJobSlotContainerMemoryLimit;
+    std::optional<i64> UserJobMemoryLimit;
+
+    REGISTER_YSON_STRUCT_LITE(TJobResourceLimits);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TJobResourceLimits);
+
 struct TExecAttributes
     : public NYTree::TYsonStructLite
 {
@@ -160,6 +177,9 @@ struct TExecAttributes
 
     //! GPU devices used by job.
     std::vector<TIntrusivePtr<TGpuDevice>> GpuDevices;
+
+    //! Resource limits for the job.
+    TIntrusivePtr<TJobResourceLimits> ResourceLimits;
 
     REGISTER_YSON_STRUCT_LITE(TExecAttributes);
 


### PR DESCRIPTION
Right now there is no simple way to understand what resources the job requested, and it gets even more complicated around memory_limit (there are at least 3 memory limits with different meanings)

This PR adds resource_limits to exec_attributes of a job

Feel free to propose a better solution on how ytsaurus users can understand what resource_limits are for a job

---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk/cms/excel/cron/microservices (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type:
Component:

TODO IF NEEDED

