### PR TITLE
yt/ytlib: add region into cluster connection

### DIFF
--- a/yt/yt/ytlib/api/native/config.cpp
+++ b/yt/yt/ytlib/api/native/config.cpp
@@ -173,6 +173,8 @@ void TConnectionStaticConfig::Register(TRegistrar registrar)
     registrar.Parameter("connection_name", &TThis::ConnectionName)
         .Alias("name")
         .Default("default");
+    registrar.Parameter("region", &TThis::Region)
+        .Default();
     registrar.Parameter("banned_replica_tracker_cache", &TThis::BannedReplicaTrackerCache)
         .DefaultNew();
 }

--- a/yt/yt/ytlib/api/native/config.h
+++ b/yt/yt/ytlib/api/native/config.h
@@ -214,6 +214,9 @@ struct TConnectionStaticConfig
     //! Visible in profiling as tag `connection_name`.
     TString ConnectionName;
 
+    //! Region defines geographical location, largest tier in cloud hierarchy.
+    std::optional<std::string> Region;
+
     TSlruCacheConfigPtr BannedReplicaTrackerCache;
 
     //! Replaces all master addresses with given master cache addresses.


### PR DESCRIPTION
In cloud hierarchy "region" represent geographical location which
may contain several "Availability Zones" (AZ),
which in other hand may contain several "Data Centers" (DC).

Region in cluster connection allows to project it to cloud and network.

Each cluster node also could announce which Data Center it belongs.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: feature
Component: misc-server

Add field "region" into cluster connection configuration.
