### PR TITLE
[chyt/2.17] Fix tests after incomplete TLS cherry-pick

### DIFF
--- a/yt/yt/core/bus/unittests/ssl_ut.cpp
+++ b/yt/yt/core/bus/unittests/ssl_ut.cpp
@@ -74,12 +74,16 @@ public:
         AddressWithIpV4 = Format("127.0.0.1:%v", Port);
         AddressWithIpV6 = Format("[::1]:%v", Port);
 
-        CACert = TPemBlobConfig::CreateFileReference(CreatePemFile("ca.pem"));
-        PrivateKey = TPemBlobConfig::CreateFileReference(CreatePemFile("key.pem"));
-        CertificateChain = TPemBlobConfig::CreateFileReference(CreatePemFile("cert.pem"));
-        CACertWithIPInSAN = TPemBlobConfig::CreateFileReference(CreatePemFile("ca_with_ip_in_san.pem"));
-        PrivateKeyWithIpInSAN = TPemBlobConfig::CreateFileReference(CreatePemFile("key_with_ip_in_san.pem"));
-        CertificateChainWithIpInSAN = TPemBlobConfig::CreateFileReference(CreatePemFile("cert_with_ip_in_san.pem"));
+        CACert = CreateTestKeyFile("ca.pem");
+        PrivateKey = CreateTestKeyFile("key.pem");
+        CertificateChain = CreateTestKeyFile("cert.pem");
+        CACertWithIPInSAN = CreateTestKeyFile("ca_with_ip_in_san.pem");
+        PrivateKeyWithIpInSAN = CreateTestKeyFile("key_with_ip_in_san.pem");
+        CertificateChainWithIpInSAN = CreateTestKeyFile("cert_with_ip_in_san.pem");
+
+        CACertEC = CreateTestKeyFile("ca_ec.pem");
+        PrivateKeyEC = CreateTestKeyFile("key_ec.pem");
+        CertificateChainEC = CreateTestKeyFile("cert_ec.pem");
     }
 };
 


### PR DESCRIPTION
Previous cherry-pick is incomplete.

(cherry picked from commit 03a2974b4318513a866c0dfe7cb6598bec3423dd)
