### PR TITLE
yt/server: add operation statistics "time/relative_start" and "time/relative_finish"

### DIFF
--- a/yt/yt/server/controller_agent/controllers/job_helpers.cpp
+++ b/yt/yt/server/controller_agent/controllers/job_helpers.cpp
@@ -173,7 +173,8 @@ TBriefJobStatisticsPtr BuildBriefStatistics(std::unique_ptr<TJobSummary> jobSumm
 
 void UpdateJobletFromSummary(
     const TJobSummary& jobSummary,
-    const TJobletPtr& joblet)
+    const TJobletPtr& joblet,
+    TInstant operationStartTime)
 {
     using namespace NStatisticPath;
 
@@ -198,8 +199,12 @@ void UpdateJobletFromSummary(
         jobSummary.FinishTime.value_or(TInstant::Now()),
         joblet->LastUpdateTime);
     auto duration = endTime - joblet->StartTime;
+    auto relativeStartTime = joblet->StartTime - operationStartTime;
+    auto relativeFinishTime = endTime - operationStartTime;
 
     controllerStatistics->ReplacePathWithSample("/time/total"_SP, duration.MilliSeconds());
+    controllerStatistics->ReplacePathWithSample("/time/relative_start"_SP, relativeStartTime.MilliSeconds());
+    controllerStatistics->ReplacePathWithSample("/time/relative_finish"_SP, relativeFinishTime.MilliSeconds());
 
     auto getCumulativeMemory = [] (i64 memory, TDuration period) {
         double cumulativeMemory = static_cast<double>(memory) * period.MilliSeconds();

--- a/yt/yt/server/controller_agent/controllers/job_helpers.h
+++ b/yt/yt/server/controller_agent/controllers/job_helpers.h
@@ -62,7 +62,8 @@ bool CheckJobActivity(
 //! - Update some auxiliary fields like FinishTime.
 void UpdateJobletFromSummary(
     const TJobSummary& jobSummary,
-    const TJobletPtr& joblet);
+    const TJobletPtr& joblet,
+    TInstant operationStartTime);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -1582,7 +1582,7 @@ void TOperationControllerBase::AbortAllJoblets(EAbortReason abortReason, bool ho
 
         auto jobSummary = TAbortedJobSummary(joblet->JobId, abortReason);
         jobSummary.FinishTime = now;
-        UpdateJobletFromSummary(jobSummary, joblet);
+        UpdateJobletFromSummary(jobSummary, joblet, StartTime_);
         LogFinishedJobFluently(ELogEventType::JobAborted, joblet)
             .Item("reason").Value(abortReason);
         UpdateAggregatedFinishedJobStatistics(joblet, jobSummary);
@@ -3287,7 +3287,7 @@ bool TOperationControllerBase::OnJobCompleted(
                 jobSummary->ReadInputDataSlices.size());
         }
 
-        UpdateJobletFromSummary(*jobSummary, joblet);
+        UpdateJobletFromSummary(*jobSummary, joblet, StartTime_);
 
         joblet->Task->UpdateMemoryDigests(joblet, /*resourceOverdraft*/ false);
         UpdateActualHistogram(*jobSummary);
@@ -3416,7 +3416,7 @@ bool TOperationControllerBase::OnJobFailed(
             ShouldUpdateProgressAttributesInCypress_ = true;
         }
 
-        UpdateJobletFromSummary(*jobSummary, joblet);
+        UpdateJobletFromSummary(*jobSummary, joblet, StartTime_);
 
         LogFinishedJobFluently(ELogEventType::JobFailed, joblet)
             .Item("error").Value(error);
@@ -3554,7 +3554,7 @@ bool TOperationControllerBase::OnJobAborted(
         // Such inconsistencies blocks saving job results in case of operation failure
         TForbidContextSwitchGuard guard;
 
-        UpdateJobletFromSummary(*jobSummary, joblet);
+        UpdateJobletFromSummary(*jobSummary, joblet, StartTime_);
 
         if (abortReason == EAbortReason::ResourceOverdraft) {
             joblet->Task->UpdateMemoryDigests(joblet, /*resourceOverdraft*/ true);
@@ -3810,7 +3810,7 @@ void TOperationControllerBase::OnJobRunning(
         return;
     }
 
-    UpdateJobletFromSummary(*jobSummary, joblet);
+    UpdateJobletFromSummary(*jobSummary, joblet, StartTime_);
 
     GetJobProfiler()->ProfileRunningJob(*joblet);
 

--- a/yt/yt/server/scheduler/helpers.cpp
+++ b/yt/yt/server/scheduler/helpers.cpp
@@ -205,6 +205,8 @@ const std::vector<TStatisticsDescription>& GetOperationStatisticsDescriptions()
         {"time/gpu_check", "GPU liveness check duration", "ms"},
         {"time/exec", "Time from the start to the end of job_proxy process", "ms"},
         {"time/artifacts_caching", "Job's artifact files downloading to the chunk cache duration", "ms"},
+        {"time/relative_start", "Time from operation start till job start", "ms"},
+        {"time/relative_finish", "Time from operation start till job finish or last status update", "ms"},
 
         {"data/input/chunk_count", "Data slices read by job", "pieces"},
         {"data/input/row_count", "Number of rows read by job", "pieces"},


### PR DESCRIPTION
"time/relative_start" - from operation start till job start
"time/relative_finish" - from operation start till job finish or last update.

They describes job statistics time interval within operation timeline.
I.e. when execution have happened and how fresh statistics is.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: feature
Component: map-redice

Add operation job statistics "time/relative_start", "time/relative_finish".
