### PR TITLE
Consider SSL_CERT_FILE and SSL_CERT_DIR environment variables in python binaries

### DIFF
--- a/contrib/tools/python3/Lib/ssl.py
+++ b/contrib/tools/python3/Lib/ssl.py
@@ -543,7 +543,10 @@ class SSLContext(_SSLContext):
         if not isinstance(purpose, _ASN1Object):
             raise TypeError(purpose)
 
-        self.load_verify_locations(cadata=builtin_cadata())
+        cafile, capath, cadata = os.environ.get("SSL_CERT_FILE"), os.environ.get("SSL_CERT_DIR"), None
+        if cafile is None:
+            cadata=builtin_cadata()
+        self.load_verify_locations(cafile=cafile, capath=capath, cadata=cadata)
 
         if sys.platform == "win32":
             for storename in self._windows_cert_stores:

--- a/library/python/certifi/certifi/binary.py
+++ b/library/python/certifi/certifi/binary.py
@@ -1,4 +1,5 @@
 import ssl
+import os
 
 
 def builtin_ca():
@@ -17,7 +18,12 @@ load_verify_locations = ssl.SSLContext.load_verify_locations
 
 def load_verify_locations__callable(self, cafile=None, capath=None, cadata=None):
     if callable(cafile):
-        cafile, capath, cadata = cafile()
+        envfile = os.environ.get("SSL_CERT_FILE")
+        if envfile is None:
+            cafile, capath, cadata = cafile()
+        else:
+            cafile = envfile
+        capath = os.environ.get("SSL_CERT_DIR", capath)
 
     return load_verify_locations(self, cafile, capath, cadata)
 

--- a/yt/python/contrib/python-requests/requests/certs.py
+++ b/yt/python/contrib/python-requests/requests/certs.py
@@ -17,6 +17,10 @@ import os
 import sys
 
 def where():
+    cafile = os.environ.get("SSL_CERT_FILE")
+    if cafile is not None:
+        return cafile
+
     is_arcadia_python = hasattr(sys, "extra_modules")
 
     if is_arcadia_python:


### PR DESCRIPTION
There are several ways how builtin CA bundle reaches SSLContext:
- SSLContext.load_default_certs()
- certify.where() -> (callable) -> patched SSLContext.load_verify_locations()
- yt python-requests certify.where() -> (blob) -> SSLContext

Lets use here path from environment variable SSL_CERT_FILE when defined.
This aligns with most modern design and golang behaviour.

Environment variable SSL_CERT_DIR provides directories with certificates
while will be used in addition to main CA bundle.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
