### PR TITLE
Remove extra slash from include

### DIFF
--- a/library/cpp/yt/logging/plain_text_formatter/formatter.h
+++ b/library/cpp/yt/logging/plain_text_formatter/formatter.h
@@ -2,7 +2,7 @@
 
 #include <library/cpp/yt/string/raw_formatter.h>
 
-#include <library/cpp/yt/logging//logger.h>
+#include <library/cpp/yt/logging/logger.h>
 
 namespace NYT::NLogging {
 


### PR DESCRIPTION

---
> If this change is not needed to be mentioned in release notes then just remove changelog entry.
> If this change is needed to be mentioned in release notes then please add changelog entry at the end of pull request description, using this format:
>
> * Changelog entry
> Type: ?       # fix/feature (Select one value, example: `Type: fix`)
> Component: ?  # master/proxy/scheduler/dynamic-tables/controller-agent/queue-agent/query-tracker
>               # map-reduce/misc-server/odin/spyt/chyt/strawberry/python-sdk/python-yson/python-rpc-bindings/java-sdk
>               # cpp-sdk/go-sdk/cms/excel/cron/microservices (Select one value, example: `Component: scheduler`)
> Description of this change which will be added in release notes.

* Changelog entry
Type: fix
Component: logging

`clang` gets confused with the extra slash and keeps failing

```
In file included from /workspace/third_party/ytsaurus-cpp-sdk/library/cpp/yt/logging/plain_text_formatter/formatter.h:5:
/workspace/third_party/ytsaurus-cpp-sdk/library/cpp/yt/logging//logger.h:81:1: error: redefinition of 'GetEnumTraitsImpl'
...
/workspace/third_party/ytsaurus-cpp-sdk/library/cpp/yt/logging/logger.h:81:1: note: previous definition is here
   81 | DEFINE_ENUM(ELogMessageKind,
```