### PR TITLE
yt/yt/core/https: handle plain http connections too

### DIFF
--- a/yt/yt/core/http/client.cpp
+++ b/yt/yt/core/http/client.cpp
@@ -141,6 +141,7 @@ private:
     {
         auto context = New<TDialerContext>();
         context->Host = urlRef.Host;
+        context->BypassTLS = urlRef.Protocol == "http";
 
         auto address = GetAddress(urlRef);
 

--- a/yt/yt/core/http/unittests/http_ut.cpp
+++ b/yt/yt/core/http/unittests/http_ut.cpp
@@ -684,6 +684,7 @@ TEST_P(THttpServerTest, CertificateValidation)
     Server->Start();
 
     auto clientConfig = New<NHttps::TClientConfig>();
+    EXPECT_FALSE(clientConfig->AllowHTTP);
     clientConfig->Credentials = New<NHttps::TClientCredentialsConfig>();
     auto client = NHttps::CreateClient(clientConfig, Poller);
 
@@ -696,6 +697,23 @@ TEST_P(THttpServerTest, CertificateValidation)
         EXPECT_THROW_WITH_ERROR_CODE(result.ThrowOnError(), NRpc::EErrorCode::SslError);
         EXPECT_THROW_WITH_SUBSTRING(result.ThrowOnError(), "SSL_do_handshake failed");
     }
+}
+
+TEST_P(THttpServerTest, HttpInHttpsClient)
+{
+    if (GetParam()) {
+        return;
+    }
+
+    Server->AddHandler("/", New<TOKHttpHandler>());
+    Server->Start();
+
+    auto clientConfig = New<NHttps::TClientConfig>();
+    clientConfig->AllowHTTP = true;
+    auto httpsClient = NHttps::CreateClient(clientConfig, Poller);
+
+    auto rsp = WaitFor(httpsClient->Get(TestUrl)).ValueOrThrow();
+    ASSERT_EQ(EStatusCode::OK, rsp->GetStatusCode());
 }
 
 TEST_P(THttpServerTest, SimpleRequest)

--- a/yt/yt/core/https/client.cpp
+++ b/yt/yt/core/https/client.cpp
@@ -114,8 +114,11 @@ IClientPtr CreateClient(
     }
     sslContext->Commit();
 
+    auto dialerConfig = New<TDialerConfig>();
+    dialerConfig->AllowBypassTLS = config->AllowHTTP;
+
     auto tlsDialer = sslContext->CreateDialer(
-        New<TDialerConfig>(),
+        dialerConfig,
         poller,
         HttpLogger());
 

--- a/yt/yt/core/https/config.cpp
+++ b/yt/yt/core/https/config.cpp
@@ -29,6 +29,8 @@ void TClientConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("credentials", &TThis::Credentials)
         .Optional();
+    registrar.Parameter("allow_http", &TThis::AllowHTTP)
+        .Default(false);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/https/config.h
+++ b/yt/yt/core/https/config.h
@@ -56,6 +56,9 @@ struct TClientConfig
     // If missing then builtin certificate store is used.
     TClientCredentialsConfigPtr Credentials;
 
+    // Allow bypass TLS for http://... URLs.
+    bool AllowHTTP;
+
     REGISTER_YSON_STRUCT(TClientConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yt/core/net/config.cpp
+++ b/yt/yt/core/net/config.cpp
@@ -10,6 +10,8 @@ void TDialerConfig::Register(TRegistrar registrar)
         .Default(true);
     registrar.Parameter("enable_aggressive_reconnect", &TThis::EnableAggressiveReconnect)
         .Default(false);
+    registrar.Parameter("allow_bypass_tls", &TThis::AllowBypassTLS)
+        .Default(false);
     registrar.Parameter("min_rto", &TThis::MinRto)
         .Default(TDuration::MilliSeconds(100));
     registrar.Parameter("max_rto", &TThis::MaxRto)

--- a/yt/yt/core/net/config.h
+++ b/yt/yt/core/net/config.h
@@ -17,6 +17,7 @@ struct TDialerConfig
 {
     bool EnableNoDelay;
     bool EnableAggressiveReconnect;
+    bool AllowBypassTLS;
 
     TDuration MinRto;
     TDuration MaxRto;

--- a/yt/yt/core/net/dialer.h
+++ b/yt/yt/core/net/dialer.h
@@ -20,6 +20,8 @@ struct TDialerContext final
 {
     //! Host is used for TlsDialer.
     std::optional<TString> Host;
+    //! BypassTLS is used by HTTPS client for plain HTTP connections.
+    bool BypassTLS = false;
 };
 
 DEFINE_REFCOUNTED_TYPE(TDialerContext)


### PR DESCRIPTION
Now https client is able to handle "http://..." URLs too.
Off by default, requires setting AllowHTTP = true in config.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: feature
Component: cpp-sdk

Add option to handle both "http://" and "https://" URLs by single client.
