### PR TITLE
Arrow string types should be represented as YT utf8 and arrow binary types as YT string

### DIFF
--- a/yt/yt/client/arrow/schema.cpp
+++ b/yt/yt/client/arrow/schema.cpp
@@ -52,11 +52,11 @@ NTableClient::TLogicalTypePtr GetLogicalTypeFromArrowType(const std::shared_ptr<
             return SimpleLogicalType(ESimpleLogicalValueType::Double);
         case arrow20::Type::type::STRING:
         case arrow20::Type::type::LARGE_STRING:
-            return SimpleLogicalType(ESimpleLogicalValueType::String);
+            return SimpleLogicalType(ESimpleLogicalValueType::Utf8);
         case arrow20::Type::type::BINARY:
         case arrow20::Type::type::LARGE_BINARY:
         case arrow20::Type::type::FIXED_SIZE_BINARY:
-            return SimpleLogicalType(ESimpleLogicalValueType::Any);
+            return SimpleLogicalType(ESimpleLogicalValueType::String);
         case arrow20::Type::type::LIST:
             return ListLogicalType(
                 GetLogicalTypeFromArrowType(std::reinterpret_pointer_cast<arrow20::ListType>(arrowType)->value_field()));

--- a/yt/yt/client/arrow/unittests/schema_ut.cpp
+++ b/yt/yt/client/arrow/unittests/schema_ut.cpp
@@ -55,10 +55,10 @@ TEST(TArrowSchemaConverterTest, ConvertSimpleTypes)
         TColumnSchema("f_float16", SimpleLogicalType(ESimpleLogicalValueType::Float)),
         TColumnSchema("f_float32", SimpleLogicalType(ESimpleLogicalValueType::Float)),
         TColumnSchema("f_float64", SimpleLogicalType(ESimpleLogicalValueType::Double)),
-        TColumnSchema("f_utf8", SimpleLogicalType(ESimpleLogicalValueType::String)),
-        TColumnSchema("f_large_utf8", SimpleLogicalType(ESimpleLogicalValueType::String)),
-        TColumnSchema("f_binary", SimpleLogicalType(ESimpleLogicalValueType::Any)),
-        TColumnSchema("f_large_binary", SimpleLogicalType(ESimpleLogicalValueType::Any)),
+        TColumnSchema("f_utf8", SimpleLogicalType(ESimpleLogicalValueType::Utf8)),
+        TColumnSchema("f_large_utf8", SimpleLogicalType(ESimpleLogicalValueType::Utf8)),
+        TColumnSchema("f_binary", SimpleLogicalType(ESimpleLogicalValueType::String)),
+        TColumnSchema("f_large_binary", SimpleLogicalType(ESimpleLogicalValueType::String)),
         TColumnSchema("f_decimal", DecimalLogicalType(35,18)),
         TColumnSchema("f_date32", SimpleLogicalType(ESimpleLogicalValueType::Int32)),
         TColumnSchema("f_date64", SimpleLogicalType(ESimpleLogicalValueType::Int64)),
@@ -94,7 +94,7 @@ TEST(TArrowSchemaConverterTest, ConvertComplexTypes)
             }, /*removedFieldStableNames*/ {})),
         }, /*removedFieldStableNames*/ {})),
         TColumnSchema("f_map", DictLogicalType(
-            SimpleLogicalType(ESimpleLogicalValueType::String),
+            SimpleLogicalType(ESimpleLogicalValueType::Utf8),
             OptionalLogicalType(SimpleLogicalType(ESimpleLogicalValueType::Uint64))
         )),
         TColumnSchema("f_opt", OptionalLogicalType(SimpleLogicalType(ESimpleLogicalValueType::Int32)))


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: misc-server

Arrow string types should be represented as YT utf8 and arrow binary types as YT string.
