### PR TITLE
libevent: avoid redefining arc4random_buf on glibc

### DIFF
--- a/contrib/libs/libevent/arc4random.c
+++ b/contrib/libs/libevent/arc4random.c
@@ -484,6 +484,7 @@ arc4random(void)
 }
 #endif
 
+#if !defined(__GLIBC__) || (__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 36)
 ARC4RANDOM_EXPORT void
 arc4random_buf(void *buf_, size_t n)
 {
@@ -497,6 +498,7 @@ arc4random_buf(void *buf_, size_t n)
 	}
 	ARC4_UNLOCK_();
 }
+#endif
 
 #ifndef ARC4RANDOM_NOUNIFORM
 /*


### PR DESCRIPTION
Tested on Ubuntu 18.04 and 20.04: build OK.

On Ubuntu 24.04 (glibc 2.39) and newer Ubuntu releases: the build fails because arc4random_buf is defined both by glibc and libevent/arc4random.c. This patch guards the local arc4random_buf() so it is only compiled on glibc < 2.36