### PR TITLE
Add debug logging for PingTx failure

### DIFF
--- a/yt/cpp/mapreduce/client/transaction_pinger.cpp
+++ b/yt/cpp/mapreduce/client/transaction_pinger.cpp
@@ -179,6 +179,7 @@ private:
         try {
             PingTx(HttpClient_, pingableTx);
         } catch (const std::exception& e) {
+            YT_LOG_DEBUG("DoPingTransaction has failed: %v", e.what());
             if (auto* errorResponse = dynamic_cast<const TErrorResponse*>(&e)) {
                 if (errorResponse->GetError().ContainsErrorCode(NYT::NClusterErrorCodes::NTransactionClient::NoSuchTransaction)) {
                     YT_UNUSED_FUTURE(periodic->Stop());


### PR DESCRIPTION
Exceptions like this were being silently ignored:

```
2026-01-06 16:30:19,509023	D	YqlPlugin	2026-01-06 16:30:19.509 DEBUG ytserver-yql-agent(pid=7, tid=...) [YT] transaction_pinger.cpp:182: {} DoPingTransaction has failed: HTTP request failed\n    origin          yqla-0.yql-agents.... (pid 7, thread tx_http_client_, fid ...)\n    datetime        2026-01-06T16:30:19.508879Z\n    url             http-proxies.../api/v3/ping_tx\n\n  Connection was closed before the first byte of HTTP message\n      origin          yqla-0.yql-agents.... (pid 7, thread tx_http_client_, fid ...)\n      datetime        2026-01-06T16:30:19.508720Z\n      connection_id   ...\n      request_id      0-0-0-0\ntx_pinger_pool:		
```

Feel free to edit.