### PR TITLE
Remove misleading code from python sdk that adds Authorization headers to response, which may be logged unobfuscated

### DIFF
--- a/yt/python/yt/wrapper/http_driver.py
+++ b/yt/python/yt/wrapper/http_driver.py
@@ -160,13 +160,8 @@ class TokenAuth(AuthBase):
         if self.token is not None:
             request.headers["Authorization"] = "OAuth " + self.token
 
-    def handle_redirect(self, request, **kwargs):
-        self.set_token(request)
-        return request
-
     def __call__(self, request):
         self.set_token(request)
-        request.register_hook("response", self.handle_redirect)
         return request
 
 


### PR DESCRIPTION
Remove misleading code from python sdk that adds Authorization headers to response, which may be logged unobfuscated

Issue: https://github.com/ytsaurus/ytsaurus/issues/1563

---

* Changelog entry
Type: fix
Component: python-sdk

Fixed Authorization headers appearing in response when it is logged

