### PR TITLE
CRI job environment: wait for first slot initialization before going further

### DIFF
--- a/yt/yt/server/node/exec_node/job_environment.cpp
+++ b/yt/yt/server/node/exec_node/job_environment.cpp
@@ -1091,18 +1091,11 @@ public:
         PodSpecs_.clear();
         SlotCpusetCpus_.clear();
         CpuLimit_ = cpuLimit;
+        FirstSlotInitialized_.Reset();
 
         PodDescriptors_.resize(slotCount);
         PodSpecs_.resize(slotCount);
         SlotCpusetCpus_.resize(slotCount);
-
-        // Init fake slot to download resource once before running init slots concurrently
-        // we need to wait for it before initializing slots.
-        auto tmpPodSpec = New<NCri::TCriPodSpec>();
-        tmpPodSpec->Name = Format("%v%v", SlotPodPrefix, 0);
-        auto tmpPodDescriptor = WaitFor(Executor_->RunPodSandbox(tmpPodSpec)).ValueOrThrow();
-        WaitFor(Executor_->StopPodSandbox(tmpPodDescriptor)).ThrowOnError();
-        WaitFor(Executor_->RemovePodSandbox(tmpPodDescriptor)).ThrowOnError();
 
         WaitFor(ImageCache_->Initialize())
             .ThrowOnError();
@@ -1116,6 +1109,14 @@ public:
     TFuture<void> InitSlot(int slotIndex) override
     {
         YT_ASSERT_THREAD_AFFINITY(JobThread);
+
+        // Wait for first slot initialization to avoid downloading shared resources concurrently.
+        if (FirstSlotInitialized_) {
+            auto error = WaitForFast(FirstSlotInitialized_);
+            if (!error.IsOK()) {
+                return MakeFuture(error);
+            }
+        }
 
         auto podSpec = New<NCri::TCriPodSpec>();
         podSpec->Name = Format("%v%v", SlotPodPrefix, slotIndex);
@@ -1136,6 +1137,10 @@ public:
                 }
             })
             .Via(Bootstrap_->GetJobInvoker()));
+
+        if (!FirstSlotInitialized_) {
+            FirstSlotInitialized_ = slotInitFuture.AsVoid();
+        }
 
         return slotInitFuture.AsVoid();
     }
@@ -1294,6 +1299,7 @@ private:
     std::vector<TCriPodSpecPtr> PodSpecs_;
     std::vector<std::string> SlotCpusetCpus_;
     double CpuLimit_ = 0;
+    TFuture<void> FirstSlotInitialized_;
 
     const TActionQueuePtr MounterThread_ = New<TActionQueue>("CriMounter");
 


### PR DESCRIPTION
Avoid unneeded pod start-stop at exec node bootstrap.
This is slow and triggers bugs.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
