### PR TITLE
exec_node/slot_manager: automatic resurrection

### DIFF
--- a/yt/yt/server/lib/exec_node/config.cpp
+++ b/yt/yt/server/lib/exec_node/config.cpp
@@ -155,6 +155,17 @@ void TSlotManagerDynamicConfig::Register(TRegistrar registrar)
             .BackoffJitter = 1.0,
         });
 
+    registrar.Parameter("resurrection_backoff_strategy", &TThis::ResurrectionBackoffStrategy)
+        .Default({
+            .InvocationCount = 0,  // No automatic resurrection by default.
+            .MinBackoff = TDuration::Seconds(10),
+            .MaxBackoff = TDuration::Minutes(10),
+            .BackoffMultiplier = 1.5,
+        });
+
+    registrar.Parameter("force_disable_job_environment", &TThis::ForceDisableJobEnvironment)
+        .Default(false);
+
     registrar.Parameter("should_close_descriptors", &TThis::ShouldCloseDescriptors)
         .Default(false);
 

--- a/yt/yt/server/lib/exec_node/config.h
+++ b/yt/yt/server/lib/exec_node/config.h
@@ -162,6 +162,12 @@ struct TSlotManagerDynamicConfig
 
     TConstantBackoffOptions DisableJobsBackoffStrategy;
 
+    //! Backoff strategy for automatic job environment resurrection.
+    TExponentialBackoffOptions ResurrectionBackoffStrategy;
+
+    //! Force disable job environment for checking resurrection.
+    bool ForceDisableJobEnvironment;
+
     // COMPAT(psushin): temporary flag to disable CloseAllDescriptors machinery.
     bool ShouldCloseDescriptors;
 

--- a/yt/yt/server/node/exec_node/slot_manager.h
+++ b/yt/yt/server/node/exec_node/slot_manager.h
@@ -221,6 +221,8 @@ private:
 
     TBackoffStrategy DisableJobsBackoffStrategy_;
 
+    TBackoffStrategy ResurrectionBackoffStrategy_;
+
     std::atomic<ESlotManagerState> State_ = ESlotManagerState::Disabled;
 
     std::atomic<bool> JobProxyReady_ = false;
@@ -322,6 +324,7 @@ private:
 
     struct TSlotManagerInfo
     {
+        ESlotManagerState State;
         int SlotCount;
         int FreeSlotCount;
         int UsedIdleSlotCount;
@@ -353,6 +356,7 @@ private:
     bool GuardedHasArmedTransientAlerts() const;
 
     bool CanResurrect() const;
+    void EnqueueResurrectionBackoff();
 
     void SetDisabledState();
 


### PR DESCRIPTION
This add automatic resurrection for job environment:
simply reinitialize after error, with exponential backoff.
Not active by default: default invocation_count = 0.

Few additions to simplify experiments:
"force_disable_job_environment" - disable environment and start crash loop.
"orchid/exec_node/slot_manager/state" - slot manager state inside orchid.

Present code cannot handle CRI, it is very complicated and tied to porto.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: feature
Component: map-reduce

Add option to automatic resurrection for disabled exec node job environment.
