### PR TITLE
yt/cpp/mapreduce/client: handle https in transaction pinger

### DIFF
--- a/yt/cpp/mapreduce/client/client.cpp
+++ b/yt/cpp/mapreduce/client/client.cpp
@@ -1673,7 +1673,7 @@ ITransactionPingerPtr TClient::GetTransactionPinger()
 {
     auto g = Guard(Lock_);
     if (!TransactionPinger_) {
-        TransactionPinger_ = CreateTransactionPinger(Context_.Config);
+        TransactionPinger_ = CreateTransactionPinger(Context_.Config, Context_.UseTLS);
     }
     return TransactionPinger_;
 }

--- a/yt/cpp/mapreduce/client/transaction_pinger.h
+++ b/yt/cpp/mapreduce/client/transaction_pinger.h
@@ -32,7 +32,7 @@ public:
     virtual void RemoveTransaction(const TPingableTransaction& pingableTx) = 0;
 };
 
-ITransactionPingerPtr CreateTransactionPinger(const TConfigPtr& config);
+ITransactionPingerPtr CreateTransactionPinger(const TConfigPtr& config, bool useTLS = false);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/cpp/mapreduce/client/ya.make
+++ b/yt/cpp/mapreduce/client/ya.make
@@ -50,6 +50,7 @@ PEERDIR(
 PEERDIR(
     yt/yt/core
     yt/yt/core/http
+    yt/yt/core/https
 )
 
 IF (BUILD_TYPE == "PROFILE")


### PR DESCRIPTION
Use HTTPS client and schema for client context with TLS.

Reported-by: Nikita Sokolov <faucct@tracto.ai>
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
Link: https://github.com/ytsaurus/ytsaurus/pull/1559

---

* Changelog entry
Type: fix
Component: cpp-sdk

Handle HTTPS in yt/cpp/mapreduce/client transaction pinger.
