### PR TITLE
Added allow_failure and subrequest_timeout options for multilookups

### DIFF
--- a/yt/yt/client/api/dynamic_table_client.h
+++ b/yt/yt/client/api/dynamic_table_client.h
@@ -6,6 +6,8 @@
 
 #include <yt/yt/client/query_client/query_statistics.h>
 
+#include <yt/yt/core/misc/error.h>
+
 namespace NYT::NApi {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -56,6 +58,11 @@ struct TMultiLookupOptions
     , public TMultiplexingBandOptions
 {
     std::optional<std::string> ExecutionPool;
+
+    //! If set to true, the request will succeed even if some subrequests fail
+    //! (e.g., table does not exist or is unmounted). Failed subrequests will have
+    //! their error reported in the result's Error field.
+    bool AllowFailure = false;
 };
 
 struct TExplainQueryOptions
@@ -84,6 +91,11 @@ struct TLookupRowsResult
     //! unavailable keys.
     //! Indexes are guaranteed to be unique and increasing.
     std::vector<int> UnavailableKeyIndexes;
+
+    //! If TMultiLookupOptions::AllowFailure is set, this field contains the error
+    //! for failed subrequests (e.g., table does not exist or is unmounted).
+    //! When set, Rowset may be null or empty.
+    std::optional<TError> Error;
 };
 
 using TUnversionedLookupRowsResult = TLookupRowsResult<IUnversionedRowset>;

--- a/yt/yt/client/api/dynamic_table_client.h
+++ b/yt/yt/client/api/dynamic_table_client.h
@@ -94,7 +94,6 @@ struct TLookupRowsResult
 
     //! If TMultiLookupOptions::AllowFailure is set, this field contains the error
     //! for failed subrequests (e.g., table does not exist or is unmounted).
-    //! When set, Rowset may be null or empty.
     std::optional<TError> Error;
 };
 

--- a/yt/yt/client/api/dynamic_table_client.h
+++ b/yt/yt/client/api/dynamic_table_client.h
@@ -96,8 +96,8 @@ struct TLookupRowsResult
     //! Indexes are guaranteed to be unique and increasing.
     std::vector<int> UnavailableKeyIndexes;
 
-    //! If TMultiLookupOptions::AllowFailure is set, this field contains the error
-    //! for failed subrequests (e.g., table does not exist or is unmounted).
+    //! If TMultiLookupOptions::AllowFailure or TMultiLookupOptions::SubrequestTimeout is set,
+    //! this field contains the error for failed subrequests.
     std::optional<TError> Error;
 };
 

--- a/yt/yt/client/api/dynamic_table_client.h
+++ b/yt/yt/client/api/dynamic_table_client.h
@@ -63,6 +63,10 @@ struct TMultiLookupOptions
     //! (e.g., table does not exist or is unmounted). Failed subrequests will have
     //! their error reported in the result's Error field.
     bool AllowFailure = false;
+
+    //! If set, subrequests that do not complete within this duration will have
+    //! their result's Error set to EErrorCode::Timeout.
+    std::optional<TDuration> SubrequestTimeout;
 };
 
 struct TExplainQueryOptions

--- a/yt/yt/client/api/rpc_proxy/client_base.cpp
+++ b/yt/yt/client/api/rpc_proxy/client_base.cpp
@@ -1073,6 +1073,7 @@ TFuture<std::vector<TUnversionedLookupRowsResult>> TClientBase::MultiLookupRows(
     req->set_retention_timestamp(options.RetentionTimestamp);
     req->set_multiplexing_band(static_cast<NProto::EMultiplexingBand>(options.MultiplexingBand));
     ToProto(req->mutable_tablet_read_options(), options);
+    req->set_allow_failure(options.AllowFailure);
 
     YT_OPTIONAL_TO_PROTO(req, execution_pool, options.ExecutionPool);
 
@@ -1092,6 +1093,14 @@ TFuture<std::vector<TUnversionedLookupRowsResult>> TClientBase::MultiLookupRows(
         for (const auto& subresponse : rsp->subresponses()) {
             int endAttachmentIndex = beginAttachmentIndex + subresponse.attachment_count();
             YT_VERIFY(endAttachmentIndex <= std::ssize(rsp->Attachments()));
+
+            if (subresponse.has_error()) {
+                beginAttachmentIndex = endAttachmentIndex;
+                result.push_back({
+                    .Error = FromProto<TError>(subresponse.error()),
+                });
+                continue;
+            }
 
             std::vector<TSharedRef> subresponseAttachments(
                 rsp->Attachments().begin() + beginAttachmentIndex,

--- a/yt/yt/client/api/rpc_proxy/client_base.cpp
+++ b/yt/yt/client/api/rpc_proxy/client_base.cpp
@@ -1074,6 +1074,9 @@ TFuture<std::vector<TUnversionedLookupRowsResult>> TClientBase::MultiLookupRows(
     req->set_multiplexing_band(static_cast<NProto::EMultiplexingBand>(options.MultiplexingBand));
     ToProto(req->mutable_tablet_read_options(), options);
     req->set_allow_failure(options.AllowFailure);
+    if (options.SubrequestTimeout) {
+        req->set_subrequest_timeout(ToProto(*options.SubrequestTimeout));
+    }
 
     YT_OPTIONAL_TO_PROTO(req, execution_pool, options.ExecutionPool);
 

--- a/yt/yt/client/api/rpc_proxy/client_base.cpp
+++ b/yt/yt/client/api/rpc_proxy/client_base.cpp
@@ -1074,9 +1074,7 @@ TFuture<std::vector<TUnversionedLookupRowsResult>> TClientBase::MultiLookupRows(
     req->set_multiplexing_band(static_cast<NProto::EMultiplexingBand>(options.MultiplexingBand));
     ToProto(req->mutable_tablet_read_options(), options);
     req->set_allow_failure(options.AllowFailure);
-    if (options.SubrequestTimeout) {
-        req->set_subrequest_timeout(ToProto(*options.SubrequestTimeout));
-    }
+    YT_OPTIONAL_SET_PROTO(req, subrequest_timeout, options.SubrequestTimeout);
 
     YT_OPTIONAL_TO_PROTO(req, execution_pool, options.ExecutionPool);
 

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -4437,7 +4437,7 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, MultiLookup)
         context,
         request,
         &options);
- 
+
     if (request->has_allow_failure()) {
         options.AllowFailure = request->allow_failure();
     }

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -4437,7 +4437,10 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, MultiLookup)
         context,
         request,
         &options);
-
+ 
+    if (request->has_allow_failure()) {
+        options.AllowFailure = request->allow_failure();
+    }
     std::vector<TMultiLookupSubrequest> subrequests;
     std::vector<TDetailedProfilingInfoPtr> profilingInfos;
     subrequests.reserve(subrequestCount);
@@ -4521,16 +4524,25 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, MultiLookup)
             std::vector<int> rowCounts;
             rowCounts.reserve(subrequestCount);
             for (const auto& result : results) {
-                const auto& rowset = result.Rowset;
                 auto* subresponse = response->add_subresponses();
-                auto attachments = PrepareRowsetForAttachment(subresponse, rowset);
-                subresponse->set_attachment_count(attachments.size());
-                ToProto(subresponse->mutable_unavailable_key_indexes(), result.UnavailableKeyIndexes);
-                response->Attachments().insert(
-                    response->Attachments().end(),
-                    attachments.begin(),
-                    attachments.end());
-                rowCounts.push_back(rowset->GetRows().Size());
+                if (result.Error) {
+                    ToProto(subresponse->mutable_error(), *result.Error);
+                    subresponse->set_attachment_count(0);
+                    // Create an empty rowset descriptor for failed subrequests
+                    // The descriptor is required by proto, but will have no columns since we have no schema
+                    subresponse->mutable_rowset_descriptor();
+                    rowCounts.push_back(0);
+                } else {
+                    const auto& rowset = result.Rowset;
+                    auto attachments = PrepareRowsetForAttachment(subresponse, rowset);
+                    subresponse->set_attachment_count(attachments.size());
+                    ToProto(subresponse->mutable_unavailable_key_indexes(), result.UnavailableKeyIndexes);
+                    response->Attachments().insert(
+                        response->Attachments().end(),
+                        attachments.begin(),
+                        attachments.end());
+                    rowCounts.push_back(rowset->GetRows().Size());
+                }
             }
 
             for (const auto& detailedProfilingInfo : profilingInfos) {

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -4528,8 +4528,6 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, MultiLookup)
                 if (result.Error) {
                     ToProto(subresponse->mutable_error(), *result.Error);
                     subresponse->set_attachment_count(0);
-                    // Create an empty rowset descriptor for failed subrequests
-                    // The descriptor is required by proto, but will have no columns since we have no schema
                     subresponse->mutable_rowset_descriptor();
                     rowCounts.push_back(0);
                 } else {

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -4438,9 +4438,7 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, MultiLookup)
         request,
         &options);
 
-    if (request->has_allow_failure()) {
-        options.AllowFailure = request->allow_failure();
-    }
+    options.AllowFailure = request->allow_failure();
     if (request->has_subrequest_timeout()) {
         options.SubrequestTimeout = FromProto<TDuration>(request->subrequest_timeout());
     }

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -4441,6 +4441,9 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, MultiLookup)
     if (request->has_allow_failure()) {
         options.AllowFailure = request->allow_failure();
     }
+    if (request->has_subrequest_timeout()) {
+        options.SubrequestTimeout = FromProto<TDuration>(request->subrequest_timeout());
+    }
     std::vector<TMultiLookupSubrequest> subrequests;
     std::vector<TDetailedProfilingInfoPtr> profilingInfos;
     subrequests.reserve(subrequestCount);

--- a/yt/yt/tests/cpp/test_rpc_api/test_rpc_api.cpp
+++ b/yt/yt/tests/cpp/test_rpc_api/test_rpc_api.cpp
@@ -436,6 +436,121 @@ TEST_F(TMultiLookupTest, MultiLookup)
     test(versionedLookupOptions, getYsonWithTimestamp(yson0, 0), getYsonWithTimestamp(yson1, 1));
 }
 
+TEST_F(TMultiLookupTest, MultiLookupAllowFailure)
+{
+    WriteUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 0; <id=1> 0;");
+    WriteUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 1; <id=1> 1;");
+
+    auto key0 = PrepareUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 0;");
+    auto key1 = PrepareUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 1;");
+
+    // Test with AllowFailure: one valid table and one non-existent table.
+    {
+        TMultiLookupOptions multiLookupOptions;
+        multiLookupOptions.AllowFailure = true;
+
+        auto results = WaitFor(Client_->MultiLookupRows(
+            {
+                {
+                    .Path = Table_,
+                    .NameTable = std::get<1>(key0),
+                    .Keys = std::get<0>(key0),
+                },
+                {
+                    .Path = "//tmp/nonexistent_table",
+                    .NameTable = std::get<1>(key1),
+                    .Keys = std::get<0>(key1),
+                },
+            },
+            multiLookupOptions))
+            .ValueOrThrow();
+
+        ASSERT_EQ(2u, results.size());
+
+        // First subrequest should succeed.
+        EXPECT_FALSE(results[0].Error.has_value());
+        const auto& rowset0 = results[0].Rowset;
+        ASSERT_EQ(1u, rowset0->GetRows().Size());
+        auto expected = ToString(YsonToSchemalessRow("<id=0> 0; <id=1> 0;"));
+        auto actual = ToString(rowset0->GetRows()[0]);
+        EXPECT_EQ(expected, actual);
+
+        // Second subrequest should have an error.
+        EXPECT_TRUE(results[1].Error.has_value());
+        EXPECT_FALSE(results[1].Error->IsOK());
+    }
+
+    // Test with AllowFailure when all subrequests succeed.
+    {
+        TMultiLookupOptions multiLookupOptions;
+        multiLookupOptions.AllowFailure = true;
+
+        auto results = WaitFor(Client_->MultiLookupRows(
+            {
+                {
+                    .Path = Table_,
+                    .NameTable = std::get<1>(key0),
+                    .Keys = std::get<0>(key0),
+                },
+                {
+                    .Path = Table_,
+                    .NameTable = std::get<1>(key1),
+                    .Keys = std::get<0>(key1),
+                },
+            },
+            multiLookupOptions))
+            .ValueOrThrow();
+
+        ASSERT_EQ(2u, results.size());
+
+        EXPECT_FALSE(results[0].Error.has_value());
+        EXPECT_FALSE(results[1].Error.has_value());
+
+        const auto& rowset0 = results[0].Rowset;
+        const auto& rowset1 = results[1].Rowset;
+
+        ASSERT_EQ(1u, rowset0->GetRows().Size());
+        ASSERT_EQ(1u, rowset1->GetRows().Size());
+
+        auto expected0 = ToString(YsonToSchemalessRow("<id=0> 0; <id=1> 0;"));
+        auto actual0 = ToString(rowset0->GetRows()[0]);
+        EXPECT_EQ(expected0, actual0);
+
+        auto expected1 = ToString(YsonToSchemalessRow("<id=0> 1; <id=1> 1;"));
+        auto actual1 = ToString(rowset1->GetRows()[0]);
+        EXPECT_EQ(expected1, actual1);
+    }
+
+    // Test without AllowFailure: should throw on non-existent table.
+    {
+        EXPECT_THROW_WITH_SUBSTRING(
+            WaitFor(Client_->MultiLookupRows(
+                {
+                    {
+                        .Path = Table_,
+                        .NameTable = std::get<1>(key0),
+                        .Keys = std::get<0>(key0),
+                    },
+                    {
+                        .Path = "//tmp/nonexistent_table",
+                        .NameTable = std::get<1>(key1),
+                        .Keys = std::get<0>(key1),
+                    },
+                },
+                TMultiLookupOptions()))
+                .ValueOrThrow(),
+            "nonexistent_table");
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TClearTmpTestBase

--- a/yt/yt/tests/cpp/test_rpc_api/test_rpc_api.cpp
+++ b/yt/yt/tests/cpp/test_rpc_api/test_rpc_api.cpp
@@ -551,6 +551,128 @@ TEST_F(TMultiLookupTest, MultiLookupAllowFailure)
     }
 }
 
+TEST_F(TMultiLookupTest, MultiLookupSubrequestTimeout)
+{
+    WriteUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 0; <id=1> 0;");
+    WriteUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 1; <id=1> 1;");
+
+    auto key0 = PrepareUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 0;");
+    auto key1 = PrepareUnversionedRow(
+        {"k0", "v1"},
+        "<id=0> 1;");
+
+    // Test SubrequestTimeout when all subrequests succeed within the timeout.
+    {
+        TMultiLookupOptions multiLookupOptions;
+        multiLookupOptions.SubrequestTimeout = TDuration::Seconds(30);
+
+        auto results = WaitFor(Client_->MultiLookupRows(
+            {
+                {
+                    .Path = Table_,
+                    .NameTable = std::get<1>(key0),
+                    .Keys = std::get<0>(key0),
+                },
+                {
+                    .Path = Table_,
+                    .NameTable = std::get<1>(key1),
+                    .Keys = std::get<0>(key1),
+                },
+            },
+            multiLookupOptions))
+            .ValueOrThrow();
+
+        ASSERT_EQ(2u, results.size());
+
+        EXPECT_FALSE(results[0].Error.has_value());
+        EXPECT_FALSE(results[1].Error.has_value());
+
+        const auto& rowset0 = results[0].Rowset;
+        const auto& rowset1 = results[1].Rowset;
+
+        ASSERT_EQ(1u, rowset0->GetRows().Size());
+        ASSERT_EQ(1u, rowset1->GetRows().Size());
+
+        auto expected0 = ToString(YsonToSchemalessRow("<id=0> 0; <id=1> 0;"));
+        auto actual0 = ToString(rowset0->GetRows()[0]);
+        EXPECT_EQ(expected0, actual0);
+
+        auto expected1 = ToString(YsonToSchemalessRow("<id=0> 1; <id=1> 1;"));
+        auto actual1 = ToString(rowset1->GetRows()[0]);
+        EXPECT_EQ(expected1, actual1);
+    }
+
+    // Test SubrequestTimeout without AllowFailure: a non-timeout subrequest
+    // failure (nonexistent table) must propagate as a thrown error rather than
+    // being silently absorbed.
+    {
+        TMultiLookupOptions multiLookupOptions;
+        multiLookupOptions.SubrequestTimeout = TDuration::Seconds(30);
+
+        EXPECT_THROW_WITH_SUBSTRING(
+            WaitFor(Client_->MultiLookupRows(
+                {
+                    {
+                        .Path = Table_,
+                        .NameTable = std::get<1>(key0),
+                        .Keys = std::get<0>(key0),
+                    },
+                    {
+                        .Path = "//tmp/nonexistent_table",
+                        .NameTable = std::get<1>(key1),
+                        .Keys = std::get<0>(key1),
+                    },
+                },
+                multiLookupOptions))
+                .ValueOrThrow(),
+            "nonexistent_table");
+    }
+
+    // Test SubrequestTimeout combined with AllowFailure: non-timeout failures
+    // are reported per-subrequest in the Error field.
+    {
+        TMultiLookupOptions multiLookupOptions;
+        multiLookupOptions.SubrequestTimeout = TDuration::Seconds(30);
+        multiLookupOptions.AllowFailure = true;
+
+        auto results = WaitFor(Client_->MultiLookupRows(
+            {
+                {
+                    .Path = Table_,
+                    .NameTable = std::get<1>(key0),
+                    .Keys = std::get<0>(key0),
+                },
+                {
+                    .Path = "//tmp/nonexistent_table",
+                    .NameTable = std::get<1>(key1),
+                    .Keys = std::get<0>(key1),
+                },
+            },
+            multiLookupOptions))
+            .ValueOrThrow();
+
+        ASSERT_EQ(2u, results.size());
+
+        // First subrequest should succeed.
+        EXPECT_FALSE(results[0].Error.has_value());
+        const auto& rowset0 = results[0].Rowset;
+        ASSERT_EQ(1u, rowset0->GetRows().Size());
+        auto expected = ToString(YsonToSchemalessRow("<id=0> 0; <id=1> 0;"));
+        auto actual = ToString(rowset0->GetRows()[0]);
+        EXPECT_EQ(expected, actual);
+
+        // Second subrequest should have an error.
+        EXPECT_TRUE(results[1].Error.has_value());
+        EXPECT_FALSE(results[1].Error->IsOK());
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TClearTmpTestBase

--- a/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
@@ -1003,8 +1003,26 @@ std::vector<TUnversionedLookupRowsResult> TClient::DoMultiLookupRows(
             .Run());
     }
 
-    return WaitFor(AllSucceeded(std::move(asyncResults)))
-        .ValueOrThrow();
+    if (options.AllowFailure) {
+        auto resultsOrErrors = WaitFor(AllSet(std::move(asyncResults)))
+            .ValueOrThrow();
+
+        std::vector<TUnversionedLookupRowsResult> results;
+        results.reserve(subrequests.size());
+        for (auto& resultOrError : resultsOrErrors) {
+            if (resultOrError.IsOK()) {
+                results.push_back(std::move(resultOrError.Value()));
+            } else {
+                results.push_back(TUnversionedLookupRowsResult{
+                    .Error = std::move(resultOrError),
+                });
+            }
+        }
+        return results;
+    } else {
+        return WaitFor(AllSucceeded(std::move(asyncResults)))
+            .ValueOrThrow();
+    }
 }
 
 template <class IRowset, class TRow>

--- a/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
@@ -1003,15 +1003,23 @@ std::vector<TUnversionedLookupRowsResult> TClient::DoMultiLookupRows(
             .Run());
     }
 
-    if (options.AllowFailure) {
-        auto resultsOrErrors = WaitFor(AllSet(std::move(asyncResults)))
-            .ValueOrThrow();
+    if (options.SubrequestTimeout || options.AllowFailure) {
+        std::vector<TErrorOr<TUnversionedLookupRowsResult>> resultsOrErrors;
+        if (options.SubrequestTimeout) {
+            resultsOrErrors = WaitFor(AllSetWithTimeout(std::move(asyncResults), *options.SubrequestTimeout))
+                .ValueOrThrow();
+        } else {
+            resultsOrErrors = WaitFor(AllSet(std::move(asyncResults)))
+                .ValueOrThrow();
+        }
 
         std::vector<TUnversionedLookupRowsResult> results;
         results.reserve(subrequests.size());
         for (auto& resultOrError : resultsOrErrors) {
             if (resultOrError.IsOK()) {
                 results.push_back(std::move(resultOrError.Value()));
+            } else if (!options.AllowFailure && resultOrError.GetCode() != NYT::EErrorCode::Timeout) {
+                resultOrError.ThrowOnError();
             } else {
                 results.push_back(TUnversionedLookupRowsResult{
                     .Error = std::move(resultOrError),

--- a/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
+++ b/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
@@ -639,6 +639,7 @@ message TReqMultiLookup
     optional EReplicaConsistency replica_consistency = 6;
     optional EMultiplexingBand multiplexing_band = 4;
     optional string execution_pool = 7;
+    optional bool allow_failure = 8 [default = false];
 }
 
 message TRspMultiLookup
@@ -648,6 +649,7 @@ message TRspMultiLookup
         required TRowsetDescriptor rowset_descriptor = 1;
         required int32 attachment_count = 2;
         repeated int32 unavailable_key_indexes = 3;
+        optional NYT.NProto.TError error = 4;
     }
 
     repeated TSubresponse subresponses = 1;

--- a/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
+++ b/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
@@ -640,6 +640,7 @@ message TReqMultiLookup
     optional EMultiplexingBand multiplexing_band = 4;
     optional string execution_pool = 7;
     optional bool allow_failure = 8 [default = false];
+    optional uint64 subrequest_timeout = 9; // TDuration
 }
 
 message TRspMultiLookup


### PR DESCRIPTION
Feature for https://github.com/ytsaurus/ytsaurus/issues/1406

Hello! I’ve added new `allow_failure` and `subrequest_timeout` options for `multilookup` requests in the RPC proxy.

Both options are needed for cases when there is something wrong with one of the tables in subrequest and you want to still get results from other tables.

`allow_failure` option allows you to receive data even if some of the tables in the subrequests are unmounted or do not exist.

`subrequest_timeout` option helps you handle cases when one of the tables started responding slowly and you want to get data from other tables.

Without these options if you query 10 tables and even one of them is unmounted or missing or is slow to respond, the entire request fails.
* Changelog entry
Type: feature
Component: proxy

Added new `allow_failure` and `subrequest_timeout`  options for `multilookup` requests.