### PR TITLE
yt/yt/core/crypto: use built-in CA when config is not specified

### DIFF
--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -734,6 +734,7 @@ TInstant TSslContext::GetCommitTime() const
 void TSslContext::ApplyConfig(const TSslContextConfigPtr& config, TCertificatePathResolver pathResolver)
 {
     if (!config) {
+        UseBuiltinOpenSslX509Store();
         return;
     }
 

--- a/yt/yt/core/https/client.cpp
+++ b/yt/yt/core/https/client.cpp
@@ -107,11 +107,7 @@ IClientPtr CreateClient(
     const IPollerPtr& poller)
 {
     auto sslContext =  New<TSslContext>();
-    if (config->Credentials) {
-        sslContext->ApplyConfig(config->Credentials);
-    } else {
-        sslContext->UseBuiltinOpenSslX509Store();
-    }
+    sslContext->ApplyConfig(config->Credentials);
     sslContext->Commit();
 
     auto dialerConfig = New<TDialerConfig>();

--- a/yt/yt/library/s3/http.cpp
+++ b/yt/yt/library/s3/http.cpp
@@ -220,11 +220,7 @@ namespace {
 NYT::NCrypto::TSslContextPtr CreateSslContext(const NYT::NCrypto::TSslContextConfigPtr& config, NYT::NCrypto::TCertificatePathResolver pathResolver = nullptr)
 {
     auto sslContext = New<NYT::NCrypto::TSslContext>();
-    if (config) {
-        sslContext->ApplyConfig(config, std::move(pathResolver));
-    } else {
-        sslContext->UseBuiltinOpenSslX509Store();
-    }
+    sslContext->ApplyConfig(config, std::move(pathResolver));
     sslContext->Commit();
     return sslContext;
 }


### PR DESCRIPTION
Just consolidation of logic in one place.
No changes in behavior for known users.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
