### PR TITLE
Fix use-after-free in TError during program shutdown

### DIFF
--- a/library/cpp/yt/error/error.cpp
+++ b/library/cpp/yt/error/error.cpp
@@ -244,19 +244,17 @@ std::vector<TError>& ApplyWhitelist(std::vector<TError>& errors, const THashSet<
 
 ////////////////////////////////////////////////////////////////////////////////
 
-TError::TErrorOr() = default;
+void TError::TImplDeleter::operator()(TImpl* impl) const
+{
+    delete impl;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 TError::~TErrorOr() = default;
 
 TError::TErrorOr(const TError& other)
-{
-    if (!other.IsOK()) {
-        Impl_ = std::make_unique<TImpl>(*other.Impl_);
-    }
-}
-
-TError::TErrorOr(TError&& other) noexcept
-    : Impl_(std::move(other.Impl_))
+    : Impl_(other.IsOK() ? nullptr : new TImpl(*other.Impl_))
 { }
 
 TError::TErrorOr(const TErrorException& errorEx) noexcept
@@ -268,7 +266,7 @@ TError::TErrorOr(const TErrorException& errorEx) noexcept
 
 TError::TErrorOr(const std::exception& ex)
 {
-    if (auto simpleException = dynamic_cast<const TSimpleException*>(&ex)) {
+    if (auto* simpleException = dynamic_cast<const TSimpleException*>(&ex)) {
         *this = TError(NYT::EErrorCode::Generic, TRuntimeFormat{simpleException->GetMessage()});
         // NB: clang-14 is incapable of capturing structured binding variables
         //  so we force materialize them via this function call.
@@ -298,30 +296,20 @@ TError::TErrorOr(const std::exception& ex)
 }
 
 TError::TErrorOr(std::string message, TDisableFormat)
-    : Impl_(std::make_unique<TImpl>(std::move(message)))
+    : TError(std::make_unique<TImpl>(std::move(message)))
 {
     Enrich();
 }
 
 TError::TErrorOr(TErrorCode code, std::string message, TDisableFormat)
-    : Impl_(std::make_unique<TImpl>(code, std::move(message)))
+    : TError(std::make_unique<TImpl>(code, std::move(message)))
 {
     Enrich();
 }
 
 TError& TError::operator = (const TError& other)
 {
-    if (other.IsOK()) {
-        Impl_.reset();
-    } else {
-        Impl_ = std::make_unique<TImpl>(*other.Impl_);
-    }
-    return *this;
-}
-
-TError& TError::operator = (TError&& other) noexcept
-{
-    Impl_ = std::move(other.Impl_);
+    *this = TError(other);
     return *this;
 }
 
@@ -690,13 +678,13 @@ void TError::RegisterFromExceptionEnricher(TFromExceptionEnricher enricher)
 }
 
 TError::TErrorOr(std::unique_ptr<TImpl> impl)
-    : Impl_(std::move(impl))
+    : Impl_(impl.release())
 { }
 
 void TError::MakeMutable()
 {
     if (!Impl_) {
-        Impl_ = std::make_unique<TImpl>();
+        Impl_.reset(new TImpl());
     }
 }
 
@@ -732,31 +720,30 @@ TError& TError::operator <<= (const std::vector<TErrorAttribute>& attributes) &
 
 TError& TError::operator <<= (const TError& innerError) &
 {
-    MutableInnerErrors()->push_back(innerError);
+    if (!innerError.IsOK()) {
+        MutableInnerErrors()->push_back(innerError);
+    }
     return *this;
 }
 
 TError& TError::operator <<= (TError&& innerError) &
 {
-    MutableInnerErrors()->push_back(std::move(innerError));
+    if (!innerError.IsOK()) {
+        MutableInnerErrors()->push_back(std::move(innerError));
+    }
     return *this;
 }
 
 TError& TError::operator <<= (const std::vector<TError>& innerErrors) &
 {
-    MutableInnerErrors()->insert(
-        MutableInnerErrors()->end(),
-        innerErrors.begin(),
-        innerErrors.end());
+    std::ranges::copy_if(innerErrors, std::back_inserter(*MutableInnerErrors()), std::not_fn(&TError::IsOK));
     return *this;
 }
 
 TError& TError::operator <<= (std::vector<TError>&& innerErrors) &
 {
-    MutableInnerErrors()->insert(
-        MutableInnerErrors()->end(),
-        std::make_move_iterator(innerErrors.begin()),
-        std::make_move_iterator(innerErrors.end()));
+    auto filteredErrors = std::views::filter(innerErrors, std::not_fn(&TError::IsOK));
+    std::ranges::move(filteredErrors, std::back_inserter(*MutableInnerErrors()));
     return *this;
 }
 

--- a/library/cpp/yt/error/error.cpp
+++ b/library/cpp/yt/error/error.cpp
@@ -33,10 +33,10 @@ constexpr TStringBuf ErrorMessageTruncatedSuffix = "...<message truncated>";
 
 namespace {
 
-class TEnricherStorage
+struct TEnricherStorage
 {
-public:
-    static TEnricherStorage* Get() {
+    static TEnricherStorage* Get()
+    {
         return LeakySingleton<TEnricherStorage>();
     }
 

--- a/library/cpp/yt/error/error.h
+++ b/library/cpp/yt/error/error.h
@@ -251,9 +251,6 @@ private:
     void EnrichFromException(const std::exception& exception);
 
     friend class TErrorAttributes;
-
-    static TEnricher Enricher_;
-    static TFromExceptionEnricher FromExceptionEnricher_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
---

Type: fix
Component: library/cpp/yt/error

Problem: TError::Enricher_ and TError::FromExceptionEnricher_ are static class members whose destructors are registered when error.cpp is loaded. However, if any code calls Singleton<>() during static initialization before error.cpp loads, the OnExit handler gets registered in standard atexit() first. Due to LIFO ordering, at program exit the enrichers are destroyed before OnExit() runs, but OnExit() then destroys Singletons whose destructors may create TError objects (e.g., to cancel futures), which invokes Enrich() on the already-destroyed std::function, causing use-after-free. This can lead to intermittent segfaults depending on the link order of translation units.

Solution: Store enrichers in a LeakySingleton<TEnricherStorage> so they are never destroyed, as TError can be created anywhere including during program shutdown.