### PR TITLE
Support master --compatibility-info without passing the config

### DIFF
--- a/yt/yt/library/program/program.cpp
+++ b/yt/yt/library/program/program.cpp
@@ -88,6 +88,9 @@ TProgram::TProgram()
     Opts_.AddLongOption("build", "Prints build information")
         .NoArgument()
         .StoreValue(&PrintBuild_, true);
+    Opts_.AddLongOption("compatibility-info", "Prints compatibility info (e.g. current reign)")
+        .NoArgument()
+        .StoreValue(&PrintCompatibilityInfo_, true);
     Opts_.SetFreeArgsNum(0);
 }
 
@@ -98,7 +101,7 @@ void TProgram::SetCrashOnError()
     CrashOnError_ = true;
 }
 
-void TProgram::HandleVersionAndBuild()
+void TProgram::HandleProgramInfo()
 {
     if (PrintVersion_) {
         PrintVersionAndExit();
@@ -109,6 +112,15 @@ void TProgram::HandleVersionAndBuild()
     if (PrintBuild_) {
         PrintBuildAndExit();
     }
+    if (PrintCompatibilityInfo_) {
+        DoPrintCompatibilityInfo();
+        Exit(0);
+    }
+}
+
+void TProgram::DoPrintCompatibilityInfo()
+{
+    THROW_ERROR_EXCEPTION("Compatibility info is not implemented for this program");
 }
 
 int TProgram::Run(int argc, const char** argv)
@@ -119,7 +131,7 @@ int TProgram::Run(int argc, const char** argv)
     OptsParseResult_ = std::make_unique<TOptsParseResult>(this, argc, argv);
 
     auto run = [&] {
-        HandleVersionAndBuild();
+        HandleProgramInfo();
         DoRun();
     };
 

--- a/yt/yt/library/program/program.h
+++ b/yt/yt/library/program/program.h
@@ -24,8 +24,8 @@ public:
     [[noreturn]]
     int Run(int argc, const char** argv);
 
-    //! Handles --version/--yt-version/--build [--yson] if they are present.
-    void HandleVersionAndBuild();
+    //! Handles --version/--yt-version/--build/--compatibility-info [--yson] if they are present.
+    void HandleProgramInfo();
 
     //! Nongracefully aborts the program.
     /*!
@@ -47,6 +47,7 @@ protected:
     bool PrintYTVersion_ = false;
     bool PrintVersion_ = false;
     bool PrintBuild_ = false;
+    bool PrintCompatibilityInfo_ = false;
     bool UseYson_ = false;
 
     virtual void DoRun() = 0;
@@ -70,6 +71,11 @@ protected:
     //! but some YT components (e.g. CHYT) can override it to provide its own version.
     [[noreturn]]
     virtual void PrintVersionAndExit();
+
+    //! Handler for --compatibility-info command argument.
+    //! By default, throws an exception. Override to provide compatibility information
+    //! (e.g., current reign for master).
+    virtual void DoPrintCompatibilityInfo();
 
     [[noreturn]]
     void Exit(int code) noexcept;


### PR DESCRIPTION
Previously the `--compatibility-info` flag required passing the master config:
```
root@b87863f0a363:/# /bin/ytserver-master --compatibility-info
(NYT::TErrorException) Error parsing config file 
    origin          (unknown) (pid 18, thread ytserver-master, fid 0)
    datetime        2026-02-02T18:11:24.149029Z
  (Error 2: No such file or directory) util/system/file.cpp:936: can't open "" with mode RdOnly|Seq (0x00000028)
      origin          (unknown) (pid 18, thread ytserver-master, fid 0)
      datetime        2026-02-02T18:11:24.149258Z
      exception_type  TFileError
```
That is not needed to retrieve the reign.

Moved flag handling to `TProgram` class to exit before config loading.

By default `--compatibility-info` outputs a plain text now, if `--yson` flag is not passed:
```
$ ./ytserver-all ytserver-master --compatibility-info
Current Reign: 3204
$ ./ytserver-all ytserver-master --compatibility-info --yson
{
    "current_reign" = 3204;
}
```

---
* Changelog entry
Type: fix
Component: master

Allow --compatibility-info to work without providing a config file.

