### PR TITLE
Implement RuntimeConfig

### DIFF
--- a/yt/yql/agent/config.h
+++ b/yt/yql/agent/config.h
@@ -39,9 +39,6 @@ struct TYqlAgentConfig
 
     std::vector<std::string> InsecureSecretPathSubjects;
 
-    std::optional<size_t> MemoryLimit;
-    std::optional<bool> DisableBacktraceSymbolizing;
-
     REGISTER_YSON_STRUCT(TYqlAgentConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yql/agent/config.h
+++ b/yt/yql/agent/config.h
@@ -39,6 +39,9 @@ struct TYqlAgentConfig
 
     std::vector<std::string> InsecureSecretPathSubjects;
 
+    std::optional<size_t> MemoryLimit;
+    std::optional<bool> DisableBacktraceSymbolizing;
+
     REGISTER_YSON_STRUCT(TYqlAgentConfig);
 
     static void Register(TRegistrar registrar);

--- a/yt/yql/plugin/config.cpp
+++ b/yt/yql/plugin/config.cpp
@@ -5,9 +5,9 @@
 #include <yt/yt/core/logging/config.h>
 #include <yt/yt/core/ytree/fluent.h>
 
-#include <util/string/vector.h>
-
 #include <yt/yt/core/misc/backtrace.h>
+
+#include <util/string/vector.h>
 
 #ifdef _unix_
     #include <sys/resource.h>

--- a/yt/yql/plugin/config.cpp
+++ b/yt/yql/plugin/config.cpp
@@ -321,7 +321,7 @@ void TRuntimeConfig::ApplyLimitations() const {
 
         int err = setrlimit(RLIMIT_AS, &lim_addr_space);
         if (err) {
-            throw yexception() << "Can't set address space limit: " << err;
+            throw yexception() << "Can't set address space limit: " << errno;
         }
     }
 #endif

--- a/yt/yql/plugin/config.cpp
+++ b/yt/yql/plugin/config.cpp
@@ -312,12 +312,17 @@ void TProcessYqlPluginConfig::Register(TRegistrar registrar)
         .DefaultNew();
 }
 
-void TRuntimeConfig::ApplyLimitations() const {
+void TRuntimeConfig::ApplyLimitations() const
+{
 #ifdef _unix_
     if (MemoryLimit) {
+        if (*MemoryLimit < 0) {
+            throw yexception() << "Negative memory limit is not allowed: " << *MemoryLimit;
+        }
         struct rlimit lim_addr_space;
-        lim_addr_space.rlim_cur = *MemoryLimit;
-        lim_addr_space.rlim_max = *MemoryLimit;
+        rlim_t limit = static_cast<rlim_t>(*MemoryLimit);
+        lim_addr_space.rlim_cur = limit;
+        lim_addr_space.rlim_max = limit;
 
         int err = setrlimit(RLIMIT_AS, &lim_addr_space);
         if (err) {

--- a/yt/yql/plugin/config.h
+++ b/yt/yql/plugin/config.h
@@ -124,6 +124,23 @@ DEFINE_REFCOUNTED_TYPE(TAdditionalSystemLib)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+struct TRuntimeConfig
+    : public NYTree::TYsonStruct
+{
+    bool DisableBacktraceSymbolizing;
+    std::optional<size_t> MemoryLimit;
+
+    void ApplyLimitations() const;
+
+    REGISTER_YSON_STRUCT(TRuntimeConfig);
+
+    static void Register(TRegistrar registrar);
+};
+
+DEFINE_REFCOUNTED_TYPE(TRuntimeConfig)
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TProcessYqlPluginConfig
     : public NYTree::TYsonStruct
 {
@@ -137,6 +154,8 @@ struct TProcessYqlPluginConfig
     TDuration RunRequestTimeout;
 
     NLogging::TLogManagerConfigPtr LogManagerTemplate;
+
+    TRuntimeConfigPtr RuntimeConfig;
 
     REGISTER_YSON_STRUCT(TProcessYqlPluginConfig);
 

--- a/yt/yql/plugin/config.h
+++ b/yt/yql/plugin/config.h
@@ -128,7 +128,7 @@ struct TRuntimeConfig
     : public NYTree::TYsonStruct
 {
     bool DisableBacktraceSymbolizing;
-    std::optional<size_t> MemoryLimit;
+    std::optional<i64> MemoryLimit;
 
     void ApplyLimitations() const;
 

--- a/yt/yql/plugin/process/program.cpp
+++ b/yt/yql/plugin/process/program.cpp
@@ -66,6 +66,8 @@ protected:
 
         YT_VERIFY(config->BusServer->UnixDomainSocketPath);
 
+        config->PluginConfig->ProcessPluginConfig->RuntimeConfig->ApplyLimitations();
+
         auto options = ConvertToOptions(
             config->PluginConfig,
             NYson::ConvertToYsonString(config->SingletonsConfig),

--- a/yt/yql/plugin/public.h
+++ b/yt/yql/plugin/public.h
@@ -14,6 +14,7 @@ DECLARE_REFCOUNTED_STRUCT(TDQManagerConfig)
 DECLARE_REFCOUNTED_STRUCT(TAdditionalSystemLib)
 DECLARE_REFCOUNTED_STRUCT(TProcessYqlPluginConfig)
 DECLARE_REFCOUNTED_STRUCT(TYqlPluginConfig)
+DECLARE_REFCOUNTED_STRUCT(TRuntimeConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/core/misc/backtrace.cpp
+++ b/yt/yt/core/misc/backtrace.cpp
@@ -16,6 +16,8 @@ namespace NDetail {
 
 using TBacktraceBuffer = std::array<const void*, 99>; // 99 is to keep formatting :)
 
+bool BacktraceSymbolizing = true;
+
 Y_NO_INLINE NBacktrace::TBacktrace GetBacktrace(TBacktraceBuffer* buffer)
 {
 #ifdef _unix_
@@ -42,7 +44,15 @@ Y_NO_INLINE void DumpBacktrace(const std::function<void(TStringBuf)>& writeCallb
 {
     NDetail::TBacktraceBuffer buffer;
     auto backtrace = NDetail::GetBacktrace(&buffer);
-    NBacktrace::SymbolizeBacktrace(backtrace, writeCallback, startPC);
+    if (!NDetail::BacktraceSymbolizing) {
+        writeCallback(TStringBuf("<backtrace symbolization is disabled>"));
+    } else {
+        NBacktrace::SymbolizeBacktrace(backtrace, writeCallback, startPC);
+    }
+}
+
+void DisableBacktraceSymbolizing() {
+    NDetail::BacktraceSymbolizing = false;
 }
 
 std::string DumpBacktrace()

--- a/yt/yt/core/misc/backtrace.cpp
+++ b/yt/yt/core/misc/backtrace.cpp
@@ -51,7 +51,8 @@ Y_NO_INLINE void DumpBacktrace(const std::function<void(TStringBuf)>& writeCallb
     }
 }
 
-void DisableBacktraceSymbolizing() {
+void DisableBacktraceSymbolizing()
+{
     NDetail::BacktraceSymbolizing = false;
 }
 

--- a/yt/yt/core/misc/backtrace.h
+++ b/yt/yt/core/misc/backtrace.h
@@ -21,6 +21,10 @@ void DumpBacktrace(
 //! Captures the current backtrace and symbolizes it into a string.
 std::string DumpBacktrace();
 
+//! Disables backtrace symbolization. On each DumpBacktrace call,
+//! user will receive a message that symbolizing is disabled.
+void DisableBacktraceSymbolizing();
+
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NYT

--- a/yt/yt/core/misc/backtrace.h
+++ b/yt/yt/core/misc/backtrace.h
@@ -21,8 +21,8 @@ void DumpBacktrace(
 //! Captures the current backtrace and symbolizes it into a string.
 std::string DumpBacktrace();
 
-//! Disables backtrace symbolization. On each DumpBacktrace call,
-//! user will receive a message that symbolization is disabled.
+//! Disables backtrace symbolization. When symbolization is disabled,
+//! DumpBacktrace may report that symbolization is disabled instead of symbolizing.
 void DisableBacktraceSymbolizing();
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/misc/backtrace.h
+++ b/yt/yt/core/misc/backtrace.h
@@ -22,7 +22,7 @@ void DumpBacktrace(
 std::string DumpBacktrace();
 
 //! Disables backtrace symbolization. On each DumpBacktrace call,
-//! user will receive a message that symbolizing is disabled.
+//! user will receive a message that symbolization is disabled.
 void DisableBacktraceSymbolizing();
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
* Changelog entry
Type: Feature
Component: query-tracker

Implemented RuntimeConfig: it hold (for now) backtrace symbolization and memory limit settings, it also can be used for any future per-process purposes.
In current PR's version, only subprocesses, spawned to execute YQL query, will apply that limits.
