### PR TITLE
[stable/25.3] yt/cpp/mapreduce/client: handle https in transaction pinger

### DIFF
--- a/yt/cpp/mapreduce/client/CMakeLists.darwin-arm64.txt
+++ b/yt/cpp/mapreduce/client/CMakeLists.darwin-arm64.txt
@@ -46,6 +46,7 @@ target_link_libraries(cpp-mapreduce-client PUBLIC
   cpp-mapreduce-io
   yt-yt-core
   yt-core-http
+  yt-core-https
   tools-enum_parser-enum_serialization_runtime
 )
 

--- a/yt/cpp/mapreduce/client/CMakeLists.darwin-x86_64.txt
+++ b/yt/cpp/mapreduce/client/CMakeLists.darwin-x86_64.txt
@@ -46,6 +46,7 @@ target_link_libraries(cpp-mapreduce-client PUBLIC
   cpp-mapreduce-io
   yt-yt-core
   yt-core-http
+  yt-core-https
   tools-enum_parser-enum_serialization_runtime
 )
 

--- a/yt/cpp/mapreduce/client/CMakeLists.linux-aarch64.txt
+++ b/yt/cpp/mapreduce/client/CMakeLists.linux-aarch64.txt
@@ -49,6 +49,7 @@ target_link_libraries(cpp-mapreduce-client PUBLIC
   cpp-mapreduce-io
   yt-yt-core
   yt-core-http
+  yt-core-https
   tools-enum_parser-enum_serialization_runtime
 )
 

--- a/yt/cpp/mapreduce/client/CMakeLists.linux-x86_64.txt
+++ b/yt/cpp/mapreduce/client/CMakeLists.linux-x86_64.txt
@@ -49,6 +49,7 @@ target_link_libraries(cpp-mapreduce-client PUBLIC
   cpp-mapreduce-io
   yt-yt-core
   yt-core-http
+  yt-core-https
   tools-enum_parser-enum_serialization_runtime
 )
 

--- a/yt/cpp/mapreduce/client/client.cpp
+++ b/yt/cpp/mapreduce/client/client.cpp
@@ -1522,7 +1522,7 @@ ITransactionPingerPtr TClient::GetTransactionPinger()
 {
     auto g = Guard(Lock_);
     if (!TransactionPinger_) {
-        TransactionPinger_ = CreateTransactionPinger(Context_.Config);
+        TransactionPinger_ = CreateTransactionPinger(Context_.Config, Context_.UseTLS);
     }
     return TransactionPinger_;
 }

--- a/yt/cpp/mapreduce/client/transaction_pinger.cpp
+++ b/yt/cpp/mapreduce/client/transaction_pinger.cpp
@@ -22,6 +22,9 @@
 #include <yt/yt/core/http/client.h>
 #include <yt/yt/core/http/http.h>
 
+#include <yt/yt/core/https/client.h>
+#include <yt/yt/core/https/config.h>
+
 #include <library/cpp/yson/node/node_io.h>
 
 #include <library/cpp/yt/threading/spin_lock.h>
@@ -60,17 +63,18 @@ void CheckError(const TString& requestId, NHttp::IResponsePtr response)
 
 void PingTx(NHttp::IClientPtr httpClient, const TPingableTransaction& tx)
 {
-    auto url = TString::Join("http://", tx.GetContext().ServerName, "/api/", tx.GetContext().Config->ApiVersion, "/ping_tx");
+    const auto context = tx.GetContext();
+    auto url = TString::Join(context.UseTLS ? "https://" : "http://", context.ServerName, "/api/", context.Config->ApiVersion, "/ping_tx");
     auto headers = New<NHttp::THeaders>();
     auto requestId = CreateGuidAsString();
 
     headers->Add("Host", url);
     headers->Add("User-Agent", TProcessState::Get()->ClientVersion);
 
-    if (const auto& serviceTicketAuth = tx.GetContext().ServiceTicketAuth) {
+    if (const auto& serviceTicketAuth = context.ServiceTicketAuth) {
         const auto serviceTicket = serviceTicketAuth->Ptr->IssueServiceTicket();
         headers->Add("X-Ya-Service-Ticket", serviceTicket);
-    } else if (const auto& token = tx.GetContext().Token; !token.empty()) {
+    } else if (const auto& token = context.Token; !token.empty()) {
         headers->Add("Authorization", "OAuth " + token);
     }
 
@@ -86,7 +90,7 @@ void PingTx(NHttp::IClientPtr httpClient, const TPingableTransaction& tx)
 
     YT_LOG_DEBUG("REQ %v - sending request (HostName: %v; Method POST %v; X-YT-Parameters (sent in body): %v)",
         requestId,
-        tx.GetContext().ServerName,
+        context.ServerName,
         url,
         strParams
     );
@@ -200,15 +204,23 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-ITransactionPingerPtr CreateTransactionPinger(const TConfigPtr& config)
+ITransactionPingerPtr CreateTransactionPinger(const TConfigPtr& config, bool useTLS)
 {
     YT_LOG_DEBUG("Using async transaction pinger");
-    auto httpClientConfig = NYT::New<NHttp::TClientConfig>();
-    httpClientConfig->MaxIdleConnections = 16;
     auto httpPoller = NConcurrency::CreateThreadPoolPoller(
         config->AsyncHttpClientThreads,
         "tx_http_client_poller");
-    auto httpClient = NHttp::CreateClient(std::move(httpClientConfig), std::move(httpPoller));
+    NHttp::IClientPtr httpClient;
+
+    if (useTLS) {
+        auto httpsClientConfig = NYT::New<NHttps::TClientConfig>();
+        httpsClientConfig->MaxIdleConnections = 16;
+        httpClient = NHttps::CreateClient(std::move(httpsClientConfig), std::move(httpPoller));
+    } else {
+        auto httpClientConfig = NYT::New<NHttp::TClientConfig>();
+        httpClientConfig->MaxIdleConnections = 16;
+        httpClient = NHttp::CreateClient(std::move(httpClientConfig), std::move(httpPoller));
+    }
 
     return MakeIntrusive<TSharedTransactionPinger>(
         std::move(httpClient),

--- a/yt/cpp/mapreduce/client/transaction_pinger.h
+++ b/yt/cpp/mapreduce/client/transaction_pinger.h
@@ -32,7 +32,7 @@ public:
     virtual void RemoveTransaction(const TPingableTransaction& pingableTx) = 0;
 };
 
-ITransactionPingerPtr CreateTransactionPinger(const TConfigPtr& config);
+ITransactionPingerPtr CreateTransactionPinger(const TConfigPtr& config, bool useTLS = false);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/cpp/mapreduce/client/ya.make
+++ b/yt/cpp/mapreduce/client/ya.make
@@ -48,6 +48,7 @@ PEERDIR(
 PEERDIR(
     yt/yt/core
     yt/yt/core/http
+    yt/yt/core/https
 )
 
 IF (BUILD_TYPE == "PROFILE")


### PR DESCRIPTION
Use HTTPS client and schema for client context with TLS.

Reported-by: Nikita Sokolov <faucct@tracto.ai>
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
Link: https://github.com/ytsaurus/ytsaurus/pull/1559

---

* Changelog entry
Type: fix
Component: cpp-sdk

Handle HTTPS in yt/cpp/mapreduce/client transaction pinger.

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1567
commit_hash:1830efe8ab8a5ec527cd3fdc249032372237545f

(cherry picked from commit 9f601ed5fe770ea68b57612c6c0e771a6c88921d)
