### PR TITLE
[query-tracker/0.1] Use get_config_from_env for YtClient in init scripts

### DIFF
--- a/yt/python/yt/environment/init_operations_archive.py
+++ b/yt/python/yt/environment/init_operations_archive.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 
 import yt.yson as yson
-from yt.wrapper import YtClient, config, ypath_split
+from yt.wrapper import YtClient, ypath_split
+from yt.wrapper.default_config import get_config_from_env
 
 from yt.environment.init_cluster import get_default_resource_limits
 
@@ -1262,7 +1263,7 @@ def build_arguments_parser():
     parser.add_argument("--force", action="store_true", default=False)
     parser.add_argument("--archive-path", type=str, default=DEFAULT_ARCHIVE_PATH)
     parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
-    parser.add_argument("--proxy", type=str, default=config["proxy"]["url"])
+    parser.add_argument("--proxy", type=str, default=None)
     parser.add_argument("--retransform", action="store_true", default=False)
     parser.add_argument("--pool", type=str, default=None)
 
@@ -1296,7 +1297,7 @@ def main():
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
 
     args = build_arguments_parser().parse_args()
-    client = YtClient(proxy=args.proxy, token=config["token"])
+    client = YtClient(proxy=args.proxy, config=get_config_from_env())
 
     run(
         client=client,

--- a/yt/python/yt/environment/init_query_tracker_state.py
+++ b/yt/python/yt/environment/init_query_tracker_state.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python3
 
-from yt.wrapper import YtClient, config
+from yt.common import update_inplace
+from yt.wrapper import YtClient
+from yt.wrapper.default_config import get_config_from_env
 
 from yt.environment.migrationlib import TableInfo, Migration, Conversion
 
@@ -2010,7 +2012,7 @@ def build_arguments_parser():
     parser.add_argument("--force", action="store_true", default=False)
     parser.add_argument("--state-path", type=str, default=DEFAULT_STATE_PATH)
     parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
-    parser.add_argument("--proxy", type=str, default=config["proxy"]["url"])
+    parser.add_argument("--proxy", type=str, default=None)
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--target-version", type=int)
@@ -2024,12 +2026,14 @@ def main():
     args = build_arguments_parser().parse_args()
     client = YtClient(
         proxy=args.proxy,
-        token=config["token"],
-        config={
-            "pickling": {
-                "ignore_system_modules": False,
-            },
-        },
+        config=update_inplace(
+            get_config_from_env(),
+            {
+                "pickling": {
+                    "ignore_system_modules": False,
+                },
+            }
+        ),
     )
 
     target_version = args.target_version

--- a/yt/python/yt/environment/init_queue_agent_state.py
+++ b/yt/python/yt/environment/init_queue_agent_state.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
-from yt.wrapper import config, YtClient, ypath_split, ypath_join
+from yt.wrapper import YtClient, ypath_split, ypath_join
+from yt.wrapper.default_config import get_config_from_env
 
 from yt.environment.migrationlib import TableInfo, Migration, Conversion, TypeV3
 
@@ -559,7 +560,7 @@ def build_arguments_parser():
 
     parser.add_argument("--version", action="version", version=str(SCRIPT_VERSION))
 
-    parser.add_argument("--proxy", type=str, default=config["proxy"]["url"])
+    parser.add_argument("--proxy", type=str, default=None)
     parser.add_argument("--root", type=str, default=DEFAULT_ROOT,
                         help="Root directory for state tables; defaults to {}".format(DEFAULT_ROOT))
     parser.add_argument("--shard-count", type=int, default=DEFAULT_SHARD_COUNT)
@@ -592,7 +593,7 @@ def run_migration(client, root, target_version=None, shard_count=1, force=False,
 
 def main():
     args = build_arguments_parser().parse_args()
-    client = YtClient(proxy=args.proxy, token=config["token"])
+    client = YtClient(proxy=args.proxy, config=get_config_from_env())
 
     target_version = args.target_version
     if args.latest:


### PR DESCRIPTION
- **init_operations_archive: use get_config_from_env**
- **init_queue_agent_state: use get_config_from_env**
- **init_query_tracker_state: use get_config_from_env**

---

Init scripts should respect configuration files and environment variables.
For example this is required for passing CA-bundle for HTTPS-only cluster.

There is simple way to fetch all options from environment and config files.
Unfortunately this is not default behaviour and contains some boilerplate.

update_config_from_env() configs applying order:
- config argument
- apply env YT_CONFIG_PATCHES
- apply config file YT_CONFIG_PATH (~/.yt/config)
- apply env YT_*

YtClient configs applying order:
- get_default_config()
- apply config argument
- apply proxy and token argument
- apply remote patch

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1516

Co-authored-by: denvr <denvr@ytsaurus.tech>
commit_hash:e45f5f78cbd8cec8157a1a76f9b9dfbedf6aadf2

(cherry picked from commit 61fdad70be24b74e915e269546fa6d8d0a61462d)
