### PR TITLE
[stable/25.2] yt/server/http_proxy: hide content at creating document

### DIFF
--- a/yt/yt/server/http_proxy/helpers.cpp
+++ b/yt/yt/server/http_proxy/helpers.cpp
@@ -216,6 +216,10 @@ NYTree::IMapNodePtr HideSecretParameters(const TString& commandName, NYTree::IMa
         secretParameters.push_back("/environment");
     }
 
+    if (commandName == "create") {
+        secretParameters.push_back("/attributes/value");
+    }
+
     bool needCleanup = false;
     for (const auto& ypath : secretParameters) {
         if (FindNodeByYPath(parameters, ypath)) {

--- a/yt/yt/server/http_proxy/unittests/helpers_ut.cpp
+++ b/yt/yt/server/http_proxy/unittests/helpers_ut.cpp
@@ -7,10 +7,15 @@
 
 #include <yt/yt/core/misc/error.h>
 
+#include <yt/yt/core/ytree/convert.h>
+#include <yt/yt/core/ytree/fluent.h>
+#include <yt/yt/core/ytree/node.h>
+
 namespace NYT::NHttpProxy {
 namespace {
 
 using namespace NAuth;
+using namespace NYTree;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -54,6 +59,47 @@ TEST(TTestCsrfToken, Sample)
     auto token = SignCsrfToken("prime", "abcd", now);
     CheckCsrfToken(token, "prime", "abcd", now - TDuration::Minutes(1))
         .ThrowOnError();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(THideSecretParametersTest, CreateCommandMasksValueAndDoesNotMutateOriginal)
+{
+    // Test that /attributes/value is masked when commandName == "create"
+    // and that the original parameters node is not mutated
+    auto original = BuildYsonNodeFluently()
+        .BeginMap()
+            .Item("type").Value("document")
+            .Item("attributes").BeginMap()
+                .Item("value").Value("secret_content_here")
+                .Item("public_field").Value("public_data")
+            .EndMap()
+        .EndMap();
+
+    auto originalPtr = original->AsMap().Get();
+    auto result = HideSecretParameters("create", original->AsMap());
+
+    // Verify original still has the secret value (not mutated)
+    auto originalValue = FindNodeByYPath(original->AsMap(), "/attributes/value");
+    ASSERT_TRUE(originalValue);
+    EXPECT_EQ(ConvertTo<TString>(originalValue), "secret_content_here");
+
+    // Verify the result has the value masked
+    auto maskedValue = FindNodeByYPath(result, "/attributes/value");
+    ASSERT_TRUE(maskedValue);
+    EXPECT_EQ(ConvertTo<TString>(maskedValue), "***");
+
+    // Verify other fields remain unchanged in result
+    auto publicField = FindNodeByYPath(result, "/attributes/public_field");
+    ASSERT_TRUE(publicField);
+    EXPECT_EQ(ConvertTo<TString>(publicField), "public_data");
+
+    auto typeField = FindNodeByYPath(result, "/type");
+    ASSERT_TRUE(typeField);
+    EXPECT_EQ(ConvertTo<TString>(typeField), "document");
+
+    // Verify result is a different object
+    EXPECT_NE(result.Get(), originalPtr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Initial document content is passed as attribute "value",
which should not be logged.

It seems RPC proxy is not affected.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>

---

* Changelog entry
Type: bug
Component: http-proxy

Do not log initial document content.

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1572

Co-authored-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
commit_hash:3a3102dd68195ea91cc9499c90c5c28dec64f762

(cherry picked from commit ce35b7febeb3b08654d1713290ccb38847b5333f)
