### PR TITLE
[stable/25.3] yt/python/native: use address resolver section from config in server format

### DIFF
--- a/yt/python/yt/wrapper/native_driver.py
+++ b/yt/python/yt/wrapper/native_driver.py
@@ -88,7 +88,7 @@ def read_config(path):
         return (
             driver_config,
             None,
-            None,
+            driver_config.get("address_resolver"),
             None
         )
 


### PR DESCRIPTION
Fix yt cli with native driver for IPv4-only setup when we use server config:

  export YT_DRIVER_CONFIG_PATH=/config/ytserver-master.yson
  yt list /

client config format:

    {
        "address_resolver"={
            "enable_ipv4"=%true;
            "enable_ipv6"=%true;
            retries=1000;
        };
        driver={
            "primary_master"={
                ...
            };
        };
    };

server config format:

    {
        "address_resolver"={
            "enable_ipv4"=%true;
            "enable_ipv6"=%true;
            retries=1000;
        };
        "primary_master"={
            ...
        };
    };

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>

---

* Changelog entry
Type: fix
Component: python-sdk

Use address resolver config in server format for python native driver.

---

Pull Request resolved: https://github.com/ytsaurus/ytsaurus/pull/1599
commit_hash:dbc5227498c063b226e86da86c8344f88fbdd527

(cherry picked from commit 2816f6fe94f7feffc04d3ff547333cc4ffc1b8e8)
