### PR TITLE
Add depth limit to serializing TEerror to proto (issue 1595)

### DIFF
--- a/yt/yt/core/misc/error.cpp
+++ b/yt/yt/core/misc/error.cpp
@@ -458,7 +458,42 @@ void Deserialize(TError& error, NYson::TYsonPullParserCursor* cursor)
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void ToProto(NYT::NProto::TError* protoError, const TError& error)
+namespace {
+
+// Errors whose depth exceeds |ErrorSerializationDepthLimit| are serialized
+// as children of their ancestor on depth |ErrorSerializationDepthLimit - 1|.
+[[maybe_unused]]
+void SerializeInnerErrorsProto(NYT::NProto::TError* protoError, const TError& error, int depth)
+{
+    if (depth >= ErrorSerializationDepthLimit) {
+        // Ignore deep inner errors.
+        return;
+    }
+
+    auto visit = [&] (NYT::NProto::TError* protoError, const TError& error, int depth) {
+        ToProto(protoError->add_inner_errors(), error, depth);
+    };
+
+    for (const auto& innerError : error.InnerErrors()) {
+        if (depth < ErrorSerializationDepthLimit - 1) {
+            visit(protoError, innerError, depth + 1);
+        } else {
+            YT_VERIFY(depth == ErrorSerializationDepthLimit - 1);
+            TraverseError(
+                innerError,
+                [&] (const TError& e, int depth) {
+                    visit(protoError, e, depth);
+                },
+                depth + 1);
+        }
+    }
+}
+
+} //namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+void ToProto(NYT::NProto::TError* protoError, const TError& error, int depth)
 {
     if (error.IsOK()) {
         protoError->set_code(ToProto(NYT::EErrorCode::OK));
@@ -524,9 +559,13 @@ void ToProto(NYT::NProto::TError* protoError, const TError& error)
         addAttribute(SpanIdKey, GetSpanId(error));
     }
 
+    if (depth > ErrorSerializationDepthLimit) {
+        addAttribute(TString(OriginalErrorDepthAttribute), depth);
+    }
+
     protoError->clear_inner_errors();
-    for (const auto& innerError : error.InnerErrors()) {
-        ToProto(protoError->add_inner_errors(), innerError);
+    if (!error.InnerErrors().empty()) {
+        SerializeInnerErrorsProto(protoError, error, depth);
     }
 }
 

--- a/yt/yt/core/misc/error.h
+++ b/yt/yt/core/misc/error.h
@@ -65,7 +65,7 @@ void Deserialize(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-void ToProto(NProto::TError* protoError, const TError& error);
+void ToProto(NProto::TError* protoError, const TError& error, int depth = 0);
 void FromProto(TError* error, const NProto::TError& protoError);
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/misc/unittests/error_serialization_to_proto_ut.cpp
+++ b/yt/yt/core/misc/unittests/error_serialization_to_proto_ut.cpp
@@ -1,0 +1,48 @@
+#include <yt/yt/core/test_framework/framework.h>
+
+#include <yt/yt/core/misc/error.h>
+#include <yt/yt/core/misc/protobuf_helpers.h>
+#include <yt/yt_proto/yt/core/misc/proto/error.pb.h>
+
+#include <algorithm>
+#include <iostream>
+
+namespace NYT {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+int GetMaxDepth(const TError& error, int currentDepth = 0) {
+    int maxDepth = currentDepth;
+    
+    for (const auto& innerError : error.InnerErrors()) {
+        maxDepth = std::max(maxDepth, GetMaxDepth(innerError, currentDepth + 1));
+    }
+    
+    return maxDepth;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TErrorProtoTest, SerializationDepthLimit)
+{
+    constexpr int Depth = 100;
+    auto error = TError(TErrorCode(Depth), "error");
+    for (int i = Depth - 1; i > 0; --i) {
+        error = TError(TErrorCode(i), "error") << std::move(error);
+    }
+
+    NYT::NProto::TError protoError;
+    ToProto(&protoError, error);
+
+    TError deserializedError;
+    FromProto(&deserializedError, protoError);
+
+    int countInnerErrorsDepth = GetMaxDepth(deserializedError);
+    ASSERT_EQ(countInnerErrorsDepth, ErrorSerializationDepthLimit);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace
+} // namespace NYT

--- a/yt/yt/core/misc/unittests/error_serialization_to_proto_ut.cpp
+++ b/yt/yt/core/misc/unittests/error_serialization_to_proto_ut.cpp
@@ -4,11 +4,19 @@
 #include <yt/yt/core/misc/protobuf_helpers.h>
 #include <yt/yt_proto/yt/core/misc/proto/error.pb.h>
 
+#include <yt/yt/core/yson/string.h>
+
+#include <yt/yt/core/ytree/attributes.h>
+#include <yt/yt/core/ytree/convert.h>
+
 #include <algorithm>
 #include <iostream>
 
 namespace NYT {
 namespace {
+
+using namespace NYson;
+using namespace NYTree;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -28,6 +36,8 @@ TEST(TErrorProtoTest, SerializationDepthLimit)
 {
     constexpr int Depth = 100;
     auto error = TError(TErrorCode(Depth), "error");
+
+    // not using 0 depth because inner error are not serialized to proto if error code is OK
     for (int i = Depth - 1; i > 0; --i) {
         error = TError(TErrorCode(i), "error") << std::move(error);
     }
@@ -40,6 +50,34 @@ TEST(TErrorProtoTest, SerializationDepthLimit)
 
     int countInnerErrorsDepth = GetMaxDepth(deserializedError);
     ASSERT_EQ(countInnerErrorsDepth, ErrorSerializationDepthLimit);
+
+    // this is already tested in error_ut.cpp
+    auto errorYson = ConvertToYsonString(deserializedError);
+    auto errorNode = ConvertTo<IMapNodePtr>(errorYson);
+
+    for (int i = 1; i < ErrorSerializationDepthLimit; ++i) {
+        ASSERT_EQ(errorNode->GetChildValueOrThrow<i64>("code"), i);
+        ASSERT_EQ(errorNode->GetChildValueOrThrow<TString>("message"), "error");
+        ASSERT_FALSE(errorNode->GetChildOrThrow("attributes")->AsMap()->FindChild("original_error_depth"));
+        auto innerErrors = errorNode->GetChildOrThrow("inner_errors")->AsList()->GetChildren();
+        ASSERT_EQ(innerErrors.size(), 1u);
+        errorNode = innerErrors[0]->AsMap();
+    }
+    auto innerErrors = errorNode->GetChildOrThrow("inner_errors")->AsList();
+    const auto& children = innerErrors->GetChildren();
+    ASSERT_EQ(std::ssize(children), Depth - ErrorSerializationDepthLimit);
+    for (int i = 0; i < std::ssize(children); ++i) {
+        auto child = children[i]->AsMap();
+        ASSERT_EQ(child->GetChildValueOrThrow<i64>("code"), i + ErrorSerializationDepthLimit + 1);
+        ASSERT_EQ(child->GetChildValueOrThrow<TString>("message"), "error");
+        auto originalErrorDepth = child->GetChildOrThrow("attributes")->AsMap()->FindChild("original_error_depth");
+        if (i > 0) {
+            ASSERT_TRUE(originalErrorDepth);
+            ASSERT_EQ(originalErrorDepth->GetValue<i64>(), i + ErrorSerializationDepthLimit);
+        } else {
+            ASSERT_FALSE(originalErrorDepth);
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/core/misc/unittests/ya.make
+++ b/yt/yt/core/misc/unittests/ya.make
@@ -28,6 +28,7 @@ SRCS(
     duration_moving_average_ut.cpp
     ema_counter_ut.cpp
     enum_ut.cpp
+    error_serialization_to_proto_ut.cpp
     error_ut.cpp
     fair_scheduler_ut.cpp
     fair_share_hierarchical_queue_ut.cpp


### PR DESCRIPTION

Here is the solution for the issue:
https://github.com/ytsaurus/ytsaurus/issues/1595