### PR TITLE
Remove deprecated ClientMapTimeout

### DIFF
--- a/yt/yql/plugin/config.cpp
+++ b/yt/yql/plugin/config.cpp
@@ -23,7 +23,6 @@ constexpr auto DefaultGatewaySettings = std::to_array<std::pair<TStringBuf, TStr
     {"DefaultMaxJobFails", "5"},
     {"DefaultMemoryLimit", "512m"},
     {"MapJoinLimit", "2048m"},
-    {"ClientMapTimeout", "10s"},
     {"MapJoinShardCount", "4"},
     {"CommonJoinCoreLimit", "128m"},
     {"CombineCoreLimit", "128m"},


### PR DESCRIPTION
From log:
`WARN  ytserver-yql-agent(pid=71096, tid=0x00007F173A7306C0) [default] yql_dispatch.cpp:186: Pragma "ClientMapTimeout" is deprecated and has no effect	Yql:4`
Type: fix
Component: query-tracker

https://github.com/ytsaurus/ytsaurus/blob/main/yt/yql/providers/yt/common/yql_yt_settings.cpp#L152