### PR TITLE
Add repository conditions to prevent scheduled/push/PR workflows from running in forks

### DIFF
--- a/.github/workflows/chyt_release.yaml
+++ b/.github/workflows/chyt_release.yaml
@@ -23,6 +23,7 @@ env:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -189,7 +190,7 @@ jobs:
       - release
       - push-test-to-prod
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/cpp.yaml
+++ b/.github/workflows/cpp.yaml
@@ -21,6 +21,7 @@ env:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -234,7 +235,7 @@ jobs:
       - docker-cmake
       - docker-ya-make
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1
@@ -253,7 +254,7 @@ jobs:
       - docker-ya-make
       - docker-cmake
       - build-strawberry
-    if: always()
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     uses: ./.github/workflows/check-status-and-send-alert.yaml
     with:
       is_failure: ${{ contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'ytsaurus/ytsaurus'
     permissions: write-all
     env:
       src-root: "./yt/docs"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   check:
     name: Run checks
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -58,7 +59,7 @@ jobs:
   send-alert:
     needs:
       - check
-    if: always()
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     uses: ./.github/workflows/check-status-and-send-alert.yaml
     with:
       is_failure: ${{ contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   check:
     name: Run checks
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,7 +54,7 @@ jobs:
   send-alert:
     needs:
       - check
-    if: always()
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     uses: ./.github/workflows/check-status-and-send-alert.yaml
     with:
       is_failure: ${{ contains(join(needs.*.result, ','), 'failure') }}

--- a/.github/workflows/job_environment_release.yaml
+++ b/.github/workflows/job_environment_release.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -81,7 +82,7 @@ jobs:
       - start-vm
       - release
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   create-task-for-ytsaurus-ci:
+    if: github.repository == 'ytsaurus/ytsaurus'
     uses: ./.github/workflows/ytsaurus-ci-runner.yaml
     with:
       scenario: nightly-dev

--- a/.github/workflows/python_release.yaml
+++ b/.github/workflows/python_release.yaml
@@ -12,6 +12,7 @@ env:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -211,7 +212,7 @@ jobs:
       - test_release
       - prod_release
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/query_tracker_release.yaml
+++ b/.github/workflows/query_tracker_release.yaml
@@ -23,6 +23,7 @@ env:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -189,7 +190,7 @@ jobs:
       - release
       - push-test-to-prod
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/sidecars-release.yaml
+++ b/.github/workflows/sidecars-release.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -67,7 +68,7 @@ jobs:
       - start-vm
       - release
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/strawberry_release.yaml
+++ b/.github/workflows/strawberry_release.yaml
@@ -11,6 +11,7 @@ env:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -96,7 +97,7 @@ jobs:
       - start-vm
       - release
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/ytmsvc-release.yaml
+++ b/.github/workflows/ytmsvc-release.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: ubuntu-latest
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -76,7 +77,7 @@ jobs:
       - start-vm
       - release
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1

--- a/.github/workflows/ytsaurus_release.yaml
+++ b/.github/workflows/ytsaurus_release.yaml
@@ -23,6 +23,7 @@ env:
 jobs:
   start-vm:
     name: Start VM
+    if: github.repository == 'ytsaurus/ytsaurus'
     runs-on: trampoline
     outputs:
       label: ${{ steps.start-yc-runner.outputs.label }}
@@ -190,7 +191,7 @@ jobs:
       - release
       - push-test-to-prod
     runs-on: trampoline
-    if: ${{ always() }}
+    if: always() && github.repository == 'ytsaurus/ytsaurus'
     steps:
       - name: Stop YC runner
         uses: yc-actions/yc-github-runner@v1


### PR DESCRIPTION
Scheduled, push, and PR workflows that require secrets fail silently or
error in forks where those secrets are unavailable.

Adds if: github.repository == 'ytsaurus/ytsaurus' guards to the affected jobs,
consistent with the existing pattern in cache-heater.yaml.

Co-authored-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
