### PR TITLE
yql-agent: Align default query limits with the effective thread pool cap

### DIFF
--- a/yt/yql/agent/config.cpp
+++ b/yt/yql/agent/config.cpp
@@ -32,7 +32,7 @@ void TYqlAgentConfig::Register(TRegistrar registrar)
     registrar.Parameter("issue_token_attempts", &TThis::IssueTokenAttempts)
         .Default(10);
     registrar.Parameter("yql_thread_count", &TThis::YqlThreadCount)
-        .Default(256);
+        .Default(64);
     registrar.Parameter("max_supported_yql_version", &TThis::MaxSupportedYqlVersion)
         .Default();
     registrar.Parameter("default_yql_ui_version", &TThis::DefaultYqlUIVersion)
@@ -48,7 +48,7 @@ void TYqlAgentConfig::Register(TRegistrar registrar)
 void TYqlAgentDynamicConfig::Register(TRegistrar registrar)
 {
     registrar.Parameter("max_simultaneous_queries", &TThis::MaxSimultaneousQueries)
-        .Default(128);
+        .Default(63);
     registrar.Parameter("state_check_period", &TThis::StateCheckPeriod)
         .Default(TDuration::Seconds(15));
     registrar.Parameter("gateways", &TThis::GatewaysConfig)


### PR DESCRIPTION
## Summary
- lower the default `yql_thread_count` from `256` to `64`
- lower the default `max_simultaneous_queries` from `128` to `63`

## Why
https://github.com/ytsaurus/ytsaurus/blob/2fbfbafe710ff3a5ef1f3bf42679042723756c1c/yt/yt/core/concurrency/thread_pool_detail.h#L17
The YQL agent thread pool is effectively capped at 64 threads, so the previous defaults did not match runtime behavior. Setting the defaults to 64/63 makes the shipped configuration closer to the effective limit while preserving the current concurrency guard semantics.

It also protects from thread pool overloading that we saw recently: 64 queries are running, and 64 queries are waiting to start. With new defaults 63 queries will be running, while 64th one will be throttled

