### PR TITLE
Logging: cleanup old timestamp-suffixed segments on rotation checks

### DIFF
--- a/yt/yt/core/logging/file_log_writer.cpp
+++ b/yt/yt/core/logging/file_log_writer.cpp
@@ -66,6 +66,11 @@ public:
 
     void MaybeRotate() override
     {
+        if (FirstMaybeRotate_) {
+            FirstMaybeRotate_ = false;
+            RemoveOldSegments();
+        }
+
         const auto& rotationPolicy = Config_->RotationPolicy;
         auto now = TInstant::Now();
         if ((!rotationPolicy->RotationPeriod || LastRotationTimestamp_ + *rotationPolicy->RotationPeriod > now) &&
@@ -138,6 +143,7 @@ private:
     TString FileName_;
 
     std::atomic<bool> Disabled_ = false;
+    bool FirstMaybeRotate_ = true;
     TInstant LastRotationTimestamp_;
 
     std::unique_ptr<TFile> File_;
@@ -251,7 +257,7 @@ private:
         }
     }
 
-    void Rotate()
+    void RemoveOldSegments()
     {
         try {
             auto fileNames = ListFiles();
@@ -261,8 +267,19 @@ private:
                 YT_LOG_DEBUG("Remove log segment (FilePath: %v)", filePath);
                 NFS::Remove(filePath);
             }
-            fileNames.resize(count);
+        } catch (const std::exception& ex) {
+            YT_LOG_ERROR(ex, "Failed to remove old log segments");
+        } catch (...) {
+            YT_ABORT();
+        }
+    }
 
+    void Rotate()
+    {
+        try {
+            RemoveOldSegments();
+
+            auto fileNames = ListFiles();
             RenameFiles(fileNames);
         } catch (const std::exception& ex) {
             YT_LOG_ERROR(ex, "Failed to rotate log files");

--- a/yt/yt/core/logging/unittests/logging_ut.cpp
+++ b/yt/yt/core/logging/unittests/logging_ut.cpp
@@ -1096,6 +1096,83 @@ INSTANTIATE_TEST_SUITE_P(ValueParametrized, TBuiltinRotationTest,
     std::pair(false, true),
     std::pair(false, false)));
 
+TEST_P(TBuiltinRotationTest, OldSegmentsCleanedUpWithoutRotation)
+{
+    auto [useTimestampSuffix, useLogrotateCompatibleTimestampSuffix] = GetParam();
+
+    auto logFileNamePrefix = GenerateLogFileName();
+    const int MaxSegmentCount = 3;
+    const int OldFileCount = 6;
+
+    // Create pre-existing files simulating leftovers from previous writer instances.
+    std::vector<TTempFile> oldFiles;
+    for (int index = 0; index < OldFileCount; ++index) {
+        TString fileName;
+        if (useTimestampSuffix) {
+            auto suffix = Format(".%v", TInstant::Now().ToStringLocalUpToSeconds());
+            fileName = logFileNamePrefix + suffix;
+        } else if (useLogrotateCompatibleTimestampSuffix) {
+            auto suffix = TInstant::Now().FormatLocalTime(".%Y%m%d-%H%M%S");
+            fileName = logFileNamePrefix + suffix;
+        } else {
+            fileName = Format("%v.%v", logFileNamePrefix, OldFileCount - index);
+        }
+        {
+            TFileOutput out(fileName);
+            out << Format("OldMessage%v\n", index);
+        }
+        oldFiles.emplace_back(fileName);
+        Sleep(TDuration::Seconds(1));
+    }
+
+    // Use a very long rotation period so time-based rotation never fires.
+    Configure(Format(R"({
+        rotation_check_period = 1000;
+        flush_period = 100;
+        rules = [
+            {
+                min_level = info;
+                writers = [ info ];
+            };
+        ];
+        writers = {
+            info = {
+                file_name = "%v";
+                use_timestamp_suffix = %v;
+                use_logrotate_compatible_timestamp_suffix = %v;
+                type = "file";
+                rotation_policy = {
+                    max_segment_count_to_keep = %v;
+                    rotation_period = 3600000;
+                };
+            };
+        };
+    })",
+        logFileNamePrefix,
+        ConvertToYsonString(useTimestampSuffix).AsStringBuf(),
+        ConvertToYsonString(useLogrotateCompatibleTimestampSuffix).AsStringBuf(),
+        MaxSegmentCount));
+
+    // Write a message so the writer is active.
+    WaitForPredicate([&] {
+        YT_LOG_INFO("CleanupTestMessage");
+        auto files = ListLogFiles(logFileNamePrefix, useTimestampSuffix, useLogrotateCompatibleTimestampSuffix);
+        if (files.empty()) {
+            return false;
+        }
+        return CheckPlainTextLogFileContains(files[0], "CleanupTestMessage");
+    });
+
+    // Wait for MaybeRotate() to clean up old segments.
+    WaitForPredicate([&] {
+        auto files = ListLogFiles(logFileNamePrefix, useTimestampSuffix, useLogrotateCompatibleTimestampSuffix);
+        return ssize(files) <= MaxSegmentCount;
+    });
+
+    auto files = ListLogFiles(logFileNamePrefix, useTimestampSuffix, useLogrotateCompatibleTimestampSuffix);
+    EXPECT_LE(ssize(files), MaxSegmentCount);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TAppendableZstdFileTest


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: map-reduce

Logging: cleanup old timestamp-suffixed segments on rotation checks, it fixes removing old job proxy log files.