### PR TITLE
Add job types section to operations overview documentation (en + ru)

### DIFF
--- a/yt/docs/en/_includes/user-guide/data-processing/operations/overview.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/operations/overview.md
@@ -28,7 +28,7 @@ Each operation consists of jobs of one or more types. The job type determines wh
 | Job type | Operations | Description |
 |---|---|---|
 | Map | [Map](../../../../user-guide/data-processing/operations/map.md) | Applies the user-defined mapper to a portion of the input data. |
-| OrderedMap | [Map](../../../../user-guide/data-processing/operations/map.md) (ordered mode) | Same as Map, but guarantees that input rows are delivered in order. Activated when `ordered` is set to `%true`. |
+| OrderedMap | [Map](../../../../user-guide/data-processing/operations/map.md) (ordered mode) | Same as Map, but guarantees that input rows are delivered in order. Activated when `ordered=%true` is set. |
 | Partition | [Sort](../../../../user-guide/data-processing/operations/sort.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Reads a portion of input data and distributes it across partitions based on key hash values. Used when no user-defined mapper is present. |
 | PartitionMap | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Combines the mapper with partitioning: applies the user-defined mapper and distributes the output across partitions. |
 | SimpleSort | [Sort](../../../../user-guide/data-processing/operations/sort.md) | Sorts data within a single partition when the partition is small enough to fit in one job. |
@@ -40,8 +40,8 @@ Each operation consists of jobs of one or more types. The job type determines wh
 | ReduceCombiner | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Applies a user-defined combiner to partially reduce data within large partitions before the final reduce phase. |
 | SortedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Merges already sorted input tables while preserving sort order. |
 | OrderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Merges input tables by concatenating them in a specified order. |
-| UnorderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Merges input table chunks without any ordering guarantees. Also used for auto-merging output chunks. |
-| ShallowMerge | [Auto-merge](../../../../user-guide/data-processing/operations/automerge.md) | Merges chunks at the metadata level without reading row data. Used during auto-merge of operation output. |
+| UnorderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md), [Sort](../../../../user-guide/data-processing/operations/sort.md) | Merges input table chunks without any ordering guarantees. Also used in Sort operations and for auto-merging output chunks. |
+| ShallowMerge | Used by [auto-merge feature](../../../../user-guide/data-processing/operations/automerge.md) | Merges chunks at the metadata level without reading row data. Used during auto-merge of operation output. |
 | RemoteCopy | [RemoteCopy](../../../../user-guide/data-processing/operations/remote-copy.md) | Copies data chunks from one cluster to another. |
 | Vanilla | [Vanilla](../../../../user-guide/data-processing/operations/vanilla.md) | Runs user-defined code without any predefined input/output data processing semantics. |
 

--- a/yt/docs/en/_includes/user-guide/data-processing/operations/overview.md
+++ b/yt/docs/en/_includes/user-guide/data-processing/operations/overview.md
@@ -21,6 +21,30 @@ Operations are run in **compute pools**, which are structured as a tree and serv
 
 Operations are comprised of **jobs**. Jobs as units enable the parallelism of an operation. Input data fed to an operation is divided into parts, with each such part processed by one job.
 
+## Job types { #job_types }
+
+Each operation consists of jobs of one or more types. The job type determines what kind of processing the job performs. The table below lists all scheduler job types, along with brief descriptions and which operations use them.
+
+| Job type | Operations | Description |
+|---|---|---|
+| Map | [Map](../../../../user-guide/data-processing/operations/map.md) | Applies the user-defined mapper to a portion of the input data. |
+| OrderedMap | [Map](../../../../user-guide/data-processing/operations/map.md) (ordered mode) | Same as Map, but guarantees that input rows are delivered in order. Activated when `ordered` is set to `%true`. |
+| Partition | [Sort](../../../../user-guide/data-processing/operations/sort.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Reads a portion of input data and distributes it across partitions based on key hash values. Used when no user-defined mapper is present. |
+| PartitionMap | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Combines the mapper with partitioning: applies the user-defined mapper and distributes the output across partitions. |
+| SimpleSort | [Sort](../../../../user-guide/data-processing/operations/sort.md) | Sorts data within a single partition when the partition is small enough to fit in one job. |
+| IntermediateSort | [Sort](../../../../user-guide/data-processing/operations/sort.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Sorts parts of a partition when the partition is too large for a single SimpleSort job. |
+| FinalSort | [Sort](../../../../user-guide/data-processing/operations/sort.md) | Merges sorted parts of a partition in the final stage of sorting. |
+| PartitionReduce | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Sorts a small partition in memory and applies the reducer to it. |
+| SortedReduce | [Reduce](../../../../user-guide/data-processing/operations/reduce.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Merges sorted streams and applies the user-defined reducer to each group of rows sharing the same key. |
+| JoinReduce | [Reduce](../../../../user-guide/data-processing/operations/reduce.md) | A variant of SortedReduce used when the operation has foreign (join) input tables. |
+| ReduceCombiner | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Applies a user-defined combiner to partially reduce data within large partitions before the final reduce phase. |
+| SortedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Merges already sorted input tables while preserving sort order. |
+| OrderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Merges input tables by concatenating them in a specified order. |
+| UnorderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Merges input table chunks without any ordering guarantees. Also used for auto-merging output chunks. |
+| ShallowMerge | [Auto-merge](../../../../user-guide/data-processing/operations/automerge.md) | Merges chunks at the metadata level without reading row data. Used during auto-merge of operation output. |
+| RemoteCopy | [RemoteCopy](../../../../user-guide/data-processing/operations/remote-copy.md) | Copies data chunks from one cluster to another. |
+| Vanilla | [Vanilla](../../../../user-guide/data-processing/operations/vanilla.md) | Runs user-defined code without any predefined input/output data processing semantics. |
+
 ## Parameters of a running operation
 
 {% note info "Note" %}

--- a/yt/docs/ru/_includes/user-guide/data-processing/operations/overview.md
+++ b/yt/docs/ru/_includes/user-guide/data-processing/operations/overview.md
@@ -28,7 +28,7 @@
 | Тип джоба | Операции | Описание |
 |---|---|---|
 | Map | [Map](../../../../user-guide/data-processing/operations/map.md) | Применяет пользовательский маппер к части входных данных. |
-| OrderedMap | [Map](../../../../user-guide/data-processing/operations/map.md) (упорядоченный режим) | Аналогичен Map, но гарантирует, что входные строки поступают в определённом порядке. Активируется при `ordered` = `%true`. |
+| OrderedMap | [Map](../../../../user-guide/data-processing/operations/map.md) (упорядоченный режим) | Аналогичен Map, но гарантирует, что входные строки поступают в определённом порядке. Активируется при `ordered=%true`. |
 | Partition | [Sort](../../../../user-guide/data-processing/operations/sort.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Читает часть входных данных и распределяет их по партициям на основе хеша ключа. Используется при отсутствии пользовательского маппера. |
 | PartitionMap | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Совмещает маппер с партиционированием: применяет пользовательский маппер и распределяет результат по партициям. |
 | SimpleSort | [Sort](../../../../user-guide/data-processing/operations/sort.md) | Сортирует данные внутри одной партиции, если она достаточно мала для обработки одним джобом. |
@@ -38,10 +38,10 @@
 | SortedReduce | [Reduce](../../../../user-guide/data-processing/operations/reduce.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Сливает отсортированные потоки и применяет пользовательский редьюсер к каждой группе строк с одинаковым ключом. |
 | JoinReduce | [Reduce](../../../../user-guide/data-processing/operations/reduce.md) | Вариант SortedReduce, используемый при наличии внешних (foreign) входных таблиц. |
 | ReduceCombiner | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Применяет пользовательский комбайнер для частичной редукции данных в больших партициях перед финальной фазой reduce. |
-| SortedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает уже отсортированные входные таблицы с сохранением порядка сортировки. |
+| SortedMerge | [Sort](../../../../user-guide/data-processing/operations/sort.md), [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает уже отсортированные входные таблицы с сохранением порядка сортировки. |
 | OrderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает входные таблицы путём конкатенации в указанном порядке. |
-| UnorderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает чанки входных таблиц без гарантий порядка. Также используется для автоматического слияния выходных чанков. |
-| ShallowMerge | [Auto-merge](../../../../user-guide/data-processing/operations/automerge.md) | Сливает чанки на уровне метаданных без чтения данных строк. Используется при автоматическом слиянии выходных данных операции. |
+| UnorderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md), [Sort](../../../../user-guide/data-processing/operations/sort.md) | Сливает чанки входных таблиц без гарантий порядка. Также используется для автоматического слияния выходных чанков. |
+| ShallowMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md), [автоматическое слияние чанков](../../../../user-guide/data-processing/operations/automerge.md) | Сливает чанки на уровне метаданных без чтения данных строк. Используется при автоматическом слиянии выходных данных операции. |
 | RemoteCopy | [RemoteCopy](../../../../user-guide/data-processing/operations/remote-copy.md) | Копирует чанки данных с одного кластера на другой. |
 | Vanilla | [Vanilla](../../../../user-guide/data-processing/operations/vanilla.md) | Запускает пользовательский код без предопределённой семантики обработки входных/выходных данных. |
 

--- a/yt/docs/ru/_includes/user-guide/data-processing/operations/overview.md
+++ b/yt/docs/ru/_includes/user-guide/data-processing/operations/overview.md
@@ -21,6 +21,30 @@
 
 В рамках операции выполняются **джобы** (jobs). Джобы являются единицей параллелизма операции. Входные данные операции делятся на части. Каждая часть входных данных обрабатывается одним джобом.
 
+## Типы джобов { #job_types }
+
+Каждая операция состоит из джобов одного или нескольких типов. Тип джоба определяет, какую обработку выполняет данный джоб. В таблице ниже перечислены все типы джобов планировщика с кратким описанием и указанием, какие операции их используют.
+
+| Тип джоба | Операции | Описание |
+|---|---|---|
+| Map | [Map](../../../../user-guide/data-processing/operations/map.md) | Применяет пользовательский маппер к части входных данных. |
+| OrderedMap | [Map](../../../../user-guide/data-processing/operations/map.md) (упорядоченный режим) | Аналогичен Map, но гарантирует, что входные строки поступают в определённом порядке. Активируется при `ordered` = `%true`. |
+| Partition | [Sort](../../../../user-guide/data-processing/operations/sort.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Читает часть входных данных и распределяет их по партициям на основе хеша ключа. Используется при отсутствии пользовательского маппера. |
+| PartitionMap | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Совмещает маппер с партиционированием: применяет пользовательский маппер и распределяет результат по партициям. |
+| SimpleSort | [Sort](../../../../user-guide/data-processing/operations/sort.md) | Сортирует данные внутри одной партиции, если она достаточно мала для обработки одним джобом. |
+| IntermediateSort | [Sort](../../../../user-guide/data-processing/operations/sort.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Сортирует части партиции, если она слишком велика для одного джоба SimpleSort. |
+| FinalSort | [Sort](../../../../user-guide/data-processing/operations/sort.md) | Сливает отсортированные части партиции на финальном этапе сортировки. |
+| PartitionReduce | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Сортирует маленькую партицию в памяти и применяет к ней редьюсер. |
+| SortedReduce | [Reduce](../../../../user-guide/data-processing/operations/reduce.md), [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Сливает отсортированные потоки и применяет пользовательский редьюсер к каждой группе строк с одинаковым ключом. |
+| JoinReduce | [Reduce](../../../../user-guide/data-processing/operations/reduce.md) | Вариант SortedReduce, используемый при наличии внешних (foreign) входных таблиц. |
+| ReduceCombiner | [MapReduce](../../../../user-guide/data-processing/operations/mapreduce.md) | Применяет пользовательский комбайнер для частичной редукции данных в больших партициях перед финальной фазой reduce. |
+| SortedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает уже отсортированные входные таблицы с сохранением порядка сортировки. |
+| OrderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает входные таблицы путём конкатенации в указанном порядке. |
+| UnorderedMerge | [Merge](../../../../user-guide/data-processing/operations/merge.md) | Сливает чанки входных таблиц без гарантий порядка. Также используется для автоматического слияния выходных чанков. |
+| ShallowMerge | [Auto-merge](../../../../user-guide/data-processing/operations/automerge.md) | Сливает чанки на уровне метаданных без чтения данных строк. Используется при автоматическом слиянии выходных данных операции. |
+| RemoteCopy | [RemoteCopy](../../../../user-guide/data-processing/operations/remote-copy.md) | Копирует чанки данных с одного кластера на другой. |
+| Vanilla | [Vanilla](../../../../user-guide/data-processing/operations/vanilla.md) | Запускает пользовательский код без предопределённой семантики обработки входных/выходных данных. |
+
 ## Параметры запущенной операции
 
 {% note info "Примечание" %}


### PR DESCRIPTION
Added a "Job types" section to the operations overview documentation in both English and Russian (yt/docs/en/_includes/ and yt/docs/ru/_includes/). The new section is placed right after the existing paragraph about jobs and before "Parameters of a running operation".

The section contains a table listing all 17 scheduler job types from the EJobType enum (yt/yt/client/job_tracker_client/public.h), with:

Job type name (matching the enum values)
Operations that use each job type (with links to the respective operation docs) Brief description of what each job type does

Job types covered:
Map, OrderedMap, Partition, PartitionMap,
SimpleSort, IntermediateSort, FinalSort,
PartitionReduce, SortedReduce, JoinReduce, ReduceCombiner, SortedMerge, OrderedMerge, UnorderedMerge, ShallowMerge, RemoteCopy, and Vanilla.

Internal/system job types (SchedulerUnknown, master jobs) were intentionally excluded as they are not user-facing.