### PR TITLE
Add HLL tests and activate HLL as aggregate column

### DIFF
--- a/yt/yt/client/table_client/schema.cpp
+++ b/yt/yt/client/table_client/schema.cpp
@@ -1979,9 +1979,6 @@ void ValidateColumnSchema(
             "dict_sum",
         };
         for (int precision = 7; precision <= 14; ++precision) {
-            result.insert(Format("hll_%v", precision));
-            result.insert(Format("hll_%v_state", precision));
-            result.insert(Format("hll_%v_merge", precision));
             result.insert(Format("hll_%v_merge_state", precision));
         }
         return result;

--- a/yt/yt/client/table_client/schema.cpp
+++ b/yt/yt/client/table_client/schema.cpp
@@ -1967,16 +1967,25 @@ void ValidateColumnSchema(
     bool isTableDynamic,
     const TSchemaValidationOptions& options)
 {
-    static const auto allowedAggregates = THashSet<std::string, THash<TStringBuf>, TEqualTo<>>{
-        "sum",
-        "min",
-        "max",
-        "first",
-        "xdelta",
-        "_yt_stored_replica_set",
-        "_yt_last_seen_replica_set",
-        "dict_sum",
-    };
+    static const auto allowedAggregates = [] {
+        auto result = THashSet<std::string, THash<TStringBuf>, TEqualTo<>>{
+            "sum",
+            "min",
+            "max",
+            "first",
+            "xdelta",
+            "_yt_stored_replica_set",
+            "_yt_last_seen_replica_set",
+            "dict_sum",
+        };
+        for (int precision = 7; precision <= 14; ++precision) {
+            result.insert(Format("hll_%v", precision));
+            result.insert(Format("hll_%v_state", precision));
+            result.insert(Format("hll_%v_merge", precision));
+            result.insert(Format("hll_%v_merge_state", precision));
+        }
+        return result;
+    }();
 
     static const auto allowedNestedAggregates = THashSet<std::string, THash<TStringBuf>, TEqualTo<>>{
         "sum",

--- a/yt/yt/client/unittests/schema_ut.cpp
+++ b/yt/yt/client/unittests/schema_ut.cpp
@@ -327,6 +327,36 @@ TEST(TTableSchemaTest, ColumnSchemaValidation)
         TColumnSchema("Name", EValueType::String)
             .SetAggregate(std::string("sum")));
 
+    // HLL aggregate columns.
+    for (int precision = 7; precision <= 14; ++precision) {
+        ValidateColumnSchema(
+            TColumnSchema("Name", EValueType::String)
+                .SetAggregate(Format("hll_%v", precision)));
+        ValidateColumnSchema(
+            TColumnSchema("Name", EValueType::String)
+                .SetAggregate(Format("hll_%v_state", precision)));
+        ValidateColumnSchema(
+            TColumnSchema("Name", EValueType::String)
+                .SetAggregate(Format("hll_%v_merge", precision)));
+        ValidateColumnSchema(
+            TColumnSchema("Name", EValueType::String)
+                .SetAggregate(Format("hll_%v_merge_state", precision)));
+    }
+
+    // Invalid aggregate function names.
+    expectBad(
+        TColumnSchema("Name", EValueType::String)
+            .SetAggregate(std::string("cardinality")));
+    expectBad(
+        TColumnSchema("Name", EValueType::String)
+            .SetAggregate(std::string("avg")));
+    expectBad(
+        TColumnSchema("Name", EValueType::String)
+            .SetAggregate(std::string("hll_5_merge_state")));
+    expectBad(
+        TColumnSchema("Name", EValueType::String)
+            .SetAggregate(std::string("hll_15_merge_state")));
+
     // Struct field validation
     expectBad(
         TColumnSchema("Column", StructLogicalType({

--- a/yt/yt/library/query/engine/udf/hyperloglog.cpp
+++ b/yt/yt/library/query/engine/udf/hyperloglog.cpp
@@ -144,29 +144,43 @@ extern "C" uint64_t HyperLogLogGetFingerprint(TUnversionedValue* value);
     } \
 \
     extern "C" void hll_ ## PRECISION ## _merge_state_update( \
-        TExpressionContext* /*context*/, \
+        TExpressionContext* context, \
         TUnversionedValue* result, \
         TUnversionedValue* state, \
         TUnversionedValue* newValue) \
     { \
-        result->Type = EValueType::String; \
-        result->Length = state->Length; \
-        result->Data.String = state->Data.String; \
-\
-        HyperLogLogMergeWithValidation ## PRECISION(state->Data.String, newValue->Data.String, newValue->Length); \
+        if (newValue->Type == EValueType::Null) { \
+            *result = *state; \
+            return; \
+        } \
+        if (state->Type == EValueType::Null) { \
+            HyperLogLogAllocate ## PRECISION(context, result); \
+        } else { \
+            result->Type = EValueType::String; \
+            result->Length = state->Length; \
+            result->Data.String = state->Data.String; \
+        } \
+        HyperLogLogMergeWithValidation ## PRECISION(result->Data.String, newValue->Data.String, newValue->Length); \
     } \
 \
     extern "C" void hll_ ## PRECISION ## _merge_state_merge( \
-        TExpressionContext* /*context*/, \
+        TExpressionContext* context, \
         TUnversionedValue* result, \
         TUnversionedValue* state1, \
         TUnversionedValue* state2) \
     { \
-        result->Type = EValueType::String; \
-        result->Length = state1->Length; \
-        result->Data.String = state1->Data.String; \
-\
-        HyperLogLogMerge ## PRECISION(state1->Data.String, state2->Data.String); \
+        if (state2->Type == EValueType::Null) { \
+            *result = *state1; \
+            return; \
+        } \
+        if (state1->Type == EValueType::Null) { \
+            HyperLogLogAllocate ## PRECISION(context, result); \
+        } else { \
+            result->Type = EValueType::String; \
+            result->Length = state1->Length; \
+            result->Data.String = state1->Data.String; \
+        } \
+        HyperLogLogMerge ## PRECISION(result->Data.String, state2->Data.String); \
     } \
 \
     extern "C" void hll_ ## PRECISION ## _merge_state_finalize( \

--- a/yt/yt/tests/integration/dynamic_tables/test_aggregate_columns.py
+++ b/yt/yt/tests/integration/dynamic_tables/test_aggregate_columns.py
@@ -2,7 +2,7 @@ from .test_sorted_dynamic_tables import TestSortedDynamicTablesBase
 
 from yt_commands import (
     authors,
-    create, create_dynamic_table, alter_table, read_table,
+    create, create_dynamic_table, alter_table, read_table, write_table,
     start_transaction, commit_transaction,
     lookup_rows, select_rows, insert_rows, delete_rows,
     sync_create_cells, sync_mount_table, sync_flush_table, sync_compact_table, sync_unmount_table)
@@ -365,6 +365,379 @@ class TestAggregateColumns(TestSortedDynamicTablesBase):
         sync_create_cells(1)
         with pytest.raises(YtError):
             self._create_table_with_aggregate_column("//tmp/t", aggregate=aggregate)
+
+    @authors("abatovkin")
+    @pytest.mark.parametrize("precision", [7, 10, 14])
+    def test_aggregate_hll(self, precision):
+        sync_create_cells(1)
+
+        register_count = 1 << precision
+
+        def make_empty_hll():
+            return b"\x00" * register_count
+
+        def hll_add(state, fingerprint):
+            registers = bytearray(state)
+            fingerprint |= (1 << 63)
+            index = fingerprint & (register_count - 1)
+            shifted = fingerprint >> precision
+            zeroes_plus_one = 0
+            while zeroes_plus_one < 64 and (shifted & 1) == 0:
+                shifted >>= 1
+                zeroes_plus_one += 1
+            zeroes_plus_one += 1
+            if registers[index] < zeroes_plus_one:
+                registers[index] = zeroes_plus_one
+            return bytes(registers)
+
+        def hll_merge(state1, state2):
+            r1 = bytearray(state1)
+            r2 = bytearray(state2)
+            return bytes(max(a, b) for a, b in zip(r1, r2))
+
+        def farm_hash_int64(value):
+            # Use a simple hash for test purposes; the exact hash function
+            # does not matter as long as we are consistent within the test
+            import hashlib
+            h = hashlib.md5(str(value).encode()).digest()
+            return int.from_bytes(h[:8], "little")
+
+        aggregate_name = "hll_{}_merge_state".format(precision)
+
+        schema = [
+            {"name": "key", "type": "int64", "sort_order": "ascending"},
+            {"name": "hll_state", "type": "string", "aggregate": aggregate_name},
+        ]
+        create_dynamic_table("//tmp/t_hll", schema=schema)
+        sync_mount_table("//tmp/t_hll")
+
+        hll1 = make_empty_hll()
+        for i in range(100):
+            hll1 = hll_add(hll1, farm_hash_int64(i))
+
+        hll2 = make_empty_hll()
+        for i in range(50, 150):
+            hll2 = hll_add(hll2, farm_hash_int64(i))
+
+        insert_rows("//tmp/t_hll", [{"key": 1, "hll_state": hll1}], aggregate=True)
+        insert_rows("//tmp/t_hll", [{"key": 1, "hll_state": hll2}], aggregate=True)
+
+        expected_merged = hll_merge(hll1, hll2)
+
+        rows = lookup_rows("//tmp/t_hll", [{"key": 1}])
+        assert len(rows) == 1
+        actual_state = get_bytes(rows[0]["hll_state"])
+        assert actual_state == expected_merged
+
+        sync_flush_table("//tmp/t_hll")
+
+        rows = lookup_rows("//tmp/t_hll", [{"key": 1}])
+        assert len(rows) == 1
+        actual_state = get_bytes(rows[0]["hll_state"])
+        assert actual_state == expected_merged
+
+        hll3 = make_empty_hll()
+        for i in range(200, 300):
+            hll3 = hll_add(hll3, farm_hash_int64(i))
+
+        insert_rows("//tmp/t_hll", [{"key": 1, "hll_state": hll3}], aggregate=True)
+        expected_merged = hll_merge(expected_merged, hll3)
+
+        sync_flush_table("//tmp/t_hll")
+        sync_compact_table("//tmp/t_hll")
+
+        rows = lookup_rows("//tmp/t_hll", [{"key": 1}])
+        assert len(rows) == 1
+        actual_state = get_bytes(rows[0]["hll_state"])
+        assert actual_state == expected_merged
+
+    @authors("abatovkin")
+    def test_aggregate_hll_overwrite(self):
+        """Test that writing without aggregate flag overwrites the HLL state."""
+        sync_create_cells(1)
+
+        precision = 14
+        register_count = 1 << precision
+
+        def make_empty_hll():
+            return b"\x00" * register_count
+
+        def hll_add(state, fingerprint):
+            registers = bytearray(state)
+            fingerprint |= (1 << 63)
+            index = fingerprint & (register_count - 1)
+            shifted = fingerprint >> precision
+            zeroes_plus_one = 0
+            while zeroes_plus_one < 64 and (shifted & 1) == 0:
+                shifted >>= 1
+                zeroes_plus_one += 1
+            zeroes_plus_one += 1
+            if registers[index] < zeroes_plus_one:
+                registers[index] = zeroes_plus_one
+            return bytes(registers)
+
+        schema = [
+            {"name": "key", "type": "int64", "sort_order": "ascending"},
+            {"name": "hll_state", "type": "string", "aggregate": "hll_14_merge_state"},
+        ]
+        create_dynamic_table("//tmp/t_hll_overwrite", schema=schema)
+        sync_mount_table("//tmp/t_hll_overwrite")
+
+        hll1 = make_empty_hll()
+        for i in range(100):
+            hll1 = hll_add(hll1, i * 997)
+
+        insert_rows("//tmp/t_hll_overwrite", [{"key": 1, "hll_state": hll1}], aggregate=True)
+
+        hll2 = make_empty_hll()
+        for i in range(5):
+            hll2 = hll_add(hll2, i * 31)
+
+        insert_rows("//tmp/t_hll_overwrite", [{"key": 1, "hll_state": hll2}])
+
+        rows = lookup_rows("//tmp/t_hll_overwrite", [{"key": 1}])
+        assert len(rows) == 1
+        actual_state = get_bytes(rows[0]["hll_state"])
+        assert actual_state == hll2
+
+    @authors("abatovkin")
+    def test_aggregate_hll_multiple_keys(self):
+        """Test HLL aggregate columns with multiple keys."""
+        sync_create_cells(1)
+
+        precision = 7
+        register_count = 1 << precision
+
+        def make_empty_hll():
+            return b"\x00" * register_count
+
+        def hll_add(state, fingerprint):
+            registers = bytearray(state)
+            fingerprint |= (1 << 63)
+            index = fingerprint & (register_count - 1)
+            shifted = fingerprint >> precision
+            zeroes_plus_one = 0
+            while zeroes_plus_one < 64 and (shifted & 1) == 0:
+                shifted >>= 1
+                zeroes_plus_one += 1
+            zeroes_plus_one += 1
+            if registers[index] < zeroes_plus_one:
+                registers[index] = zeroes_plus_one
+            return bytes(registers)
+
+        def hll_merge(state1, state2):
+            return bytes(max(a, b) for a, b in zip(bytearray(state1), bytearray(state2)))
+
+        schema = [
+            {"name": "key", "type": "int64", "sort_order": "ascending"},
+            {"name": "hll_state", "type": "string", "aggregate": "hll_7_merge_state"},
+        ]
+        create_dynamic_table("//tmp/t_hll_multi", schema=schema)
+        sync_mount_table("//tmp/t_hll_multi")
+
+        states = {}
+        for key in range(3):
+            hll = make_empty_hll()
+            for i in range(50):
+                hll = hll_add(hll, (key + 1) * 1000 + i)
+            states[key] = hll
+            insert_rows("//tmp/t_hll_multi", [{"key": key, "hll_state": hll}], aggregate=True)
+
+        hll_extra_0 = make_empty_hll()
+        for i in range(50, 100):
+            hll_extra_0 = hll_add(hll_extra_0, 1000 + i)
+        insert_rows("//tmp/t_hll_multi", [{"key": 0, "hll_state": hll_extra_0}], aggregate=True)
+        states[0] = hll_merge(states[0], hll_extra_0)
+
+        hll_extra_2 = make_empty_hll()
+        for i in range(50, 100):
+            hll_extra_2 = hll_add(hll_extra_2, 3000 + i)
+        insert_rows("//tmp/t_hll_multi", [{"key": 2, "hll_state": hll_extra_2}], aggregate=True)
+        states[2] = hll_merge(states[2], hll_extra_2)
+
+        for key in range(3):
+            rows = lookup_rows("//tmp/t_hll_multi", [{"key": key}])
+            assert len(rows) == 1
+            actual_state = get_bytes(rows[0]["hll_state"])
+            assert actual_state == states[key]
+
+        sync_flush_table("//tmp/t_hll_multi")
+        sync_compact_table("//tmp/t_hll_multi")
+
+        for key in range(3):
+            rows = lookup_rows("//tmp/t_hll_multi", [{"key": key}])
+            assert len(rows) == 1
+            actual_state = get_bytes(rows[0]["hll_state"])
+            assert actual_state == states[key]
+
+    @authors("abatovkin")
+    @pytest.mark.parametrize("precision", [7, 14])
+    def test_aggregate_hll_cardinality_estimation(self, precision):
+        """End-to-end test: build HLL from raw values, insert as aggregate column,
+        merge across multiple writes/flush/compaction, and verify cardinality estimate."""
+        import hashlib
+        import math
+
+        sync_create_cells(1)
+
+        register_count = 1 << precision
+
+        def farm_hash(value):
+            h = hashlib.md5(str(value).encode()).digest()
+            return int.from_bytes(h[:8], "little")
+
+        def make_empty_hll():
+            return bytearray(register_count)
+
+        def hll_add(state, raw_value):
+            fingerprint = farm_hash(raw_value)
+            fingerprint |= (1 << 63)
+            index = fingerprint & (register_count - 1)
+            shifted = fingerprint >> precision
+            zeroes_plus_one = 0
+            while zeroes_plus_one < 64 and (shifted & 1) == 0:
+                shifted >>= 1
+                zeroes_plus_one += 1
+            zeroes_plus_one += 1
+            if state[index] < zeroes_plus_one:
+                state[index] = zeroes_plus_one
+
+        def hll_estimate(state):
+            m = register_count
+            alpha = 0.7213 / (1.0 + 1.079 / m)
+            raw = alpha * m * m / sum(2.0 ** (-r) for r in state)
+            # small range correction
+            zeros = sum(1 for r in state if r == 0)
+            if raw <= 2.5 * m and zeros > 0:
+                return m * math.log(m / zeros)
+            return raw
+
+        aggregate_name = "hll_{}_merge_state".format(precision)
+        schema = [
+            {"name": "key", "type": "int64", "sort_order": "ascending"},
+            {"name": "hll_state", "type": "string", "aggregate": aggregate_name},
+        ]
+        create_dynamic_table("//tmp/t_hll_card", schema=schema)
+        sync_mount_table("//tmp/t_hll_card")
+
+        # Simulate 3 batches of user visits:
+        # batch 1: users 0..999 (1000 unique)
+        # batch 2: users 500..1499 (500 new, 500 overlap)
+        # batch 3: users 1000..1999 (500 new, 500 overlap)
+        # Total unique: 2000
+        batches = [
+            range(0, 1000),
+            range(500, 1500),
+            range(1000, 2000),
+        ]
+
+        for batch in batches:
+            hll = make_empty_hll()
+            for user_id in batch:
+                hll_add(hll, user_id)
+            insert_rows("//tmp/t_hll_card", [{"key": 1, "hll_state": bytes(hll)}], aggregate=True)
+
+        rows = lookup_rows("//tmp/t_hll_card", [{"key": 1}])
+        estimate = hll_estimate(get_bytes(rows[0]["hll_state"]))
+        # HLL with precision 7 (128 registers) has ~9% standard error,
+        # but our simplified estimator (no bias correction) can deviate more.
+        # HLL with precision 14 (16384 registers) has ~0.8% standard error.
+        max_error = 0.20 if precision == 7 else 0.05
+        assert abs(estimate - 2000) / 2000 < max_error, \
+            "Cardinality estimate {} is too far from expected 2000 (error: {:.1%})".format(
+                estimate, abs(estimate - 2000) / 2000)
+
+        sync_flush_table("//tmp/t_hll_card")
+        sync_compact_table("//tmp/t_hll_card")
+
+        rows = lookup_rows("//tmp/t_hll_card", [{"key": 1}])
+        estimate_after_compact = hll_estimate(get_bytes(rows[0]["hll_state"]))
+        assert estimate_after_compact == estimate, \
+            "Cardinality changed after compaction: {} -> {}".format(estimate, estimate_after_compact)
+
+    @authors("abatovkin")
+    def test_aggregate_hll_batch_states_for_realtime_counters(self):
+        """Build per-batch HLL states from raw events, merge them via an aggregate column,
+        and query approximate unique users from the accumulated state."""
+        sync_create_cells(1)
+
+        create_dynamic_table("//tmp/hll_batches", schema=[
+            {"name": "batch_id", "type": "int64", "sort_order": "ascending"},
+            {"name": "counter_id", "type": "int64", "sort_order": "ascending"},
+            {"name": "user_id", "type": "int64", "sort_order": "ascending"},
+            {"name": "event_count", "type": "int64"},
+        ], enable_dynamic_store_read=True)
+        sync_mount_table("//tmp/hll_batches")
+
+        batches = {
+            0: {1: range(0, 10), 2: range(100, 110)},
+            1: {1: range(5, 15), 2: range(103, 113)},
+            2: {1: range(10, 20), 2: range(106, 116)},
+            3: {1: range(15, 25), 2: range(109, 119)},
+        }
+
+        source_rows = []
+        for batch_id, counters in batches.items():
+            for counter_id, users in counters.items():
+                for user_id in users:
+                    source_rows.append({
+                        "counter_id": counter_id,
+                        "batch_id": batch_id,
+                        "user_id": user_id,
+                        "event_count": 1,
+                    })
+        insert_rows("//tmp/hll_batches", source_rows)
+
+        schema = [
+            {"name": "counter_id", "type": "int64", "sort_order": "ascending"},
+            {"name": "users_hll_state", "type": "string", "aggregate": "hll_14_merge_state"},
+        ]
+        create_dynamic_table("//tmp/hll_counters", schema=schema)
+        sync_mount_table("//tmp/hll_counters")
+
+        exact_users = {1: set(), 2: set()}
+
+        def get_estimates():
+            return select_rows(
+                "counter_id, cardinality_merge(users_hll_state) as approx_users "
+                "from [//tmp/hll_counters] group by counter_id order by counter_id limit 1000"
+            )
+
+        for batch_id in sorted(batches):
+            batch_states = select_rows(
+                "counter_id, cardinality_state(user_id) as users_hll_state "
+                "from [//tmp/hll_batches] "
+                "where batch_id = {} "
+                "group by counter_id".format(batch_id)
+            )
+            insert_rows("//tmp/hll_counters", batch_states, aggregate=True)
+
+            for counter_id, users in batches[batch_id].items():
+                exact_users[counter_id].update(users)
+
+            estimate_rows = get_estimates()
+            assert len(estimate_rows) == 2
+            for row in estimate_rows:
+                expected = len(exact_users[row["counter_id"]])
+                assert abs(row["approx_users"] - expected) <= 2, \
+                    "Unexpected estimate after batch {} for counter {}: {} vs {}".format(
+                        batch_id, row["counter_id"], row["approx_users"], expected)
+
+        rows = lookup_rows("//tmp/hll_counters", [{"counter_id": 1}, {"counter_id": 2}])
+        assert len(rows) == 2
+
+        estimate_rows_before_compact = get_estimates()
+
+        sync_flush_table("//tmp/hll_counters")
+        sync_compact_table("//tmp/hll_counters")
+
+        estimate_rows = get_estimates()
+        assert estimate_rows == estimate_rows_before_compact
+        for row in estimate_rows:
+            expected = 25 if row["counter_id"] == 1 else 19
+            assert abs(row["approx_users"] - expected) <= 2, \
+                "Unexpected estimate after compaction for counter {}: {} vs {}".format(
+                    row["counter_id"], row["approx_users"], expected)
 
     @authors("leasid")
     def test_aggregate_xdelta(self):


### PR DESCRIPTION
Ytsaurus already has functionality for implementing hyperloglog, but it has not been utilized for creating aggregate columns and corresponding tests. This PR changes that by allowing hyperloglog to be used as an aggregate column, which will be useful for implementing unique counters

---

Type: feature
Component: dynamic tables / cypress master