### PR TITLE
Fix nil-pointer panic in CreateQueueProducerSession when opts is not provided

### DIFF
--- a/yt/go/yt/internal/rpcclient/encoder.go
+++ b/yt/go/yt/internal/rpcclient/encoder.go
@@ -740,6 +740,11 @@ func (e *Encoder) CreateQueueProducerSession(
 	sessionID string,
 	opts *yt.CreateQueueProducerSessionOptions,
 ) (result *yt.CreateQueueProducerSessionResult, err error) {
+
+	if opts == nil {
+		opts = &yt.CreateQueueProducerSessionOptions{}
+	}
+
 	req := &rpc_proxy.TReqCreateQueueProducerSession{
 		ProducerPath:    []byte(producerPath.String()),
 		QueuePath:       []byte(queuePath.String()),


### PR DESCRIPTION
This PR fixes a potential nil-pointer dereference in the Go SDK.

In Encoder.CreateQueueProducerSession we access opts.MutatingOptions, but opts is allowed to be nil by the public API. When the caller passes nil, the code panics.

Change:
- Initialize opts with an empty yt.CreateQueueProducerSessionOptions when opts == nil, so subsequent field access is safe.

Refs: #1678

* Changelog entry
Type: fix
Component: yt/go/yt/internal/rpcclient/encoder.go:736

Prevent nil-pointer panic in CreateQueueProducerSession by handling nil options (opts == nil).




