### PR TITLE
Fix Missing start_row_index in HTTP API response for pull_queue_consumer and pull_queue

### DIFF
--- a/yt/yt/client/driver/queue_commands.cpp
+++ b/yt/yt/client/driver/queue_commands.cpp
@@ -180,7 +180,7 @@ void TPullQueueCommand::DoExecute(ICommandContextPtr context)
 
     ProduceResponseParameters(context, [&] (IYsonConsumer* consumer) {
         BuildYsonMapFragmentFluently(consumer)
-            .Item("start_row_index").Value(result->GetStartOffset());
+            .Item("start_offset").Value(result->GetStartOffset());
     });
 
     auto format = context->GetOutputFormat();
@@ -255,7 +255,7 @@ void TPullQueueConsumerCommand::DoExecute(ICommandContextPtr context)
 
     ProduceResponseParameters(context, [&] (IYsonConsumer* consumer) {
         BuildYsonMapFragmentFluently(consumer)
-            .Item("start_row_index").Value(result->GetStartOffset());
+            .Item("start_offset").Value(result->GetStartOffset());
     });
 
     auto format = context->GetOutputFormat();

--- a/yt/yt/client/driver/queue_commands.cpp
+++ b/yt/yt/client/driver/queue_commands.cpp
@@ -248,6 +248,11 @@ void TPullQueueConsumerCommand::DoExecute(ICommandContextPtr context)
         Options))
         .ValueOrThrow();
 
+    ProduceResponseParameters(context, [&] (IYsonConsumer* consumer) {
+        BuildYsonMapFragmentFluently(consumer)
+            .Item("start_row_index").Value(result->GetStartOffset());
+    });
+
     auto format = context->GetOutputFormat();
     auto output = context->Request().OutputStream;
     auto writer = CreateSchemafulWriterForFormat(format, result->GetSchema(), output);

--- a/yt/yt/client/driver/queue_commands.cpp
+++ b/yt/yt/client/driver/queue_commands.cpp
@@ -178,6 +178,11 @@ void TPullQueueCommand::DoExecute(ICommandContextPtr context)
         Options))
         .ValueOrThrow();
 
+    ProduceResponseParameters(context, [&] (IYsonConsumer* consumer) {
+        BuildYsonMapFragmentFluently(consumer)
+            .Item("start_row_index").Value(result->GetStartOffset());
+    });
+
     auto format = context->GetOutputFormat();
     auto output = context->Request().OutputStream;
     auto writer = CreateSchemafulWriterForFormat(format, result->GetSchema(), output);


### PR DESCRIPTION
## Summary

Fix HTTP API to return `start_row_index` in response parameters for `pull_queue` and `pull_queue_consumer` commands.

Previously, only RPC API returned `start_offset` in the response, while HTTP API did not provide this information to clients. This caused Go SDK HTTP client to always return `StartOffset = 0` for `PullQueueConsumer`.

Closes #1680.

## Changes

Added `ProduceResponseParameters` call to return `start_row_index` in HTTP response headers for:

- `TPullQueueCommand` - reads from queue directly
- `TPullQueueConsumerCommand` - reads from queue via consumer authorization

This matches the behavior of `read_table` command, which already returns `start_row_index` in response parameters.

## Implementation

**File:** `yt/yt/client/driver/queue_commands.cpp`

```cpp
ProduceResponseParameters(context, [&] (IYsonConsumer* consumer) {
    BuildYsonMapFragmentFluently(consumer)
        .Item("start_row_index").Value(result->GetStartOffset());
});
```

## Test Plan

- Build passes: `./ya make yt/yt/client/driver`
- No HTTP-specific tests added - existing Python integration tests don't support `response_parameters` for queue commands, and adding such support is out of scope for this fix
- The changes are minimal (5 lines per command) and follow the same pattern as `read_table`, so they should not break existing functionality

---

* Changelog entry
Type: fix
Component: misc-server
Fixed HTTP API for `pull_queue` and `pull_queue_consumer` commands to return `start_row_index` in response parameters, matching RPC API behavior.
