### PR TITLE
yt/yt/core/http: throw TransportError at reusing stale connection

### DIFF
--- a/yt/yt/core/http/stream.cpp
+++ b/yt/yt/core/http/stream.cpp
@@ -399,7 +399,7 @@ void THttpInput::FinishHeaders()
 void THttpInput::EnsureHeadersReceived()
 {
     if (!ReceiveHeaders()) {
-        THROW_ERROR(AnnotateError(TError("Connection was closed before the first byte of HTTP message")));
+        THROW_ERROR(AnnotateError(TError(NRpc::EErrorCode::TransportError, "Connection was closed before the first byte of HTTP message")));
     }
 }
 


### PR DESCRIPTION
Root Cause: A classic race condition in yt/yt/core/http/connection_pool.cpp.
When the client extracts a connection from the pool:

TConnectionPool::Connect() calls CheckPooledConnection() → IsValid() → Connection->IsIdle()
IsIdle() checks !PeerDisconnectedList_.IsFired() — but this is asynchronous and
depends on the poller detecting the peer's TCP FIN. There's a window where
the server has already sent FIN to close the connection, but the poller
hasn't processed it yet. The connection appears valid, but when the client
writes the request and tries to read the response, it gets immediate EOF.

This triggers: "Connection was closed before the first byte of HTTP message".

Proper fix should be retrying request using different connection when
connection was taken from the pool and requires is safe to retry.
For example this logic is implemented inside golang http client.

Here we could simply throw error code NRpc::EErrorCode::TransportError.
And as a result request will be retried by high-level retrying logic
in yt/cpp/mapreduce/common/retry_lib.cpp

Link: https://github.com/ytsaurus/ytsaurus/issues/1691
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>

---

* Changelog entry
Type: fix
Component: cpp-sdk

Handle error and retry request if HTTP(s) connection picked from pool is stale.
