### PR TITLE
[YT Flow] Serialize states in Binary yson

### DIFF
--- a/yt/yt/flow/lib/serializer/serializer.cpp
+++ b/yt/yt/flow/lib/serializer/serializer.cpp
@@ -40,7 +40,7 @@ class TFieldSerializer final
 {
 public:
     TFieldSerializer()
-        : TYsonWriter(static_cast<TStringStream*>(this))
+        : TYsonWriter(static_cast<TStringStream*>(this), EYsonFormat::Binary)
     { }
 
     TString Build() &&


### PR DESCRIPTION
Serializing complex Ysons in Binary works faster than Text format.
I've got 10-15% performance increase in Deserialize with Binary format of states ~200KB uncompressed size.

---

* Changelog entry
Type: feature
Component: yt/flow/serializer

Set EYsonFormat::Binary for state serializer 

