### PR TITLE
Add empty target to bring contrib/python/boto3 to stable/25.1

### DIFF
--- a/yt/yt/tests/local_s3_recipe/ya.make
+++ b/yt/yt/tests/local_s3_recipe/ya.make
@@ -1,0 +1,11 @@
+PY3_PROGRAM(local_s3_recipe)
+
+SRCDIR(
+    yt/yt/tests/local_s3_recipe
+)
+
+PEERDIR(
+    contrib/python/boto3
+)
+
+END()

--- a/yt/yt/tests/ya.make
+++ b/yt/yt/tests/ya.make
@@ -4,6 +4,7 @@ RECURSE(
     compression
     cuda_core_dump_simulator
     ysonperf
+    local_s3_recipe
 )
 
 IF (NOT SANITIZER_TYPE)


### PR DESCRIPTION
# Description

Based on this [PR](https://github.com/ytsaurus/ytsaurus/pull/1461) which brought the `boto3` dependency into `main`. This dependency is currently a part of `stable/25.4`, we would really like it to appear on other `stable/25.X` branches.