### PR TITLE
[queues] fix queue/consumer snapshot ordering

### DIFF
--- a/yt/yt/benchmarks/queues/run/main.cpp
+++ b/yt/yt/benchmarks/queues/run/main.cpp
@@ -311,7 +311,11 @@ private:
     void ReportLag()
     {
         i64 nextRowIndex = 0;
-        auto partitionInfos = WaitFor(ConsumerClient_->CollectPartitions(std::vector<int>{0}, /*withLastConsumeTime*/ false))
+        auto partitionInfos = WaitFor(
+            ConsumerClient_->CollectPartitions(
+                std::vector<int>{0},
+                /*timestamp*/ std::nullopt,
+                /*withLastConsumeTime*/ false))
             .ValueOrThrow();
         if (!partitionInfos.empty()) {
             YT_VERIFY(partitionInfos.size() == 1);

--- a/yt/yt/client/queue_client/consumer_client.cpp
+++ b/yt/yt/client/queue_client/consumer_client.cpp
@@ -247,6 +247,7 @@ public:
 
     TFuture<std::vector<TPartitionInfo>> CollectPartitions(
         int expectedPartitionCount,
+        std::optional<TTimestamp> timestamp = std::nullopt,
         bool withLastConsumeTime = false) const override
     {
         if (expectedPartitionCount <= 0) {
@@ -277,6 +278,7 @@ public:
             &TGenericConsumerClient::DoCollectPartitions,
             MakeStrong(this),
             selectQuery,
+            timestamp,
             withLastConsumeTime)
             .AsyncVia(GetCurrentInvoker())
             .Run()
@@ -296,6 +298,7 @@ public:
 
     TFuture<std::vector<TPartitionInfo>> CollectPartitions(
         const std::vector<int>& partitionIndexes,
+        std::optional<TTimestamp> timestamp,
         bool withLastConsumeTime) const override
     {
         auto selectQuery = Format(
@@ -310,6 +313,7 @@ public:
             &TGenericConsumerClient::DoCollectPartitions,
             MakeStrong(this),
             selectQuery,
+            timestamp,
             withLastConsumeTime)
             .AsyncVia(GetCurrentInvoker())
             .Run()
@@ -390,6 +394,7 @@ private:
 
     std::vector<TPartitionInfo> DoCollectPartitions(
         const std::string& selectQuery,
+        std::optional<TTimestamp> timestamp,
         bool withLastConsumeTime) const
     {
         std::vector<TPartitionInfo> result;
@@ -398,6 +403,9 @@ private:
 
         TSelectRowsOptions selectRowsOptions;
         selectRowsOptions.ReplicaConsistency = EReplicaConsistency::Sync;
+        if (timestamp.has_value()) {
+            selectRowsOptions.Timestamp = timestamp.value();
+        }
         auto selectRowsResult = WaitFor(ConsumerClusterClient_->SelectRows(selectQuery, selectRowsOptions))
             .ValueOrThrow();
 

--- a/yt/yt/client/queue_client/consumer_client.h
+++ b/yt/yt/client/queue_client/consumer_client.h
@@ -58,12 +58,14 @@ struct ISubConsumerClient
     //! indices outside of range [0, expectedPartitionCount), they will be ignored.
     virtual TFuture<std::vector<TPartitionInfo>> CollectPartitions(
         int expectedPartitionCount,
+        std::optional<NTransactionClient::TTimestamp> timestamp = std::nullopt,
         bool withLastConsumeTime = false) const = 0;
 
     //! Collect partition infos.
     //! Entries in the consumer table with partition indices not in the given vector will be ignored.
     virtual TFuture<std::vector<TPartitionInfo>> CollectPartitions(
         const std::vector<int>& partitionIndexes,
+        std::optional<NTransactionClient::TTimestamp> timestamp = std::nullopt,
         bool withLastConsumeTime = false) const = 0;
 
     struct TPartitionStatistics

--- a/yt/yt/server/queue_agent/consumer_controller.cpp
+++ b/yt/yt/server/queue_agent/consumer_controller.cpp
@@ -195,6 +195,17 @@ private:
                 subConsumerSnapshot = New<TSubConsumerSnapshot>();
                 subConsumerSnapshot->Error = std::move(subConsumerSnapshotOrError);
             }
+
+            auto subBarrierTimestamp = subConsumerSnapshot->QueueLowestPartitionBarrierTimestamp;
+            if (NullTimestamp != subBarrierTimestamp) {
+                if (NullTimestamp == ConsumerSnapshot_->QueueLowestPartitionBarrierTimestamp) {
+                    ConsumerSnapshot_->QueueLowestPartitionBarrierTimestamp = subBarrierTimestamp;
+                } else {
+                    ConsumerSnapshot_->QueueLowestPartitionBarrierTimestamp =
+                        std::min(ConsumerSnapshot_->QueueLowestPartitionBarrierTimestamp, subBarrierTimestamp);
+                }
+            }
+
             ConsumerSnapshot_->SubSnapshots[queueRef] = std::move(subConsumerSnapshot);
         }
 
@@ -228,6 +239,7 @@ private:
         }
 
         subSnapshot->HasCumulativeDataWeightColumn = queueSnapshot->HasCumulativeDataWeightColumn;
+        subSnapshot->QueueLowestPartitionBarrierTimestamp = queueSnapshot->LowestPartitionBarrierTimestamp;
 
         // Assume partition count to be the same as the partition count in the current queue snapshot.
         auto partitionCount = queueSnapshot->PartitionCount;
@@ -246,8 +258,11 @@ private:
 
         {
             auto subConsumerClient = ConsumerClient_->GetSubConsumerClient(/*queueClient*/ nullptr, queueRef);
-
-            auto consumerPartitionInfos = WaitFor(subConsumerClient->CollectPartitions(partitionCount, /*withLastConsumeTime*/ true))
+            auto consumerPartitionInfos = WaitFor(
+                subConsumerClient->CollectPartitions(
+                    partitionCount,
+                    queueSnapshot->LowestPartitionBarrierTimestamp,
+                    /*withLastConsumeTime*/ true))
                 .ValueOrThrow();
 
             for (const auto& consumerPartitionInfo : consumerPartitionInfos) {
@@ -588,6 +603,7 @@ public:
             .Item("replicated_table_mapping_row").Value(consumerSnapshot->ReplicatedTableMappingRow)
             .Item("status").Do(std::bind(BuildConsumerStatusYson, consumerSnapshot, _1))
             .Item("partitions").Do(std::bind(BuildConsumerPartitionListYson, consumerSnapshot, _1))
+            .Item("queue_lowest_barrier_timestamp").Value(consumerSnapshot->QueueLowestPartitionBarrierTimestamp)
         .EndMap();
     }
 

--- a/yt/yt/server/queue_agent/queue_controller.cpp
+++ b/yt/yt/server/queue_agent/queue_controller.cpp
@@ -229,6 +229,7 @@ private:
                 ? PreviousQueueSnapshot_->PartitionSnapshots[index]
                 : nullptr;
             const auto& tabletInfo = tabletInfos[index];
+            partitionSnapshot->BarrierTimestamp = tabletInfo.BarrierTimestamp;
             partitionSnapshot->UpperRowIndex = tabletInfo.TotalRowCount;
             partitionSnapshot->LowerRowIndex = tabletInfo.TrimmedRowCount;
             partitionSnapshot->AvailableRowCount = partitionSnapshot->UpperRowIndex - partitionSnapshot->LowerRowIndex;
@@ -242,8 +243,9 @@ private:
             partitionSnapshot->WriteRate.RowCount.Update(tabletInfo.TotalRowCount);
 
             if (EnableVerboseLogging_) {
-                YT_LOG_DEBUG("New partition snapshot (PartitionIndex: %v, UpperRowIndex: %v, LowerRowIndex: %v, LastRowCommitTime: %v, CommitIdleTime: %v)",
+                YT_LOG_DEBUG("New partition snapshot (PartitionIndex: %v, BarrierTimestamp: %v, UpperRowIndex: %v, LowerRowIndex: %v, LastRowCommitTime: %v, CommitIdleTime: %v)",
                     tabletIndexes[index],
+                    partitionSnapshot->BarrierTimestamp,
                     partitionSnapshot->UpperRowIndex,
                     partitionSnapshot->LowerRowIndex,
                     partitionSnapshot->LastRowCommitTime,
@@ -258,6 +260,14 @@ private:
         for (int index = 0; index < std::ssize(tabletInfos); ++index) {
             const auto& partitionSnapshot = partitionSnapshots[tabletIndexes[index]];
             QueueSnapshot_->WriteRate += partitionSnapshot->WriteRate;
+            if (NullTimestamp != partitionSnapshot->BarrierTimestamp) {
+                if (NullTimestamp == QueueSnapshot_->LowestPartitionBarrierTimestamp) {
+                    QueueSnapshot_->LowestPartitionBarrierTimestamp = partitionSnapshot->BarrierTimestamp;
+                } else {
+                    QueueSnapshot_->LowestPartitionBarrierTimestamp =
+                        std::min(partitionSnapshot->BarrierTimestamp, QueueSnapshot_->LowestPartitionBarrierTimestamp);
+                }
+            }
         }
 
         QueueSnapshot_->Registrations = Registrations_;
@@ -399,6 +409,7 @@ public:
             .Item("replicated_table_mapping_row").Value(queueSnapshot->ReplicatedTableMappingRow)
             .Item("status").Do(std::bind(BuildQueueStatusYson, queueSnapshot, AlertManager_.Acquire(), queueExportsProgressOrError, _1))
             .Item("partitions").Do(std::bind(BuildQueuePartitionListYson, queueSnapshot, _1))
+            .Item("lowest_barrier_timestamp").Value(queueSnapshot->LowestPartitionBarrierTimestamp)
             .Item("exporters").Do(std::bind(&TOrderedDynamicTableController::BuildExporterMappingYson, this, _1))
         .EndMap();
     }

--- a/yt/yt/server/queue_agent/snapshot.h
+++ b/yt/yt/server/queue_agent/snapshot.h
@@ -43,6 +43,8 @@ struct TQueueSnapshot
     bool HasCumulativeDataWeightColumn = false;
 
     std::vector<TQueuePartitionSnapshotPtr> PartitionSnapshots;
+    NTransactionClient::TTimestamp LowestPartitionBarrierTimestamp = NTransactionClient::NullTimestamp;
+
     std::vector<NQueueClient::TConsumerRegistrationTableRow> Registrations;
 };
 
@@ -57,6 +59,7 @@ struct TQueuePartitionSnapshot
     TError Error;
 
     // Fields below are not set if error is set.
+    NTransactionClient::TTimestamp BarrierTimestamp = NTransactionClient::NullTimestamp;
     i64 LowerRowIndex = -1;
     i64 UpperRowIndex = -1;
     i64 AvailableRowCount = -1;
@@ -90,6 +93,8 @@ struct TConsumerSnapshot
     NQueueClient::TConsumerTableRow Row;
     std::optional<NQueueClient::TReplicatedTableMappingTableRow> ReplicatedTableMappingRow;
 
+    NTransactionClient::TTimestamp QueueLowestPartitionBarrierTimestamp = NTransactionClient::NullTimestamp;
+
     std::vector<NQueueClient::TConsumerRegistrationTableRow> Registrations;
     THashMap<NQueueClient::TCrossClusterReference, TSubConsumerSnapshotPtr> SubSnapshots;
 };
@@ -111,6 +116,8 @@ struct TSubConsumerSnapshot
     //! Temporary information for debugging. Equal to the same value of the corresponding queue.
     //! COMPAT(achulkov2): Remove this.
     bool HasCumulativeDataWeightColumn = false;
+
+    NTransactionClient::TTimestamp QueueLowestPartitionBarrierTimestamp = NTransactionClient::NullTimestamp;
 
     std::vector<TConsumerPartitionSnapshotPtr> PartitionSnapshots;
 };

--- a/yt/yt/server/queue_agent/snapshot_representation.cpp
+++ b/yt/yt/server/queue_agent/snapshot_representation.cpp
@@ -102,6 +102,7 @@ void BuildQueuePartitionYson(const TQueuePartitionSnapshotPtr& snapshot, TFluent
 
     fluent
         .BeginMap()
+            .Item("barrier_timestamp").Value(snapshot->BarrierTimestamp)
             .Item("lower_row_index").Value(snapshot->LowerRowIndex)
             .Item("upper_row_index").Value(snapshot->UpperRowIndex)
             .Item("available_row_count").Value(snapshot->AvailableRowCount)

--- a/yt/yt/tests/library/yt_queue_agent_test_base.py
+++ b/yt/yt/tests/library/yt_queue_agent_test_base.py
@@ -3,7 +3,7 @@ from yt_env_setup import YTEnvSetup
 from yt_chaos_test_base import ChaosTestBase
 
 from yt_commands import (execute_batch, get, get_batch_output, get_connection_orchid_value, make_batch_request, multiset_attributes, read_table, set, ls, wait, create, remove, sync_mount_table,
-                         sync_create_cells, exists, select_rows, sync_reshard_table, print_debug, get_driver, register_queue_consumer, sync_freeze_table, sync_unfreeze_table,
+                         sync_create_cells, exists, select_rows, sync_reshard_table, print_debug, get_driver, register_queue_consumer, sync_freeze_table, sync_unfreeze_table, generate_timestamp,
                          create_table_replica, sync_enable_table_replica, advance_consumer, insert_rows, wait_for_tablet_state, abort_transactions, raises_yt_error)
 
 from yt_helpers import parse_yt_time, calculate_object_diff
@@ -266,6 +266,21 @@ class QueueOrchid(ObjectOrchid):
     def get_exporter_orchid(self, export_name: str = "default"):
         return QueueExporterOrchid(self, export_name)
 
+    def get_lowest_barrier_timestamp(self):
+        return get(f"{self.orchid_path()}/lowest_barrier_timestamp")
+
+    def wait_fresh_pass(self):
+        fresh_ts = generate_timestamp()
+        pass_index = self.get_pass_index()
+
+        def _is_ready():
+            if self.get_pass_index() < pass_index + 2:
+                return False
+            barrier = self.get_lowest_barrier_timestamp()
+            return barrier == 0 or barrier >= fresh_ts
+
+        wait(_is_ready, sleep_backoff=0.15)
+
 
 class OwnedQueueOrchid(ObjectOrchid):
     OBJECT_TYPE = "owned_queue"
@@ -285,6 +300,21 @@ class ConsumerOrchid(ObjectOrchid):
     def get_subconsumer(self, queue_ref):
         status, partitions = self.get_consumer()
         return status["queues"][queue_ref], partitions[queue_ref]
+
+    def get_queue_lowest_barrier_timestamp(self):
+        return get(f"{self.orchid_path()}/queue_lowest_barrier_timestamp")
+
+    def wait_fresh_pass(self):
+        fresh_ts = generate_timestamp()
+        pass_index = self.get_pass_index()
+
+        def _is_ready():
+            if self.get_pass_index() < pass_index + 2:
+                return False
+            barrier = self.get_queue_lowest_barrier_timestamp()
+            return barrier == 0 or barrier >= fresh_ts
+
+        wait(_is_ready, sleep_backoff=0.15)
 
 
 class QueueAgentOrchid(OrchidWithRegularPasses):


### PR DESCRIPTION
If a consumer is reading a queue faster than the PassPeriod, we can sometimes end up in a situation where the queue snapshot is older than the consumer snapshot.
It leads to incorrect consumer disposition and may report wrong partition lag row counts (e.g. <0, even though the consumer is not actually ahead).

I could not think of a deterministic test to reproduce this.
Also, I believe that querying each consumer partition snapshot with the corresponding queue partition barrier timestamp would end up DDOSing the consumer tablets, but using the lowest barrier is fine.

---

* Changelog entry
Type: fix
Component: queue-agent

Use lowest barrier timestamp of queue partitions when querying consumer partition snapshot.