### PR TITLE
[go] wire: add RowMarshaler interface to bypass row-level reflection

### DIFF
--- a/yt/go/wire/encode.go
+++ b/yt/go/wire/encode.go
@@ -17,6 +17,48 @@ type NameTableEntry struct {
 	Name string
 }
 
+// Resolver translates a column name to its NameTable id, registering the
+// name on first use. Implementations must be safe for concurrent use,
+// because Encode invokes row marshaling in parallel.
+type Resolver interface {
+	LookupOrAdd(name string) uint16
+}
+
+// RowMarshaler is implemented by types that supply their own wire row
+// encoding. If a value passed to Encode (or its pointed-to value, when
+// the value is a non-nil pointer) implements RowMarshaler, Encode calls
+// MarshalRow instead of using reflection. Column ids must be obtained
+// via the supplied Resolver so that all rows in the batch reference the
+// same NameTable.
+type RowMarshaler interface {
+	MarshalRow(r Resolver) (Row, error)
+}
+
+// nameTableResolver wraps Encode's per-call indexMap so RowMarshaler
+// implementations can register column names without touching internals.
+type nameTableResolver struct {
+	indexMap map[NameTableEntry]uint16
+	mapLock  *sync.RWMutex
+}
+
+func (r *nameTableResolver) LookupOrAdd(name string) uint16 {
+	k := NameTableEntry{Name: name}
+	r.mapLock.RLock()
+	id, ok := r.indexMap[k]
+	r.mapLock.RUnlock()
+	if ok {
+		return id
+	}
+	r.mapLock.Lock()
+	defer r.mapLock.Unlock()
+	if id, ok = r.indexMap[k]; ok {
+		return id
+	}
+	id = uint16(len(r.indexMap))
+	r.indexMap[k] = id
+	return id
+}
+
 func Encode(items []any) (NameTable, []Row, error) {
 	rows := make([]Row, len(items))
 	if len(items) == 0 {
@@ -62,6 +104,10 @@ func encode(item any, indexMap map[NameTableEntry]uint16, mapLock *sync.RWMutex)
 	vv := reflect.ValueOf(item)
 	if item == nil || vv.Kind() == reflect.Ptr && vv.IsNil() {
 		return nil, xerrors.Errorf("unsupported nil item")
+	}
+
+	if m, ok := item.(RowMarshaler); ok {
+		return m.MarshalRow(&nameTableResolver{indexMap: indexMap, mapLock: mapLock})
 	}
 
 	return encodeReflect(vv, indexMap, mapLock)

--- a/yt/go/wire/encode.go
+++ b/yt/go/wire/encode.go
@@ -17,10 +17,10 @@ type NameTableEntry struct {
 	Name string
 }
 
-// Resolver translates a column name to its NameTable id, registering the
-// name on first use. Implementations must be safe for concurrent use,
+// NameTableBuilder translates a column name to its NameTable id, registering
+// the name on first use. Implementations must be safe for concurrent use,
 // because Encode invokes row marshaling in parallel.
-type Resolver interface {
+type NameTableBuilder interface {
 	LookupOrAdd(name string) uint16
 }
 
@@ -28,34 +28,34 @@ type Resolver interface {
 // encoding. If a value passed to Encode (or its pointed-to value, when
 // the value is a non-nil pointer) implements RowMarshaler, Encode calls
 // MarshalRow instead of using reflection. Column ids must be obtained
-// via the supplied Resolver so that all rows in the batch reference the
-// same NameTable.
+// via the supplied NameTableBuilder so that all rows in the batch
+// reference the same NameTable.
 type RowMarshaler interface {
-	MarshalRow(r Resolver) (Row, error)
+	MarshalRow(b NameTableBuilder) (Row, error)
 }
 
-// nameTableResolver wraps Encode's per-call indexMap so RowMarshaler
+// nameTableBuilder wraps Encode's per-call indexMap so RowMarshaler
 // implementations can register column names without touching internals.
-type nameTableResolver struct {
+type nameTableBuilder struct {
 	indexMap map[NameTableEntry]uint16
 	mapLock  *sync.RWMutex
 }
 
-func (r *nameTableResolver) LookupOrAdd(name string) uint16 {
+func (b *nameTableBuilder) LookupOrAdd(name string) uint16 {
 	k := NameTableEntry{Name: name}
-	r.mapLock.RLock()
-	id, ok := r.indexMap[k]
-	r.mapLock.RUnlock()
+	b.mapLock.RLock()
+	id, ok := b.indexMap[k]
+	b.mapLock.RUnlock()
 	if ok {
 		return id
 	}
-	r.mapLock.Lock()
-	defer r.mapLock.Unlock()
-	if id, ok = r.indexMap[k]; ok {
+	b.mapLock.Lock()
+	defer b.mapLock.Unlock()
+	if id, ok = b.indexMap[k]; ok {
 		return id
 	}
-	id = uint16(len(r.indexMap))
-	r.indexMap[k] = id
+	id = uint16(len(b.indexMap))
+	b.indexMap[k] = id
 	return id
 }
 
@@ -107,7 +107,7 @@ func encode(item any, indexMap map[NameTableEntry]uint16, mapLock *sync.RWMutex)
 	}
 
 	if m, ok := item.(RowMarshaler); ok {
-		return m.MarshalRow(&nameTableResolver{indexMap: indexMap, mapLock: mapLock})
+		return m.MarshalRow(&nameTableBuilder{indexMap: indexMap, mapLock: mapLock})
 	}
 
 	return encodeReflect(vv, indexMap, mapLock)

--- a/yt/go/wire/encode_test.go
+++ b/yt/go/wire/encode_test.go
@@ -397,3 +397,49 @@ func compareNameTables(t *testing.T, expected, actual NameTable) {
 
 	require.Equal(t, expected, actual)
 }
+
+type customRow struct {
+	A string
+	B uint64
+}
+
+func (s *customRow) MarshalRow(r Resolver) (Row, error) {
+	return Row{
+		NewBytes(r.LookupOrAdd("a"), []byte(s.A)),
+		NewUint64(r.LookupOrAdd("b"), s.B),
+	}, nil
+}
+
+var _ RowMarshaler = (*customRow)(nil)
+
+func TestEncodeRowMarshaler(t *testing.T) {
+	nt, rows, err := Encode([]any{
+		&customRow{A: "x", B: 7},
+		&customRow{A: "y", B: 8},
+	})
+	require.NoError(t, err)
+	require.Equal(t, NameTable{{Name: "a"}, {Name: "b"}}, nt)
+	require.Equal(t, []Row{
+		{NewBytes(0, []byte("x")), NewUint64(1, 7)},
+		{NewBytes(0, []byte("y")), NewUint64(1, 8)},
+	}, rows)
+}
+
+// rowMarshalerOverReflect implements RowMarshaler in addition to having
+// reflectable yson-tagged fields. Encode must call MarshalRow and never
+// fall through to the reflection path.
+type rowMarshalerOverReflect struct {
+	Reflected string `yson:"reflected"`
+}
+
+func (s *rowMarshalerOverReflect) MarshalRow(r Resolver) (Row, error) {
+	return Row{NewBytes(r.LookupOrAdd("from_marshaler"), []byte(s.Reflected))}, nil
+}
+
+func TestEncodeRowMarshalerTakesPrecedenceOverReflect(t *testing.T) {
+	nt, _, err := Encode([]any{
+		&rowMarshalerOverReflect{Reflected: "value"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, NameTable{{Name: "from_marshaler"}}, nt)
+}

--- a/yt/go/wire/encode_test.go
+++ b/yt/go/wire/encode_test.go
@@ -1,6 +1,7 @@
 package wire
 
 import (
+	"bytes"
 	"sort"
 	"testing"
 
@@ -8,6 +9,7 @@ import (
 
 	"go.ytsaurus.tech/library/go/ptr"
 	"go.ytsaurus.tech/yt/go/schema"
+	"go.ytsaurus.tech/yt/go/yson"
 )
 
 type innterStruct struct {
@@ -442,4 +444,135 @@ func TestEncodeRowMarshalerTakesPrecedenceOverReflect(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, NameTable{{Name: "from_marshaler"}}, nt)
+}
+
+// reflectBenchStub is a generic row shape with a few primitive scalars
+// plus one map field that gets serialised as Any. It's wide enough to
+// exercise the hot parts of wire.Encode.
+type reflectBenchStub struct {
+	S1   string            `yson:"s1"`
+	S2   string            `yson:"s2"`
+	S3   string            `yson:"s3"`
+	U1   uint64            `yson:"u1"`
+	U2   uint64            `yson:"u2"`
+	N    uint32            `yson:"n"`
+	Tags map[string]string `yson:"tags"`
+}
+
+// handrolledBenchStub has the same logical shape as reflectBenchStub
+// but supplies MarshalRow so Encode bypasses reflection.
+type handrolledBenchStub struct {
+	S1   string
+	S2   string
+	S3   string
+	U1   uint64
+	U2   uint64
+	N    uint32
+	Tags map[string]string
+}
+
+func (s *handrolledBenchStub) MarshalRow(r Resolver) (Row, error) {
+	idS1 := r.LookupOrAdd("s1")
+	idS2 := r.LookupOrAdd("s2")
+	idS3 := r.LookupOrAdd("s3")
+	idU1 := r.LookupOrAdd("u1")
+	idU2 := r.LookupOrAdd("u2")
+	idN := r.LookupOrAdd("n")
+	idTags := r.LookupOrAdd("tags")
+
+	// Emit the tags map as binary YSON without reflection.
+	var buf bytes.Buffer
+	w := yson.NewWriterConfig(&buf, yson.WriterConfig{Format: yson.FormatBinary})
+	w.BeginMap()
+	for k, v := range s.Tags {
+		w.MapKeyString(k)
+		w.String(v)
+	}
+	w.EndMap()
+	if err := w.Finish(); err != nil {
+		return nil, err
+	}
+
+	return Row{
+		NewBytes(idS1, []byte(s.S1)),
+		NewBytes(idS2, []byte(s.S2)),
+		NewBytes(idS3, []byte(s.S3)),
+		NewUint64(idU1, s.U1),
+		NewUint64(idU2, s.U2),
+		NewUint64(idN, uint64(s.N)),
+		NewAny(idTags, append([]byte(nil), buf.Bytes()...)),
+	}, nil
+}
+
+func benchTags() map[string]string {
+	return map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+		"k3": "v3",
+		"k4": "v4",
+		"k5": "v5",
+		"k6": "v6",
+		"k7": "v7",
+		"k8": "v8",
+	}
+}
+
+func makeReflectBatch(n int) []any {
+	out := make([]any, n)
+	tags := benchTags()
+	for i := 0; i < n; i++ {
+		out[i] = &reflectBenchStub{
+			S1:   "abc",
+			S2:   "def",
+			S3:   "the quick brown fox jumps over the lazy dog",
+			U1:   uint64(i),
+			U2:   uint64(i * 2),
+			N:    uint32(i),
+			Tags: tags,
+		}
+	}
+	return out
+}
+
+func makeHandrolledBatch(n int) []any {
+	out := make([]any, n)
+	tags := benchTags()
+	for i := 0; i < n; i++ {
+		out[i] = &handrolledBenchStub{
+			S1:   "abc",
+			S2:   "def",
+			S3:   "the quick brown fox jumps over the lazy dog",
+			U1:   uint64(i),
+			U2:   uint64(i * 2),
+			N:    uint32(i),
+			Tags: tags,
+		}
+	}
+	return out
+}
+
+func BenchmarkEncode(b *testing.B) {
+	const batch = 1000
+	b.Run("reflect", func(b *testing.B) {
+		items := makeReflectBatch(batch)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _, err := Encode(items)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("row_marshaler", func(b *testing.B) {
+		items := makeHandrolledBatch(batch)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _, err := Encode(items)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }

--- a/yt/go/wire/encode_test.go
+++ b/yt/go/wire/encode_test.go
@@ -405,10 +405,10 @@ type customRow struct {
 	B uint64
 }
 
-func (s *customRow) MarshalRow(r Resolver) (Row, error) {
+func (s *customRow) MarshalRow(b NameTableBuilder) (Row, error) {
 	return Row{
-		NewBytes(r.LookupOrAdd("a"), []byte(s.A)),
-		NewUint64(r.LookupOrAdd("b"), s.B),
+		NewBytes(b.LookupOrAdd("a"), []byte(s.A)),
+		NewUint64(b.LookupOrAdd("b"), s.B),
 	}, nil
 }
 
@@ -434,8 +434,8 @@ type rowMarshalerOverReflect struct {
 	Reflected string `yson:"reflected"`
 }
 
-func (s *rowMarshalerOverReflect) MarshalRow(r Resolver) (Row, error) {
-	return Row{NewBytes(r.LookupOrAdd("from_marshaler"), []byte(s.Reflected))}, nil
+func (s *rowMarshalerOverReflect) MarshalRow(b NameTableBuilder) (Row, error) {
+	return Row{NewBytes(b.LookupOrAdd("from_marshaler"), []byte(s.Reflected))}, nil
 }
 
 func TestEncodeRowMarshalerTakesPrecedenceOverReflect(t *testing.T) {
@@ -471,14 +471,14 @@ type handrolledBenchStub struct {
 	Tags map[string]string
 }
 
-func (s *handrolledBenchStub) MarshalRow(r Resolver) (Row, error) {
-	idS1 := r.LookupOrAdd("s1")
-	idS2 := r.LookupOrAdd("s2")
-	idS3 := r.LookupOrAdd("s3")
-	idU1 := r.LookupOrAdd("u1")
-	idU2 := r.LookupOrAdd("u2")
-	idN := r.LookupOrAdd("n")
-	idTags := r.LookupOrAdd("tags")
+func (s *handrolledBenchStub) MarshalRow(b NameTableBuilder) (Row, error) {
+	idS1 := b.LookupOrAdd("s1")
+	idS2 := b.LookupOrAdd("s2")
+	idS3 := b.LookupOrAdd("s3")
+	idU1 := b.LookupOrAdd("u1")
+	idU2 := b.LookupOrAdd("u2")
+	idN := b.LookupOrAdd("n")
+	idTags := b.LookupOrAdd("tags")
 
 	// Emit the tags map as binary YSON without reflection.
 	var buf bytes.Buffer


### PR DESCRIPTION
Discussion: #1711

### Summary

Adds a row-level `RowMarshaler` interface to `wire.Encode`, mirroring how `yson.Writer.Any` honors `MarshalYSON`. If a value passed to `Encode` (or its pointed-to value) implements `RowMarshaler`, `MarshalRow(Resolver) (Row, error)` is called instead of the reflection-based path. Column ids come through a `Resolver` that wraps the per-call `NameTable`, so hand-rolled rows compose cleanly with reflection-encoded ones in the same batch.

This lets services that maintain custom YSON marshalers for the HTTP transport keep equivalent client-side performance after switching to the RPC transport. Today, `ytrpc` always goes through reflection in `wire.Encode`, while `ythttp` honors per-row `MarshalYSON` — so a service that already optimised its YSON path takes a CPU regression on migration.

### Public API

```go
// Resolver translates a column name to its NameTable id, registering the
// name on first use. Implementations must be safe for concurrent use.
type Resolver interface {
    LookupOrAdd(name string) uint16
}

// RowMarshaler is implemented by types that supply their own wire row
// encoding. If a value passed to Encode implements RowMarshaler,
// MarshalRow is called instead of reflection-based encoding.
type RowMarshaler interface {
    MarshalRow(r Resolver) (Row, error)
}
```

The change is strictly additive: types that don't implement `RowMarshaler` use the existing reflection path with no behaviour change.

### Tests

- `TestEncodeRowMarshaler` — encoded `NameTable` and `[]Row` match the expected output for a batch of two rows that implement `RowMarshaler`.
- `TestEncodeRowMarshalerTakesPrecedenceOverReflect` — a type that has both yson-tagged fields and `MarshalRow` is encoded via `MarshalRow` (the reflection-derived `NameTable` entries do not appear).

### Benchmark

`BenchmarkEncode` (added) compares `wire.Encode` against a generic row shape (a few primitive scalars + one `map[string]string` serialised as `Any`), batch=1000, on Apple M4 Pro:

| mode | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| reflect | 1.69ms | 6.40 MB | 69k |
| row_marshaler | 1.24ms | 5.27 MB | 31k |

The hand-rolled marshaler saves ~27% time and ~55% allocations on this shape.

### Why this matters

For services migrating high-throughput dynamic-table writers from `ythttp` to `ytrpc`, `wire.Encode`'s reflection-only path is currently a significant client-side CPU and allocation tax versus the YSON path with hand-rolled `MarshalYSON`. With this hook, a service can supply a `MarshalRow` that builds the row directly and recover the gap (in our internal benchmarks against a real production-like row shape, the closure to within ~10% of `MarshalYSON`).

The per-field `encoding.BinaryMarshaler` / `encoding.TextMarshaler` hooks already in `convertValue` are not sufficient: they always emit `TypeBytes`, so they cannot populate `Any`-typed columns that hold nested data.