### PR TITLE
Go SDK: IPVersion config

### DIFF
--- a/yt/go/bus/bus.go
+++ b/yt/go/bus/bus.go
@@ -40,6 +40,7 @@ const (
 
 type Options struct {
 	Address string
+	Network string
 	Logger  log.Logger
 
 	EncryptionMode EncryptionMode
@@ -553,8 +554,13 @@ func (c *Bus) establishEncryption(isServer bool) error {
 }
 
 func Dial(ctx context.Context, options Options) (*Bus, error) {
+	network := options.Network
+	if network == "" {
+		network = "tcp"
+	}
+
 	var dialer net.Dialer
-	conn, err := dialer.DialContext(ctx, "tcp", options.Address)
+	conn, err := dialer.DialContext(ctx, network, options.Address)
 	if err != nil {
 		return nil, err
 	}

--- a/yt/go/bus/client.go
+++ b/yt/go/bus/client.go
@@ -106,6 +106,12 @@ func WithTLSConfig(c *tls.Config) ClientOption {
 	}
 }
 
+func WithNetwork(network string) ClientOption {
+	return func(conn *ClientConn) {
+		conn.network = network
+	}
+}
+
 var ErrConnClosed = xerrors.NewSentinel("connection closed")
 
 type ClientConn struct {
@@ -127,6 +133,7 @@ type ClientConn struct {
 	featureIDFormatter          featureIDFormatter
 
 	address string
+	network string
 
 	dialed chan struct{}
 	bus    *Bus
@@ -292,6 +299,7 @@ func (c *ClientConn) runSender() {
 func (c *ClientConn) dial(ctx context.Context) {
 	opts := Options{
 		Address:        c.address,
+		Network:        c.network,
 		Logger:         c.log,
 		EncryptionMode: c.encryptionMode,
 		TLSConfig:      c.tlsConfig,

--- a/yt/go/bus/client_test.go
+++ b/yt/go/bus/client_test.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"context"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -465,6 +466,53 @@ func TestTestServiceWithTLS(t *testing.T) {
 		rsp, err := c.SomeCall(context.Background(), req)
 		require.NoError(t, err)
 		require.Equal(t, int32(142), *rsp.B)
+	})
+}
+
+func TestClient_WithNetwork(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	addr, stop := StartTestService(t)
+	defer stop()
+
+	_, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	ipv4Addr := net.JoinHostPort("127.0.0.1", port)
+
+	t.Run("DefaultConnects", func(t *testing.T) {
+		c := NewTestServiceClient(ipv4Addr)
+		defer func() {
+			c.Close()
+			<-c.conn.Done()
+		}()
+
+		_, err := c.DoNothing(context.Background(), &testservice.TReqDoNothing{})
+		require.NoError(t, err)
+	})
+
+	t.Run("TCP4ConnectsToIPv4", func(t *testing.T) {
+		c := NewTestServiceClient(ipv4Addr, WithNetwork("tcp4"))
+		defer func() {
+			c.Close()
+			<-c.conn.Done()
+		}()
+
+		_, err := c.DoNothing(context.Background(), &testservice.TReqDoNothing{})
+		require.NoError(t, err)
+	})
+
+	t.Run("TCP6FailsForIPv4Address", func(t *testing.T) {
+		c := NewTestServiceClient(ipv4Addr, WithNetwork("tcp6"))
+		defer func() {
+			c.Close()
+			<-c.conn.Done()
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, err := c.DoNothing(ctx, &testservice.TReqDoNothing{})
+		require.Error(t, err)
 	})
 }
 

--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -423,9 +423,6 @@ func parseEnvBool(name string) bool {
 }
 
 func (c *Config) GetIPVersion() IPVersion {
-	if c.IPVersion == IPVersionV4 || c.IPVersion == IPVersionV6 {
-		return c.IPVersion
-	}
 	force4 := parseEnvBool("YT_FORCE_IPV4")
 	force6 := parseEnvBool("YT_FORCE_IPV6")
 	if force4 && force6 {
@@ -437,7 +434,7 @@ func (c *Config) GetIPVersion() IPVersion {
 	if force6 {
 		return IPVersionV6
 	}
-	return IPVersionAny
+	return c.IPVersion
 }
 
 const (

--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -187,6 +187,17 @@ type Config struct {
 	// NOTE: this codec has nothing to do with codec used for storing table chunks.
 	CompressionCodec ClientCompressionCodec
 
+	// IPVersion restricts the address family used for outbound connections.
+	//
+	// Applies to:
+	//   - bus TCP dials (RPC client only)
+	//   - HTTP dials (proxy discovery for RPC, all requests for HTTP client) —
+	//     only when HTTPClient is unset; a user-provided HTTPClient is responsible
+	//     for configuring its own transport.
+	//
+	// Default (IPVersionAny) uses system dual-stack resolution.
+	IPVersion IPVersion
+
 	// HTTPClient allows to override default http.Client.
 	//
 	// If this option is provided, http client is not configured using other config options,
@@ -458,6 +469,26 @@ func (c ClientCompressionCodec) BlockCodec() (string, bool) {
 		//		return "brotli_11", true
 	default:
 		return "", false
+	}
+}
+
+// IPVersion restricts address family used for outbound connections.
+type IPVersion int
+
+const (
+	IPVersionAny IPVersion = iota
+	IPVersionV4
+	IPVersionV6
+)
+
+func (v IPVersion) Network() string {
+	switch v {
+	case IPVersionV4:
+		return "tcp4"
+	case IPVersionV6:
+		return "tcp6"
+	default:
+		return "tcp"
 	}
 }
 

--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -195,7 +196,7 @@ type Config struct {
 	//     only when HTTPClient is unset; a user-provided HTTPClient is responsible
 	//     for configuring its own transport.
 	//
-	// Default (IPVersionAny) uses system dual-stack resolution.
+	// Config value can be overridden by YT_FORCE_IPV4 and YT_FORCE_IPV6 environment variables.
 	IPVersion IPVersion
 
 	// HTTPClient allows to override default http.Client.
@@ -407,6 +408,36 @@ func (c *Config) GetClientCompressionCodec() ClientCompressionCodec {
 	}
 
 	return c.CompressionCodec
+}
+
+func parseEnvBool(name string) bool {
+	v := os.Getenv(name)
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
+}
+
+func (c *Config) GetIPVersion() IPVersion {
+	if c.IPVersion == IPVersionV4 || c.IPVersion == IPVersionV6 {
+		return c.IPVersion
+	}
+	force4 := parseEnvBool("YT_FORCE_IPV4")
+	force6 := parseEnvBool("YT_FORCE_IPV6")
+	if force4 && force6 {
+		return IPVersionV4
+	}
+	if force4 {
+		return IPVersionV4
+	}
+	if force6 {
+		return IPVersionV6
+	}
+	return IPVersionAny
 }
 
 const (

--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -196,7 +196,7 @@ type Config struct {
 	//     only when HTTPClient is unset; a user-provided HTTPClient is responsible
 	//     for configuring its own transport.
 	//
-	// Config value can be overridden by YT_FORCE_IPV4 and YT_FORCE_IPV6 environment variables.
+	// YT_FORCE_IPV4 and YT_FORCE_IPV6 environment variables can be used, but non Any config value takes priority.
 	IPVersion IPVersion
 
 	// HTTPClient allows to override default http.Client.
@@ -423,15 +423,15 @@ func parseEnvBool(name string) bool {
 }
 
 func (c *Config) GetIPVersion() IPVersion {
-	force4 := parseEnvBool("YT_FORCE_IPV4")
-	force6 := parseEnvBool("YT_FORCE_IPV6")
-	if force4 && force6 {
+	if c.IPVersion != IPVersionAny {
+		return c.IPVersion
+	}
+	forceV4 := parseEnvBool("YT_FORCE_IPV4")
+	forceV6 := parseEnvBool("YT_FORCE_IPV6")
+	if forceV4 {
 		return IPVersionV4
 	}
-	if force4 {
-		return IPVersionV4
-	}
-	if force6 {
+	if forceV6 {
 		return IPVersionV6
 	}
 	return c.IPVersion

--- a/yt/go/yt/config.go
+++ b/yt/go/yt/config.go
@@ -426,12 +426,10 @@ func (c *Config) GetIPVersion() IPVersion {
 	if c.IPVersion != IPVersionAny {
 		return c.IPVersion
 	}
-	forceV4 := parseEnvBool("YT_FORCE_IPV4")
-	forceV6 := parseEnvBool("YT_FORCE_IPV6")
-	if forceV4 {
+	if parseEnvBool("YT_FORCE_IPV4") {
 		return IPVersionV4
 	}
-	if forceV6 {
+	if parseEnvBool("YT_FORCE_IPV6") {
 		return IPVersionV6
 	}
 	return c.IPVersion

--- a/yt/go/yt/config_test.go
+++ b/yt/go/yt/config_test.go
@@ -192,3 +192,66 @@ func TestClusterURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetIPVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		ipVersion IPVersion
+		envIPv4   string
+		envIPv6   string
+		want      IPVersion
+		wantNet   string
+	}{
+		{
+			name:      "config overrides env",
+			ipVersion: IPVersionV4,
+			envIPv4:   "",
+			envIPv6:   "true",
+			want:      IPVersionV4,
+			wantNet:   "tcp4",
+		},
+		{
+			name:      "env force ipv4",
+			ipVersion: IPVersionAny,
+			envIPv4:   "true",
+			envIPv6:   "",
+			want:      IPVersionV4,
+			wantNet:   "tcp4",
+		},
+		{
+			name:      "env force ipv6",
+			ipVersion: IPVersionAny,
+			envIPv4:   "",
+			envIPv6:   "true",
+			want:      IPVersionV6,
+			wantNet:   "tcp6",
+		},
+		{
+			name:      "both env true prefers ipv4",
+			ipVersion: IPVersionAny,
+			envIPv4:   "true",
+			envIPv6:   "true",
+			want:      IPVersionV4,
+			wantNet:   "tcp4",
+		},
+		{
+			name:      "any no env",
+			ipVersion: IPVersionAny,
+			envIPv4:   "",
+			envIPv6:   "",
+			want:      IPVersionAny,
+			wantNet:   "tcp",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("YT_FORCE_IPV4", tc.envIPv4)
+			t.Setenv("YT_FORCE_IPV6", tc.envIPv6)
+
+			conf := Config{IPVersion: tc.ipVersion}
+			got := conf.GetIPVersion()
+			require.Equal(t, tc.want, got)
+			require.Equal(t, tc.wantNet, got.Network())
+		})
+	}
+}

--- a/yt/go/yt/config_test.go
+++ b/yt/go/yt/config_test.go
@@ -203,12 +203,12 @@ func TestGetIPVersion(t *testing.T) {
 		wantNet   string
 	}{
 		{
-			name:      "config overrides env",
+			name:      "env ipv6 overrides config ipv4",
 			ipVersion: IPVersionV4,
 			envIPv4:   "",
 			envIPv6:   "true",
-			want:      IPVersionV4,
-			wantNet:   "tcp4",
+			want:      IPVersionV6,
+			wantNet:   "tcp6",
 		},
 		{
 			name:      "env force ipv4",

--- a/yt/go/yt/config_test.go
+++ b/yt/go/yt/config_test.go
@@ -203,12 +203,28 @@ func TestGetIPVersion(t *testing.T) {
 		wantNet   string
 	}{
 		{
-			name:      "env ipv6 overrides config ipv4",
+			name:      "config ipv4 ignores env ipv6",
 			ipVersion: IPVersionV4,
 			envIPv4:   "",
 			envIPv6:   "true",
+			want:      IPVersionV4,
+			wantNet:   "tcp4",
+		},
+		{
+			name:      "config ipv6 ignores env ipv4",
+			ipVersion: IPVersionV6,
+			envIPv4:   "true",
+			envIPv6:   "",
 			want:      IPVersionV6,
 			wantNet:   "tcp6",
+		},
+		{
+			name:      "config ipv4 ignores both env",
+			ipVersion: IPVersionV4,
+			envIPv4:   "true",
+			envIPv6:   "true",
+			want:      IPVersionV4,
+			wantNet:   "tcp4",
 		},
 		{
 			name:      "env force ipv4",

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -751,10 +751,12 @@ func BuildHTTPClient(c *yt.Config) (*http.Client, error) {
 		KeepAlive: 30 * time.Second,
 	}
 
+	network := c.GetIPVersion().Network()
+
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
-				return dialContext(ctx, netDialer, c.GetIPVersion().Network(), addr)
+				return dialContext(ctx, netDialer, network, addr)
 			},
 
 			MaxIdleConns:        0,

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -753,8 +753,8 @@ func BuildHTTPClient(c *yt.Config) (*http.Client, error) {
 
 	httpClient := &http.Client{
 		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				return dialContext(ctx, netDialer, network, addr)
+			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+				return dialContext(ctx, netDialer, c.IPVersion.Network(), addr)
 			},
 
 			MaxIdleConns:        0,

--- a/yt/go/yt/internal/httpclient/client.go
+++ b/yt/go/yt/internal/httpclient/client.go
@@ -754,7 +754,7 @@ func BuildHTTPClient(c *yt.Config) (*http.Client, error) {
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
-				return dialContext(ctx, netDialer, c.IPVersion.Network(), addr)
+				return dialContext(ctx, netDialer, c.GetIPVersion().Network(), addr)
 			},
 
 			MaxIdleConns:        0,

--- a/yt/go/yt/internal/rpcclient/client.go
+++ b/yt/go/yt/internal/rpcclient/client.go
@@ -57,7 +57,7 @@ func BuildHTTPClient(c *yt.Config) (*http.Client, error) {
 		RootCAs: certPool,
 	}
 
-	network := c.IPVersion.Network()
+	network := c.GetIPVersion().Network()
 	dialer := &net.Dialer{}
 
 	httpClient := &http.Client{
@@ -116,7 +116,7 @@ func NewClient(conf *yt.Config) (*client, error) {
 		clientOpts := []bus.ClientOption{
 			bus.WithLogger(c.log.Logger()),
 			bus.WithDefaultProtocolVersionMajor(ProtocolVersionMajor),
-			bus.WithNetwork(conf.IPVersion.Network()),
+			bus.WithNetwork(conf.GetIPVersion().Network()),
 		}
 		if conf.UseTLS && transport.TLSClientConfig != nil {
 			busTLSConfig := transport.TLSClientConfig.Clone()

--- a/yt/go/yt/internal/rpcclient/client.go
+++ b/yt/go/yt/internal/rpcclient/client.go
@@ -57,8 +57,15 @@ func BuildHTTPClient(c *yt.Config) (*http.Client, error) {
 		RootCAs: certPool,
 	}
 
+	network := c.IPVersion.Network()
+	dialer := &net.Dialer{}
+
 	httpClient := &http.Client{
 		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			},
+
 			MaxIdleConns:        0,
 			MaxIdleConnsPerHost: 100,
 			MaxConnsPerHost:     100,
@@ -109,6 +116,7 @@ func NewClient(conf *yt.Config) (*client, error) {
 		clientOpts := []bus.ClientOption{
 			bus.WithLogger(c.log.Logger()),
 			bus.WithDefaultProtocolVersionMajor(ProtocolVersionMajor),
+			bus.WithNetwork(conf.IPVersion.Network()),
 		}
 		if conf.UseTLS && transport.TLSClientConfig != nil {
 			busTLSConfig := transport.TLSClientConfig.Clone()


### PR DESCRIPTION
Hello! I added IPVersion option to Go SDK which allows choosing IP address family.

In C++/Python SDKs there are force_ipv4/force_ipv6 fields that do the same thing, I needed that behaviour in Go.

Changelog entry
Type: feature
Component: go-sdk
Added IPVersion to config which allows choosing IP address family