### PR TITLE
Secure mTLS secrets passed to job proxy via environment variables

### DIFF
--- a/yt/yt/core/crypto/config.cpp
+++ b/yt/yt/core/crypto/config.cpp
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "secure_environment.h"
 
 #include <util/system/env.h>
 
@@ -33,6 +34,9 @@ TPemBlobConfigPtr TPemBlobConfig::CreateFileReference(const TString& fileName)
 TString TPemBlobConfig::LoadBlob(TCertificatePathResolver pathResolver) const
 {
     if (EnvironmentVariable) {
+        if (auto value = GetSecureEnvironment()->Find<TString>(*EnvironmentVariable)) {
+            return *std::move(value);
+        }
         if (auto value = TryGetEnv(*EnvironmentVariable)) {
             return *std::move(value);
         }

--- a/yt/yt/core/crypto/secure_environment.cpp
+++ b/yt/yt/core/crypto/secure_environment.cpp
@@ -1,0 +1,187 @@
+#include "secure_environment.h"
+
+#include <yt/yt/core/ytree/helpers.h>
+
+#include <yt/yt/library/undumpable/undumpable.h>
+
+#include <library/cpp/yt/memory/chunked_memory_pool.h>
+#include <library/cpp/yt/memory/leaky_singleton.h>
+
+#include <util/system/env.h>
+
+namespace NYT::NCrypto {
+
+using namespace NYTree;
+using namespace NYson;
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TSecureMemoryPoolTag
+{ };
+
+////////////////////////////////////////////////////////////////////////////////
+
+class TSecureMemoryChunkProvider
+    : public IMemoryChunkProvider
+{
+public:
+    std::unique_ptr<TAllocationHolder> Allocate(size_t size, TRefCountedTypeCookie cookie) override
+    {
+        return std::unique_ptr<THolder>(TAllocationHolder::Allocate<THolder>(size, cookie));
+    }
+
+private:
+    struct THolder
+        : public TAllocationHolder
+    {
+        THolder(TMutableRef ref, TRefCountedTypeCookie cookie)
+            : TAllocationHolder(ref, cookie)
+        {
+            MarkUndumpableOob(ref.Begin(), ref.Size());
+        }
+
+        ~THolder() override
+        {
+            auto ref = GetRef();
+            SecureZero(ref.Begin(), ref.Size());
+            UnmarkUndumpableOob(ref.Begin());
+        }
+    };
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+template <class TUnderlyingRef>
+class TSecureZeroHolder
+    : public TSharedRangeHolder
+{
+public:
+    explicit TSecureZeroHolder(const TUnderlyingRef& ref)
+        : Ref_(ref)
+    { }
+
+    ~TSecureZeroHolder()
+    {
+        SecureZero(Ref_.data(), Ref_.size() * sizeof(*Ref_.data()));
+    }
+private:
+    const TUnderlyingRef Ref_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! IAttributeDictionary implementation that securely stores YSON values in
+//! undumpable memory allocated from a TChunkedMemoryPool and wiped at delete.
+/*!
+ *  Values are captured into pool memory via Capture() and wrapped
+ *  in TSharedRef-backed TYsonString objects with a zeroing holder.
+ *
+ *  This relies on TChunkedMemoryPool never deallocating individual
+ *  allocations and the pool outliving all TYsonString instances.
+ *  This is always true when pool lives for the singleton lifetime.
+ *
+ *  This class is NOT thread-safe on its own.
+ *  Thread-safety is provided by wrapping with CreateThreadSafeAttributes().
+ *
+ *  Right now access isn't always zero-copy and could leak content.
+ *  TODO(khlebnikov): Add zero-copy Find<TStringBuf> or YPath resolver.
+ */
+class TSecureAttributeDictionary
+    : public IAttributeDictionary
+{
+public:
+    TSecureAttributeDictionary()
+        : Pool_(
+            GetRefCountedTypeCookie<TSecureMemoryPoolTag>(),
+            New<TSecureMemoryChunkProvider>())
+    { }
+
+    std::vector<TKey> ListKeys() const override
+    {
+        std::vector<TKey> keys;
+        keys.reserve(Map_.size());
+        for (const auto& [key, value] : Map_) {
+            keys.push_back(key);
+        }
+        return keys;
+    }
+
+    std::vector<TKeyValuePair> ListPairs() const override
+    {
+        std::vector<TKeyValuePair> pairs;
+        pairs.reserve(Map_.size());
+        for (const auto& pair : Map_) {
+            pairs.push_back(pair);
+        }
+        return pairs;
+    }
+
+    TValue FindYson(TKeyView key) const override
+    {
+        auto it = Map_.find(key);
+        return it == Map_.end() ? TYsonString() : it->second;
+    }
+
+    void SetYson(TKeyView key, const TValue& value) override
+    {
+        Map_[key] = Capture(value);
+    }
+
+    bool Remove(TKeyView key) override
+    {
+        return Map_.erase(key) > 0;
+    }
+
+private:
+    TChunkedMemoryPool Pool_;
+    THashMap<TKey, TYsonString, THash<std::string_view>, TEqualTo<std::string_view>> Map_;
+
+    //! Captures the value content into the memory pool.
+    TYsonString Capture(const TYsonString& value)
+    {
+        auto copy = Pool_.Capture(value.ToSharedRef());
+        TSharedRef ref(copy.data(), copy.size(), New<TSecureZeroHolder<TMutableRange<char>>>(copy));
+        return TYsonString(ref, value.GetType());
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct TSecureEnvironmentHolder
+{
+    IAttributeDictionaryPtr Underlying;
+    IAttributeDictionaryPtr Dictionary;
+
+    TSecureEnvironmentHolder()
+    {
+        Underlying = New<TSecureAttributeDictionary>();
+        Dictionary = CreateThreadSafeAttributes(Underlying.Get());
+    }
+};
+
+const IAttributeDictionaryPtr& GetSecureEnvironment()
+{
+    return LeakySingleton<TSecureEnvironmentHolder>()->Dictionary;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MoveToSecureEnvironment(const std::vector<TStringBuf>& names, const std::vector<TStringBuf>& namePrefixes)
+{
+    auto secureEnv = GetSecureEnvironment();
+    IterateEnv([&](TStringBuf name, TStringBuf value) {
+        if (std::ranges::find(names, name) != names.end() ||
+            std::ranges::find_if(namePrefixes, [&] (TStringBuf prefix) { return name.StartsWith(prefix); }) != namePrefixes.end())
+        {
+            // TODO(khlebnikov): Add EYsonType::String and do zero-copy.
+            // NOTE: Right now it works because "ReadUnquotedString" in YSON parser.
+            // secureEnv->SetYson(name, TYsonString(value, EYsonType(-2)));
+            secureEnv->Set(name, value);
+            ::memset(const_cast<char*>(value.data()), '*', value.size());
+        }
+    });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NCrypto

--- a/yt/yt/core/crypto/secure_environment.h
+++ b/yt/yt/core/crypto/secure_environment.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <yt/yt/core/ytree/attributes.h>
+
+#include <util/generic/strbuf.h>
+
+namespace NYT::NCrypto {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Returns the singleton thread-safe attribute dictionary for secure environment variables.
+/*!
+ *  Provides a secure in-process storage for sensitive configuration values
+ *  (tokens, keys, certificates, etc.) that can be populated at server start
+ *  or at any later point.
+ *
+ *  Implements IAttributeDictionary (like TEphemeralAttributeDictionary) but
+ *  allocates YSON value storage from a TChunkedMemoryPool backed by undumpable
+ *  memory, so that sensitive data is excluded from core dumps.
+ *
+ *  Memory used for storing values is zeroed at removing or overwriting value,
+ *  and never freed or reused for new secrets, thus dangling pointers stay safe.
+ *
+ *  The returned dictionary is thread-safe.
+ *
+ *  Usage:
+ *    auto env = GetSecureEnvironment();
+ *    env->Set("YT_TOKEN", token);
+ *    auto token = env->Find<TString>("YT_TOKEN");
+ */
+const NYTree::IAttributeDictionaryPtr& GetSecureEnvironment();
+
+//! Move into secure environment variables with given names or prefixes.
+//! Original environment variable values are filled with '*' characters.
+/*!
+ *  Usage:
+ *  MoveToSecureEnvironment(
+ *    std::vector<TStringBuf>{"YT_TOKEN"},
+ *    std::vector<TStringBuf>{"YT_SECURE_VAULT"},
+ *  );
+ */
+void MoveToSecureEnvironment(const std::vector<TStringBuf>& names, const std::vector<TStringBuf>& namePrefixes = {});
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NCrypto

--- a/yt/yt/core/crypto/unittests/secure_environment_ut.cpp
+++ b/yt/yt/core/crypto/unittests/secure_environment_ut.cpp
@@ -1,0 +1,132 @@
+#include <yt/yt/core/test_framework/framework.h>
+
+#include <yt/yt/core/crypto/secure_environment.h>
+
+#include <yt/yt/library/undumpable/undumpable.h>
+
+#include <util/system/env.h>
+
+namespace NYT::NCrypto {
+namespace {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(TSecureEnvironmentTest, Singleton)
+{
+    auto env1 = GetSecureEnvironment();
+    auto env2 = GetSecureEnvironment();
+    EXPECT_EQ(env1.Get(), env2.Get());
+}
+
+TEST(TSecureEnvironmentTest, SetFindRemove)
+{
+    auto env = GetSecureEnvironment();
+    env->Set("test_key_1", "test_value_1");
+
+    auto value = env->Find<TString>("test_key_1");
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, "test_value_1");
+
+    // Cleanup.
+    EXPECT_TRUE(env->Remove("test_key_1"));
+    ASSERT_FALSE(env->Contains("test_key_1"));
+
+    // Removing again returns false.
+    EXPECT_FALSE(env->Remove("test_key_1"));
+
+    ASSERT_FALSE(env->Contains("nonexistent_key"));
+    EXPECT_FALSE(env->Find<TString>("nonexistent_key").has_value());
+}
+
+TEST(TSecureEnvironmentTest, ListKeys)
+{
+    auto env = GetSecureEnvironment();
+    env->Set("list_key_1", "v1");
+    env->Set("list_key_2", "v2");
+
+    auto keys = env->ListKeys();
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "list_key_1") != keys.end());
+    EXPECT_TRUE(std::find(keys.begin(), keys.end(), "list_key_2") != keys.end());
+
+    env->Remove("list_key_1");
+    env->Remove("list_key_2");
+}
+
+TEST(TSecureEnvironmentTest, Zeroing)
+{
+    auto env = GetSecureEnvironment();
+    env->Set("test_key_2", "test_value_1");
+    auto value1 = env->FindYson("test_key_2").AsStringBuf();
+    EXPECT_EQ(value1, "\x1\x18test_value_1");
+
+    // Overwrite.
+    env->Set("test_key_2", "test_value_2");
+    auto value2 = env->FindYson("test_key_2").AsStringBuf();
+    EXPECT_EQ(value2, "\x1\x18test_value_2");
+
+    // Previous value is zeroed.
+    EXPECT_NE(value1.data(), value2.data());
+    EXPECT_EQ(value1.find_first_not_of('\0'), std::string_view::npos);
+
+    auto value = env->Find<TString>("test_key_2");
+    ASSERT_TRUE(value.has_value());
+    EXPECT_EQ(*value, "test_value_2");
+
+    // Cleanup.
+    env->Remove("test_key_2");
+    EXPECT_EQ(value2.find_first_not_of('\0'), std::string_view::npos);
+}
+
+TEST(TSecureEnvironmentTest, UndumpableMemory)
+{
+    auto env = GetSecureEnvironment();
+    auto sizeBefore = GetUndumpableMemorySize();
+
+    // Insert a value large enough to trigger a new pool chunk allocation.
+    TString largeValue(1<<20, 'X');
+    env->Set("undumpable_key", largeValue);
+    auto sizeAfter = GetUndumpableMemorySize();
+    EXPECT_GE(sizeAfter, sizeBefore + largeValue.size());
+
+    env->Remove("undumpable_key");
+
+    auto sizeAfterRemove = GetUndumpableMemorySize();
+    EXPECT_GE(sizeAfterRemove, sizeAfter);
+}
+
+TEST(TSecureEnvironmentTest, MoveEnv)
+{
+    // Move undefined variable.
+    MoveToSecureEnvironment(std::vector<TStringBuf>{"YT_SECURE_TEST_MISSING"});
+    EXPECT_FALSE(GetSecureEnvironment()->Find<TString>("YT_SECURE_TEST_MISSING").has_value());
+
+    // Move defined variables.
+    SetEnv("YT_SECURE_TEST_EXACT", "secret_value");
+    SetEnv("YT_SECURE_TEST_PREFIX_TEST", "secret_value_2");
+
+    MoveToSecureEnvironment(std::vector<TStringBuf>{"YT_SECURE_TEST_EXACT"}, std::vector<TStringBuf>{"YT_SECURE_TEST_PREFIX_"});
+
+    // Value is now in secure env.
+    auto secureValue = GetSecureEnvironment()->Find<TString>("YT_SECURE_TEST_EXACT");
+    ASSERT_TRUE(secureValue.has_value());
+    EXPECT_EQ(*secureValue, "secret_value");
+
+    auto secureValue2 = GetSecureEnvironment()->Find<TString>("YT_SECURE_TEST_PREFIX_TEST");
+    ASSERT_TRUE(secureValue2.has_value());
+    EXPECT_EQ(*secureValue2, "secret_value_2");
+
+    // Original env string has been filled with '*'.
+    EXPECT_EQ(GetEnv("YT_SECURE_TEST_EXACT"), std::string(secureValue->size(), '*'));
+    EXPECT_EQ(GetEnv("YT_SECURE_TEST_PREFIX_TEST"), std::string(secureValue2->size(), '*'));
+
+    // Cleanup secure env.
+    GetSecureEnvironment()->Remove("YT_SECURE_TEST_EXACT");
+    GetSecureEnvironment()->Remove("YT_SECURE_TEST_PREFIX_TEST");
+    UnsetEnv("YT_SECURE_TEST_EXACT");
+    UnsetEnv("YT_SECURE_TEST_PREFIX_TEST");
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace
+} // namespace NYT::NCrypto

--- a/yt/yt/core/crypto/unittests/ya.make
+++ b/yt/yt/core/crypto/unittests/ya.make
@@ -6,6 +6,7 @@ PROTO_NAMESPACE(yt)
 
 SRCS(
     crypto_ut.cpp
+    secure_environment_ut.cpp
     tls_ut.cpp
 )
 

--- a/yt/yt/core/ya.make
+++ b/yt/yt/core/ya.make
@@ -103,6 +103,7 @@ SRCS(
 
     crypto/config.cpp
     crypto/crypto.cpp
+    crypto/secure_environment.cpp
     crypto/tls.cpp
 
     logging/appendable_compressed_file.cpp

--- a/yt/yt/server/job_proxy/job_proxy.cpp
+++ b/yt/yt/server/job_proxy/job_proxy.cpp
@@ -112,6 +112,8 @@
 #include <yt/yt/core/concurrency/thread_pool_poller.h>
 #include <yt/yt/core/concurrency/throughput_throttler.h>
 
+#include <yt/yt/core/crypto/secure_environment.h>
+
 #include <yt/yt/core/tracing/trace_context.h>
 
 #include <yt/yt/core/misc/fs.h>
@@ -859,6 +861,19 @@ void TJobProxy::EnableRpcProxyInJobProxy(int rpcProxyWorkerThreadPoolSize, bool 
 IJobProxyEnvironmentPtr TJobProxy::FindJobProxyEnvironment() const
 {
     return JobProxyEnvironment_.Acquire();
+}
+
+void TJobProxy::SecureEnvironmentVariables() const
+{
+    std::vector<TStringBuf> names;
+    for (const auto& variable : Config_->EnvironmentVariables) {
+        if (!variable->ForwardToUserJob.value_or(true)) {
+            names.push_back(variable->Name);
+        }
+    }
+    if (!names.empty()) {
+        NCrypto::MoveToSecureEnvironment(names);
+    }
 }
 
 TJobResult TJobProxy::RunJob()

--- a/yt/yt/server/job_proxy/job_proxy.h
+++ b/yt/yt/server/job_proxy/job_proxy.h
@@ -95,6 +95,8 @@ public:
 
     void OnProgressSaved(TInstant when);
 
+    void SecureEnvironmentVariables() const;
+
 private:
     DECLARE_THREAD_AFFINITY_SLOT(JobThread);
 

--- a/yt/yt/server/job_proxy/program.cpp
+++ b/yt/yt/server/job_proxy/program.cpp
@@ -129,6 +129,7 @@ protected:
         ConfigureSingletons(config);
 
         auto jobProxy = New<TJobProxy>(std::move(config), OperationId_, JobId_);
+        jobProxy->SecureEnvironmentVariables();
         jobProxy->Run();
 
         // Everything should be properly destructed.

--- a/yt/yt/tests/integration/node/test_job_proxy.py
+++ b/yt/yt/tests/integration/node/test_job_proxy.py
@@ -661,6 +661,14 @@ class TestJobProxyTls(YTEnvSetup):
     def test_smoke(self):
         run_test_vanilla("true", track=True)
 
+    def test_secure_environment(self):
+        script = [
+            "grep -q JobProxyMain /proc/$PPID/comm",
+            "grep -q YT_JOB_PROXY_BUS_CLIENT_PRIVATE_KEY /proc/$PPID/environ",
+            "! grep -q 'PRIVATE KEY' /proc/$PPID/environ",
+        ]
+        run_test_vanilla(" && ".join(script), track=True)
+
 
 @authors("khlebnikov")
 class TestJobProxyTlsCri(TestJobProxyTls):


### PR DESCRIPTION
**Implement Secure Environment in undumpable memory with zeroing**

Singleton GetSecureEnvironment() implements interface IAttributeDictionary.

Function MoveToSecureEnvironment() moves environment variables with given
names or name prefixes into secure environment and hides original values.

**Secure mTLS secrets passed to job proxy via environment variables**

Protect environment variables which are not should be forwarded to user job.
For example mTLS certificates passed to job-proxy via environment.

This solution is better than nothing for case when execution environments
are not completely isolated and provides some protection for all cases.

I.e. certificates will not be included as plain text in code dumps and
no longer exposed in /proc/pid/environ.

---

* Changelog entry
Type: feature
Component: map-reduce

Secure mTLS secrets passed to job proxy via environment variables
