### PR TITLE
yt/yt/core/crypto: prefer CA set by SSL_CERT_FILE and SSL_CERT_DIR

### DIFF
--- a/yt/yt/core/crypto/tls.cpp
+++ b/yt/yt/core/crypto/tls.cpp
@@ -800,6 +800,7 @@ TInstant TSslContext::GetCommitTime() const
 void TSslContext::ApplyConfig(const TSslContextConfigPtr& config, TCertificatePathResolver pathResolver)
 {
     if (!config) {
+        UseDefaultOpenSslX509Store();
         return;
     }
 
@@ -837,9 +838,9 @@ void TSslContext::ApplyConfig(const TSslContextConfigPtr& config, TCertificatePa
     Impl_->SetInsecureSkipVerify(config->InsecureSkipVerify);
 }
 
-void TSslContext::UseBuiltinOpenSslX509Store()
+void TSslContext::UseDefaultOpenSslX509Store()
 {
-    SSL_CTX_set_cert_store(Impl_->GetContext(), GetBuiltinOpenSslX509Store().Release());
+    SSL_CTX_set_cert_store(Impl_->GetContext(), GetDefaultOpenSslX509Store().Release());
 }
 
 void TSslContext::SetCipherList(const std::string& list)
@@ -976,6 +977,8 @@ void TSslContext::AddCertificateAuthority(const TPemBlobConfigPtr& pem, TCertifi
 {
     if (pem) {
         AddCertificateAuthority(pem->LoadBlob(resolver));
+    } else {
+        UseDefaultOpenSslX509Store();
     }
 }
 

--- a/yt/yt/core/crypto/tls.h
+++ b/yt/yt/core/crypto/tls.h
@@ -74,7 +74,7 @@ public:
 
     void ApplyConfig(const TSslContextConfigPtr& config, TCertificatePathResolver pathResolver = nullptr);
 
-    void UseBuiltinOpenSslX509Store();
+    void UseDefaultOpenSslX509Store();
 
     void SetCipherList(const std::string& list);
 

--- a/yt/yt/core/crypto/unittests/tls_ut.cpp
+++ b/yt/yt/core/crypto/unittests/tls_ut.cpp
@@ -14,7 +14,10 @@
 
 #include <yt/yt/core/rpc/grpc/dispatcher.h>
 
+#include <yt/yt/core/crypto/config.h>
 #include <yt/yt/core/crypto/tls.h>
+
+#include <util/system/env.h>
 
 namespace NYT {
 namespace {
@@ -49,9 +52,46 @@ public:
         Poller->Shutdown();
     }
 
+    void PingPong()
+    {
+        auto localhost = TNetworkAddress::CreateIPv6Loopback(0);
+        Listener = Context->CreateListener(localhost, Poller, Poller);
+
+        auto config = New<TDialerConfig>();
+        config->SetDefaults();
+        Dialer = Context->CreateDialer(config, Poller, NetLogger());
+
+        auto context = New<TDialerContext>();
+        context->Host = "localhost";
+
+        auto asyncFirstSide = Dialer->Dial(Listener->GetAddress(), context);
+        auto asyncSecondSide = Listener->Accept();
+
+        auto firstSide = WaitForFast(asyncFirstSide).ValueOrThrow();
+        auto secondSide = WaitForFast(asyncSecondSide).ValueOrThrow();
+
+        auto buffer = TSharedRef::FromString(std::string("ping"));
+        auto outputBuffer = TSharedMutableRef::Allocate(4);
+
+        auto result = WaitForFast(firstSide->Write(buffer));
+        ASSERT_EQ(WaitForFast(secondSide->Read(outputBuffer)).ValueOrThrow(), 4u);
+        result.ThrowOnError();
+        ASSERT_EQ(ToString(outputBuffer), ToString(buffer));
+
+        WaitForFast(secondSide->Write(buffer)).ThrowOnError();
+        ASSERT_EQ(WaitForFast(firstSide->Read(outputBuffer)).ValueOrThrow(), 4u);
+        ASSERT_EQ(ToString(outputBuffer), ToString(buffer));
+
+        WaitFor(firstSide->Close())
+            .ThrowOnError();
+        ASSERT_EQ(WaitForFast(secondSide->Read(outputBuffer)).ValueOrThrow(), 0u);
+    }
+
     NRpc::NGrpc::TGrpcLibraryLockPtr GrpcLock;
     TSslContextPtr Context;
     IPollerPtr Poller;
+    IListenerPtr Listener;
+    IDialerPtr Dialer;
 };
 
 TEST_F(TTlsTest, CreateContext)
@@ -79,37 +119,81 @@ TEST_F(TTlsTest, CreateDialer)
 
 TEST_F(TTlsTest, SimplePingPong)
 {
-    auto localhost = TNetworkAddress::CreateIPv6Loopback(0);
-    auto listener = Context->CreateListener(localhost, Poller, Poller);
+    PingPong();
+}
 
-    auto config = New<TDialerConfig>();
-    config->SetDefaults();
-    auto dialer = Context->CreateDialer(config, Poller, NetLogger());
+TEST_F(TTlsTest, LoadCertificatesFromValues)
+{
+    auto config = New<TSslContextConfig>();
+    config->CertificateAuthority = CreateTestKeyBlob("ca.pem");
+    config->CertificateChain = CreateTestKeyBlob("cert.pem");
+    config->PrivateKey = CreateTestKeyBlob("key.pem");
+    Context->Reset();
+    Context->ApplyConfig(config);
+    Context->Commit();
+    PingPong();
+}
 
-    auto context = New<TDialerContext>();
-    context->Host = "localhost";
+TEST_F(TTlsTest, LoadCertificatesFromFiles)
+{
+    auto config = New<TSslContextConfig>();
+    config->CertificateAuthority = CreateTestKeyFile("ca.pem");
+    config->CertificateChain = CreateTestKeyFile("cert.pem");
+    config->PrivateKey = CreateTestKeyFile("key.pem");
+    Context->Reset();
+    Context->ApplyConfig(config);
+    Context->Commit();
+    PingPong();
+}
 
-    auto asyncFirstSide = dialer->Dial(listener->GetAddress(), context);
-    auto asyncSecondSide = listener->Accept();
+TEST_F(TTlsTest, LoadBuiltInCertificateAuthorityForEmptyConfig)
+{
+    UnsetEnv("SSL_CERT_FILE");
+    Context->Reset();
+    Context->ApplyConfig(nullptr);
+    Context->AddCertificate(GetTestKeyContent("cert.pem"));
+    Context->AddPrivateKey(GetTestKeyContent("key.pem"));
+    Context->Commit();
+    EXPECT_THROW_WITH_SUBSTRING(PingPong(), "SSL_do_handshake failed");
+}
 
-    auto firstSide = WaitForFast(asyncFirstSide).ValueOrThrow();
-    auto secondSide = WaitForFast(asyncSecondSide).ValueOrThrow();
+TEST_F(TTlsTest, LoadBuiltInCertificateAuthorityAsDefault)
+{
+    UnsetEnv("SSL_CERT_FILE");
+    auto config = New<TSslContextConfig>();
+    config->CertificateChain = CreateTestKeyFile("cert.pem");
+    config->PrivateKey = CreateTestKeyFile("key.pem");
+    Context->Reset();
+    Context->ApplyConfig(config);
+    Context->Commit();
+    EXPECT_THROW_WITH_SUBSTRING(PingPong(), "SSL_do_handshake failed");
+}
 
-    auto buffer = TSharedRef::FromString(std::string("ping"));
-    auto outputBuffer = TSharedMutableRef::Allocate(4);
+TEST_F(TTlsTest, LoadEnvironmentCertificateAuthorityForEmptyConfig)
+{
+    auto ca = CreateTestKeyFile("ca.pem");
+    SetEnv("SSL_CERT_FILE", TString(*ca->FileName));
+    Context->Reset();
+    Context->ApplyConfig(nullptr);
+    Context->AddCertificate(GetTestKeyContent("cert.pem"));
+    Context->AddPrivateKey(GetTestKeyContent("key.pem"));
+    Context->Commit();
+    PingPong();
+    UnsetEnv("SSL_CERT_FILE");
+}
 
-    auto result = WaitForFast(firstSide->Write(buffer));
-    ASSERT_EQ(WaitForFast(secondSide->Read(outputBuffer)).ValueOrThrow(), 4u);
-    result.ThrowOnError();
-    ASSERT_EQ(ToString(outputBuffer), ToString(buffer));
-
-    WaitForFast(secondSide->Write(buffer)).ThrowOnError();
-    ASSERT_EQ(WaitForFast(firstSide->Read(outputBuffer)).ValueOrThrow(), 4u);
-    ASSERT_EQ(ToString(outputBuffer), ToString(buffer));
-
-    WaitFor(firstSide->Close())
-        .ThrowOnError();
-    ASSERT_EQ(WaitForFast(secondSide->Read(outputBuffer)).ValueOrThrow(), 0u);
+TEST_F(TTlsTest, LoadEnvironmentCertificateAuthorityAsDefault)
+{
+    auto ca = CreateTestKeyFile("ca.pem");
+    SetEnv("SSL_CERT_FILE", TString(*ca->FileName));
+    auto config = New<TSslContextConfig>();
+    config->CertificateChain = CreateTestKeyFile("cert.pem");
+    config->PrivateKey = CreateTestKeyFile("key.pem");
+    Context->Reset();
+    Context->ApplyConfig(config);
+    Context->Commit();
+    PingPong();
+    UnsetEnv("SSL_CERT_FILE");
 }
 
 TEST(TTlsTestWithoutFixtureTest, LoadCertificateChain)

--- a/yt/yt/core/https/client.cpp
+++ b/yt/yt/core/https/client.cpp
@@ -107,11 +107,7 @@ IClientPtr CreateClient(
     const IPollerPtr& poller)
 {
     auto sslContext =  New<TSslContext>();
-    if (config->Credentials) {
-        sslContext->ApplyConfig(config->Credentials);
-    } else {
-        sslContext->UseBuiltinOpenSslX509Store();
-    }
+    sslContext->ApplyConfig(config->Credentials);
     sslContext->Commit();
 
     auto dialerConfig = New<TDialerConfig>();

--- a/yt/yt/core/https/server.cpp
+++ b/yt/yt/core/https/server.cpp
@@ -101,11 +101,6 @@ private:
     IPollerPtr OwnPoller_;
 };
 
-static void ApplySslConfig(const TSslContextPtr& sslContext, const TServerCredentialsConfigPtr& sslConfig)
-{
-    sslContext->ApplyConfig(sslConfig);
-}
-
 IServerPtr CreateServer(
     const TServerConfigPtr& config,
     const IPollerPtr& poller,
@@ -113,13 +108,14 @@ IServerPtr CreateServer(
     const IInvokerPtr& controlInvoker,
     std::optional<NCrypto::TCertProfiler> certProfiler)
 {
-    auto sslContext = New<TSslContext>();
-    ApplySslConfig(sslContext, config->Credentials);
+    auto sslConfig = config->Credentials;
+    auto sslContext =  New<TSslContext>();
+    sslContext->ApplyConfig(sslConfig);
     sslContext->Commit();
 
-    auto sslConfig = config->Credentials;
     TPeriodicExecutorPtr certificateUpdater;
-    if (sslConfig->UpdatePeriod &&
+    if (sslConfig &&
+        sslConfig->UpdatePeriod &&
         sslConfig->CertificateChain->FileName &&
         sslConfig->PrivateKey->FileName)
     {
@@ -140,7 +136,7 @@ IServerPtr CreateServer(
                             config->ServerName,
                             modificationTime);
                         sslContext->Reset();
-                        ApplySslConfig(sslContext, sslConfig);
+                        sslContext->ApplyConfig(sslConfig);
                         sslContext->Commit(modificationTime);
                         YT_LOG_INFO("TLS certificates updated (ServerName: %v)",
                             config->ServerName);
@@ -166,7 +162,7 @@ IServerPtr CreateServer(
         acceptor);
 
     TPeriodicExecutorPtr certificateSensorsUpdater;
-    if (certProfiler && sslConfig->CertificateChain) {
+    if (certProfiler && sslConfig && sslConfig->CertificateChain) {
         auto certChainToExpiry = certProfiler->Profiler.Gauge("/cert_chain_to_expiry");
         // Update expiry time ASAP after creation.
         certChainToExpiry.Update(GetCertTimeToExpiry(sslConfig->CertificateChain));

--- a/yt/yt/library/s3/http.cpp
+++ b/yt/yt/library/s3/http.cpp
@@ -220,11 +220,7 @@ namespace {
 NYT::NCrypto::TSslContextPtr CreateSslContext(const NYT::NCrypto::TSslContextConfigPtr& config, NYT::NCrypto::TCertificatePathResolver pathResolver = nullptr)
 {
     auto sslContext = New<NYT::NCrypto::TSslContext>();
-    if (config) {
-        sslContext->ApplyConfig(config, std::move(pathResolver));
-    } else {
-        sslContext->UseBuiltinOpenSslX509Store();
-    }
+    sslContext->ApplyConfig(config, std::move(pathResolver));
     sslContext->Commit();
     return sslContext;
 }


### PR DESCRIPTION
Use CA certificates provided by environment instead of default built-in.
This aligns with most modern design, golang and curl behaviour.

Default Certificate Authority bundle includes:

builtin "certs/cacert.pem" when SSL_CERT_FILE and SSL_CERT_DIR both unset
SSL_CERT_FILE when set or /usr/local/ssl/cert.pem when unset
SSL_CERT_DIR when set or /usr/local/ssl/certs when unset

Link: https://github.com/ytsaurus/ytsaurus/pull/1635
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>

---

* Changelog entry
Type: fix
Component: cpp-sdk

Prefer CA certificates set by SSL_CERT_FILE and SSL_CERT_DIR
