### PR TITLE
Go SDK: partial result error handling

### DIFF
--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -1317,8 +1317,15 @@ type LookupRowsOptions struct {
 }
 
 type MultiLookupSubrequest struct {
-	Path                ypath.Path
-	KeepMissingRows     *bool
+	Path            ypath.Path
+	KeepMissingRows *bool
+	// EnablePartialResult allows the subrequest to succeed even when some tablets
+	// are unavailable.
+	//
+	// When set, rows for unavailable keys are omitted instead of failing the whole
+	// subrequest. The returned TableReader still yields all available rows, but
+	// TableReader.Err returns a *yterrors.PartialResultError reporting the unavailable
+	// key indexes, so callers can detect that the result is partial.
 	EnablePartialResult *bool
 	UseLookupCache      *bool
 	Columns             []string

--- a/yt/go/yt/internal/rpcclient/call.go
+++ b/yt/go/yt/internal/rpcclient/call.go
@@ -43,6 +43,7 @@ type ProtoMultiLookupSubresp interface {
 	ProtoRowset
 
 	GetAttachmentCount() int32
+	GetUnavailableKeyIndexes() []int32
 }
 
 type ProtoRowset interface {

--- a/yt/go/yt/internal/rpcclient/client.go
+++ b/yt/go/yt/internal/rpcclient/client.go
@@ -21,6 +21,7 @@ import (
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/internal"
+	"go.ytsaurus.tech/yt/go/yterrors"
 )
 
 var _ yt.Client = (*client)(nil)
@@ -213,6 +214,12 @@ func (c *client) doMultiLookup(
 		reader, err := newTableReader(rows, subresponse.GetRowsetDescriptor())
 		if err != nil {
 			return nil, xerrors.Errorf("unable to create table reader for subresponse %d: %w", i, err)
+		}
+
+		if unavailable := subresponse.GetUnavailableKeyIndexes(); len(unavailable) > 0 {
+			reader.partialErr = &yterrors.PartialResultError{
+				UnavailableKeyIndexes: append([]int32(nil), unavailable...),
+			}
 		}
 
 		readers[i] = reader

--- a/yt/go/yt/internal/rpcclient/table_reader.go
+++ b/yt/go/yt/internal/rpcclient/table_reader.go
@@ -21,6 +21,9 @@ type tableReader struct {
 	err     error
 	end     bool
 	started bool
+
+	// partialErr is set when the lookup used EnablePartialResult and some keys were unavailable.
+	partialErr error
 }
 
 func newTableReader(rows []wire.Row, d *rpc_proxy.TRowsetDescriptor) (*tableReader, error) {
@@ -86,7 +89,10 @@ func (r *tableReader) Next() bool {
 }
 
 func (r *tableReader) Err() error {
-	return r.err
+	if r.err != nil {
+		return r.err
+	}
+	return r.partialErr
 }
 
 func (r *tableReader) Close() error {

--- a/yt/go/yterrors/partial_result_error.go
+++ b/yt/go/yterrors/partial_result_error.go
@@ -1,0 +1,11 @@
+package yterrors
+
+type PartialResultError struct {
+	UnavailableKeyIndexes []int32
+}
+
+func (e *PartialResultError) Error() string {
+	return "partial lookup result: some keys unavailable"
+}
+
+var _ error = &PartialResultError{}

--- a/yt/go/yterrors/ya.make
+++ b/yt/go/yterrors/ya.make
@@ -6,6 +6,7 @@ SRCS(
     error.go
     error_code.go
     http_error.go
+    partial_result_error.go
     interop.go
     utf8.go
 )


### PR DESCRIPTION
Hello! Was missing error feedback when using EnablePartialResult option, so I added it.

* Changelog entry
Type: feature
Component: go-sdk

Added PartialResultError that is returned when EnablePartialResult is used and some tablets are unavailable.

