### PR TITLE
Add quiet mode to check-permission using CLI

### DIFF
--- a/yt/docs/en/_includes/api/cli/commands.md
+++ b/yt/docs/en/_includes/api/cli/commands.md
@@ -2531,7 +2531,7 @@ usage: yt add-member [-h] [--params PARAMS] [--member MEMBER] [--group GROUP] [m
 checks permission for Cypress node
 
 ```bash
-usage: yt check-permission [-h] [--params PARAMS] [--user USER] [--permission PERMISSION] [--path PATH] [--read-from READ_FROM] [--cache-sticky-group-size CACHE_STICKY_GROUP_SIZE]
+usage: yt check-permission [-h] [--params PARAMS] [--user USER] [--permission PERMISSION] [--path PATH] [-q] [--read-from READ_FROM] [--cache-sticky-group-size CACHE_STICKY_GROUP_SIZE]
                            [--columns COLUMNS] [--format FORMAT]
                            [user] [permission] [path]
 ```
@@ -2553,6 +2553,8 @@ usage: yt check-permission [-h] [--params PARAMS] [--user USER] [--permission PE
 > `--permission`    one of read, write, administer, create, use
 
 > `--path`    address in Cypress. See also: [YPATH](../../../user-guide/storage/ypath.md)
+
+> `-q, --quiet`    do not write anything to standard output; exit with 0 if permission is granted, 1 otherwise
 
 > `--read-from`    Can be set to «cache» to enable reads from system cache
 

--- a/yt/docs/ru/_includes/api/cli/commands.md
+++ b/yt/docs/ru/_includes/api/cli/commands.md
@@ -2531,7 +2531,7 @@ usage: yt add-member [-h] [--params PARAMS] [--member MEMBER] [--group GROUP] [m
 checks permission for Cypress node
 
 ```bash
-usage: yt check-permission [-h] [--params PARAMS] [--user USER] [--permission PERMISSION] [--path PATH] [--read-from READ_FROM] [--cache-sticky-group-size CACHE_STICKY_GROUP_SIZE]
+usage: yt check-permission [-h] [--params PARAMS] [--user USER] [--permission PERMISSION] [--path PATH] [-q] [--read-from READ_FROM] [--cache-sticky-group-size CACHE_STICKY_GROUP_SIZE]
                            [--columns COLUMNS] [--format FORMAT]
                            [user] [permission] [path]
 ```
@@ -2553,6 +2553,8 @@ usage: yt check-permission [-h] [--params PARAMS] [--user USER] [--permission PE
 > `--permission`    one of read, write, administer, create, use
 
 > `--path`    address in Cypress. See also: [YPATH](../../../user-guide/storage/ypath.md)
+
+> `-q, --quiet`    do not write anything to standard output; exit with 0 if permission is granted, 1 otherwise
 
 > `--read-from`    Can be set to «cache» to enable reads from system cache
 

--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -1965,7 +1965,14 @@ def add_unlock_parser(add_parser):
 
 @copy_docstring_from(yt.check_permission)
 def check_permission(**kwargs):
-    print_to_output(yt.check_permission(**kwargs), eoln=False)
+    quiet = kwargs.pop("quiet", False)
+    if quiet:
+        kwargs["format"] = None
+    result = yt.check_permission(**kwargs)
+    if quiet:
+        yt.config._cleanup()
+        sys.exit(0 if result["action"] == "allow" else 1)
+    print_to_output(result, eoln=False)
 
 
 def add_check_permission_parser(add_parser):
@@ -1973,6 +1980,8 @@ def add_check_permission_parser(add_parser):
     add_hybrid_argument(parser, "user")
     add_hybrid_argument(parser, "permission", help="one of read, write, administer, create, use")
     add_ypath_argument(parser, "path", hybrid=True)
+    parser.add_argument("-q", "--quiet", action="store_true",
+                        help="do not write anything to standard output; exit with 0 if permission is granted, 1 otherwise")
     add_read_from_arguments(parser)
     add_structured_argument(parser, "--columns")
     add_structured_format_argument(parser, default=output_format)

--- a/yt/python/yt/wrapper/tests/test_yt_cli.py
+++ b/yt/python/yt/wrapper/tests/test_yt_cli.py
@@ -627,6 +627,20 @@ class TestYtBinary(object):
         stdout = yt_cli.check_output(["yt", "check-permission", "test_user", "read", "//home/wrapper_test/table", "--columns", "[a]"])
         assert b"allow" in stdout
 
+        yt_cli.env["PYTHONWARNINGS"] = "default::ResourceWarning"
+        try:
+            completed_process = yt_cli.run(["yt", "check-permission", "test_user", "read", table, "--quiet"])
+            assert completed_process.returncode == 0
+            assert completed_process.stdout == b""
+            assert completed_process.stderr == b""
+
+            completed_process = yt_cli.run(["yt", "check-permission", "test_user", "write", table, "-q"])
+            assert completed_process.returncode == 1
+            assert completed_process.stdout == b""
+            assert completed_process.stderr == b""
+        finally:
+            del yt_cli.env["PYTHONWARNINGS"]
+
     @authors("ilyaibraev")
     def test_transfer_account_resources(self, yt_cli: YtCli):
         yt_cli.check_output(["yt", "create", "account", "--attributes", "{name=a1;resource_limits={node_count=10}}"])


### PR DESCRIPTION
- **Problem**
  `yt check-permission` lacked a machine-friendly mode for branchable shell usage; it always printed payload output instead of returning a clean status-only signal.

- **Changes**
  - Added `-q` / `--quiet` to `yt check-permission`.
  - In quiet mode, command suppresses stdout and exits immediately with:
    - `0` when permission action is `allow`
    - `1` otherwise
  - Updated CLI docs (EN/RU) for new flag.
  - Added CLI test coverage for both allow/deny quiet-mode paths.

- **Behavior example**
  ```bash
  yt check-permission user read //path -q
  # no stdout; exit code is 0 if allowed, 1 if denied
  ```

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>

---

* Changelog entry
Type: feature
Component: python-sdk

Add quiet mode to check-permission using CLI in shell
