### PR TITLE
[stable/25.2] Fix requests with empty path in yt/http

### DIFF
--- a/yt/yt/core/http/client.cpp
+++ b/yt/yt/core/http/client.cpp
@@ -264,9 +264,13 @@ private:
             request->SetHeaders(headers);
         }
 
+        auto urlPath = TString(urlRef.Path);
+        if (urlPath.empty()) {
+            urlPath = "/";
+        }
         auto requestPath = (urlRef.RawQuery.empty() && Config_->OmitQuestionMarkForEmptyQuery)
-            ? TString(urlRef.Path)
-            : Format("%v?%v", urlRef.Path, urlRef.RawQuery);
+            ? urlPath
+            : Format("%v?%v", urlPath, urlRef.RawQuery);
         request->WriteRequest(method, requestPath);
 
         return {std::move(request), std::move(response)};

--- a/yt/yt/core/http/unittests/http_ut.cpp
+++ b/yt/yt/core/http/unittests/http_ut.cpp
@@ -688,6 +688,15 @@ TEST_P(THttpServerTest, SimpleRequest)
     ASSERT_EQ(EStatusCode::OK, rsp->GetStatusCode());
 }
 
+TEST_P(THttpServerTest, EmptyPath)
+{
+    Server->AddHandler("/", New<TOKHttpHandler>());
+    Server->Start();
+
+    auto rsp = WaitFor(Client->Get(TestUrl)).ValueOrThrow();
+    ASSERT_EQ(EStatusCode::OK, rsp->GetStatusCode());
+}
+
 class TEchoHttpHandler
     : public IHttpHandler
 {


### PR DESCRIPTION
По <https://datatracker.ietf.org/doc/html/rfc2616#section-5.1.2>, путь в HTTP-запросе не может быть пустым; в случае отсутствия пути необходимо указывать "/":

> Note that the absolute path cannot be empty; if none is present in the original URI, it MUST be given as "/" (the server root).

Старый код при запросе на URL без пути (например, `http://localhost:1234`), посылал запрос вида

```
GET  HTTP/1.1
<Headers>
```

Вместо

```
GET / HTTP/1.1
<Headers>
```
commit_hash:57a75f2bb07925c4323602d41d37a6911f03e4d5

(cherry picked from commit 569cae98a6dbeab293282b71a0a60d2fd0cce040)
