### PR TITLE
yt/python/contrib/python-requests: prefer CA set by SSL_CERT_FILE

### DIFF
--- a/yt/python/contrib/python-requests/requests/certs.py
+++ b/yt/python/contrib/python-requests/requests/certs.py
@@ -17,6 +17,10 @@ import os
 import sys
 
 def where():
+    cafile = os.environ.get("SSL_CERT_FILE")
+    if cafile is not None:
+        return cafile
+
     is_arcadia_python = hasattr(sys, "extra_modules")
 
     if is_arcadia_python:


### PR DESCRIPTION
This code contains yet another special management of CA bundle.
Let's at least respect "SSL_CERT_FILE" settings.

Link: https://github.com/ytsaurus/ytsaurus/pull/1635
Link: https://github.com/ytsaurus/ytsaurus/pull/1731
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>

---

* Changelog entry
Type: feature
Component: python-sdk

Respect CA bundle defined by environment variable `SSL_CERT_FILE`
