### PR TITLE
Add job profiler support to Go and Python MapReduce SDKs

### DIFF
--- a/yt/go/mapreduce/job_profiler.go
+++ b/yt/go/mapreduce/job_profiler.go
@@ -1,0 +1,45 @@
+package mapreduce
+
+import (
+	"fmt"
+	"os"
+	"runtime/pprof"
+	"strings"
+
+	"go.ytsaurus.tech/yt/go/yson"
+)
+
+func startJobProfiler() func() {
+	noop := func() {}
+
+	var spec struct {
+		Binary string `yson:"binary"`
+		Type   string `yson:"type"`
+	}
+	raw := os.Getenv("YT_JOB_PROFILER_SPEC")
+	if raw == "" {
+		return noop
+	}
+	if err := yson.Unmarshal([]byte(raw), &spec); err != nil || spec.Binary != "user_job" {
+		return noop
+	}
+
+	out, err := os.OpenFile(os.Getenv("YT_"+strings.ToUpper(spec.Type)+"_PROFILER_PATH"), os.O_WRONLY, 0)
+	if err != nil {
+		out = os.NewFile(8, "yt-job-profile")
+	}
+
+	switch spec.Type {
+	case "cpu":
+		if err := pprof.StartCPUProfile(out); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "job profiler: %v\n", err)
+			_ = out.Close()
+			return noop
+		}
+		return func() { pprof.StopCPUProfile(); _ = out.Close() }
+	case "memory":
+		return func() { _ = pprof.WriteHeapProfile(out); _ = out.Close() }
+	}
+	_ = out.Close()
+	return noop
+}

--- a/yt/go/mapreduce/main.go
+++ b/yt/go/mapreduce/main.go
@@ -65,6 +65,8 @@ func JobMain() int {
 		return 3
 	}
 
+	defer startJobProfiler()()
+
 	outs := make([]io.Closer, args.nOutputPipes)
 
 	switch job := state.Job.(type) {

--- a/yt/go/mapreduce/spec/spec.go
+++ b/yt/go/mapreduce/spec/spec.go
@@ -27,6 +27,13 @@ type DiskRequest struct {
 	MediumName string `yson:"medium_name,omitempty"`
 }
 
+type JobProfiler struct {
+	Binary               string  `yson:"binary,omitempty"` // "user_job" or "job_proxy"
+	Type                 string  `yson:"type,omitempty"`   // "cpu", "memory", "peak_memory"
+	ProfilingProbability float64 `yson:"profiling_probability,omitempty"`
+	SamplingFrequency    int     `yson:"sampling_frequency,omitempty"`
+}
+
 type UserScript struct {
 	// Command specifies shell command that would be executed inside job.
 	//
@@ -62,6 +69,9 @@ type UserScript struct {
 	UseSmapsMemoryTracker  *bool          `yson:"use_smaps_memory_tracker,omitempty"`
 	Monitoring             map[string]any `yson:"monitoring,omitempty"`
 	EnableGpuCheck         *bool          `yson:"enable_gpu_check,omitempty"`
+
+	// Profilers requests collection of job profiles. See JobProfiler.
+	Profilers []*JobProfiler `yson:"profilers,omitempty"`
 
 	// Following fields are used only in vanilla operations.
 	JobCount         int           `yson:"job_count,omitempty"`

--- a/yt/go/mapreduce/ya.make
+++ b/yt/go/mapreduce/ya.make
@@ -9,6 +9,7 @@ SRCS(
     debug.go
     io.go
     job.go
+    job_profiler.go
     job_state.go
     main.go
     mapreduce.go

--- a/yt/python/yt/wrapper/py_runner_helpers.py
+++ b/yt/python/yt/wrapper/py_runner_helpers.py
@@ -268,6 +268,31 @@ def check_allowed_structured_skiff_attributes(params):
         raise YtError("@yt.wrapper.with_context decorator may be used only with mappers")
 
 
+def start_user_job_profiler():
+    raw_spec = os.environ.get("YT_JOB_PROFILER_SPEC")
+    output = os.environ.get("YT_CPU_PROFILER_PATH")
+    if not raw_spec or not output:
+        return
+    import yt.yson
+    spec = yt.yson._loads_from_native_str(raw_spec)
+    if spec.get("binary") != "user_job" or spec.get("type") != "cpu":
+        return
+    import subprocess
+    import signal
+    import atexit
+    try:
+        process = subprocess.Popen([
+            os.environ.get("YT_PY_SPY_BINARY", "py-spy"), "record",
+            "--pid", str(os.getpid()), "--output", output,
+            "--format", os.environ.get("YT_PYTHON_JOB_PROFILER_FORMAT", "speedscope"),
+            "--rate", str(spec.get("sampling_frequency", 100)), "--subprocesses"])
+    except OSError as error:
+        sys.stderr.write("Cannot start py-spy: {0}\n".format(error))
+        return
+    # py-spy flushes the profile when interrupted; do so however the job exits.
+    atexit.register(lambda: (process.send_signal(signal.SIGINT), process.wait()))
+
+
 def process_rows(operation_dump_filename, config_dump_filename, start_time):
     from itertools import chain, groupby, starmap
     import time
@@ -297,6 +322,8 @@ def process_rows(operation_dump_filename, config_dump_filename, start_time):
         yt.wrapper.config.config = config_unpickler.load(f_config_dump)
 
     yt.wrapper.py_runner_helpers.check_job_environment_variables()
+
+    yt.wrapper.py_runner_helpers.start_user_job_profiler()
 
     unpickler_name = yt.wrapper.config.config["pickling"]["framework"]
     unpickler = Unpickler(unpickler_name)

--- a/yt/python/yt/wrapper/spec_builders.py
+++ b/yt/python/yt/wrapper/spec_builders.py
@@ -508,6 +508,10 @@ class UserJobSpecBuilder(object):
     def network_project(self, network_project):
         return _set_spec_value(self, "network_project", network_project)
 
+    @spec_option("Specifies the list of job profilers")
+    def profilers(self, profilers):
+        return _set_spec_value(self, "profilers", profilers)
+
     @spec_option("Adds environment variable")
     def environment_variable(self, key, value):
         self._spec.setdefault("environment", {})


### PR DESCRIPTION
Allow user jobs to request CPU/memory profiles via the operation spec.

- Go SDK: new JobProfiler spec type and UserScript.Profilers field; the job runner collects a pprof profile (runtime/pprof) when the job proxy selects the job for profiling, writing it to the profile pipe.
- Python SDK: profilers() spec option on UserJobSpecBuilder and a py-spy-based CPU profiler started from py_runner_helpers when YT_JOB_PROFILER_SPEC is set.

