### PR TITLE
yt/yt/core/bus: test catching exception from TSslContext::ApplyConfig

### DIFF
--- a/yt/yt/core/bus/tcp/unittests/ssl_ut.cpp
+++ b/yt/yt/core/bus/tcp/unittests/ssl_ut.cpp
@@ -762,6 +762,38 @@ TEST_F(TSslTest, BlackHole)
         .ThrowOnError();
 }
 
+TEST_F(TSslTest, IncorrectConfig)
+{
+    auto unknownCommand = TSslContextCommand::Create("UnknownCommand", "Argument");
+
+    auto serverConfig = TBusServerConfig::CreateTcp(Port);
+    serverConfig->EncryptionMode = EEncryptionMode::Required;
+    serverConfig->VerificationMode = EVerificationMode::None;
+    serverConfig->CertificateChain = CertificateChain;
+    serverConfig->PrivateKey = PrivateKey;
+    serverConfig->SslConfigurationCommands.push_back(unknownCommand);
+    auto server = CreateBusServer(serverConfig);
+    server->Start(New<TEmptyBusHandler>());
+
+    auto clientConfig = TBusClientConfig::CreateTcp(AddressWithHostName);
+    clientConfig->EncryptionMode = EEncryptionMode::Required;
+    clientConfig->VerificationMode = EVerificationMode::None;
+    clientConfig->SslConfigurationCommands.push_back(unknownCommand);
+    auto client = CreateBusClient(clientConfig);
+
+    auto bus = client->CreateBus(New<TEmptyBusHandler>());
+    auto error = WaitForFast(bus->GetReadyFuture());
+    EXPECT_FALSE(error.IsOK());
+    EXPECT_EQ(error.GetCode(), EErrorCode::SslError);
+    EXPECT_THROW_MESSAGE_HAS_SUBSTR(
+        error.ThrowOnError(),
+        NYT::TErrorException,
+        "Failed to load TLS/SSL certificates");
+
+    WaitForFast(server->Stop())
+        .ThrowOnError();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace


### PR DESCRIPTION
Test for "YT-27641: Abort connection if SSL certificates/keys/CAs can not be read"

This code is executed inside RunNoExcept context and cannot throw.
There many reasons for errors within ApplyConfig, in test is used
incorrect SslConfigurationCommands is just for simplicity.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
