### PR TITLE
[queues] Use response codecs for PullRows in native api

### DIFF
--- a/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
@@ -3130,7 +3130,10 @@ IUnversionedRowsetPtr TClient::DoPullQueueViaTabletNodeApi(
     ValidateTabletMountedOrFrozen(tableInfo, tabletInfo);
     auto channel = GetReadCellChannelOrThrow(tabletInfo->CellId);
     TQueryServiceProxy proxy(channel);
-    proxy.SetDefaultTimeout(options.Timeout.value_or(Connection_->GetConfig()->DefaultFetchTableRowsTimeout));
+
+    const auto& connectionConfig = Connection_->GetConfig();
+    proxy.SetDefaultResponseCodec(connectionConfig->SelectRowsResponseCodec);
+    proxy.SetDefaultTimeout(options.Timeout.value_or(connectionConfig->DefaultFetchTableRowsTimeout));
 
     auto req = proxy.FetchTableRows();
     ToProto(req->mutable_tablet_id(), tabletInfo->TabletId);

--- a/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
@@ -3131,10 +3131,6 @@ IUnversionedRowsetPtr TClient::DoPullQueueViaTabletNodeApi(
     auto channel = GetReadCellChannelOrThrow(tabletInfo->CellId);
     TQueryServiceProxy proxy(channel);
 
-    const auto& connectionConfig = Connection_->GetConfig();
-    proxy.SetDefaultResponseCodec(connectionConfig->SelectRowsResponseCodec);
-    proxy.SetDefaultTimeout(options.Timeout.value_or(connectionConfig->DefaultFetchTableRowsTimeout));
-
     auto req = proxy.FetchTableRows();
     ToProto(req->mutable_tablet_id(), tabletInfo->TabletId);
     ToProto(req->mutable_cell_id(), tabletInfo->CellId);
@@ -3144,6 +3140,10 @@ IUnversionedRowsetPtr TClient::DoPullQueueViaTabletNodeApi(
     req->set_max_row_count(rowBatchReadOptions.MaxRowCount);
     req->set_max_data_weight(rowBatchReadOptions.MaxDataWeight);
     ToProto(req->mutable_options()->mutable_workload_descriptor(), options.WorkloadDescriptor);
+
+    const auto& connectionConfig = Connection_->GetConfig();
+    req->SetTimeout(options.Timeout.value_or(connectionConfig->DefaultFetchTableRowsTimeout));
+    req->SetResponseCodec(connectionConfig->PullQueueResponseCodec);
 
     auto rsp = WaitFor(req->Invoke())
         .ValueOrThrow();

--- a/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_dynamic_tables_impl.cpp
@@ -3143,7 +3143,9 @@ IUnversionedRowsetPtr TClient::DoPullQueueViaTabletNodeApi(
 
     const auto& connectionConfig = Connection_->GetConfig();
     req->SetTimeout(options.Timeout.value_or(connectionConfig->DefaultFetchTableRowsTimeout));
-    req->SetResponseCodec(connectionConfig->PullQueueResponseCodec);
+    if (connectionConfig->PullQueueResponseCodec.has_value()) {
+        req->SetResponseCodec(connectionConfig->PullQueueResponseCodec.value());
+    }
 
     auto rsp = WaitFor(req->Invoke())
         .ValueOrThrow();

--- a/yt/yt/ytlib/api/native/config.cpp
+++ b/yt/yt/ytlib/api/native/config.cpp
@@ -330,6 +330,9 @@ void TConnectionDynamicConfig::Register(TRegistrar registrar)
     registrar.Parameter("lookup_rows_ext_memory_logging_suppression_timeout", &TThis::LookupRowsExtMemoryLoggingSuppressionTimeout)
         .Optional();
 
+    registrar.Parameter("pull_queue_response_codec", &TThis::PullQueueResponseCodec)
+        .Default(NCompression::ECodec::None);
+
     registrar.Parameter("default_get_tablet_errors_limit", &TThis::DefaultGetTabletErrorsLimit)
         .Default(5)
         .GreaterThan(0);

--- a/yt/yt/ytlib/api/native/config.cpp
+++ b/yt/yt/ytlib/api/native/config.cpp
@@ -331,7 +331,7 @@ void TConnectionDynamicConfig::Register(TRegistrar registrar)
         .Optional();
 
     registrar.Parameter("pull_queue_response_codec", &TThis::PullQueueResponseCodec)
-        .Default(NCompression::ECodec::None);
+        .Optional();
 
     registrar.Parameter("default_get_tablet_errors_limit", &TThis::DefaultGetTabletErrorsLimit)
         .Default(5)

--- a/yt/yt/ytlib/api/native/config.h
+++ b/yt/yt/ytlib/api/native/config.h
@@ -310,6 +310,8 @@ struct TConnectionDynamicConfig
     std::optional<TDuration> LookupRowsInMemoryLoggingSuppressionTimeout;
     std::optional<TDuration> LookupRowsExtMemoryLoggingSuppressionTimeout;
 
+    NCompression::ECodec PullQueueResponseCodec;
+
     int DefaultGetTabletErrorsLimit;
 
     NYPath::TYPath UdfRegistryPath;

--- a/yt/yt/ytlib/api/native/config.h
+++ b/yt/yt/ytlib/api/native/config.h
@@ -310,7 +310,7 @@ struct TConnectionDynamicConfig
     std::optional<TDuration> LookupRowsInMemoryLoggingSuppressionTimeout;
     std::optional<TDuration> LookupRowsExtMemoryLoggingSuppressionTimeout;
 
-    NCompression::ECodec PullQueueResponseCodec;
+    std::optional<NCompression::ECodec> PullQueueResponseCodec;
 
     int DefaultGetTabletErrorsLimit;
 


### PR DESCRIPTION


---
* Changelog entry
Type: fix
Component: native-api / proxy

Native connection config has lookup/select RPC codecs but "native tablet node pull" never used them unlike legacy "select pull"

