### PR TITLE
yt/yt/library/tcmalloc: add madvise_preference

### DIFF
--- a/yt/yt/library/tcmalloc/config.cpp
+++ b/yt/yt/library/tcmalloc/config.cpp
@@ -86,6 +86,7 @@ TTCMallocConfigPtr TTCMallocConfig::ApplyDynamic(const TDynamicTCMallocConfigPtr
     UpdateYsonStructField(mergedConfig->MaxPerCpuCacheSize, dynamicConfig->MaxPerCpuCacheSize);
     UpdateYsonStructField(mergedConfig->MaxTotalThreadCacheBytes, dynamicConfig->MaxTotalThreadCacheBytes);
     UpdateYsonStructField(mergedConfig->BackgroundReleaseRate, dynamicConfig->BackgroundReleaseRate);
+    UpdateYsonStructField(mergedConfig->MadvisePreference, dynamicConfig->MadvisePreference);
     mergedConfig->HeapSizeLimit->ApplyDynamicInplace(dynamicConfig->HeapSizeLimit);
     mergedConfig->Postprocess();
     return mergedConfig;
@@ -112,6 +113,9 @@ void TTCMallocConfig::Register(TRegistrar registrar)
         .Default(24_MB);
     registrar.Parameter("background_release_rate", &TThis::BackgroundReleaseRate)
         .Default(32_MB);
+
+    registrar.Parameter("madvise_preference", &TThis::MadvisePreference)
+        .Optional();
 
     registrar.Parameter("heap_size_limit", &TThis::HeapSizeLimit)
         .DefaultNew();
@@ -140,6 +144,9 @@ void TDynamicTCMallocConfig::Register(TRegistrar registrar)
         .Default();
     registrar.Parameter("background_release_rate", &TThis::BackgroundReleaseRate)
         .Default();
+
+    registrar.Parameter("madvise_preference", &TThis::MadvisePreference)
+        .Optional();
 
     registrar.Parameter("heap_size_limit", &TThis::HeapSizeLimit)
         .DefaultNew();

--- a/yt/yt/library/tcmalloc/config.h
+++ b/yt/yt/library/tcmalloc/config.h
@@ -70,6 +70,14 @@ DEFINE_REFCOUNTED_TYPE(TDynamicHeapSizeLimitConfig)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+DEFINE_ENUM(EMadvisePreference,
+    (Never)
+    (DontNeed)
+    (Free)
+    (FreeAndDontNeed));
+
+////////////////////////////////////////////////////////////////////////////////
+
 struct TTCMallocConfig
     : public NYTree::TYsonStruct
 {
@@ -90,6 +98,8 @@ struct TTCMallocConfig
     i64 MaxPerCpuCacheSize;
     i64 MaxTotalThreadCacheBytes;
     i64 BackgroundReleaseRate;
+
+    std::optional<EMadvisePreference> MadvisePreference;
 
     THeapSizeLimitConfigPtr HeapSizeLimit;
 
@@ -120,6 +130,8 @@ struct TDynamicTCMallocConfig
     std::optional<i64> MaxPerCpuCacheSize;
     std::optional<i64> MaxTotalThreadCacheBytes;
     std::optional<i64> BackgroundReleaseRate;
+
+    std::optional<EMadvisePreference> MadvisePreference;
 
     TDynamicHeapSizeLimitConfigPtr HeapSizeLimit;
 

--- a/yt/yt/library/tcmalloc/tcmalloc_manager.cpp
+++ b/yt/yt/library/tcmalloc/tcmalloc_manager.cpp
@@ -20,6 +20,7 @@
 #include <util/system/shellcommand.h>
 
 #include <tcmalloc/malloc_extension.h>
+#include <tcmalloc/parameters.h>
 
 #include <thread>
 #include <mutex>
@@ -442,6 +443,23 @@ public:
 
     void Configure(const TTCMallocConfigPtr& config)
     {
+        if (config->MadvisePreference) {
+            switch (*config->MadvisePreference) {
+                case EMadvisePreference::Never:
+                    TCMalloc_Internal_SetMadvise(tcmalloc::tcmalloc_internal::MadvisePreference::kNever);
+                    break;
+                case EMadvisePreference::DontNeed:
+                    TCMalloc_Internal_SetMadvise(tcmalloc::tcmalloc_internal::MadvisePreference::kDontNeed);
+                    break;
+                case EMadvisePreference::Free:
+                    TCMalloc_Internal_SetMadvise(tcmalloc::tcmalloc_internal::MadvisePreference::kFreeOnly);
+                    break;
+                case EMadvisePreference::FreeAndDontNeed:
+                    TCMalloc_Internal_SetMadvise(tcmalloc::tcmalloc_internal::MadvisePreference::kFreeAndDontNeed);
+                    break;
+            }
+        }
+
         tcmalloc::MallocExtension::SetProfileSamplingInterval(config->ProfileSamplingRate);
         tcmalloc::MallocExtension::SetMaxPerCpuCacheSize(config->MaxPerCpuCacheSize);
         tcmalloc::MallocExtension::SetMaxTotalThreadCacheBytes(config->MaxTotalThreadCacheBytes);


### PR DESCRIPTION
Add option for tuning tcmalloc madvise strategy.
Default is MADV_DONTNEED, desired is MADV_FREE.

This also could be independent ALLOCATOR profile:
"TCMALLOC_MF_256K"

MADV_FREE allows to keep freed pages in place until next use,
unless kernel memory reclaimer removes them under memory pressure.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
