### PR TITLE
[Not for commit, example] Set explicit allign for i128.

### DIFF
--- a/yql/essentials/minikql/comp_nodes/mkql_dictitems.cpp
+++ b/yql/essentials/minikql/comp_nodes/mkql_dictitems.cpp
@@ -190,8 +190,8 @@ private:
         const auto good = BasicBlock::Create(context, "good", ctx.Func);
         const auto done = BasicBlock::Create(context, "done", ctx.Func);
 
-        const auto pairPtr = new AllocaInst(pairType, 0U, "pair_ptr", block);
-        new StoreInst(ConstantAggregateZero::get(pairType), pairPtr, block);
+        const auto pairPtr = new AllocaInst(pairType, 0U, nullptr, i128defaultAlign, "pair_ptr", block);
+        new StoreInst(ConstantAggregateZero::get(pairType), pairPtr, false, i128defaultAlign, block);
 
         const auto keyPtr = GetElementPtrInst::CreateInBounds(pairType, pairPtr, {ConstantInt::get(indexType, 0), ConstantInt::get(indexType, 0)}, "key_ptr", block);
         const auto payPtr = GetElementPtrInst::CreateInBounds(pairType, pairPtr, {ConstantInt::get(indexType, 0), ConstantInt::get(indexType, 1)}, "pay_ptr", block);
@@ -208,9 +208,9 @@ private:
         const auto output = ResPair.GenNewArray(2U, itemsPtr, ctx, block);
         AddRefBoxed(output, ctx, block);
         const auto items = new LoadInst(itemsType, itemsPtr, "items", block);
-        const auto pair = new LoadInst(pairType, pairPtr, "pair", block);
-        new StoreInst(pair, items, block);
-        new StoreInst(output, valuePtr, block);
+        const auto pair = new LoadInst(pairType, pairPtr, "pair", false, i128defaultAlign, block);
+        new StoreInst(pair, items, false, i128defaultAlign, block);
+        new StoreInst(output, valuePtr, false, i128defaultAlign, block);
         BranchInst::Create(done, block);
 
         block = done;

--- a/yql/essentials/minikql/computation/mkql_computation_node_codegen.h.txt
+++ b/yql/essentials/minikql/computation/mkql_computation_node_codegen.h.txt
@@ -91,6 +91,13 @@ using NYql::GetMethodIndex;
 
 using namespace llvm;
 
+// Explicit alignment value for i128 (TUnboxedValuePod).
+// LLVM16 doesn't have a default alignment value for i128. It's taken from some other type and equals 8.
+// But for compatibility between C++ and LLVM IR code, we need exactly this value because the C++ compiler never generates IR using i128,
+// even representing __int128 in IR as an i64 pair with alignment of 8.
+// In LLVM18, the default alignment value for i128 is explicitly set to 16, and we need to explicitly set it to 8 for our generated instructions.
+const auto i128defaultAlign = llvm::Align(8);
+
 // This macro is needed to mark calls as "calls to LLVM functions".
 // This prevents false positive UBSan triggers at the C++ <-> JIT interface layer.
 // The root cause of these triggers has not been identified.


### PR DESCRIPTION
The example for https://github.com/ytsaurus/ytsaurus/pull/1762#issuecomment-4790027299