### PR TITLE
Trust system certificate store in yt (#846)

### DIFF
--- a/yt/python/yt/wrapper/default_config.py
+++ b/yt/python/yt/wrapper/default_config.py
@@ -83,6 +83,7 @@ class DefaultConfigType(TypedDict, total=False):
         network_name: Optional[str]
         prefer_https: bool
         ca_bundle_path: Optional[str]
+        use_system_ca: bool
         default_suffix: Optional[str]
         tvm_only: bool
         accept_encoding: Optional[Union[Literal["gzip"], Literal["br"], Literal["identity"]]]
@@ -472,6 +473,8 @@ default_config = {
         "prefer_https": False,
 
         "ca_bundle_path": None,
+
+        "use_system_ca": True,
 
         # Suffix appended to url if it is short.
         "default_suffix": DEFAULT_HOST_SUFFIX,

--- a/yt/python/yt/wrapper/http_helpers.py
+++ b/yt/python/yt/wrapper/http_helpers.py
@@ -18,6 +18,7 @@ from yt.common import _pretty_format_for_logging, get_fqdn as _get_fqdn
 import io
 import os
 import re
+import ssl
 import sys
 import time
 import types
@@ -114,6 +115,82 @@ def get_retriable_errors():
             YtRequestTimedOut, YtRetriableError, YtTransportError)
 
 
+def _get_requests_ca_bundle():
+    # Path to the CA bundle shipped with the (vendored) requests/certifi, or None when it is not
+    # available (e.g. in the opensource build, where certs.where() returns None).
+    lazy_import_requests()
+    try:
+        from yt.packages.requests import certs
+        return certs.where()
+    except Exception:
+        return None
+
+
+def _system_trust_store_available():
+    # Whether OpenSSL will find an operating system trust store through its default verify paths.
+    # ssl.get_default_verify_paths() resolves SSL_CERT_FILE / SSL_CERT_DIR and the compiled-in
+    # defaults, so this mirrors what ssl.create_default_context() actually consults. We check the
+    # paths rather than SSLContext.cert_store_stats() because OpenSSL loads dir-hashed certs lazily,
+    # leaving the stats at zero even when a populated store is present.
+    paths = ssl.get_default_verify_paths()
+    if paths.cafile and os.path.exists(paths.cafile):
+        return True
+    try:
+        if paths.capath and os.path.isdir(paths.capath) and os.listdir(paths.capath):
+            return True
+    except OSError:
+        # The directory exists but is not listable (e.g. permissions); treat the store as absent
+        # rather than failing client setup.
+        pass
+    return False
+
+
+def _add_ca_file(context, path):
+    # Trust the CA bundle at `path`, tolerating a missing, empty or malformed file: such input is
+    # logged and skipped instead of raising out of session setup. `path` may be None (no-op).
+    if not path:
+        return
+    if not os.path.exists(path):
+        logger.error("CA file is absent (%s)", path)
+        return
+    try:
+        context.load_verify_locations(cafile=path)
+    except (ssl.SSLError, OSError) as error:
+        logger.error("Failed to load CA file (%s): %s", path, error)
+
+
+def _create_ssl_context(ca_bundle_path=None, use_system_ca=True):
+    # An SSLContext used to verify the proxy's TLS certificate. Trust is assembled here and bound to
+    # the session adapter (see configure_ip), rather than via requests' REQUESTS_CA_BUNDLE handling
+    # or process-global environment, so it also works with the vendored yt.packages.urllib3 stack
+    # and does not leak across clients; see https://github.com/ytsaurus/ytsaurus/issues/846.
+    if use_system_ca:
+        # Trust the operating system store (honors SSL_CERT_FILE / SSL_CERT_DIR), e.g. corporate
+        # roots that requests/certifi ignores by default.
+        context = ssl.create_default_context()
+        # The CA bundle vendored with requests/certifi is only a fallback for environments without a
+        # usable system trust store (e.g. a minimal container); when the OS provides one we rely on
+        # it alone so the host's policy (additions and removals) is honored.
+        if not _system_trust_store_available():
+            _add_ca_file(context, _get_requests_ca_bundle())
+    else:
+        # Do not trust the OS store; verify only against the vendored bundle (requests' default)
+        # plus the explicit/extra CAs added below, preserving the pre-system-ca behavior.
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        _add_ca_file(context, _get_requests_ca_bundle())
+
+    # Honor a CA bundle provided through the environment, the same way requests/curl do. We load it
+    # into the context instead of relying on requests reading the variable (its CA handling is
+    # bypassed by the bound ssl_context) and instead of mutating the process-global environment.
+    for env_var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE"):
+        _add_ca_file(context, os.environ.get(env_var))
+
+    # An explicit ca_bundle_path from the config is always trusted on top of the above.
+    _add_ca_file(context, ca_bundle_path)
+
+    return context
+
+
 class ProxyProvider(object):
     __metaclass__ = ABCMeta
 
@@ -129,21 +206,19 @@ class ProxyProvider(object):
 def _setup_new_session(client) -> "requests.Session":
     lazy_import_requests()
     session = requests.Session()
-    configure_proxy(session,
-                    get_config(client)["proxy"]["http_proxy"],
-                    get_config(client)["proxy"]["https_proxy"])
-    configure_ip(session,
-                 get_config(client)["proxy"]["force_ipv4"],
-                 get_config(client)["proxy"]["force_ipv6"])
+    proxy_config = get_config(client)["proxy"]
 
-    ca_bundle_path = get_config(client)["proxy"]["ca_bundle_path"]
-    if ca_bundle_path:
-        if os.path.exists(ca_bundle_path):
-            if os.environ.get("REQUESTS_CA_BUNDLE"):
-                logger.warning("CA override (%s -> %s)", ca_bundle_path, os.environ.get("REQUESTS_CA_BUNDLE"))
-            os.environ["REQUESTS_CA_BUNDLE"] = ca_bundle_path
-        else:
-            logger.error("CA file is absent (%s)", ca_bundle_path)
+    configure_proxy(session, proxy_config["http_proxy"], proxy_config["https_proxy"])
+
+    ssl_context = _create_ssl_context(
+        ca_bundle_path=proxy_config["ca_bundle_path"],
+        use_system_ca=proxy_config["use_system_ca"],
+    )
+
+    configure_ip(session,
+                 proxy_config["force_ipv4"],
+                 proxy_config["force_ipv6"],
+                 ssl_context=ssl_context)
 
     return session
 
@@ -172,18 +247,36 @@ def configure_proxy(session, http_proxy, https_proxy):
         session.proxies.update(proxies)
 
 
-def configure_ip(session, force_ipv4=False, force_ipv6=False):
+def configure_ip(session, force_ipv4=False, force_ipv6=False, ssl_context=None):
     lazy_import_requests()
-    if force_ipv4 or force_ipv6:
-        protocol = socket.AF_INET if force_ipv4 else socket.AF_INET6
 
-        class HTTPAdapter(requests.adapters.HTTPAdapter):
-            def init_poolmanager(self, *args, **kwargs):
-                return super(HTTPAdapter, self).init_poolmanager(*args,
-                                                                 socket_af=protocol,
-                                                                 **kwargs)
-        session.mount("http://", HTTPAdapter())
-        session.mount("https://", HTTPAdapter())
+    socket_af = None
+    if force_ipv4 or force_ipv6:
+        socket_af = socket.AF_INET if force_ipv4 else socket.AF_INET6
+
+    if socket_af is None and ssl_context is None:
+        return
+
+    class HTTPAdapter(requests.adapters.HTTPAdapter):
+        def init_poolmanager(self, *args, **kwargs):
+            if socket_af is not None:
+                kwargs["socket_af"] = socket_af
+            if ssl_context is not None:
+                kwargs["ssl_context"] = ssl_context
+            return super(HTTPAdapter, self).init_poolmanager(*args, **kwargs)
+
+        def cert_verify(self, conn, url, verify, cert):
+            if ssl_context is not None and verify and url.lower().startswith("https"):
+                # Server-cert trust is delegated to ssl_context. Pass verify=False so the base
+                # method does not require requests' default CA bundle (absent in the opensource
+                # build), then re-enable verification against the context.
+                super(HTTPAdapter, self).cert_verify(conn, url, False, cert)
+                conn.cert_reqs = "CERT_REQUIRED"
+            else:
+                super(HTTPAdapter, self).cert_verify(conn, url, verify, cert)
+
+    session.mount("http://", HTTPAdapter())
+    session.mount("https://", HTTPAdapter())
 
 
 def get_error_from_headers(headers):

--- a/yt/python/yt/wrapper/tests/files/https_client_probe.py
+++ b/yt/python/yt/wrapper/tests/files/https_client_probe.py
@@ -1,0 +1,35 @@
+"""Connect the yt client to an HTTPS proxy and perform a single request.
+
+Run in a subprocess by test_https.py so each scenario builds a fresh client session against the
+chosen proxy configuration. Exits 0 on success, non-zero (with a traceback on stderr) on any
+failure, e.g. a TLS verification error.
+"""
+
+import argparse
+
+import yt.wrapper as yt
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--proxy-url", required=True)
+    parser.add_argument("--use-system-ca", action="store_true")
+    parser.add_argument("--ca-bundle-path", default=None)
+    args = parser.parse_args()
+
+    client = yt.YtClient(config={
+        "backend": "http",
+        "proxy": {
+            "url": args.proxy_url,
+            "enable_proxy_discovery": False,
+            "use_system_ca": args.use_system_ca,
+            "ca_bundle_path": args.ca_bundle_path,
+            # Fail fast: TLS errors are otherwise retried until the request timeout.
+            "retries": {"enable": False},
+        },
+    })
+    client.exists("/")
+
+
+if __name__ == "__main__":
+    main()

--- a/yt/python/yt/wrapper/tests/test_https.py
+++ b/yt/python/yt/wrapper/tests/test_https.py
@@ -1,0 +1,123 @@
+"""Integration tests for trusting the system certificate store in the HTTP client (issue #846).
+
+They bring up a real local YTsaurus cluster with TLS enabled (a self-signed CA is generated on
+the fly and the HTTP proxy serves HTTPS with a certificate signed by it) and connect the real
+``yt.wrapper`` Python client to the HTTPS proxy.
+
+The cluster CA is exposed to the operating system trust store (consulted by ``ssl.create_default_context``)
+via the ``SSL_CERT_FILE`` environment variable rather than installed system-wide (which would need
+root). Each scenario runs in its own subprocess (``files/https_client_probe.py``) so that the
+client builds a fresh session against the chosen configuration.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+from yt.testlib import authors
+
+from yt.wrapper.testlib.conftest_helpers import init_environment_for_test_session, _yt_env
+from yt.wrapper.testlib.helpers import get_python, get_test_file_path
+
+
+# SSL_CERT_FILE only seeds the OpenSSL/system trust store on Linux; the cluster cluster fixture
+# itself runs only on Linux CI, but skip explicitly for the cases that rely on the variable.
+linux_only = pytest.mark.skipif(not sys.platform.startswith("linux"), reason="SSL_CERT_FILE is OpenSSL/Linux-specific")
+
+
+@pytest.fixture(scope="class", params=["v4"])
+def test_environment_tls(request):
+    return init_environment_for_test_session(
+        request,
+        request.param,
+        env_options={"enable_tls": True},
+    )
+
+
+@pytest.fixture(scope="function")
+def yt_env_tls(request, test_environment_tls):
+    return _yt_env(request, test_environment_tls)
+
+
+def _probe_https_client(env, use_system_ca, ca_bundle_path=None, seed_system_ca=False, requests_ca_bundle_env=None):
+    subprocess_env = dict(os.environ)
+    if requests_ca_bundle_env:
+        subprocess_env["REQUESTS_CA_BUNDLE"] = requests_ca_bundle_env
+    else:
+        subprocess_env.pop("REQUESTS_CA_BUNDLE", None)
+    if seed_system_ca:
+        # Put the cluster CA into the trust store that ssl.create_default_context() consults.
+        subprocess_env["SSL_CERT_FILE"] = env.yt_config.public_ca_cert
+    else:
+        subprocess_env.pop("SSL_CERT_FILE", None)
+
+    command = [get_python(), get_test_file_path("https_client_probe.py"), "--proxy-url", env.get_https_proxy_url()]
+    if use_system_ca:
+        command.append("--use-system-ca")
+    if ca_bundle_path:
+        command += ["--ca-bundle-path", ca_bundle_path]
+
+    return subprocess.run(
+        command,
+        env=subprocess_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.usefixtures("yt_env_tls")
+class TestHttpsSystemCa(object):
+    @linux_only
+    @authors("desertfury")
+    def test_system_ca_disabled_rejects_cluster_cert(self, yt_env_tls):
+        # Reproduces issue #846: without the fix (use_system_ca=False) the client verifies only
+        # against the certifi bundle and rejects the cluster's self-signed certificate, even though
+        # its CA is present in the system trust store (SSL_CERT_FILE).
+        proc = _probe_https_client(yt_env_tls.env, use_system_ca=False, seed_system_ca=True)
+        assert proc.returncode != 0
+        assert "verify" in proc.stderr.lower() or "ca certificate" in proc.stderr.lower(), proc.stderr
+
+    @linux_only
+    @authors("desertfury")
+    def test_system_ca_trusts_cluster_cert(self, yt_env_tls):
+        # The fix: with use_system_ca the client trusts the operating system certificate store
+        # (seeded via SSL_CERT_FILE) and accepts the self-signed certificate, no ca_bundle_path.
+        proc = _probe_https_client(yt_env_tls.env, use_system_ca=True, seed_system_ca=True)
+        assert proc.returncode == 0, proc.stderr
+
+    @authors("desertfury")
+    def test_system_ca_honors_requests_ca_bundle_env(self, yt_env_tls):
+        # use_system_ca trusts a CA supplied only via the REQUESTS_CA_BUNDLE environment variable
+        # (as requests itself would), even when it is absent from the system trust store. The
+        # variable is folded into the ssl_context rather than read by requests.
+        proc = _probe_https_client(
+            yt_env_tls.env,
+            use_system_ca=True,
+            seed_system_ca=False,
+            requests_ca_bundle_env=yt_env_tls.env.yt_config.public_ca_cert,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+    @authors("desertfury")
+    def test_system_ca_rejects_untrusted_cert(self, yt_env_tls):
+        # Sanity: use_system_ca does not blindly trust everything — a certificate whose CA is in
+        # neither the system store nor ca_bundle_path is still rejected.
+        proc = _probe_https_client(yt_env_tls.env, use_system_ca=True, seed_system_ca=False)
+        assert proc.returncode != 0
+        assert "verify" in proc.stderr.lower(), proc.stderr
+
+    @authors("desertfury")
+    def test_ca_bundle_path_still_works(self, yt_env_tls):
+        # Control: the pre-existing proxy/ca_bundle_path knob keeps working (both with and without
+        # the system-CA path), so the change does not regress explicit CA bundles.
+        for use_system_ca in (False, True):
+            proc = _probe_https_client(
+                yt_env_tls.env,
+                use_system_ca=use_system_ca,
+                ca_bundle_path=yt_env_tls.env.yt_config.public_ca_cert,
+            )
+            assert proc.returncode == 0, proc.stderr

--- a/yt/python/yt/wrapper/tests/ya.make
+++ b/yt/python/yt/wrapper/tests/ya.make
@@ -91,6 +91,9 @@ DEPENDS(
     yt/yt/tools/yt_sudo_fixup
     yt/yt/experiments/public/ytserver_dummy
 
+    # openssl CLI is used by test_https.py to generate TLS certificates.
+    contrib/libs/openssl/apps
+
     # Used in some tests to check cpp binaries in operations.
     yt/python/yt/wrapper/tests/files/cpp_bin
 
@@ -120,6 +123,7 @@ RESOURCE(
     ${CURDIR}/files/empty /yt_python_test/files/empty
     ${CURDIR}/files/getnumber.cpp /yt_python_test/files/getnumber.cpp
     ${CURDIR}/files/helpers.py /yt_python_test/files/helpers.py
+    ${CURDIR}/files/https_client_probe.py /yt_python_test/files/https_client_probe.py
     ${CURDIR}/files/many_output.py /yt_python_test/files/many_output.py
     ${CURDIR}/files/my_op.py /yt_python_test/files/my_op.py
     ${CURDIR}/files/split.py /yt_python_test/files/split.py
@@ -170,6 +174,7 @@ TEST_SRCS(
     test_errors.py
     test_file_commands.py
     test_fuse.py
+    test_https.py
     test_ipython.py
     test_job_commands.py
     test_job_tool.py


### PR DESCRIPTION
  The yt Python client makes HTTPS requests through the vendored requests, which verifies TLS certificates only against the bundled certifi CA list and ignores the operating system trust store (e.g. corporate root certificates). See #846.

  When proxy/use_system_ca is enabled (default), the client now builds an ssl.create_default_context() — verifying against the OS trust store and honoring SSL_CERT_FILE/SSL_CERT_DIR, REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE, and an explicit proxy/ca_bundle_path — and binds it to its own requests session adapter. The vendored certifi bundle is kept only as a fallback when no system store is available. Trust is assembled per session instead of mutating the process-global REQUESTS_CA_BUNDLE, so there is no cross-client side effect, and it applies to any yt client, not just the CLI. No new dependency is required.

  Add an integration test (test_https.py) on a local TLS cluster with a self-signed CA: it reproduces #846, verifies the fix, checks that a CA provided only via REQUESTS_CA_BUNDLE is honored, that an untrusted cert is still rejected, and that ca_bundle_path keeps working.

  Changelog entry
  Type: fix
  Component: python-sdk
  The yt HTTP client now trusts the operating system certificate store (certifi as fallback), configurable via proxy/use_system_ca.