### PR TITLE
Detect empty executable files in operations

### DIFF
--- a/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
+++ b/yt/yt/server/controller_agent/controllers/operation_controller_detail.cpp
@@ -7864,6 +7864,10 @@ void TOperationControllerBase::GetUserFilesAttributes()
                             file.Executable = attributes.Get<bool>("executable", false);
                             file.Executable = file.Path.GetExecutable().value_or(file.Executable);
 
+                            if (file.Executable && attributes.Get<i64>("chunk_count") == 0) {
+                                THROW_ERROR_EXCEPTION("Executable file %v is empty", file.Path);
+                            }
+
                             if (file.Layer) {
                                 if (attributes.Get<i64>("chunk_count") == 0) {
                                     THROW_ERROR_EXCEPTION("File %v is empty", file.Path);


### PR DESCRIPTION
Related to #604.

Add a sanity check that rejects operations whose `file_paths` contain an executable file (`executable=true`) with `chunk_count == 0`.

Posix shell silently executes non-binary files without a `#!` shebang as shell scripts. As a result, an empty file always "runs successfully", giving the user no indication that the operation command is missing. The check catches this common mistake early, at operation start, with a clear error message.

The analogous check for layer files already existed; this change adds the same guard for regular executable files.

