### PR TITLE
Set explicit allign for i128 in YQL IR generation.

### DIFF
--- a/yql/essentials/minikql/codegen/codegen.cpp
+++ b/yql/essentials/minikql/codegen/codegen.cpp
@@ -667,6 +667,7 @@ public:
             error.print("error after ParseIR()", os);
             ythrow yexception() << what;
         }
+
         module->setTargetTriple(Triple_);
         module->setDataLayout(Engine_->getDataLayout().getStringRepresentation());
         if (uniqId) {

--- a/yql/essentials/minikql/codegen/codegen.cpp
+++ b/yql/essentials/minikql/codegen/codegen.cpp
@@ -235,6 +235,33 @@ bool CompareFuncOffsets(const std::pair<ui64, llvm::Function*>& lhs,
     return lhs.first < rhs.first;
 }
 
+std::string SetI128DefaultAlignment(std::string dl) {
+    Y_ENSURE(!dl.empty(), "Empty DataLayout string representation.");
+    const auto i128 = "i128:"sv;
+    if (const auto pos = dl.find(i128); std::string::npos == pos) {
+        const auto i64 = "i64:"sv;
+        const auto p64 = dl.find(i64);
+        const auto sep = dl.find('-', p64 + i64.size());
+        dl.insert(sep, "-i128:64"sv);
+    } else {
+        const auto val = pos + i128.size();
+        const auto sep = dl.find('-', pos + i128.size());
+        const auto end = std::string::npos == sep ? std::string::npos : sep - val;
+        dl.replace(val, end, "64"sv);
+    }
+    return dl;
+}
+
+void SetTargetMachineDataLayout(llvm::TargetMachine& targetMachine, const std::string& dataLayout) {
+    struct TTargetMachineDataLayoutAccessor: public llvm::TargetMachine {
+        void SetDataLayout(const std::string& dataLayout) {
+            const_cast<llvm::DataLayout&>(DL) = llvm::DataLayout(dataLayout);
+        }
+    };
+
+    static_cast<TTargetMachineDataLayoutAccessor&>(targetMachine).SetDataLayout(dataLayout);
+}
+
 #if defined(_asan_enabled_)
 // LLVM 18 ASan emits ELF boundary symbols even for an empty globals range.
 // RuntimeDyld treats address 0 as "not found", so use a real empty range.
@@ -316,7 +343,15 @@ public:
             engineBuilder.setMCPU(hostCpu);
         }
 
-        Engine_.reset(engineBuilder.create());
+        auto targetMachine = std::unique_ptr<llvm::TargetMachine>(engineBuilder.selectTarget());
+        if (!targetMachine) {
+            ythrow yexception() << "Failed to construct LLVM target machine: " << what;
+        }
+
+        const auto dataLayout = SetI128DefaultAlignment(targetMachine->createDataLayout().getStringRepresentation());
+        SetTargetMachineDataLayout(*targetMachine, dataLayout);
+
+        Engine_.reset(engineBuilder.create(targetMachine.release()));
         if (!Engine_) {
             ythrow yexception() << "Failed to construct ExecutionEngine: " << what;
         }
@@ -632,7 +667,6 @@ public:
             error.print("error after ParseIR()", os);
             ythrow yexception() << what;
         }
-
         module->setTargetTriple(Triple_);
         module->setDataLayout(Engine_->getDataLayout().getStringRepresentation());
         if (uniqId) {

--- a/yql/essentials/minikql/codegen/codegen_ut.cpp
+++ b/yql/essentials/minikql/codegen/codegen_ut.cpp
@@ -245,6 +245,17 @@ Function* CreateUseExternalFromGeneratedFunction128(const ICodegen::TPtr& codege
 
 Y_UNIT_TEST_SUITE(TCodegenTests) {
 
+Y_UNIT_TEST(DataLayout) {
+    auto codegen = ICodegen::Make(ETarget::Linux);
+    UNIT_ASSERT_STRING_CONTAINS(codegen->GetModule().getDataLayoutStr(), "-i64:64-i128:64-"sv);
+
+    if (SupportsBitCode) {
+        auto bitcode = NResource::Find("/llvm_bc/Funcs");
+        codegen->LoadBitCode(bitcode, "Funcs");
+        UNIT_ASSERT_STRING_CONTAINS(codegen->GetModule().getDataLayoutStr(), "-i64:64-i128:64-"sv);
+    }
+}
+
 Y_UNIT_TEST(FibNative) {
     auto codegen = ICodegen::Make(ETarget::Native);
     auto func = CreateFibFunction(codegen->GetModule(), codegen->GetContext());


### PR DESCRIPTION
Currently, when generating IR in YQL for the i128 type, alignment 8 is used,
and this is exactly what is required for correct generation. 

But this is achieved thanks to this code [here](https://github.com/ytsaurus/ytsaurus/blob/main/contrib/libs/llvm16/lib/IR/DataLayout.cpp#L637-L641).
It's better to directly set the explicit layout for the i128 type.

Type: fix
Component: query-tracker
