### PR TITLE
Log welcome debug info in Python SDK

### DIFF
--- a/yt/python/yt/wrapper/driver.py
+++ b/yt/python/yt/wrapper/driver.py
@@ -2,7 +2,7 @@ from . import http_driver
 
 from . import native_driver
 from .batch_response import apply_function_to_result
-from .common import YtError, update, simplify_structure, set_param, hide_secure_vault
+from .common import YtError, update, simplify_structure, set_param, hide_secure_vault, get_version
 from .config import get_option, set_option, get_config, get_backend_type
 from .format import create_format, JsonFormat, YsonFormat, YtFormatError
 from .http_helpers import get_http_api_version, get_http_api_commands
@@ -14,7 +14,10 @@ import yt.yson as yson
 
 from copy import deepcopy
 
+import importlib.util
+import logging
 import os
+import sys
 import threading
 
 
@@ -22,6 +25,43 @@ _DEFAULT_COMMAND_PARAMS = {
     "transaction_id": YT_NULL_TRANSACTION_ID,
     "ping_ancestor_transactions": False
 }
+
+_welcome_debug_info_logged = False
+_welcome_debug_info_lock = threading.Lock()
+
+
+def _log_welcome_debug_info():
+    global _welcome_debug_info_logged
+
+    with _welcome_debug_info_lock:
+        if _welcome_debug_info_logged:
+            return
+        _welcome_debug_info_logged = True
+
+    try:
+        if yson.TYPE == "BINARY":
+            import yt_yson_bindings
+            yson_bindings_info = getattr(yt_yson_bindings, "VERSION", "unknown")
+        else:
+            yson_bindings_info = "not found"
+
+        if importlib.util.find_spec("yt_driver_rpc_bindings") is not None:
+            rpc_bindings_info = "found"
+        else:
+            rpc_bindings_info = "not found"
+
+        logger.log_once(
+            logging.DEBUG,
+            "YT wrapper version: %s; python: %s.%s.%s (%s); yson bindings: %s; rpc bindings: %s",
+            get_version(),
+            sys.version_info.major,
+            sys.version_info.minor,
+            sys.version_info.micro,
+            sys.executable,
+            yson_bindings_info,
+            rpc_bindings_info)
+    except Exception:
+        pass
 
 
 def get_commands_description(client=None):
@@ -77,6 +117,9 @@ def make_request(command_name,
                  batch_yson_dumps=True,
                  mutation_id=None,
                  client=None):
+
+    if not _welcome_debug_info_logged:
+        _log_welcome_debug_info()
 
     if client:
         client_created_with_pids = get_option("_created_with_pids", client)

--- a/yt/python/yt/wrapper/tests/serverless/test_misc.py
+++ b/yt/python/yt/wrapper/tests/serverless/test_misc.py
@@ -1,6 +1,10 @@
 import yt.logger as yt_logger
 import yt.wrapper as yt
 
+from yt.wrapper import driver as yt_driver
+
+import logging
+
 from typing import get_type_hints
 from unittest import mock
 
@@ -38,3 +42,20 @@ def test_log_once():
         assert logger_mock.call_count == 5, "hit after clean"
         yt_logger.log_once(30, 'test1')
         assert logger_mock.call_count == 6, "miss after clean"
+
+
+@authors("papilov")
+def test_welcome_debug_info():
+    with mock.patch.object(yt_logger.LOGGER, "log") as logger_mock, \
+            mock.patch.object(yt_logger, "LOG_ONCE_BUFF", {}), \
+            mock.patch.object(yt_driver, "_welcome_debug_info_logged", False):
+        yt_driver._log_welcome_debug_info()
+        yt_driver._log_welcome_debug_info()
+        assert logger_mock.call_count == 1
+        level, template = logger_mock.call_args[0][0], logger_mock.call_args[0][1]
+        assert level == logging.DEBUG
+        message = template % logger_mock.call_args[0][2:]
+        assert "YT wrapper version: " in message
+        assert "python: " in message
+        assert "yson bindings: " in message
+        assert "rpc bindings: " in message


### PR DESCRIPTION
Closes #1443.

**Motivation.** Users' debug logs carry no information about the client version, python, or bindings availability, which makes debugging their environments harder.

**What changed.** On the first actual command going through `yt.wrapper` (top of `driver.make_request` — the common funnel for the http, native/rpc and batch backends, covering both module-level functions and `YtClient` methods), the SDK logs a single DEBUG line with the same data as `yt --version`:

```
YT wrapper version: 0.13.30; python: 3.11.9 (/usr/bin/python3); yson bindings: 0.4.10; rpc bindings: found
```

- once per process: module-level flag + lock, emitted via the existing `yt.logger.log_once`;
- nothing is logged at import time; steady-state overhead is one boolean check per request;
- rpc bindings availability is detected with `importlib.util.find_spec`, so the heavy bindings module is never imported by this code;
- the whole path is wrapped in `try/except`, so a failure of welcome logging can never break a client call.

**How verified.**
- new no-cluster unit test `tests/serverless/test_misc.py::test_welcome_debug_info` (follows the `test_log_once` pattern);
- standalone check with a DEBUG capture handler and two failing requests against a fake proxy: the welcome line appears exactly once, before the first HTTP attempt; also exercised with yson bindings installed and with an rpc-bindings stub that raises on import (reported "found" while the stub was not imported);
- 16 threads racing into the helper produce exactly one record;
- `flake8 --max-line-length=100` shows no new findings vs baseline.

This change was developed with AI assistance (Claude Code); I reviewed and verified all of it locally.

* Changelog entry
Type: feature
Component: python-sdk

Python SDK now logs a one-time debug message on the first executed command with the client version, python version and executable path, and yson/rpc bindings availability (the same data as `yt --version`) to simplify debugging from user debug logs.
