### PR TITLE
Warn about an incorrect //sys/client_config server configuration in Python SDK

### DIFF
--- a/yt/python/yt/wrapper/config_remote_patch.py
+++ b/yt/python/yt/wrapper/config_remote_patch.py
@@ -110,7 +110,12 @@ class RemotePatchableValueBase(object):
             cluster_data = cls._REMOTE_CACHE[cache_key]
         elif path and client:
             try:
-                cluster_data = client.get(client.config["config_remote_patch_path"], read_from="cache", attributes=["value"])
+                cluster_data = client.get(
+                    client.config["config_remote_patch_path"],
+                    read_from="cache",
+                    attributes=["value", "type"],
+                )
+                _validate_remote_config_node(path, cluster_data)
                 if not isinstance(cluster_data, yson.yson_types.YsonMap):
                     # cache bad config
                     cluster_data = {}
@@ -253,3 +258,27 @@ def _validate_query_link_pattern(local_value, remote_value):
     except KeyError:
         raise RuntimeError("Wrong placeholder")
     return ret
+
+
+def _validate_remote_config_node(path, cluster_data):
+    # type: (str, object) -> None
+    def _node_type(node):
+        attributes = getattr(node, "attributes", None)
+        return attributes.get("type") if attributes else None
+
+    node_type = _node_type(cluster_data)
+    if node_type != "map_node":
+        logger.warning(
+            "Node \"%s\" exists, but has type \"%s\" instead of \"map_node\", "
+            "remote config patch is not applied",
+            path, node_type)
+    elif "default" not in cluster_data:
+        logger.warning(
+            "Node \"%s\" exists, but required config \"%s/default\" is absent, "
+            "remote config patch is not applied",
+            path, path)
+    elif _node_type(cluster_data["default"]) != "document":
+        logger.warning(
+            "Node \"%s/default\" exists, but has type \"%s\" instead of \"document\", "
+            "remote config patch is not applied",
+            path, _node_type(cluster_data["default"]))

--- a/yt/python/yt/wrapper/tests/serverless/test_config_remote_patch.py
+++ b/yt/python/yt/wrapper/tests/serverless/test_config_remote_patch.py
@@ -1,0 +1,86 @@
+import yt.logger as yt_logger
+import yt.yson as yson
+
+from yt.wrapper.config_remote_patch import RemotePatchableValueBase
+from yt.wrapper.errors import YtResolveError
+
+from unittest import mock
+
+from yt.testlib import authors
+
+
+@authors("papilov")
+def test_config_remote_patch_misconfiguration_warnings(monkeypatch):
+    monkeypatch.delenv("YT_APPLY_REMOTE_PATCH_AT_START", raising=False)
+
+    def _document(value):
+        node = yson.YsonEntity()
+        node.attributes["type"] = "document"
+        node.attributes["value"] = yson.YsonMap(value)
+        return node
+
+    def _map_node(children):
+        node = yson.YsonMap(children)
+        node.attributes["type"] = "map_node"
+        return node
+
+    def _fetch_remote_patch(data):
+        client = mock.Mock()
+        client.config = {
+            "apply_remote_patch_at_start": True,
+            "config_remote_patch_path": "//sys/client_config",
+            "proxy": {"url": "test_cluster"},
+        }
+        if isinstance(data, Exception):
+            client.get.side_effect = data
+        else:
+            client.get.return_value = data
+        with mock.patch.object(RemotePatchableValueBase, "_REMOTE_CACHE", {}), \
+                mock.patch.object(yt_logger.LOGGER, "warning") as warning_mock, \
+                mock.patch.object(yt_logger.LOGGER, "error"):
+            patch = RemotePatchableValueBase._get_remote_patch(client)
+        assert client.get.call_count == 1, "misconfiguration checks should not add requests"
+        assert client.get.call_args.kwargs["attributes"] == ["value", "type"]
+        warnings = [call.args[0] % tuple(call.args[1:]) for call in warning_mock.call_args_list]
+        return patch, warnings
+
+    # Healthy configuration: no warnings, patch is applied.
+    healthy_data = _map_node({"default": _document({"remote_option": 1})})
+    patch, warnings = _fetch_remote_patch(healthy_data)
+    assert warnings == []
+    assert patch == {"remote_option": 1}
+
+    # //sys/client_config exists, but is not a map_node (scalar node).
+    string_node = yson.YsonString(b"garbage")
+    string_node.attributes["type"] = "string_node"
+    patch, warnings = _fetch_remote_patch(string_node)
+    assert not patch
+    assert len(warnings) == 1
+    assert "\"//sys/client_config\" exists, but has type \"string_node\" instead of \"map_node\"" \
+        in warnings[0]
+
+    # //sys/client_config exists, but is a document (its content is returned by get).
+    document_content = _map_node({"default": yson.YsonMap({"remote_option": 1})})
+    document_content.attributes["type"] = "document"
+    patch, warnings = _fetch_remote_patch(document_content)
+    assert not patch
+    assert len(warnings) == 1
+    assert "has type \"document\" instead of \"map_node\"" in warnings[0]
+
+    # //sys/client_config/default exists, but is not a document.
+    patch, warnings = _fetch_remote_patch(_map_node({"default": _map_node({"remote_option": 1})}))
+    assert not patch
+    assert len(warnings) == 1
+    assert "\"//sys/client_config/default\" exists, but has type \"map_node\" " \
+        "instead of \"document\"" in warnings[0]
+
+    # //sys/client_config exists, but the required config //sys/client_config/default is absent.
+    patch, warnings = _fetch_remote_patch(_map_node({}))
+    assert not patch
+    assert len(warnings) == 1
+    assert "required config \"//sys/client_config/default\" is absent" in warnings[0]
+
+    # No warnings when the cluster does not have //sys/client_config at all.
+    patch, warnings = _fetch_remote_patch(YtResolveError({"code": 500, "message": "resolve error"}))
+    assert not patch
+    assert warnings == []

--- a/yt/python/yt/wrapper/tests/serverless/ya.make
+++ b/yt/python/yt/wrapper/tests/serverless/ya.make
@@ -34,6 +34,7 @@ EXPLICIT_DATA()
 SET(SRCS
     __init__.py
     test_common.py
+    test_config_remote_patch.py
     test_formats.py
     test_misc.py
     test_schema.py


### PR DESCRIPTION
Fixes #1442.

**Motivation.** An incorrect server configuration of the remote client config (`//sys/client_config` with `document` children, handled in `config_remote_patch.py`) currently goes unnoticed: the patch silently degrades to an empty one.

**What changed.** `RemotePatchableValueBase._get_remote_cluster_data` now additionally requests the `type` attribute in the already existing `get` call (no extra requests) and warns about three obvious misconfigurations on the first fetch (the result is cached per proxy+path, so the warning is emitted once per process per cluster):

1. `//sys/client_config` exists, but is not a `map_node` (including the case when it is itself a `document`);
2. `//sys/client_config/default` exists, but is not a `document`;
3. `//sys/client_config` exists, but the required `//sys/client_config/default` config is absent.

Warnings only: degradation behavior is unchanged and no new exceptions reach the user. Both `YtClient` and global module usage go through this code path.

**How verified.** New no-cluster test `tests/serverless/test_config_remote_patch.py` (registered in `ya.make`) covers the healthy state, all three broken states (plus the "client_config is itself a document" variant) and the "node does not exist" state; it also asserts that exactly one `get` request with `attributes=["value", "type"]` is made. `flake8 --max-line-length=100` is clean on the changed lines.

This change was developed with AI assistance (Claude Code); I reviewed and verified all of it locally.

* Changelog entry
Type: feature
Component: python-sdk

Python SDK now warns about an incorrect `//sys/client_config` server configuration (wrong `//sys/client_config` node type, wrong `//sys/client_config/default` node type, or a missing `default` config) on the first remote config patch fetch.
