### PR TITLE
Fix bool operator for YsonStringProxy

### DIFF
--- a/yt/python/yt/yson/yson_types.py
+++ b/yt/python/yt/yson/yson_types.py
@@ -166,6 +166,9 @@ class YsonStringProxy(YsonType):
         else:
             return NotImplemented
 
+    def __bool__(self):
+        return bool(self._bytes)
+
     def __ne__(self, other):
         return not (self == other)
 


### PR DESCRIPTION
For unicode strings this behaviour could happen:

if my_string:
       ^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/yt/yson/yson_types.py", line 96, in fun
    raise NotUnicodeError('Method "{}" is not allowed: YSON string "{}" '
yt.yson.yson_types.NotUnicodeError: Method "__len__" is not allowed: YSON string "b'\xf9\xees6...'" could not be decoded to Unicode, see https://ytsaurus.tech/docs/en/api/python/userdoc#python3_strings

***** Details:
Method "__len__" is not allowed: YSON string "b'\xf9\xees6...'" could not be decoded to Unicode

With __bool__ method it is now fixed