### PR TITLE
Attach table from S3 storages

### DIFF
--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -68,7 +68,7 @@ Cypress (metainformation tree) commands:
 File commands:
     read-file, write-file
 Table commands:
-    read-table, read-blob-table, write-table, create-temp-table,
+    read-table, read-blob-table, attach-table, write-table, create-temp-table,
     alter-table, get-table-columnar-statistics, dirtable
 Dynamic table commands:
     mount-table, unmount-table, remount-table, freeze-table, unfreeze-table, get-tablet-infos,
@@ -592,6 +592,11 @@ def add_upload_orc_parser(add_parser):
     parser.add_argument("--input-file", type=str, required=True)
 
 
+@copy_docstring_from(yt.attach_table)
+def attach_table(**kwargs):
+    yt.attach_table(**kwargs)
+
+
 @copy_docstring_from(yt.write_table)
 def write_table(**kwargs):
     func_args = dict(kwargs)
@@ -619,6 +624,30 @@ def add_write_file_parser(add_parser):
         parser.add_argument("--executable", action="store_true", help="do file executable")
         parser.add_argument("--compute-md5", action="store_true", help="compute md5 of file content")
         add_no_compression_arg(parser)
+
+
+def add_attach_table_parser(add_parser):
+    parser = add_parser(
+        "attach-table",
+        attach_table,
+        epilog="Rewrite table by default. For append mode specify <append=true> before path.")
+    add_ypath_argument(
+        parser,
+        "--dst",
+        required=True,
+        dest="destination_table",
+        help="Path to an existing destination table in Cypress",
+    )
+    parser.add_argument(
+        "--src",
+        action="append",
+        required=True,
+        dest="source_uris",
+        help='S3 URI of a Parquet source, e.g. "s3://bucket/data.parquet"',
+    )
+    parser.add_argument("--medium", help="Require this S3 medium on the destination table")
+    parser.add_argument("--source-format", choices=["parquet"], help="Source format (defaults to .parquet suffix)")
+    parser.add_argument("--allow-incompatible-source-schemas", action="store_true")
 
 
 def add_write_table_parser(add_parser):
@@ -3197,6 +3226,7 @@ def _prepare_parser():
     add_create_account_parser(add_parser)
     add_create_pool_parser(add_parser)
     add_read_table_parser(add_parser)
+    add_attach_table_parser(add_parser)
     add_write_table_parser(add_parser)
     add_create_temp_table_parser(add_parser)
 

--- a/yt/python/yt/wrapper/client_api.py
+++ b/yt/python/yt/wrapper/client_api.py
@@ -4,7 +4,7 @@ except ImportError:
     pass
 from .cypress_commands import search, concatenate, find_free_subpath, create_revision_parameter, get_table_schema  # noqa
 from .table_commands import (  # noqa
-    create_temp_table, write_table, read_table, read_blob_table, infer_table_schema,
+    create_temp_table, attach_table, write_table, read_table, read_blob_table, infer_table_schema,
     write_table_structured, read_table_structured, dump_parquet, upload_parquet, dump_orc, upload_orc)
 from .download_core_dump import download_core_dump  # noqa
 from .dynamic_table_commands import select_rows, insert_rows, delete_rows, lookup_rows, lock_rows, explain_query  # noqa

--- a/yt/python/yt/wrapper/client_impl.py
+++ b/yt/python/yt/wrapper/client_impl.py
@@ -3924,6 +3924,24 @@ class YtClient(ClientState):
             compute_md5=compute_md5, size_hint=size_hint, filename_hint=filename_hint, progress_monitor=progress_monitor
         )
 
+    def attach_table(
+        self,
+        destination_table,
+        source_uris,
+        allow_incompatible_source_schemas=None,
+        medium=None,
+        source_format=None,
+    ):
+        """Attach external Parquet objects as chunks of an existing static table."""
+        return client_api.attach_table(
+            destination_table,
+            source_uris,
+            allow_incompatible_source_schemas=allow_incompatible_source_schemas,
+            medium=medium,
+            source_format=source_format,
+            client=self,
+        )
+
     def write_table(
         self,
         table: Union[str, ForwardRef("TablePath")],

--- a/yt/python/yt/wrapper/table_commands.py
+++ b/yt/python/yt/wrapper/table_commands.py
@@ -1087,6 +1087,28 @@ def is_empty(table, client=None):
         row_count(TablePath(table, client=client), client=client))
 
 
+def attach_table(destination_table, source_uris, allow_incompatible_source_schemas=None,
+                 medium=None, source_format=None, client=None):
+    """Attach external Parquet objects as chunks of an existing static table.
+
+    :param destination_table: output table. Its primary medium must be an S3 medium.
+    :type destination_table: str or :class:`TablePath <yt.wrapper.ypath.TablePath>`
+    :param source_uris: S3 object URIs, e.g. ``s3://bucket/path/data.parquet``.
+    :type source_uris: list[str]
+    :param allow_incompatible_source_schemas: permit sources whose inferred schema
+        is not fully compatible with the table schema.
+    :param medium: require the destination table to use this S3 medium.
+    :param source_format: explicit source format; currently only ``parquet`` is supported.
+    """
+    params = {"path": TablePath(destination_table, client=client)}
+    set_param(params, "source_uris", source_uris)
+    set_param(params, "allow_incompatible_source_schemas", allow_incompatible_source_schemas)
+    set_param(params, "medium", medium)
+    set_param(params, "source_format", source_format)
+
+    return make_request("attach_table", params, client=client)
+
+
 def get_sorted_by(table, default=None, client=None):
     """Returns "sorted_by" table attribute or `default` if attribute doesn't exist.
 

--- a/yt/yt/client/api/delegating_client.h
+++ b/yt/yt/client/api/delegating_client.h
@@ -88,6 +88,12 @@ public:
         const TTableWriterOptions& options),
         (path, options))
 
+    DELEGATE_METHOD(TFuture<void>, AttachTable, (
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const TAttachTableOptions& options),
+        (path, std::move(sourceUris), options))
+
     // Queues
     DELEGATE_METHOD(TFuture<NQueueClient::IQueueRowsetPtr>, PullQueue, (
         const NYPath::TRichYPath& queuePath,

--- a/yt/yt/client/api/delegating_transaction.cpp
+++ b/yt/yt/client/api/delegating_transaction.cpp
@@ -65,6 +65,12 @@ DELEGATE_METHOD(TFuture<ITableWriterPtr>, CreateTableWriter, (
     const TTableWriterOptions& options),
     (path, options))
 
+DELEGATE_METHOD(TFuture<void>, AttachTable, (
+    const NYPath::TRichYPath& path,
+    std::vector<std::string> sourceUris,
+    const TAttachTableOptions& options),
+    (path, std::move(sourceUris), options))
+
 DELEGATE_METHOD(TFuture<NYson::TYsonString>, GetNode, (
     const NYPath::TYPath& path,
     const TGetNodeOptions& options),

--- a/yt/yt/client/api/delegating_transaction.h
+++ b/yt/yt/client/api/delegating_transaction.h
@@ -60,6 +60,11 @@ public:
         const NYPath::TRichYPath& path,
         const TTableWriterOptions& options) override;
 
+    TFuture<void> AttachTable(
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const TAttachTableOptions& options) override;
+
     // Cypress
     TFuture<NYson::TYsonString> GetNode(
         const NYPath::TYPath& path,

--- a/yt/yt/client/api/not_implemented_client.h
+++ b/yt/yt/client/api/not_implemented_client.h
@@ -76,6 +76,11 @@ public:
         const NYPath::TRichYPath& /*path*/,
         const TTableWriterOptions& /*options*/))
 
+    UNIMPLEMENTED_METHOD(TFuture<void>, AttachTable, (
+        const NYPath::TRichYPath& /*path*/,
+        std::vector<std::string> /*sourceUris*/,
+        const TAttachTableOptions& /*options*/))
+
     // Queues
     UNIMPLEMENTED_METHOD(TFuture<NQueueClient::IQueueRowsetPtr>, PullQueue, (
         const NYPath::TRichYPath& /*queuePath*/,

--- a/yt/yt/client/api/rpc_proxy/api_service_proxy.h
+++ b/yt/yt/client/api/rpc_proxy/api_service_proxy.h
@@ -157,6 +157,7 @@ public:
         .SetStreamingEnabled(true));
     DEFINE_RPC_PROXY_METHOD(NRpcProxy::NProto, WriteTable,
         .SetStreamingEnabled(true));
+    DEFINE_RPC_PROXY_METHOD(NRpcProxy::NProto, AttachTable);
     DEFINE_RPC_PROXY_METHOD(NRpcProxy::NProto, GetColumnarStatistics);
     DEFINE_RPC_PROXY_METHOD(NRpcProxy::NProto, PartitionTables);
     DEFINE_RPC_PROXY_METHOD(NRpcProxy::NProto, ReadTablePartition,

--- a/yt/yt/client/api/rpc_proxy/client_base.cpp
+++ b/yt/yt/client/api/rpc_proxy/client_base.cpp
@@ -835,6 +835,30 @@ TFuture<ITableWriterPtr> TClientBase::CreateTableWriter(
 
 ////////////////////////////////////////////////////////////////////////////////
 
+TFuture<void> TClientBase::AttachTable(
+    const TRichYPath& path,
+    std::vector<std::string> sourceUris,
+    const TAttachTableOptions& options)
+{
+    auto proxy = CreateApiServiceProxy();
+    auto req = proxy.AttachTable();
+
+    SetTimeoutOptions(*req, options);
+
+    ToProto(req->mutable_path(), path);
+    ToProto(req->mutable_source_uris(), sourceUris);
+    req->set_allow_incompatible_source_schemas(options.AllowIncompatibleSourceSchemas);
+    YT_OPTIONAL_SET_PROTO(req, medium, options.Medium);
+    if (options.SourceFormat) {
+        req->set_source_format(ToUnderlying(*options.SourceFormat));
+    }
+    ToProto(req->mutable_transactional_options(), options);
+
+    return req->Invoke().As<void>();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 TFuture<TDistributedWriteSessionWithCookies> TClientBase::StartDistributedWriteSession(
     const NYPath::TRichYPath& path,
     const TDistributedWriteSessionStartOptions& options)

--- a/yt/yt/client/api/rpc_proxy/client_base.h
+++ b/yt/yt/client/api/rpc_proxy/client_base.h
@@ -184,6 +184,11 @@ public:
         const NYPath::TRichYPath& path,
         const NApi::TTableWriterOptions& options) override;
 
+    TFuture<void> AttachTable(
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const NApi::TAttachTableOptions& options) override;
+
     // Distributed table client
     TFuture<TDistributedWriteSessionWithCookies> StartDistributedWriteSession(
         const NYPath::TRichYPath& path,

--- a/yt/yt/client/api/rpc_proxy/transaction_impl.cpp
+++ b/yt/yt/client/api/rpc_proxy/transaction_impl.cpp
@@ -842,6 +842,18 @@ TFuture<ITableWriterPtr> TTransaction::CreateTableWriter(
         PatchTransactionId(options));
 }
 
+TFuture<void> TTransaction::AttachTable(
+    const TRichYPath& path,
+    std::vector<std::string> sourceUris,
+    const TAttachTableOptions& options)
+{
+    ValidateActive();
+    return Client_->AttachTable(
+        path,
+        std::move(sourceUris),
+        PatchTransactionId(options));
+}
+
 TFuture<NYson::TYsonString> TTransaction::GetNode(
     const TYPath& path,
     const TGetNodeOptions& options)

--- a/yt/yt/client/api/rpc_proxy/transaction_impl.h
+++ b/yt/yt/client/api/rpc_proxy/transaction_impl.h
@@ -150,6 +150,11 @@ public:
         const NYPath::TRichYPath& path,
         const NApi::TTableWriterOptions& options) override;
 
+    TFuture<void> AttachTable(
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const NApi::TAttachTableOptions& options) override;
+
     TFuture<NYson::TYsonString> GetNode(
         const NYPath::TYPath& path,
         const NApi::TGetNodeOptions& options) override;

--- a/yt/yt/client/api/table_client.h
+++ b/yt/yt/client/api/table_client.h
@@ -66,8 +66,7 @@ struct TAttachTableOptions
     //! If specified, must be the table's S3 primary medium.
     std::optional<std::string> Medium;
 
-    //! Overrides format deduction from a source URI. Only Parquet is enabled
-    //! today; this keeps the wire API extensible for later source formats.
+    //! Overrides format deduction from a source URI.
     std::optional<NChunkClient::EExternalSourceFormat> SourceFormat;
 };
 

--- a/yt/yt/client/api/table_client.h
+++ b/yt/yt/client/api/table_client.h
@@ -3,6 +3,7 @@
 #include "client_common.h"
 #include "dynamic_table_client.h"
 
+#include <yt/yt/client/chunk_client/public.h>
 #include <yt/yt/client/table_client/chunk_stripe_statistics.h>
 #include <yt/yt/client/table_client/columnar_statistics.h>
 #include <yt/yt/client/table_client/schema.h>
@@ -11,6 +12,8 @@
 #include <yt/yt/client/tablet_client/index_info.h>
 
 #include <yt/yt/client/chaos_client/replication_card.h>
+
+#include <string>
 
 namespace NYT::NApi {
 
@@ -51,6 +54,21 @@ struct TTableWriterOptions
     bool ValidateAnyIsValidYson = false;
 
     NTableClient::TTableWriterConfigPtr Config;
+};
+
+struct TAttachTableOptions
+    : public TTransactionalOptions
+    , public TTimeoutOptions
+{
+    //! Permit a source schema that is not fully compatible with the table.
+    bool AllowIncompatibleSourceSchemas = false;
+
+    //! If specified, must be the table's S3 primary medium.
+    std::optional<std::string> Medium;
+
+    //! Overrides format deduction from a source URI. Only Parquet is enabled
+    //! today; this keeps the wire API extensible for later source formats.
+    std::optional<NChunkClient::EExternalSourceFormat> SourceFormat;
 };
 
 struct TTabletRangeOptions
@@ -419,6 +437,11 @@ struct ITableClientBase
     virtual TFuture<ITableWriterPtr> CreateTableWriter(
         const NYPath::TRichYPath& path,
         const TTableWriterOptions& options = {}) = 0;
+
+    virtual TFuture<void> AttachTable(
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const TAttachTableOptions& options = {}) = 0;
 };
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/chunk_client/chunk_replica-inl.h
+++ b/yt/yt/client/chunk_client/chunk_replica-inl.h
@@ -46,6 +46,16 @@ Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium(
 }
 
 Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium(
+    NNodeTrackerClient::TNodeId nodeId,
+    int replicaIndex,
+    int mediumIndex,
+    std::string sourceUri)
+    : TChunkReplicaWithMedium(nodeId, replicaIndex, mediumIndex)
+{
+    SourceUri_ = std::move(sourceUri);
+}
+
+Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium(
     TChunkReplica replica)
     : TChunkReplicaWithMedium(
         replica.GetNodeId(),
@@ -68,6 +78,11 @@ Y_FORCE_INLINE int TChunkReplicaWithMedium::GetMediumIndex() const
     return Value_ >> 29;
 }
 
+Y_FORCE_INLINE TStringBuf TChunkReplicaWithMedium::GetSourceUri() const
+{
+    return SourceUri_;
+}
+
 Y_FORCE_INLINE TChunkReplica TChunkReplicaWithMedium::ToChunkReplica() const
 {
     return TChunkReplica(GetNodeId(), GetReplicaIndex());
@@ -76,6 +91,9 @@ Y_FORCE_INLINE TChunkReplica TChunkReplicaWithMedium::ToChunkReplica() const
 Y_FORCE_INLINE void ToProto(NProto::TChunkReplicaSpec* protoReplica, TChunkReplicaWithMedium replica)
 {
     protoReplica->set_encoded_chunk_replica_with_medium(replica.Value_);
+    if (!replica.SourceUri_.empty()) {
+        protoReplica->set_source_uri(replica.SourceUri_);
+    }
 }
 
 Y_FORCE_INLINE void ToProto(ui64* protoReplica, TChunkReplicaWithMedium replica)
@@ -86,6 +104,7 @@ Y_FORCE_INLINE void ToProto(ui64* protoReplica, TChunkReplicaWithMedium replica)
 Y_FORCE_INLINE void FromProto(TChunkReplicaWithMedium* replica, NProto::TChunkReplicaSpec protoReplica)
 {
     replica->Value_ = protoReplica.encoded_chunk_replica_with_medium();
+    replica->SourceUri_ = protoReplica.source_uri();
 }
 
 Y_FORCE_INLINE void ToProto(ui32* protoReplica, TChunkReplicaWithMedium replica)
@@ -96,6 +115,7 @@ Y_FORCE_INLINE void ToProto(ui32* protoReplica, TChunkReplicaWithMedium replica)
 Y_FORCE_INLINE void FromProto(TChunkReplicaWithMedium* replica, ui64 protoReplica)
 {
     replica->Value_ = protoReplica;
+    replica->SourceUri_.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/chunk_client/chunk_replica.cpp
+++ b/yt/yt/client/chunk_client/chunk_replica.cpp
@@ -93,6 +93,9 @@ void ToProto(NProto::TConfirmChunkReplicaInfo* value, TChunkReplicaWithLocation 
     value->set_replica(replica.Value_);
     ToProto(value->mutable_location_uuid(), replica.ChunkLocationUuid_);
     value->set_location_index(ToProto<ui32>(replica.ChunkLocationIndex_));
+    if (!replica.SourceUri_.empty()) {
+        ToProto(value->mutable_replica_spec(), static_cast<TChunkReplicaWithMedium>(replica));
+    }
 }
 
 void FromProto(TChunkReplicaWithLocation* replica, NProto::TConfirmChunkReplicaInfo value)
@@ -100,6 +103,12 @@ void FromProto(TChunkReplicaWithLocation* replica, NProto::TConfirmChunkReplicaI
     using NYT::FromProto;
 
     replica->Value_ = value.replica();
+    replica->SourceUri_.clear();
+    if (value.has_replica_spec()) {
+        auto replicaWithMedium = FromProto<TChunkReplicaWithMedium>(value.replica_spec());
+        YT_VERIFY(replicaWithMedium.Value_ == replica->Value_);
+        replica->SourceUri_ = std::move(replicaWithMedium.SourceUri_);
+    }
     replica->ChunkLocationUuid_ = FromProto<TChunkLocationUuid>(value.location_uuid());
     // COMPAT(cherepashka)
     if (value.has_location_index()) {

--- a/yt/yt/client/chunk_client/chunk_replica.h
+++ b/yt/yt/client/chunk_client/chunk_replica.h
@@ -11,6 +11,8 @@
 
 #include <yt/yt/core/misc/protobuf_helpers.h>
 
+#include <string>
+
 namespace NYT::NChunkClient {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -24,6 +26,11 @@ public:
         NNodeTrackerClient::TNodeId nodeId,
         int replicaIndex,
         int mediumIndex);
+    TChunkReplicaWithMedium(
+        NNodeTrackerClient::TNodeId nodeId,
+        int replicaIndex,
+        int mediumIndex,
+        std::string sourceUri);
     // NB: Will be assigned to generic medium.
     explicit TChunkReplicaWithMedium(TChunkReplica replica);
 
@@ -32,6 +39,7 @@ public:
     NNodeTrackerClient::TNodeId GetNodeId() const;
     int GetReplicaIndex() const;
     int GetMediumIndex() const;
+    TStringBuf GetSourceUri() const;
 
     TChunkReplica ToChunkReplica() const;
     static TChunkReplicaList ToChunkReplicas(TRange<TChunkReplicaWithMedium> replicasWithMedia);
@@ -55,6 +63,7 @@ private:
      *  29-37: medium index (7 bits)
      */
     ui64 Value_;
+    std::string SourceUri_;
 
     explicit TChunkReplicaWithMedium(ui64 value);
 };

--- a/yt/yt/client/chunk_client/helpers.cpp
+++ b/yt/yt/client/chunk_client/helpers.cpp
@@ -50,4 +50,26 @@ void SetObjectId(NProto::TChunkSpec* chunkSpec, NObjectClient::TObjectId objectI
 
 ////////////////////////////////////////////////////////////////////////////////
 
+EExternalSourceFormat DeduceExternalSourceFormatOrThrow(TStringBuf fileName)
+{
+    if (fileName.ends_with(".parquet")) {
+        return EExternalSourceFormat::Parquet;
+    }
+
+    THROW_ERROR_EXCEPTION(
+        "Cannot deduce an enabled external source format from file name %Qv; only .parquet is supported",
+        fileName);
+}
+
+EChunkFormat GetChunkFormatFromExternalSourceFormat(EExternalSourceFormat externalFormat)
+{
+    switch (externalFormat) {
+        case EExternalSourceFormat::Parquet:
+            return EChunkFormat::TableUnversionedArrowParquet;
+    }
+    YT_ABORT();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/helpers.h
+++ b/yt/yt/client/chunk_client/helpers.h
@@ -18,6 +18,12 @@ TChunkReplicaList GetReplicasFromChunkSpec(const NProto::TChunkSpec& chunkSpec);
 void SetTabletId(NProto::TChunkSpec* chunkSpec, NTabletClient::TTabletId tabletId);
 void SetObjectId(NProto::TChunkSpec* chunkSpec, NObjectClient::TObjectId objectId);
 
+//! Deduces an enabled external source format from a source object name.
+EExternalSourceFormat DeduceExternalSourceFormatOrThrow(TStringBuf fileName);
+
+//! Maps an external source format to its synthetic chunk format.
+EChunkFormat GetChunkFormatFromExternalSourceFormat(EExternalSourceFormat externalFormat);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/public.h
+++ b/yt/yt/client/chunk_client/public.h
@@ -219,6 +219,9 @@ DEFINE_ENUM_WITH_UNDERLYING_TYPE(EChunkFormat, i8,
     ((TableVersionedIndexed)                (8))
     ((TableVersionedSlim)                   (9))
 
+    // External table chunks. The data remains in the source object.
+    ((TableUnversionedArrowParquet)         (12))
+
     // Journal chunks.
     ((JournalDefault)                       (0))
     ((JournalDistributed)                  (11))
@@ -233,6 +236,12 @@ DEFINE_ENUM_WITH_UNDERLYING_TYPE(EChunkReplicaState, i8,
     ((Active)                (1))
     ((Unsealed)              (2))
     ((Sealed)                (3))
+);
+
+//! User-visible formats supported by the external-source attach pipeline.
+//! More source formats can be added without changing the attach protocol.
+DEFINE_ENUM(EExternalSourceFormat,
+    (Parquet)
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/driver/driver.cpp
+++ b/yt/yt/client/driver/driver.cpp
@@ -193,6 +193,7 @@ public:
 
         REGISTER    (TWriteTableCommand,                   "write_table",                     Tabular,    Null,       true,  true , ApiVersion3);
         REGISTER    (TWriteTableCommand,                   "write_table",                     Tabular,    Structured, true,  true , ApiVersion4);
+        REGISTER    (TAttachTableCommand,                  "attach_table",                    Null,       Structured, true,  true,  ApiVersion4);
         REGISTER_ALL(TGetTableColumnarStatisticsCommand,   "get_table_columnar_statistics",   Null,       Structured, false, true);
         REGISTER_ALL(TReadTableCommand,                    "read_table",                      Null,       Tabular,    false, true );
         REGISTER_ALL(TReadBlobTableCommand,                "read_blob_table",                 Null,       Binary,     false, true );

--- a/yt/yt/client/driver/table_commands.cpp
+++ b/yt/yt/client/driver/table_commands.cpp
@@ -385,6 +385,51 @@ void TWriteTableCommand::DoExecute(ICommandContextPtr context)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+void TAttachTableCommand::Register(TRegistrar registrar)
+{
+    registrar.Parameter("path", &TThis::Path);
+    registrar.Parameter("source_uris", &TThis::SourceUris);
+    registrar.ParameterWithUniversalAccessor<bool>(
+        "allow_incompatible_source_schemas",
+        [] (TThis* command) -> auto& {
+            return command->Options.AllowIncompatibleSourceSchemas;
+        })
+        .Optional(/*init*/ false);
+    registrar.ParameterWithUniversalAccessor<std::optional<std::string>>(
+        "medium",
+        [] (TThis* command) -> auto& {
+            return command->Options.Medium;
+        })
+        .Optional(/*init*/ false);
+    registrar.ParameterWithUniversalAccessor<std::optional<EExternalSourceFormat>>(
+        "source_format",
+        [] (TThis* command) -> auto& {
+            return command->Options.SourceFormat;
+        })
+        .Optional(/*init*/ false);
+}
+
+void TAttachTableCommand::DoExecuteImpl(const ICommandContextPtr& context)
+{
+    auto transaction = AttachTransaction(context, false);
+
+    // This is how table upload commands preserve their ancestor locks today.
+    Options.PingAncestors = true;
+
+    PutMethodInfoInTraceContext("attach_table");
+
+    WaitFor(context->GetClient()->AttachTable(Path, SourceUris, Options))
+        .ThrowOnError();
+}
+
+void TAttachTableCommand::DoExecute(ICommandContextPtr context)
+{
+    DoExecuteImpl(context);
+    ProduceEmptyOutput(context);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 void TGetTableColumnarStatisticsCommand::Register(TRegistrar registrar)
 {
     registrar.Parameter("paths", &TThis::Paths);

--- a/yt/yt/client/driver/table_commands.h
+++ b/yt/yt/client/driver/table_commands.h
@@ -114,6 +114,30 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+//! Attaches external source files as chunks of an existing table.
+//!
+//! The public surface accepts a list of URIs so adding a new external format
+//! later does not require a new command shape.
+class TAttachTableCommand
+    : public TTypedCommand<NApi::TAttachTableOptions>
+{
+public:
+    REGISTER_YSON_STRUCT_LITE(TAttachTableCommand);
+
+    static void Register(TRegistrar registrar);
+
+protected:
+    void DoExecuteImpl(const ICommandContextPtr& context);
+
+private:
+    NYPath::TRichYPath Path;
+    std::vector<std::string> SourceUris;
+
+    void DoExecute(ICommandContextPtr context) override;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class TGetTableColumnarStatisticsCommand
     : public TTypedCommand<NApi::TGetColumnarStatisticsOptions>
 {

--- a/yt/yt/client/federated/client.cpp
+++ b/yt/yt/client/federated/client.cpp
@@ -218,6 +218,7 @@ public:
     UNIMPLEMENTED_METHOD(TFuture<ITableReaderPtr>, CreateTableReader, (const NYPath::TRichYPath&, const TTableReaderOptions&));
     UNIMPLEMENTED_METHOD(TFuture<IFileReaderPtr>, CreateFileReader, (const NYPath::TYPath&, const TFileReaderOptions&));
     UNIMPLEMENTED_METHOD(TFuture<ITableWriterPtr>, CreateTableWriter, (const NYPath::TRichYPath&, const TTableWriterOptions&));
+    UNIMPLEMENTED_METHOD(TFuture<void>, AttachTable, (const NYPath::TRichYPath&, std::vector<std::string>, const TAttachTableOptions&));
     UNIMPLEMENTED_METHOD(IFileWriterPtr, CreateFileWriter, (const NYPath::TRichYPath&, const TFileWriterOptions&));
     UNIMPLEMENTED_METHOD(IJournalReaderPtr, CreateJournalReader, (const NYPath::TYPath&, const TJournalReaderOptions&));
     UNIMPLEMENTED_METHOD(IJournalWriterPtr, CreateJournalWriter, (const NYPath::TYPath&, const TJournalWriterOptions&));
@@ -487,6 +488,7 @@ public:
     UNIMPLEMENTED_METHOD(TFuture<void>, SetBundleConfig, (const std::string&, const NBundleControllerClient::TBundleTargetConfigPtr&, const NBundleControllerClient::TSetBundleConfigOptions&));
     UNIMPLEMENTED_METHOD(TFuture<ITableReaderPtr>, CreateTableReader, (const NYPath::TRichYPath&, const TTableReaderOptions&));
     UNIMPLEMENTED_METHOD(TFuture<ITableWriterPtr>, CreateTableWriter, (const NYPath::TRichYPath&, const TTableWriterOptions&));
+    UNIMPLEMENTED_METHOD(TFuture<void>, AttachTable, (const NYPath::TRichYPath&, std::vector<std::string>, const TAttachTableOptions&));
     UNIMPLEMENTED_METHOD(TFuture<IFileReaderPtr>, CreateFileReader, (const NYPath::TYPath&, const TFileReaderOptions&));
     UNIMPLEMENTED_METHOD(IFileWriterPtr, CreateFileWriter, (const NYPath::TRichYPath&, const TFileWriterOptions&));
     UNIMPLEMENTED_METHOD(IJournalReaderPtr, CreateJournalReader, (const NYPath::TYPath&, const TJournalReaderOptions&));

--- a/yt/yt/client/hedging/hedging.cpp
+++ b/yt/yt/client/hedging/hedging.cpp
@@ -101,6 +101,7 @@ public:
     // Unsupported methods.
     UNSUPPORTED_METHOD(TFuture<ITransactionPtr>, StartTransaction, (NTransactionClient::ETransactionType, const TTransactionStartOptions&));
     UNSUPPORTED_METHOD(TFuture<ITableWriterPtr>, CreateTableWriter, (const TRichYPath&, const TTableWriterOptions&));
+    UNSUPPORTED_METHOD(TFuture<void>, AttachTable, (const TRichYPath&, std::vector<std::string>, const TAttachTableOptions&));
     UNSUPPORTED_METHOD(TFuture<void>, SetNode, (const TYPath&, const NYson::TYsonString&, const TSetNodeOptions&));
     UNSUPPORTED_METHOD(TFuture<void>, MultisetAttributesNode, (const TYPath&, const IMapNodePtr&, const TMultisetAttributesNodeOptions&));
     UNSUPPORTED_METHOD(TFuture<void>, RemoveNode, (const TYPath&, const TRemoveNodeOptions&));

--- a/yt/yt/client/table_client/helpers.cpp
+++ b/yt/yt/client/table_client/helpers.cpp
@@ -39,6 +39,7 @@ bool IsValidTableChunkFormat(EChunkFormat chunkFormat)
         chunkFormat == EChunkFormat::TableUnversionedSchemaful ||
         chunkFormat == EChunkFormat::TableUnversionedSchemalessHorizontal ||
         chunkFormat == EChunkFormat::TableUnversionedColumnar ||
+        chunkFormat == EChunkFormat::TableUnversionedArrowParquet ||
         chunkFormat == EChunkFormat::TableVersionedSimple ||
         chunkFormat == EChunkFormat::TableVersionedIndexed ||
         chunkFormat == EChunkFormat::TableVersionedColumnar ||
@@ -103,6 +104,7 @@ EOptimizeFor OptimizeForFromFormat(EChunkFormat chunkFormat)
             return EOptimizeFor::Lookup;
 
         case EChunkFormat::TableUnversionedColumnar:
+        case EChunkFormat::TableUnversionedArrowParquet:
         case EChunkFormat::TableVersionedColumnar:
             return EOptimizeFor::Scan;
 

--- a/yt/yt/client/table_client/public.h
+++ b/yt/yt/client/table_client/public.h
@@ -49,6 +49,7 @@ class THunkChunkRef;
 class TColumnMetaExt;
 class TVersionedRowDigestExt;
 class TCompressionDictionaryExt;
+class TParquetFormatMetaExt;
 class TVersionedReadOptions;
 class TVersionedWriteOptions;
 class TColumnNameToConstraintMap;

--- a/yt/yt/client/unittests/mock/client.h
+++ b/yt/yt/client/unittests/mock/client.h
@@ -144,6 +144,12 @@ public:
         const TTableWriterOptions& options),
         (override));
 
+    MOCK_METHOD(TFuture<void>, AttachTable, (
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const TAttachTableOptions& options),
+        (override));
+
     MOCK_METHOD(TFuture<NYson::TYsonString>, GetNode, (
         const NYPath::TYPath& path,
         const TGetNodeOptions& options),

--- a/yt/yt/client/unittests/mock/transaction.h
+++ b/yt/yt/client/unittests/mock/transaction.h
@@ -63,6 +63,11 @@ public:
         const NYPath::TRichYPath& path,
         const TTableWriterOptions& options), (override));
 
+    MOCK_METHOD(TFuture<void>, AttachTable, (
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const TAttachTableOptions& options), (override));
+
     MOCK_METHOD(TFuture<NYson::TYsonString>, GetNode, (
         const NYPath::TYPath& path,
         const TGetNodeOptions& options), (override));

--- a/yt/yt/library/arrow_adapter/arrow.cpp
+++ b/yt/yt/library/arrow_adapter/arrow.cpp
@@ -440,4 +440,93 @@ TArrowSchemaPtr CreateArrowSchemaFromOrcMetadata(const std::string* metadata, i6
 
 ////////////////////////////////////////////////////////////////////////////////
 
+arrow20::Result<std::shared_ptr<arrow20::Buffer>> TStatelessArrowRandomAccessFileBase::ReadAt(int64_t position, int64_t nbytes)
+{
+    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow20::AllocateResizableBuffer(nbytes));
+    ARROW_ASSIGN_OR_RAISE(auto bytesRead, ReadAt(position, nbytes, buffer->mutable_data()));
+
+    if (bytesRead < nbytes) {
+        ARROW_RETURN_NOT_OK(buffer->Resize(bytesRead));
+        buffer->ZeroPadding();
+    }
+
+    return buffer;
+}
+
+arrow20::Status TStatelessArrowRandomAccessFileBase::Seek(int64_t position)
+{
+    FilePosition_ = position;
+    return arrow20::Status::OK();
+}
+
+arrow20::Result<int64_t> TStatelessArrowRandomAccessFileBase::Tell() const
+{
+    return FilePosition_;
+}
+
+arrow20::Result<int64_t> TStatelessArrowRandomAccessFileBase::Read(int64_t nbytes, void* out)
+{
+    ARROW_ASSIGN_OR_RAISE(auto bytesRead, ReadAt(FilePosition_, nbytes, out));
+    FilePosition_ += bytesRead;
+    return bytesRead;
+}
+
+arrow20::Result<std::shared_ptr<arrow20::Buffer>> TStatelessArrowRandomAccessFileBase::Read(int64_t nbytes)
+{
+    ARROW_ASSIGN_OR_RAISE(auto buffer, ReadAt(FilePosition_, nbytes));
+    FilePosition_ += buffer->size();
+    return buffer;
+}
+
+arrow20::Status TStatelessArrowRandomAccessFileBase::Close()
+{
+    Closed_.store(true);
+    return arrow20::Status::OK();
+}
+
+bool TStatelessArrowRandomAccessFileBase::closed() const
+{
+    return Closed_.load();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TCompositeBufferArrowRandomAccessFile::TCompositeBufferArrowRandomAccessFile(
+    std::vector<TBufferDescriptor> buffers,
+    i64 fileSize)
+    : Buffers_(std::move(buffers))
+    , FileSize_(fileSize)
+{
+    YT_VERIFY(!Buffers_.empty());
+    YT_VERIFY(FileSize_ > 0);
+    YT_VERIFY(std::all_of(Buffers_.begin(), Buffers_.end(), [this] (const auto& buffer) {
+        return buffer.Offset >= 0 && buffer.Offset + std::ssize(buffer.Data) <= FileSize_;
+    }));
+}
+
+arrow20::Result<int64_t> TCompositeBufferArrowRandomAccessFile::GetSize()
+{
+    return FileSize_;
+}
+
+arrow20::Result<int64_t> TCompositeBufferArrowRandomAccessFile::ReadAt(int64_t position, int64_t nbytes, void* out)
+{
+    if (position < 0 || nbytes < 0 || position + nbytes > FileSize_) {
+        return arrow20::Status::IOError(Format(
+            "Cannot read %v bytes at position %v from file of size %v", nbytes, position, FileSize_));
+    }
+
+    for (const auto& buffer : Buffers_) {
+        if (position >= buffer.Offset && position + nbytes <= buffer.Offset + std::ssize(buffer.Data)) {
+            std::memcpy(out, buffer.Data.Begin() + position - buffer.Offset, nbytes);
+            return nbytes;
+        }
+    }
+
+    return arrow20::Status::IOError(Format(
+        "Requested read range [%v, %v) does not fall into any buffer", position, position + nbytes));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NArrow

--- a/yt/yt/library/arrow_adapter/arrow.h
+++ b/yt/yt/library/arrow_adapter/arrow.h
@@ -4,6 +4,8 @@
 
 #include <library/cpp/yt/memory/ref.h>
 
+#include <atomic>
+
 #include <util/generic/fwd.h>
 
 #include <util/stream/input.h>
@@ -66,6 +68,57 @@ i64 GetMaxStripeSize(const std::string* metadata, i64 startMetadataOffset);
 TArrowSchemaPtr CreateArrowSchemaFromParquetMetadata(const std::string* metadata, i64 startIndex);
 
 TArrowSchemaPtr CreateArrowSchemaFromOrcMetadata(const std::string* metadata, i64 startIndex);
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! A small adapter for sources which efficiently implement random reads only.
+//! Arrow's stateful methods are implemented in terms of ReadAt.
+class TStatelessArrowRandomAccessFileBase
+    : public arrow20::io::RandomAccessFile
+{
+public:
+    arrow20::Result<int64_t> GetSize() override = 0;
+    arrow20::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override = 0;
+
+    arrow20::Result<std::shared_ptr<arrow20::Buffer>> ReadAt(int64_t position, int64_t nbytes) override;
+
+    arrow20::Status Seek(int64_t position) override;
+    arrow20::Result<int64_t> Tell() const override;
+
+    arrow20::Result<int64_t> Read(int64_t nbytes, void* out) override;
+    arrow20::Result<std::shared_ptr<arrow20::Buffer>> Read(int64_t nbytes) override;
+
+    arrow20::Status Close() override;
+    bool closed() const override;
+
+private:
+    std::atomic<bool> Closed_ = false;
+    i64 FilePosition_ = 0;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Presents disjoint ranges of a file as one Arrow random-access file.
+//! Used to reconstruct a Parquet row group together with its original footer.
+class TCompositeBufferArrowRandomAccessFile
+    : public TStatelessArrowRandomAccessFileBase
+{
+public:
+    struct TBufferDescriptor
+    {
+        TSharedRef Data;
+        i64 Offset;
+    };
+
+    TCompositeBufferArrowRandomAccessFile(std::vector<TBufferDescriptor> buffers, i64 fileSize);
+
+    arrow20::Result<int64_t> GetSize() override;
+    arrow20::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+
+private:
+    const std::vector<TBufferDescriptor> Buffers_;
+    const i64 FileSize_;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/library/formats/arrow_parser.cpp
+++ b/yt/yt/library/formats/arrow_parser.cpp
@@ -2191,6 +2191,71 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+arrow20::Status DecodeRecordBatch(
+    const std::shared_ptr<arrow20::RecordBatch>& batch,
+    IValueConsumer* consumer,
+    const TArrowParserOptions& options)
+{
+    struct TArrowParserTag
+    { };
+
+    auto bufferForStringLikeValues = std::make_shared<TChunkedOutputStream>(
+        GetRefCountedTypeCookie<TArrowParserTag>(),
+        GetNullMemoryUsageTracker(),
+        256_KB,
+        1_MB);
+
+    const auto columnCount = batch->num_columns();
+    const auto rowCount = batch->num_rows();
+    if (options.MaxAllocationBytes &&
+        static_cast<ui64>(rowCount) * static_cast<ui64>(std::max(columnCount, 1)) * sizeof(TUnversionedValue) >
+            static_cast<ui64>(*options.MaxAllocationBytes))
+    {
+        THROW_ERROR_EXCEPTION("Arrow record batch is too large: %v columns x %v rows would allocate more than %v bytes",
+            columnCount,
+            rowCount,
+            *options.MaxAllocationBytes);
+    }
+
+    std::vector<TUnversionedRowValues> rowsValues(columnCount, TUnversionedRowValues(rowCount));
+    for (int columnIndex = 0; columnIndex < columnCount; ++columnIndex) {
+        const auto& columnName = batch->column_name(columnIndex);
+        const auto columnId = consumer->GetNameTable()->GetIdOrRegisterName(columnName);
+        const auto columnSchema = consumer->GetSchema()->FindColumn(columnName);
+        const auto columnType = columnSchema
+            ? columnSchema->LogicalType()
+            : OptionalLogicalType(SimpleLogicalType(ESimpleLogicalValueType::Any));
+
+        try {
+            const auto& column = batch->column(columnIndex);
+            ThrowOnError(column->ValidateFull());
+            PrepareArray(
+                DenullifyLogicalType(columnType),
+                bufferForStringLikeValues,
+                column,
+                batch->schema()->field(columnIndex),
+                rowsValues[columnIndex],
+                columnId,
+                options.MaxAllocationBytes);
+        } catch (const std::exception& ex) {
+            THROW_ERROR_EXCEPTION("Failed to parse column %Qv", columnName)
+                << ex;
+        }
+    }
+
+    for (int rowIndex = 0; rowIndex < rowCount; ++rowIndex) {
+        consumer->OnBeginRow();
+        for (int columnIndex = 0; columnIndex < columnCount; ++columnIndex) {
+            consumer->OnValue(rowsValues[columnIndex][rowIndex]);
+        }
+        consumer->OnEndRow();
+    }
+
+    return arrow20::Status::OK();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 std::unique_ptr<IParser> CreateParserForArrow(IValueConsumer* consumer, const TArrowParserOptions& options)
 {
     return std::make_unique<TArrowParser>(consumer, std::move(options));

--- a/yt/yt/library/formats/arrow_parser.h
+++ b/yt/yt/library/formats/arrow_parser.h
@@ -3,6 +3,8 @@
 #include <yt/yt/client/formats/public.h>
 #include <yt/yt/client/formats/config.h>
 
+#include <contrib/libs/apache/arrow_next/cpp/src/arrow/record_batch.h>
+
 namespace NYT::NFormats {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -14,6 +16,13 @@ struct TArrowParserOptions
     //! fuzz tests to convert OOM into a catchable exception.
     std::optional<i64> MaxAllocationBytes;
 };
+
+//! Decodes an already materialized Arrow record batch into YT values.
+//! This is used by readers for externally attached Arrow-based formats.
+arrow20::Status DecodeRecordBatch(
+    const std::shared_ptr<arrow20::RecordBatch>& batch,
+    NTableClient::IValueConsumer* consumer,
+    const TArrowParserOptions& options = {});
 
 std::unique_ptr<IParser> CreateParserForArrow(
     NTableClient::IValueConsumer* consumer,

--- a/yt/yt/library/s3/object.cpp
+++ b/yt/yt/library/s3/object.cpp
@@ -1,0 +1,51 @@
+#include "object.h"
+
+#include <yt/yt/core/misc/error.h>
+
+#include <contrib/libs/poco/Foundation/include/Poco/URI.h>
+
+namespace NYT::NS3 {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TObjectDescriptor::TObjectDescriptor(std::string bucket, std::string key, bool allowEmptyKey)
+    : Bucket_(std::move(bucket))
+    , Key_(std::move(key))
+{
+    Key_.erase(0, Key_.find_first_not_of('/'));
+
+    THROW_ERROR_EXCEPTION_IF(Bucket_.empty(), "S3 object bucket should not be empty");
+    THROW_ERROR_EXCEPTION_IF(Key_.empty() && !allowEmptyKey, "S3 object key should not be empty");
+}
+
+TObjectDescriptor TObjectDescriptor::FromUri(const std::string& uri, bool allowEmptyKey)
+{
+    Poco::URI parsedUri(uri);
+    THROW_ERROR_EXCEPTION_IF(
+        parsedUri.getScheme() != "s3",
+        "Failed to parse S3 URI %Qv: unexpected scheme %Qv",
+        uri,
+        parsedUri.getScheme());
+    THROW_ERROR_EXCEPTION_IF(
+        !parsedUri.getQuery().empty() || !parsedUri.getFragment().empty(),
+        "Failed to parse S3 URI %Qv: query and fragment are not supported",
+        uri);
+
+    try {
+        return TObjectDescriptor(parsedUri.getHost(), parsedUri.getPath(), allowEmptyKey);
+    } catch (const std::exception& ex) {
+        THROW_ERROR_EXCEPTION("Failed to parse S3 URI %Qv", uri)
+            << ex;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void FormatValue(TStringBuilderBase* builder, const TObjectDescriptor& object, TStringBuf spec)
+{
+    FormatValue(builder, Format("s3://%v/%v", object.Bucket(), object.Key()), spec);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NS3

--- a/yt/yt/library/s3/object.h
+++ b/yt/yt/library/s3/object.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "public.h"
+
+#include <library/cpp/yt/misc/property.h>
+
+namespace NYT::NS3 {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Identifies an S3 object by bucket and key.
+//!
+//! Only s3:// URIs are accepted. Leading slashes in the object key are removed
+//! so that the value can be used directly in an S3 request.
+class TObjectDescriptor
+{
+public:
+    TObjectDescriptor(std::string bucket, std::string key, bool allowEmptyKey = false);
+
+    static TObjectDescriptor FromUri(const std::string& uri, bool allowEmptyKey = false);
+
+    DEFINE_BYREF_RO_PROPERTY(std::string, Bucket);
+    DEFINE_BYREF_RO_PROPERTY(std::string, Key);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+void FormatValue(TStringBuilderBase* builder, const TObjectDescriptor& object, TStringBuf spec);
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NS3

--- a/yt/yt/library/s3/ya.make
+++ b/yt/yt/library/s3/ya.make
@@ -8,6 +8,7 @@ SRCS(
     credential_provider.cpp
     crypto_helpers.cpp
     http.cpp
+    object.cpp
 )
 
 PEERDIR(

--- a/yt/yt/server/lib/rpc_proxy/api_service.cpp
+++ b/yt/yt/server/lib/rpc_proxy/api_service.cpp
@@ -882,6 +882,7 @@ private:
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, TruncateJournal);
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, ReadTable);
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, WriteTable);
+    DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, AttachTable);
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, GetColumnarStatistics);
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, PartitionTables);
     DECLARE_RPC_SERVICE_METHOD(NApi::NRpcProxy::NProto, ReadTablePartition);
@@ -1250,6 +1251,7 @@ TApiService::TApiService(
     registerMethod(EMultiproxyMethodKind::Write, RPC_SERVICE_METHOD_DESC(WriteTable)
         .SetStreamingEnabled(true)
         .SetCancelable(true));
+    registerMethod(EMultiproxyMethodKind::Write, RPC_SERVICE_METHOD_DESC(AttachTable));
     registerMethod(EMultiproxyMethodKind::Read, RPC_SERVICE_METHOD_DESC(GetColumnarStatistics));
     registerMethod(EMultiproxyMethodKind::Read, RPC_SERVICE_METHOD_DESC(PartitionTables));
     registerMethod(EMultiproxyMethodKind::Read, RPC_SERVICE_METHOD_DESC(ReadTablePartition)
@@ -6802,6 +6804,37 @@ DEFINE_RPC_SERVICE_METHOD(TApiService, WriteTable)
         request,
         std::move(tableWriter),
         [] {});
+}
+
+DEFINE_RPC_SERVICE_METHOD(TApiService, AttachTable)
+{
+    auto client = GetAuthenticatedClientOrThrow(context, request);
+
+    PutMethodInfoInTraceContext("attach_table");
+
+    auto path = FromProto<TRichYPath>(request->path());
+    auto sourceUris = FromProto<std::vector<std::string>>(request->source_uris());
+
+    NApi::TAttachTableOptions options;
+    SetTimeoutOptions(&options, context.Get());
+    options.AllowIncompatibleSourceSchemas = request->allow_incompatible_source_schemas();
+    if (request->has_medium()) {
+        options.Medium = request->medium();
+    }
+    if (request->has_source_format()) {
+        options.SourceFormat = CheckedEnumCast<NChunkClient::EExternalSourceFormat>(request->source_format());
+    }
+    if (request->has_transactional_options()) {
+        FromProto(&options, request->transactional_options());
+    }
+
+    context->SetRequestInfo("Path: %v, SourceCount: %v", path, sourceUris.size());
+
+    ExecuteCall(
+        context,
+        [=] {
+            return client->AttachTable(path, sourceUris, options);
+        });
 }
 
 DEFINE_RPC_SERVICE_METHOD(TApiService, GetColumnarStatistics)

--- a/yt/yt/server/lib/s3/chunk_reader.cpp
+++ b/yt/yt/server/lib/s3/chunk_reader.cpp
@@ -7,8 +7,10 @@
 #include <yt/yt/ytlib/chunk_client/chunk_reader.h>
 #include <yt/yt/ytlib/chunk_client/medium_descriptor.h>
 #include <yt/yt/ytlib/chunk_client/chunk_meta_extensions.h>
+#include <yt/yt/ytlib/chunk_client/external_parquet.h>
 
 #include <yt/yt/library/s3/client.h>
+#include <yt/yt/library/s3/object.h>
 
 namespace NYT::NS3 {
 
@@ -87,12 +89,18 @@ public:
         IClientPtr client,
         const TS3MediumDescriptorPtr& mediumDescriptor,
         TS3ReaderConfigPtr config,
-        TChunkId chunkId)
+        TChunkId chunkId,
+        std::string sourceUri,
+        EChunkFormat chunkFormat)
         : Client_(std::move(client))
         , Config_(std::move(config))
         , ChunkId_(chunkId)
-        , ChunkPlacement_(mediumDescriptor->GetS3ObjectPlacementForChunk(ChunkId_))
+        , ChunkPlacement_(sourceUri.empty()
+            ? mediumDescriptor->GetS3ObjectPlacementForChunk(ChunkId_)
+            : GetExternalChunkPlacement(sourceUri))
         , ChunkMetaPlacement_(mediumDescriptor->GetS3ObjectPlacementForChunkMeta(ChunkId_))
+        , IsExternalSource_(!sourceUri.empty())
+        , ChunkFormat_(chunkFormat)
         , Logger(ChunkClientLogger())
     { }
 
@@ -140,10 +148,21 @@ private:
     const std::string ChunkFileName_;
     const TS3MediumDescriptor::TS3ObjectPlacement ChunkPlacement_;
     const TS3MediumDescriptor::TS3ObjectPlacement ChunkMetaPlacement_;
+    const bool IsExternalSource_;
+    const EChunkFormat ChunkFormat_;
     const NLogging::TLogger Logger;
 
     YT_DECLARE_SPIN_LOCK(TReaderWriterSpinLock, MetaLock_);
     TRefCountedChunkMetaPtr ChunkMeta_;
+
+    static TS3MediumDescriptor::TS3ObjectPlacement GetExternalChunkPlacement(const std::string& sourceUri)
+    {
+        const auto object = TObjectDescriptor::FromUri(sourceUri);
+        return {
+            .Bucket = object.Bucket(),
+            .Key = object.Key(),
+        };
+    }
 
     IInvokerPtr GetSessionInvoker(const TReadBlocksOptions& options) const
     {
@@ -197,15 +216,52 @@ private:
                 return DeserializeBlocks(
                     std::move(response.Data),
                     blockRange,
-                    Config_->ValidateBlockChecksums,
+                    // External Parquet row groups do not carry YT block checksums.
+                    Config_->ValidateBlockChecksums && !IsExternalSource_,
                     ChunkPlacement_.Key,
                     blocksExt,
                     /*dumpBrokenBlocks*/ {});
             }).AsyncVia(GetSessionInvoker(options)));
     }
 
-    TFuture<TRefCountedChunkMetaPtr> DoGetMeta(
-        IInvokerPtr invoker = nullptr)
+    TRefCountedChunkMetaPtr GenerateExternalMeta()
+    {
+        YT_VERIFY(IsExternalSource_);
+        YT_VERIFY(ChunkFormat_ == EChunkFormat::TableUnversionedArrowParquet);
+
+        auto chunkFile = std::make_shared<TS3ArrowRandomAccessFile>(
+            TObjectDescriptor(ChunkPlacement_.Bucket, ChunkPlacement_.Key),
+            Client_);
+        auto chunkMetaGenerator = CreateArrowTableChunkMetaGenerator(ChunkFormat_, std::move(chunkFile));
+        chunkMetaGenerator->Generate();
+        return chunkMetaGenerator->GetChunkMeta();
+    }
+
+    TRefCountedChunkMetaPtr CacheChunkMeta(const TRefCountedChunkMetaPtr& meta)
+    {
+        auto guard = WriterGuard(MetaLock_);
+        if (!ChunkMeta_) {
+            ChunkMeta_ = meta;
+        }
+        return ChunkMeta_;
+    }
+
+    TFuture<TRefCountedChunkMetaPtr> FetchChunkMetaFromMetaObject()
+    {
+        TGetObjectRequest request;
+        request.Bucket = ChunkMetaPlacement_.Bucket;
+        request.Key = ChunkMetaPlacement_.Key;
+        return Client_->GetObject(request)
+            .Apply(BIND([this, this_ = MakeStrong(this)] (const TGetObjectResponse& response) {
+                return DeserializeChunkMeta(
+                    std::move(response.Data),
+                    ChunkMetaPlacement_.Key,
+                    ChunkId_,
+                    /*dumpBrokenMeta*/ {});
+            }));
+    }
+
+    TFuture<TRefCountedChunkMetaPtr> DoGetMeta(IInvokerPtr invoker = nullptr)
     {
         {
             auto guard = ReaderGuard(MetaLock_);
@@ -215,25 +271,16 @@ private:
             }
         }
 
-        TGetObjectRequest request;
-        request.Bucket = ChunkMetaPlacement_.Bucket;
-        request.Key = ChunkMetaPlacement_.Key;
-        return Client_->GetObject(request)
-            .Apply(BIND([this, this_ = MakeStrong(this)] (const TGetObjectResponse& response) {
-                auto meta = DeserializeChunkMeta(
-                    std::move(response.Data),
-                    ChunkMetaPlacement_.Key,
-                    ChunkId_,
-                    /*dumpBrokenMeta*/ {});
+        auto actualInvoker = invoker ? invoker : GetCurrentInvoker();
+        if (IsExternalSource_) {
+            return BIND(&TS3Reader::GenerateExternalMeta, MakeStrong(this))
+                .AsyncVia(actualInvoker)
+                .Run()
+                .Apply(BIND(&TS3Reader::CacheChunkMeta, MakeStrong(this)));
+        }
 
-                auto guard = WriterGuard(MetaLock_);
-
-                if (!ChunkMeta_) {
-                    ChunkMeta_ = std::move(meta);
-                }
-
-                return ChunkMeta_;
-            }).AsyncVia(invoker ? invoker : GetCurrentInvoker()));
+        return FetchChunkMetaFromMetaObject()
+            .Apply(BIND(&TS3Reader::CacheChunkMeta, MakeStrong(this)).AsyncVia(actualInvoker));
     }
 
     TFuture<TBlocksExtPtr> GetBlocksExt(
@@ -252,7 +299,9 @@ IChunkReaderPtr CreateS3RegularChunkReader(
     IClientPtr client,
     const TS3MediumDescriptorPtr& mediumDescriptor,
     TS3ReaderConfigPtr config,
-    TChunkId chunkId)
+    TChunkId chunkId,
+    std::string sourceUri,
+    EChunkFormat chunkFormat)
 {
     YT_VERIFY(IsRegularChunkId(chunkId));
 
@@ -260,7 +309,9 @@ IChunkReaderPtr CreateS3RegularChunkReader(
         std::move(client),
         std::move(mediumDescriptor),
         std::move(config),
-        std::move(chunkId));
+        std::move(chunkId),
+        std::move(sourceUri),
+        chunkFormat);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/server/lib/s3/chunk_reader.h
+++ b/yt/yt/server/lib/s3/chunk_reader.h
@@ -6,6 +6,8 @@
 
 #include <yt/yt/ytlib/chunk_client/public.h>
 
+#include <string>
+
 namespace NYT::NS3 {
 
 ////////////////////////////////////////////////////////////////////////////
@@ -14,7 +16,9 @@ NChunkClient::IChunkReaderPtr CreateS3RegularChunkReader(
     NS3::IClientPtr client,
     const NChunkClient::TS3MediumDescriptorPtr& mediumDescriptor,
     TS3ReaderConfigPtr config,
-    NChunkClient::TChunkId chunkId);
+    NChunkClient::TChunkId chunkId,
+    std::string sourceUri = {},
+    NChunkClient::EChunkFormat chunkFormat = NChunkClient::EChunkFormat::Unknown);
 
 ////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/CMakeLists.txt
+++ b/yt/yt/server/master/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(yt-server-master PUBLIC
   cpp-yt-phdr_cache
   yt-core-https
   yt-library-orchid
+  yt-library-s3
   yt-library-server_program
   yt-library-monitoring
   library-tracing-jaeger

--- a/yt/yt/server/master/cell_master/serialize.h
+++ b/yt/yt/server/master/cell_master/serialize.h
@@ -214,6 +214,7 @@ DEFINE_ENUM(EMasterReign,
     ((FixWaitableLocksAccumulation)                                 (3339))  // ivpiskarev
     ((DetachChunkTrees)                                             (3340))  // babenko
     ((ChunkMergerInfo)                                              (3341))  // aleksandra-zh
+    ((ExternalOffshoreChunkSourceUri)                               (3342))  // pavel
 );
 
 static_assert(TEnumTraits<EMasterReign>::IsMonotonic, "Master reign enum is not monotonic");

--- a/yt/yt/server/master/cell_master/serialize.h
+++ b/yt/yt/server/master/cell_master/serialize.h
@@ -214,7 +214,7 @@ DEFINE_ENUM(EMasterReign,
     ((FixWaitableLocksAccumulation)                                 (3339))  // ivpiskarev
     ((DetachChunkTrees)                                             (3340))  // babenko
     ((ChunkMergerInfo)                                              (3341))  // aleksandra-zh
-    ((ExternalOffshoreChunkSourceUri)                               (3342))  // pavel
+    ((ExternalOffshoreChunkSourceUri)                               (3342))  // pavel-bash
 );
 
 static_assert(TEnumTraits<EMasterReign>::IsMonotonic, "Master reign enum is not monotonic");

--- a/yt/yt/server/master/chunk_server/chunk.cpp
+++ b/yt/yt/server/master/chunk_server/chunk.cpp
@@ -260,6 +260,13 @@ void TChunk::Save(NCellMaster::TSaveContext& context) const
 
     Save(context, EndorsementRequired_);
     Save(context, ConsistentReplicaPlacementHash_);
+
+    if (ExternalOffshoreSourceUri_) {
+        Save(context, true);
+        Save(context, *ExternalOffshoreSourceUri_);
+    } else {
+        Save(context, false);
+    }
 }
 
 void TChunk::Load(NCellMaster::TLoadContext& context)
@@ -310,6 +317,11 @@ void TChunk::Load(NCellMaster::TLoadContext& context)
 
     Load(context, ConsistentReplicaPlacementHash_);
 
+    if (context.GetVersion() >= EMasterReign::ExternalOffshoreChunkSourceUri && Load<bool>(context)) {
+        ExternalOffshoreSourceUri_ = std::make_unique<std::string>();
+        Load(context, *ExternalOffshoreSourceUri_);
+    }
+
     if (auto miscExt = ChunkMeta_->FindExtension<TMiscExt>()) {
         // NB: For hunk chunks can still be not confirmed because we create meta when the chunk is referenced via hunk refs.
 
@@ -330,6 +342,21 @@ void TChunk::Load(NCellMaster::TLoadContext& context)
     } else {
         YT_VERIFY(!IsConfirmed());
     }
+}
+
+void TChunk::SetExternalOffshoreSourceUri(std::string sourceUri)
+{
+    YT_VERIFY(!sourceUri.empty());
+    if (ExternalOffshoreSourceUri_) {
+        YT_VERIFY(*ExternalOffshoreSourceUri_ == sourceUri);
+    } else {
+        ExternalOffshoreSourceUri_ = std::make_unique<std::string>(std::move(sourceUri));
+    }
+}
+
+TStringBuf TChunk::GetExternalOffshoreSourceUri() const
+{
+    return ExternalOffshoreSourceUri_ ? TStringBuf(*ExternalOffshoreSourceUri_) : TStringBuf();
 }
 
 void TChunk::AddParent(TChunkTree* parent)

--- a/yt/yt/server/master/chunk_server/chunk.h
+++ b/yt/yt/server/master/chunk_server/chunk.h
@@ -26,7 +26,9 @@
 
 #include <library/cpp/yt/misc/property.h>
 
+#include <memory>
 #include <optional>
+#include <string>
 
 namespace NYT::NChunkServer {
 
@@ -184,6 +186,11 @@ public:
         const TMedium* medium,
         bool approved);
     void RemoveReplica(TChunkLocationPtrWithReplicaIndex replica, bool approved);
+
+    // An attached external object has one offshore replica. Keep its URI
+    // separately from the compact replica record used for native S3 chunks.
+    void SetExternalOffshoreSourceUri(std::string sourceUri);
+    TStringBuf GetExternalOffshoreSourceUri() const;
 
     void ApproveReplica(TAugmentedStoredChunkReplicaPtr replica);
     int GetApprovedReplicaCount() const;
@@ -480,6 +487,9 @@ private:
     //! which helps to avoid excessive CoW during snapshot construction.
     std::unique_ptr<TReplicasDataBase> ReplicasData_;
 
+    // Allocated only for an externally attached offshore chunk.
+    std::unique_ptr<std::string> ExternalOffshoreSourceUri_;
+
     TChunkRequisition ComputeAggregatedRequisition(const TChunkRequisitionRegistry* registry);
 
     const TReplicasDataBase& ReplicasData() const;
@@ -500,7 +510,7 @@ private:
 DEFINE_MASTER_OBJECT_TYPE(TChunk)
 
 // Think twice before increasing this.
-YT_STATIC_ASSERT_SIZEOF_SANITY(TChunk, 288);
+YT_STATIC_ASSERT_SIZEOF_SANITY(TChunk, 296);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -98,6 +98,8 @@
 #include <yt/yt/ytlib/node_tracker_client/helpers.h>
 
 #include <yt/yt/ytlib/chunk_client/chunk_meta_extensions.h>
+
+#include <yt/yt/library/s3/object.h>
 #include <yt/yt/ytlib/chunk_client/session_id.h>
 #include <yt/yt/ytlib/chunk_client/helpers.h>
 #include <yt/yt/ytlib/chunk_client/proto/chunk_service.pb.h>
@@ -930,7 +932,22 @@ public:
                     const_cast<TMedium*>(medium),
                     replica.GetReplicaIndex());
                 chunk->AddReplica(storedReplica, medium, /*approved*/ true);
+                if (!replica.GetSourceUri().empty()) {
+                    // Parse eagerly so an invalid external object cannot be
+                    // persisted as an otherwise healthy offshore replica.
+                    NS3::TObjectDescriptor::FromUri(std::string(replica.GetSourceUri()));
+                    chunk->SetExternalOffshoreSourceUri(std::string(replica.GetSourceUri()));
+                }
                 ScheduleChunkRefresh(chunk);
+                continue;
+            }
+
+            if (!replica.GetSourceUri().empty()) {
+                YT_LOG_ALERT(
+                    "Confirmed domestic replica unexpectedly contains an external source URI "
+                    "(ChunkId: %v, NodeId: %v)",
+                    chunk->GetId(),
+                    nodeId);
                 continue;
             }
 

--- a/yt/yt/server/master/chunk_server/chunk_owner_node_proxy.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_owner_node_proxy.cpp
@@ -116,6 +116,7 @@ bool IsAccessLoggedMethod(const std::string& method)
 }
 
 static void PopulateChunkSpecWithReplicas(
+    const TChunk* chunk,
     const TStoredChunkReplicaList& chunkReplicas,
     bool fetchParityReplicas,
     NNodeTrackerServer::TNodeDirectoryBuilder* nodeDirectoryBuilder,
@@ -138,6 +139,11 @@ static void PopulateChunkSpecWithReplicas(
                 replica.GetReplicaIndex(),
                 replica.GetEffectiveMediumIndex());
             chunkSpec->add_replicas(ToProto<ui64>(nodeReplica));
+            NChunkClient::TChunkReplicaWithMedium replicaWithMedium(
+                location->GetNode()->GetId(),
+                replica.GetReplicaIndex(),
+                replica.GetEffectiveMediumIndex());
+            ToProto(chunkSpec->add_replica_specs(), replicaWithMedium);
             nodeDirectoryBuilder->Add(nodeReplica);
         }
 
@@ -145,8 +151,10 @@ static void PopulateChunkSpecWithReplicas(
             NChunkClient::TChunkReplicaWithMedium offshoreReplica(
                 OffshoreNodeId,
                 replica.GetReplicaIndex(),
-                replica.GetEffectiveMediumIndex());
+                replica.GetEffectiveMediumIndex(),
+                std::string(chunk->GetExternalOffshoreSourceUri()));
             chunkSpec->add_replicas(ToProto<ui64>(offshoreReplica));
+            ToProto(chunkSpec->add_replica_specs(), offshoreReplica);
         }
     }
 }
@@ -271,6 +279,7 @@ void BuildChunkSpec(
         extensionTags,
         chunkSpec);
     PopulateChunkSpecWithReplicas(
+        chunk,
         chunkReplicas,
         fetchParityReplicas,
         nodeDirectoryBuilder,
@@ -427,7 +436,13 @@ private:
             }
 
             const auto& chunkReplicas = chunkReplicasOrError.Value();
+            auto* chunk = chunkManager->FindChunk(chunkId);
+            if (!IsObjectAlive(chunk)) {
+                ReplyError(TError("Chunk %v died during replica fetch", chunkId));
+                return false;
+            }
             PopulateChunkSpecWithReplicas(
+                chunk,
                 chunkReplicas,
                 FetchContext_.FetchParityReplicas,
                 &NodeDirectoryBuilder_,

--- a/yt/yt/server/master/chunk_server/private.cpp
+++ b/yt/yt/server/master/chunk_server/private.cpp
@@ -14,7 +14,7 @@ constinit const auto Logger = ChunkServerLogger;
 TStringBuf SerializeChunkFormatAsTableChunkFormat(EChunkFormat chunkFormat)
 {
     // Update the switch below when adding new EChunkFormat values.
-    static_assert(TEnumTraits<EChunkFormat>::GetDomainSize() == 13);
+    static_assert(TEnumTraits<EChunkFormat>::GetDomainSize() == 14);
 
     switch (chunkFormat) {
         case EChunkFormat::FileDefault:
@@ -25,6 +25,8 @@ TStringBuf SerializeChunkFormatAsTableChunkFormat(EChunkFormat chunkFormat)
             return TStringBuf("unversioned_schemaless_horizontal");
         case EChunkFormat::TableUnversionedColumnar:
             return TStringBuf("unversioned_columnar");
+        case EChunkFormat::TableUnversionedArrowParquet:
+            return TStringBuf("unversioned_arrow_parquet");
         case EChunkFormat::TableVersionedSimple:
             return TStringBuf("versioned_simple");
         case EChunkFormat::TableVersionedColumnar:

--- a/yt/yt/server/master/ya.make
+++ b/yt/yt/server/master/ya.make
@@ -466,6 +466,7 @@ PEERDIR(
     yt/yt/core/https
 
     yt/yt/library/orchid
+    yt/yt/library/s3
     yt/yt/library/server_program
     yt/yt/library/monitoring
     yt/yt/library/tracing/jaeger

--- a/yt/yt/server/offshore_data_gateway/offshore_data_gateway_service.cpp
+++ b/yt/yt/server/offshore_data_gateway/offshore_data_gateway_service.cpp
@@ -134,13 +134,28 @@ private:
         TChunkId chunkId)
     {
         auto replicaWithMedium = FromProto<TChunkReplicaWithMedium>(request.replica_spec());
+        const auto sourceUri = replicaWithMedium.GetSourceUri();
+        if (!sourceUri.empty()) {
+            THROW_ERROR_EXCEPTION_IF(
+                !request.has_chunk_format() ||
+                NYT::FromProto<EChunkFormat>(request.chunk_format()) != EChunkFormat::TableUnversionedArrowParquet,
+                "Unsupported external chunk format %v for source object %Qv",
+                request.has_chunk_format()
+                    ? request.chunk_format()
+                    : ToUnderlying(EChunkFormat::Unknown),
+                sourceUri);
+        }
         auto mediumDescriptor = GetS3MediumDescriptor(replicaWithMedium.GetMediumIndex());
         auto s3Client = CreateS3ClientForMedium(mediumDescriptor);
         return CreateS3RegularChunkReader(
             std::move(s3Client),
             mediumDescriptor,
             std::move(s3ReaderConfig),
-            chunkId);
+            chunkId,
+            std::string(sourceUri),
+            request.has_chunk_format()
+                ? NYT::FromProto<EChunkFormat>(request.chunk_format())
+                : EChunkFormat::Unknown);
     }
 
     IChunkWriterPtr FindSession(TSessionId sessionId)

--- a/yt/yt/tests/integration/s3/test_s3.py
+++ b/yt/yt/tests/integration/s3/test_s3.py
@@ -9,7 +9,9 @@ from yt_commands import (
     copy, move, get_singular_chunk_id, wait, get, concatenate,
     get_account_disk_space_limit, set_account_disk_space_limit,
     write_table, read_table, sync_mount_table, sync_unmount_table, insert_rows, sync_flush_table,
-    map, raises_yt_error, select_rows, lookup_rows, print_debug, write_file, read_file)
+    attach_table, map, raises_yt_error, select_rows, lookup_rows, print_debug, write_file, read_file)
+
+from yt.test_helpers import assert_items_equal
 
 import time
 import pytest
@@ -21,6 +23,9 @@ import string
 
 import boto3
 from botocore.exceptions import ClientError
+import pyarrow as pa
+import pyarrow.parquet as pq
+from io import BytesIO
 
 ################################################################################
 
@@ -190,6 +195,13 @@ class TestS3MediumBase(YTEnvSetup):
             # YT specific configuration.
             **media,
         }
+
+    @staticmethod
+    def dump_arrow_table_as_bytes(table, **kwargs):
+        buffer = BytesIO()
+        pq.write_table(table, buffer, **kwargs)
+        buffer.seek(0)
+        return buffer
 
     @classmethod
     def setup_s3_client(cls):
@@ -660,6 +672,126 @@ class TestS3Medium(TestS3MediumBase):
 ################################################################################
 
 
+class TestAttachTable(TestS3MediumBase):
+    """Parquet-only coverage for attaching source S3 objects as table chunks."""
+
+    def put_parquet(self, key, records, **kwargs):
+        bucket = self.get_s3_medium()["bucket"]
+        columns = {
+            name: [record.get(name) for record in records]
+            for name in records[0]
+        }
+        self.S3_CLIENT.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=self.dump_arrow_table_as_bytes(pa.Table.from_pydict(columns), **kwargs))
+        return f"s3://{bucket}/{key}"
+
+    def create_destination(self, path="//tmp/imported", **attributes):
+        create("table", path, attributes={
+            "primary_medium": self.get_s3_medium_name(),
+            **attributes,
+        })
+        return path
+
+    @authors("pavel-bash")
+    def test_attach_empty_sources(self):
+        destination = self.create_destination()
+
+        with pytest.raises(YtError, match="empty source URI list"):
+            attach_table(destination, source_uris=[])
+
+    @authors("pavel-bash")
+    def test_attach_parquet_and_read(self):
+        destination = self.create_destination()
+        records = [{"x": 1, "y": "first"}, {"x": 2, "y": "second"}]
+
+        source_uri = self.put_parquet("basic.parquet", records)
+        attach_table(destination, source_uris=[source_uri])
+
+        assert_items_equal(read_table(destination), records)
+        assert get(f"{destination}/@chunk_count") == 1
+
+    @authors("pavel-bash")
+    def test_attach_compressed_parquet_row_groups(self):
+        destination = self.create_destination()
+        records = [{"index": index, "value": str(index)} for index in range(64)]
+
+        source_uri = self.put_parquet(
+            "compressed.parquet",
+            records,
+            compression="gzip",
+            row_group_size=8)
+        attach_table(destination, source_uris=[source_uri])
+
+        assert_items_equal(read_table(destination), records)
+
+    @authors("pavel-bash")
+    def test_attach_multiple_parquet_sources(self):
+        destination = self.create_destination()
+        first = [{"x": 1, "y": "first"}]
+        second = [{"x": 2, "y": "second"}]
+
+        attach_table(destination, source_uris=[
+            self.put_parquet("first.parquet", first),
+            self.put_parquet("second.parquet", second),
+        ])
+
+        assert_items_equal(read_table(destination), first + second)
+        assert get(f"{destination}/@chunk_count") == 2
+
+    @authors("pavel-bash")
+    def test_attach_overwrite_and_append(self):
+        destination = self.create_destination()
+        first = [{"x": 1}]
+        second = [{"x": 2}]
+        third = [{"x": 3}]
+
+        attach_table(destination, source_uris=[self.put_parquet("first.parquet", first)])
+        attach_table(destination, source_uris=[self.put_parquet("second.parquet", second)])
+        assert read_table(destination) == second
+
+        attach_table("<append=%true>" + destination, source_uris=[self.put_parquet("third.parquet", third)])
+        assert_items_equal(read_table(destination), second + third)
+
+    @authors("pavel-bash")
+    def test_attach_explicit_parquet_format(self):
+        destination = self.create_destination()
+        records = [{"x": 1}]
+        source_uri = self.put_parquet("object-without-suffix", records)
+
+        attach_table(destination, source_uris=[source_uri], source_format="parquet")
+        assert read_table(destination) == records
+
+    @authors("pavel-bash")
+    def test_attach_rejects_incompatible_schema(self):
+        destination = self.create_destination(schema=[{"name": "x", "type": "int64"}])
+        source_uri = self.put_parquet("wrong-schema.parquet", [{"x": "not-an-int"}])
+
+        with pytest.raises(YtError, match="not compatible with the table schema"):
+            attach_table(destination, source_uris=[source_uri])
+
+    @authors("pavel-bash")
+    def test_attach_rejects_non_s3_medium_and_erasure(self):
+        source_uri = self.put_parquet("source.parquet", [{"x": 1}])
+
+        create("table", "//tmp/not_s3")
+        with pytest.raises(YtError, match="non-S3 medium"):
+            attach_table("//tmp/not_s3", source_uris=[source_uri])
+
+        destination = self.create_destination(erasure_codec="reed_solomon_6_3")
+        with pytest.raises(YtError, match="erasure codec"):
+            attach_table(destination, source_uris=[source_uri])
+
+
+################################################################################
+
+
 class TestS3MediumRpcProxy(TestS3Medium):
+    DRIVER_BACKEND = "rpc"
+    ENABLE_RPC_PROXY = True
+
+
+class TestAttachTableRpcProxy(TestAttachTable):
     DRIVER_BACKEND = "rpc"
     ENABLE_RPC_PROXY = True

--- a/yt/yt/tests/integration/s3/ya.make
+++ b/yt/yt/tests/integration/s3/ya.make
@@ -6,6 +6,7 @@ TEST_SRCS(
 
 PEERDIR(
     contrib/python/boto3
+    contrib/python/pyarrow
 )
 
 END()

--- a/yt/yt/tests/library/yt_commands.py
+++ b/yt/yt/tests/library/yt_commands.py
@@ -803,6 +803,12 @@ def write_table(path, value=None, is_raw=False, **kwargs):
     return execute_command("write_table", kwargs, input_stream=input_stream)
 
 
+def attach_table(destination_table, **kwargs):
+    attributes = {}
+    kwargs["path"] = yson.to_yson_type(destination_table, attributes=attributes)
+    return execute_command("attach_table", kwargs)
+
+
 def locate_skynet_share(path, **kwargs):
     kwargs["path"] = path
 

--- a/yt/yt/ytlib/api/native/client_impl.h
+++ b/yt/yt/ytlib/api/native/client_impl.h
@@ -484,6 +484,11 @@ public: \
     TFuture<ITableWriterPtr> CreateTableWriter(
         const NYPath::TRichYPath& path,
         const NApi::TTableWriterOptions& options) override;
+    IMPLEMENT_METHOD(void, AttachTable, (
+        const NYPath::TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const NApi::TAttachTableOptions& options),
+        (path, std::move(sourceUris), options))
 
     TFuture<TSkynetSharePartsLocationsPtr> LocateSkynetShare(
         const NYPath::TRichYPath& path,

--- a/yt/yt/ytlib/api/native/client_static_tables_impl.cpp
+++ b/yt/yt/ytlib/api/native/client_static_tables_impl.cpp
@@ -21,6 +21,7 @@
 #include <yt/yt/ytlib/table_client/config.h>
 #include <yt/yt/ytlib/table_client/columnar_statistics_fetcher.h>
 #include <yt/yt/ytlib/table_client/helpers.h>
+#include <yt/yt/ytlib/table_client/attach_table.h>
 #include <yt/yt/ytlib/table_client/schemaless_chunk_writer.h>
 
 #include <yt/yt/ytlib/table_client/proto/table_partition_cookie.pb.h>
@@ -132,6 +133,28 @@ TFuture<ITableWriterPtr> TClient::CreateTableWriter(
     return asyncSchemalessWriter.Apply(BIND([] (const IUnversionedWriterPtr& schemalessWriter) {
         return CreateApiFromSchemalessWriterAdapter(std::move(schemalessWriter));
     }));
+}
+
+void TClient::DoAttachTable(
+    const NYPath::TRichYPath& path,
+    std::vector<std::string> sourceUris,
+    const TAttachTableOptions& options)
+{
+    NApi::ITransactionPtr transaction;
+    if (options.TransactionId) {
+        TTransactionAttachOptions transactionOptions;
+        transactionOptions.Ping = options.Ping;
+        transactionOptions.PingAncestors = options.PingAncestors;
+        transaction = AttachTransaction(options.TransactionId, transactionOptions);
+    }
+
+    WaitFor(NTableClient::AttachTable(
+        path,
+        std::move(sourceUris),
+        options,
+        this,
+        std::move(transaction)))
+        .ThrowOnError();
 }
 
 std::vector<TColumnarStatistics> TClient::DoGetColumnarStatistics(

--- a/yt/yt/ytlib/api/native/transaction.cpp
+++ b/yt/yt/ytlib/api/native/transaction.cpp
@@ -660,6 +660,12 @@ public:
         const TTableWriterOptions& options),
         (path, options))
 
+    DELEGATE_TRANSACTIONAL_METHOD(TFuture<void>, AttachTable, (
+        const TRichYPath& path,
+        std::vector<std::string> sourceUris,
+        const TAttachTableOptions& options),
+        (path, std::move(sourceUris), options))
+
     DELEGATE_TRANSACTIONAL_METHOD(TFuture<TDistributedWriteSessionWithCookies>, StartDistributedWriteSession, (
         const NYPath::TRichYPath& path,
         const TDistributedWriteSessionStartOptions& options),

--- a/yt/yt/ytlib/chunk_client/external_parquet.cpp
+++ b/yt/yt/ytlib/chunk_client/external_parquet.cpp
@@ -1,0 +1,263 @@
+#include "external_parquet.h"
+
+#include "chunk_meta_extensions.h"
+
+#include <yt/yt/ytlib/table_client/chunk_meta_extensions.h>
+
+#include <yt/yt/client/arrow/schema.h>
+#include <yt/yt/client/table_client/name_table.h>
+#include <yt/yt/client/table_client/schema.h>
+
+#include <yt/yt/core/compression/public.h>
+
+#include <yt/yt/library/erasure/public.h>
+
+#include <contrib/libs/apache/arrow_next/cpp/src/parquet/arrow/reader.h>
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+namespace NYT::NChunkClient {
+
+using namespace NConcurrency;
+using namespace NTableClient;
+
+////////////////////////////////////////////////////////////////////////////////
+
+TS3ArrowRandomAccessFile::TS3ArrowRandomAccessFile(NS3::TObjectDescriptor object, NS3::IClientPtr client)
+    : Object_(std::move(object))
+    , Client_(std::move(client))
+    , FileSize_(WaitFor(Client_->HeadObject({.Bucket = Object_.Bucket(), .Key = Object_.Key()}))
+        .ValueOrThrow()
+        .Size)
+{ }
+
+arrow20::Result<int64_t> TS3ArrowRandomAccessFile::GetSize()
+{
+    return FileSize_;
+}
+
+arrow20::Result<int64_t> TS3ArrowRandomAccessFile::ReadAt(int64_t position, int64_t nbytes, void* out)
+{
+    if (position < 0 || position > FileSize_) {
+        return arrow20::Status::Invalid(Format(
+            "Read position %v is outside file bounds [0, %v)", position, FileSize_));
+    }
+
+    nbytes = std::min(nbytes, FileSize_ - position);
+    if (nbytes <= 0) {
+        return 0;
+    }
+
+    auto response = WaitFor(Client_->GetObject({
+        .Bucket = Object_.Bucket(),
+        .Key = Object_.Key(),
+        .Range = Format("bytes=%v-%v", position, position + nbytes - 1),
+    })).ValueOrThrow();
+    const auto bytesRead = std::min<i64>(nbytes, response.Data.Size());
+    std::memcpy(out, response.Data.Begin(), bytesRead);
+    return bytesRead;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+class TParquetChunkMetaGenerator
+    : public ITableChunkMetaGenerator
+{
+public:
+    explicit TParquetChunkMetaGenerator(std::shared_ptr<arrow20::io::RandomAccessFile> chunkFile)
+        : ChunkFile_(std::move(chunkFile))
+    { }
+
+    void Generate() override
+    {
+        PARQUET_ASSIGN_OR_THROW(ArrowReader_, parquet20::arrow20::OpenFile(ChunkFile_, arrow20::default_memory_pool()));
+        ParquetMeta_ = ArrowReader_->parquet_reader()->metadata();
+        PARQUET_THROW_NOT_OK(ArrowReader_->GetSchema(&ArrowSchema_));
+        Schema_ = NArrow::CreateYTTableSchemaFromArrowSchema(ArrowSchema_);
+        PARQUET_ASSIGN_OR_THROW(FileSize_, ChunkFile_->GetSize());
+
+        PrepareBlocks();
+        ChunkMeta_ = BuildChunkMeta();
+    }
+
+    i64 GetRowCount() const override
+    {
+        return ParquetMeta_->num_rows();
+    }
+
+    i64 GetUncompressedDataSize() const override
+    {
+        return FileSize_;
+    }
+
+    i64 GetCompressedDataSize() const override
+    {
+        return FileSize_;
+    }
+
+    TTableSchemaPtr GetChunkSchema() const override
+    {
+        return Schema_;
+    }
+
+    TRefCountedChunkMetaPtr GetChunkMeta() const override
+    {
+        return ChunkMeta_;
+    }
+
+private:
+    struct TBlock
+    {
+        i64 Offset;
+        i64 Size;
+        i64 RowCount;
+    };
+
+    const std::shared_ptr<arrow20::io::RandomAccessFile> ChunkFile_;
+    std::unique_ptr<parquet20::arrow20::FileReader> ArrowReader_;
+    std::shared_ptr<parquet20::FileMetaData> ParquetMeta_;
+    std::shared_ptr<arrow20::Schema> ArrowSchema_;
+    TTableSchemaPtr Schema_;
+    std::vector<TBlock> Blocks_;
+    i64 FileSize_ = 0;
+    i64 MaxBlockSize_ = 0;
+    TRefCountedChunkMetaPtr ChunkMeta_;
+
+    static i64 GetMinimumDataOffset(const parquet20::ColumnChunkMetaData& column)
+    {
+        i64 result = std::numeric_limits<i64>::max();
+        for (const auto offset : {
+                column.file_offset(),
+                column.data_page_offset(),
+                column.dictionary_page_offset(),
+                column.index_page_offset(),
+            })
+        {
+            if (offset > 0) {
+                result = std::min(result, offset);
+            }
+        }
+        return result;
+    }
+
+    void PrepareBlocks()
+    {
+        std::vector<i64> offsets;
+        offsets.reserve(ParquetMeta_->num_row_groups() + 1);
+
+        for (int rowGroupIndex = 0; rowGroupIndex < ParquetMeta_->num_row_groups(); ++rowGroupIndex) {
+            const auto rowGroup = ParquetMeta_->RowGroup(rowGroupIndex);
+            i64 offset = std::numeric_limits<i64>::max();
+            for (int columnIndex = 0; columnIndex < rowGroup->num_columns(); ++columnIndex) {
+                offset = std::min(offset, GetMinimumDataOffset(*rowGroup->ColumnChunk(columnIndex)));
+            }
+            THROW_ERROR_EXCEPTION_IF(
+                offset == std::numeric_limits<i64>::max(),
+                "Cannot determine data offset of Parquet row group %v",
+                rowGroupIndex);
+            offsets.push_back(offset);
+        }
+
+        constexpr i64 ParquetFooterTrailerSize = 8; // metadata length plus PAR1.
+        const auto footerOffset = FileSize_ - ParquetMeta_->size() - ParquetFooterTrailerSize;
+        THROW_ERROR_EXCEPTION_IF(footerOffset < 4, "Invalid Parquet footer offset %v", footerOffset);
+        offsets.push_back(footerOffset);
+
+        Blocks_.reserve(ParquetMeta_->num_row_groups());
+        for (int rowGroupIndex = 0; rowGroupIndex < ParquetMeta_->num_row_groups(); ++rowGroupIndex) {
+            const auto startOffset = offsets[rowGroupIndex];
+            const auto endOffset = offsets[rowGroupIndex + 1];
+            THROW_ERROR_EXCEPTION_IF(
+                startOffset < 0 || endOffset > FileSize_ || startOffset >= endOffset,
+                "Invalid Parquet row group bounds [%v, %v) for file of size %v",
+                startOffset,
+                endOffset,
+                FileSize_);
+
+            const auto size = endOffset - startOffset;
+            Blocks_.push_back({startOffset, size, ParquetMeta_->RowGroup(rowGroupIndex)->num_rows()});
+            MaxBlockSize_ = std::max(MaxBlockSize_, size);
+        }
+    }
+
+    TRefCountedChunkMetaPtr BuildChunkMeta() const
+    {
+        auto meta = New<TRefCountedChunkMeta>();
+        meta->set_type(ToProto(EChunkType::Table));
+        meta->set_format(ToProto(EChunkFormat::TableUnversionedArrowParquet));
+
+        NChunkClient::NProto::TBlocksExt blocksExt;
+        NTableClient::NProto::TDataBlockMetaExt dataBlockMetaExt;
+        i64 accumulatedRowCount = 0;
+        for (int index = 0; index < std::ssize(Blocks_); ++index) {
+            const auto& block = Blocks_[index];
+            auto* blockInfo = blocksExt.add_blocks();
+            blockInfo->set_offset(block.Offset);
+            blockInfo->set_size(block.Size);
+            blockInfo->set_checksum(NullChecksum);
+
+            accumulatedRowCount += block.RowCount;
+            auto* dataBlockMeta = dataBlockMetaExt.add_data_blocks();
+            dataBlockMeta->set_row_count(block.RowCount);
+            dataBlockMeta->set_chunk_row_count(accumulatedRowCount);
+            dataBlockMeta->set_uncompressed_size(block.Size);
+            dataBlockMeta->set_block_index(index);
+        }
+        SetProtoExtension(meta->mutable_extensions(), blocksExt);
+        SetProtoExtension(meta->mutable_extensions(), dataBlockMetaExt);
+
+        NTableClient::NProto::TNameTableExt nameTableExt;
+        ToProto(&nameTableExt, TNameTable::FromSchema(*Schema_));
+        SetProtoExtension(meta->mutable_extensions(), nameTableExt);
+
+        NTableClient::NProto::TTableSchemaExt tableSchemaExt;
+        ToProto(&tableSchemaExt, *Schema_);
+        SetProtoExtension(meta->mutable_extensions(), tableSchemaExt);
+
+        NTableClient::NProto::TParquetFormatMetaExt parquetFormatMetaExt;
+        parquetFormatMetaExt.set_footer(ParquetMeta_->SerializeToString());
+        parquetFormatMetaExt.set_file_size(FileSize_);
+        SetProtoExtension(meta->mutable_extensions(), parquetFormatMetaExt);
+
+        NChunkClient::NProto::TMiscExt miscExt;
+        miscExt.set_uncompressed_data_size(FileSize_);
+        miscExt.set_compressed_data_size(FileSize_);
+        miscExt.set_data_weight(FileSize_);
+        miscExt.set_meta_size(meta->ByteSizeLong());
+        miscExt.set_row_count(GetRowCount());
+        miscExt.set_compression_codec(ToProto(NCompression::ECodec::None));
+        miscExt.set_sorted(false);
+        miscExt.set_max_data_block_size(MaxBlockSize_);
+        miscExt.set_sealed(false);
+        miscExt.set_erasure_codec(ToProto(NErasure::ECodec::None));
+        miscExt.set_system_block_count(0);
+        miscExt.set_striped_erasure(false);
+        SetProtoExtension(meta->mutable_extensions(), miscExt);
+
+        return meta;
+    }
+};
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+ITableChunkMetaGeneratorPtr CreateArrowTableChunkMetaGenerator(
+    EChunkFormat chunkFormat,
+    std::shared_ptr<arrow20::io::RandomAccessFile> chunkFile,
+    TArrowTableChunkMetaGeneratorOptions /*options*/)
+{
+    THROW_ERROR_EXCEPTION_IF(
+        chunkFormat != EChunkFormat::TableUnversionedArrowParquet,
+        "Unsupported chunk format %Qlv for external Arrow table metadata generation",
+        chunkFormat);
+    return New<TParquetChunkMetaGenerator>(std::move(chunkFile));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkClient

--- a/yt/yt/ytlib/chunk_client/external_parquet.h
+++ b/yt/yt/ytlib/chunk_client/external_parquet.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "public.h"
+
+#include <yt/yt/client/api/table_client.h>
+
+#include <yt/yt/library/arrow_adapter/arrow.h>
+#include <yt/yt/library/s3/client.h>
+#include <yt/yt/library/s3/object.h>
+
+namespace NYT::NChunkClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Arrow's synchronous parquet reader backed by ranged S3 reads.
+class TS3ArrowRandomAccessFile
+    : public NArrow::TStatelessArrowRandomAccessFileBase
+{
+public:
+    //! The constructor requests the object size before returning.
+    TS3ArrowRandomAccessFile(NS3::TObjectDescriptor object, NS3::IClientPtr client);
+
+    arrow20::Result<int64_t> GetSize() override;
+    arrow20::Result<int64_t> ReadAt(int64_t position, int64_t nbytes, void* out) override;
+
+private:
+    const NS3::TObjectDescriptor Object_;
+    const NS3::IClientPtr Client_;
+    const i64 FileSize_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+DECLARE_REFCOUNTED_STRUCT(ITableChunkMetaGenerator)
+
+struct ITableChunkMetaGenerator
+    : public TRefCounted
+{
+    //! May perform I/O. Call this before accessing any result.
+    virtual void Generate() = 0;
+
+    virtual i64 GetRowCount() const = 0;
+    virtual i64 GetUncompressedDataSize() const = 0;
+    virtual i64 GetCompressedDataSize() const = 0;
+    virtual NTableClient::TTableSchemaPtr GetChunkSchema() const = 0;
+    virtual TRefCountedChunkMetaPtr GetChunkMeta() const = 0;
+};
+
+DEFINE_REFCOUNTED_TYPE(ITableChunkMetaGenerator)
+
+//! Reserved for the common Arrow external-format generator API. Parquet does
+//! not currently need generator-specific options.
+struct TArrowTableChunkMetaGeneratorOptions
+{ };
+
+//! Builds the YT chunk meta required to expose an external Arrow-format file.
+//! Parquet is the only supported format in this initial implementation.
+ITableChunkMetaGeneratorPtr CreateArrowTableChunkMetaGenerator(
+    EChunkFormat chunkFormat,
+    std::shared_ptr<arrow20::io::RandomAccessFile> chunkFile,
+    TArrowTableChunkMetaGeneratorOptions options = {});
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NChunkClient

--- a/yt/yt/ytlib/chunk_client/helpers.cpp
+++ b/yt/yt/ytlib/chunk_client/helpers.cpp
@@ -756,9 +756,21 @@ IChunkReaderPtr CreateRemoteReader(
     TChunkReaderHostPtr chunkReaderHost)
 {
     auto chunkId = FromProto<TChunkId>(chunkSpec.chunk_id());
-    // Decode replicas as TChunkReplicaWithMedium to preserve the full 64-bit value,
-    // including medium index (which TChunkReplica truncates to 29 bits).
-    auto replicas = FromProto<TChunkReplicaWithMediumList>(chunkSpec.replicas());
+    auto chunkFormat = chunkSpec.has_chunk_meta()
+        ? FromProto<EChunkFormat>(chunkSpec.chunk_meta().format())
+        : EChunkFormat::Unknown;
+    // Prefer replica specs since externally attached S3 replicas carry their
+    // source URI there. Keep the packed representation as a compatibility
+    // fallback for ordinary chunks and old masters.
+    TChunkReplicaWithMediumList replicas;
+    if (chunkSpec.replica_specs_size() > 0) {
+        replicas.reserve(chunkSpec.replica_specs_size());
+        for (const auto& replicaSpec : chunkSpec.replica_specs()) {
+            replicas.push_back(FromProto<TChunkReplicaWithMedium>(replicaSpec));
+        }
+    } else {
+        replicas = FromProto<TChunkReplicaWithMediumList>(chunkSpec.replicas());
+    }
 
     auto Logger = ChunkClientLogger().WithTag("ChunkId", chunkId);
 
@@ -821,7 +833,8 @@ IChunkReaderPtr CreateRemoteReader(
             std::move(optionsPerChunk),
             std::move(chunkReaderHost),
             chunkId,
-            std::move(replicas));
+            std::move(replicas),
+            chunkFormat);
     }
 }
 

--- a/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
+++ b/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
@@ -302,6 +302,9 @@ message TReqGetBlockSet
 
     optional double io_fair_share_weight = 18;
 
+    // Required by offshore readers for externally attached source objects.
+    optional int32 chunk_format = 19;
+
     reserved 3, 4, 9;
 }
 
@@ -337,6 +340,9 @@ message TReqGetBlockRange
     optional int64 io_consumed = 8;
 
     optional double io_fair_share_weight = 9;
+
+    // Required by offshore readers for externally attached source objects.
+    optional int32 chunk_format = 10;
 }
 
 message TRspGetBlockRange
@@ -503,6 +509,9 @@ message TReqGetChunkMeta
     optional int64 io_consumed = 11;
 
     optional double io_fair_share_weight = 12;
+
+    // Required by offshore readers for externally attached source objects.
+    optional int32 chunk_format = 13;
 }
 
 message TRspGetChunkMeta

--- a/yt/yt/ytlib/chunk_client/replication_reader.cpp
+++ b/yt/yt/ytlib/chunk_client/replication_reader.cpp
@@ -300,7 +300,8 @@ public:
         TRemoteReaderOptionsPtr options,
         TChunkReaderHostPtr chunkReaderHost,
         TChunkId chunkId,
-        TChunkReplicaWithMediumList seedReplicas)
+        TChunkReplicaWithMediumList seedReplicas,
+        EChunkFormat chunkFormat)
         : Config_(std::move(config))
         , Options_(std::move(options))
         , Client_(chunkReaderHost->Client)
@@ -309,6 +310,7 @@ public:
         , MediumDirectory_(Client_->GetNativeConnection()->GetMediumDirectory())
         , LocalDescriptor_(chunkReaderHost->LocalDescriptor)
         , ChunkId_(chunkId)
+        , ChunkFormat_(chunkFormat)
         , BlockCache_(chunkReaderHost->BlockCache)
         , ChunkMetaCache_(chunkReaderHost->ChunkMetaCache)
         , TrafficMeter_(chunkReaderHost->TrafficMeter)
@@ -412,6 +414,7 @@ private:
     const TMediumDirectoryPtr MediumDirectory_;
     const TNodeDescriptor LocalDescriptor_;
     const TChunkId ChunkId_;
+    const EChunkFormat ChunkFormat_;
     const IBlockCachePtr BlockCache_;
     const IClientChunkMetaCachePtr ChunkMetaCache_;
     const TTrafficMeterPtr TrafficMeter_;
@@ -3548,6 +3551,7 @@ private:
         req->set_block_count(BlockCount_);
         if (peerId.IsOffshore) {
             ToProto(req->mutable_replica_spec(), peer.Replica);
+            req->set_chunk_format(ToUnderlying(reader->ChunkFormat_));
         }
 
         auto rspFuture = req->Invoke();
@@ -3877,6 +3881,7 @@ private:
         YT_OPTIONAL_TO_PROTO(req, extension_tags, ExtensionTags_);
         req->set_supported_chunk_features(ToUnderlying(GetSupportedChunkFeatures()));
         ToProto(req->mutable_replica_spec(), peers[0].Replica);
+        req->set_chunk_format(ToUnderlying(reader->ChunkFormat_));
 
         auto rspFuture = req->Invoke();
         SetSessionFuture(rspFuture.As<void>());
@@ -4738,6 +4743,7 @@ public:
         , ReaderConfig_(reader->Config_)
         , ReaderOptions_(reader->Options_)
         , ChunkId_(reader->ChunkId_)
+        , ChunkFormat_(reader->ChunkFormat_)
         , Logger(reader->Logger)
     { }
 
@@ -4799,6 +4805,7 @@ private:
     const TReplicationReaderConfigPtr ReaderConfig_;
     const TRemoteReaderOptionsPtr ReaderOptions_;
     const TChunkId ChunkId_;
+    const EChunkFormat ChunkFormat_;
     const NLogging::TLogger Logger;
 
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, Lock_);
@@ -4973,6 +4980,7 @@ private:
         }
 
         ToProto(req->mutable_replica_spec(), queuedBatch.PrimaryPeer.Replica);
+        req->set_chunk_format(ToUnderlying(ChunkFormat_));
 
         return req->Invoke()
             .AsUnique().Apply(BIND(
@@ -5139,7 +5147,8 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaList seedReplicas)
+    TChunkReplicaList seedReplicas,
+    EChunkFormat chunkFormat)
 {
     TChunkReplicaWithMediumList replicaList;
     replicaList.reserve(seedReplicas.size());
@@ -5152,7 +5161,8 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
         std::move(options),
         std::move(chunkReaderHost),
         chunkId,
-        std::move(replicaList));
+        std::move(replicaList),
+        chunkFormat);
 }
 
 IChunkReaderAllowingRepairPtr CreateReplicationReader(
@@ -5160,14 +5170,16 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaWithMediumList seedReplicas)
+    TChunkReplicaWithMediumList seedReplicas,
+    EChunkFormat chunkFormat)
 {
     return New<TReplicationReader>(
         std::move(config),
         std::move(options),
         std::move(chunkReaderHost),
         chunkId,
-        std::move(seedReplicas));
+        std::move(seedReplicas),
+        chunkFormat);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/chunk_client/replication_reader.h
+++ b/yt/yt/ytlib/chunk_client/replication_reader.h
@@ -24,14 +24,16 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaList seedReplicas);
+    TChunkReplicaList seedReplicas,
+    EChunkFormat chunkFormat = EChunkFormat::Unknown);
 
 IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TReplicationReaderConfigPtr config,
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaWithMediumList seedReplicas);
+    TChunkReplicaWithMediumList seedReplicas,
+    EChunkFormat chunkFormat = EChunkFormat::Unknown);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/ytlib/table_client/attach_table.cpp
+++ b/yt/yt/ytlib/table_client/attach_table.cpp
@@ -1,0 +1,321 @@
+#include "attach_table.h"
+
+#include "chunk_meta_extensions.h"
+#include "config.h"
+#include "schemaless_table_uploader.h"
+
+#include <yt/yt/ytlib/api/native/client.h>
+#include <yt/yt/ytlib/api/native/connection.h>
+
+#include <yt/yt/ytlib/chunk_client/dispatcher.h>
+#include <yt/yt/ytlib/chunk_client/external_parquet.h>
+#include <yt/yt/ytlib/chunk_client/chunk_meta_extensions.h>
+#include <yt/yt/ytlib/chunk_client/helpers.h>
+#include <yt/yt/ytlib/chunk_client/medium_directory.h>
+#include <yt/yt/ytlib/chunk_client/medium_directory_synchronizer.h>
+
+#include <yt/yt/ytlib/transaction_client/transaction_listener.h>
+
+#include <yt/yt/client/api/transaction.h>
+#include <yt/yt/client/chunk_client/helpers.h>
+#include <yt/yt/client/node_tracker_client/public.h>
+#include <yt/yt/client/table_client/check_schema_compatibility.h>
+#include <yt/yt/client/table_client/private.h>
+
+#include <yt/yt/library/s3/client.h>
+#include <yt/yt/library/s3/credential_provider.h>
+#include <yt/yt/library/s3/object.h>
+
+#include <yt/yt/core/bus/tcp/dispatcher.h>
+#include <yt/yt/core/misc/memory_usage_tracker.h>
+
+namespace NYT::NTableClient {
+
+using namespace NApi;
+using namespace NChunkClient;
+using namespace NConcurrency;
+using namespace NNodeTrackerClient;
+using namespace NObjectClient;
+using namespace NTransactionClient;
+using namespace NYPath;
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+const THashSet<int>& GetExternalParquetMasterChunkMetaExtensionTagsFilter()
+{
+    static const THashSet<int> Result{
+        TProtoExtensionTag<NChunkClient::NProto::TMiscExt>::Value,
+        TProtoExtensionTag<NChunkClient::NProto::TBlocksExt>::Value,
+        TProtoExtensionTag<NTableClient::NProto::TDataBlockMetaExt>::Value,
+        TProtoExtensionTag<NTableClient::NProto::TTableSchemaExt>::Value,
+        TProtoExtensionTag<NTableClient::NProto::TParquetFormatMetaExt>::Value,
+    };
+    return Result;
+}
+
+class TTableAttacher
+    : public TTransactionListener
+{
+public:
+    TTableAttacher(
+        TRichYPath richPath,
+        std::vector<std::string> sourceUris,
+        NApi::TAttachTableOptions options,
+        NApi::NNative::IClientPtr client,
+        NApi::ITransactionPtr transaction)
+        : RichPath_(std::move(richPath))
+        , SourceUris_(std::move(sourceUris))
+        , AttachOptions_(std::move(options))
+        , Client_(std::move(client))
+        , Transaction_(std::move(transaction))
+        , TransactionId_(Transaction_ ? Transaction_->GetId() : NullTransactionId)
+        , Logger(TableClientLogger()
+            .WithTag("Path", RichPath_.GetPath())
+            .WithTag("TransactionId", TransactionId_))
+    {
+        if (Transaction_) {
+            StartListenTransaction(Transaction_);
+        }
+    }
+
+    ~TTableAttacher()
+    {
+        // A live upload transaction holds all chunks created during attach. Abort
+        // it on failure; Abort is harmless after EndUpload detached it.
+        if (Uploader_ && Uploader_->UploadTransaction) {
+            Y_UNUSED(WaitFor(Uploader_->UploadTransaction->Abort()));
+        }
+    }
+
+    TFuture<void> Run()
+    {
+        return BIND(&TTableAttacher::DoRun, MakeStrong(this))
+            .AsyncVia(TDispatcher::Get()->GetWriterInvoker())
+            .Run();
+    }
+
+private:
+    const TRichYPath RichPath_;
+    const std::vector<std::string> SourceUris_;
+    const NApi::TAttachTableOptions AttachOptions_;
+    const NApi::NNative::IClientPtr Client_;
+    const NApi::ITransactionPtr Transaction_;
+    const TTransactionId TransactionId_;
+    const NLogging::TLogger Logger;
+
+    std::optional<TSchemalessTableUploader> Uploader_;
+    TS3MediumDescriptorPtr S3MediumDescriptor_;
+    NS3::IClientPtr S3Client_;
+    int ChunkCount_ = 0;
+    i64 RowCount_ = 0;
+    i64 DataSize_ = 0;
+
+    NS3::IClientPtr CreateS3Client() const
+    {
+        const auto& mediumConfig = S3MediumDescriptor_->GetConfig();
+        auto credentials = NS3::CreateStaticCredentialProvider(
+            mediumConfig->AccessKeyId,
+            mediumConfig->SecretAccessKey);
+
+        auto clientConfig = New<NS3::TS3ClientConfig>();
+        clientConfig->Url = mediumConfig->Url;
+        clientConfig->Region = mediumConfig->Region;
+
+        auto client = NS3::CreateClient(
+            std::move(clientConfig),
+            std::move(credentials),
+            /*sslContextConfig*/ nullptr,
+            NBus::NTcp::TDispatcher::Get()->GetXferPoller(),
+            TDispatcher::Get()->GetWriterInvoker());
+        WaitFor(client->Start())
+            .ThrowOnError();
+        return client;
+    }
+
+    void Open()
+    {
+        THROW_ERROR_EXCEPTION_IF(SourceUris_.empty(), "Cannot attach an empty source URI list");
+        ValidateAborted();
+
+        Uploader_.emplace(New<TTableWriterOptions>(), RichPath_, Client_, TransactionId_);
+        StartListenTransaction(Uploader_->UploadTransaction);
+
+        THROW_ERROR_EXCEPTION_IF(
+            Uploader_->GetSchema()->IsSorted(),
+            "Attaching external data to sorted tables is not supported");
+        THROW_ERROR_EXCEPTION_IF(
+            Uploader_->Options->ErasureCodec != NErasure::ECodec::None,
+            "Cannot attach external data to a table with erasure codec %Qlv",
+            Uploader_->Options->ErasureCodec);
+        THROW_ERROR_EXCEPTION_IF(
+            AttachOptions_.Medium && *AttachOptions_.Medium != Uploader_->Options->MediumName,
+            "Requested medium %Qv does not match the table medium %Qv",
+            *AttachOptions_.Medium,
+            Uploader_->Options->MediumName);
+
+        const auto& connection = Client_->GetNativeConnection();
+        WaitFor(connection->GetMediumDirectorySynchronizer()->NextSync(/*force*/ true))
+            .ThrowOnError();
+        auto medium = connection->GetMediumDirectory()->GetByNameOrThrow(Uploader_->Options->MediumName);
+        THROW_ERROR_EXCEPTION_IF(
+            !medium->IsOffshore(),
+            "Cannot attach external data to a table on non-S3 medium %Qv",
+            Uploader_->Options->MediumName);
+        S3MediumDescriptor_ = medium->As<TS3MediumDescriptor>();
+
+        S3Client_ = CreateS3Client();
+
+        YT_LOG_DEBUG(
+            "Table opened for attaching external data (UploadTransactionId: %v, Medium: %v)",
+            Uploader_->UploadTransaction->GetId(),
+            Uploader_->Options->MediumName);
+    }
+
+    void AttachSource(const std::string& sourceUri)
+    {
+        YT_VERIFY(Uploader_);
+        ValidateAborted();
+
+        const auto source = NS3::TObjectDescriptor::FromUri(sourceUri);
+        const auto sourceFormat = AttachOptions_.SourceFormat
+            ? *AttachOptions_.SourceFormat
+            : DeduceExternalSourceFormatOrThrow(source.Key());
+        const auto chunkFormat = GetChunkFormatFromExternalSourceFormat(sourceFormat);
+
+        auto generator = CreateArrowTableChunkMetaGenerator(
+            chunkFormat,
+            std::make_shared<TS3ArrowRandomAccessFile>(source, S3Client_));
+        generator->Generate();
+
+        auto [compatibility, compatibilityError] = CheckTableSchemaCompatibility(
+            *generator->GetChunkSchema(),
+            *Uploader_->ChunkSchema,
+            TTableSchemaCompatibilityOptions{});
+        if (compatibility != ESchemaCompatibility::FullyCompatible && !AttachOptions_.AllowIncompatibleSourceSchemas) {
+            THROW_ERROR_EXCEPTION(
+                NTableClient::EErrorCode::IncompatibleSchemas,
+                "Inferred schema for source %Qv is not compatible with the table schema",
+                sourceUri)
+                << compatibilityError;
+        }
+
+        auto sessionId = CreateChunk(
+            Client_,
+            Uploader_->UserObject.ExternalCellTag,
+            Uploader_->Options,
+            Uploader_->UploadTransaction->GetId(),
+            Uploader_->ChunkListId,
+            Logger);
+
+        auto replica = TChunkReplicaWithMedium(
+            OffshoreNodeId,
+            GenericChunkReplicaIndex,
+            sessionId.MediumIndex,
+            sourceUri);
+
+        auto channel = Client_->GetMasterChannelOrThrow(
+            EMasterChannelKind::Leader,
+            Uploader_->UserObject.ExternalCellTag);
+        TChunkServiceProxy proxy(channel);
+        auto req = proxy.ConfirmChunk();
+        GenerateMutationId(req);
+
+        ToProto(req->mutable_chunk_id(), sessionId.ChunkId);
+        *req->mutable_chunk_info() = NChunkClient::NProto::TChunkInfo();
+        *req->mutable_chunk_meta() = *generator->GetChunkMeta();
+
+        auto memoryUsageGuard = TMemoryUsageTrackerGuard::Acquire(
+            Uploader_->Options->MemoryUsageTracker,
+            req->mutable_chunk_meta()->ByteSize());
+        FilterProtoExtensions(
+            req->mutable_chunk_meta()->mutable_extensions(),
+            GetExternalParquetMasterChunkMetaExtensionTagsFilter());
+        req->set_request_statistics(true);
+        req->set_location_uuids_supported(true);
+
+        auto* replicaInfo = req->add_replicas();
+        ToProto(replicaInfo->mutable_replica_spec(), replica);
+        ToProto(replicaInfo->mutable_location_uuid(), InvalidChunkLocationUuid);
+        ui64 encodedReplica;
+        ToProto(&encodedReplica, replica);
+        replicaInfo->set_replica(encodedReplica);
+
+        if (Uploader_->ChunkSchemaId != NullTableSchemaId) {
+            ToProto(req->mutable_schema_id(), Uploader_->ChunkSchemaId);
+        }
+
+        auto* multicellSyncExt = req->Header().MutableExtension(
+            NObjectClient::NProto::TMulticellSyncExt::multicell_sync_ext);
+        multicellSyncExt->set_suppress_upstream_sync(true);
+
+        auto responseOrError = WaitFor(req->Invoke());
+        THROW_ERROR_EXCEPTION_IF_FAILED(
+            responseOrError,
+            NChunkClient::EErrorCode::MasterCommunicationFailed,
+            "Failed to confirm attached chunk %v",
+            sessionId.ChunkId);
+
+        ++ChunkCount_;
+        RowCount_ += generator->GetRowCount();
+        DataSize_ += generator->GetUncompressedDataSize();
+
+        YT_LOG_DEBUG(
+            "Attached external Parquet chunk (ChunkId: %v, SourceUri: %v, RowCount: %v)",
+            sessionId.ChunkId,
+            sourceUri,
+            generator->GetRowCount());
+    }
+
+    void Close()
+    {
+        YT_VERIFY(Uploader_);
+        ValidateAborted();
+
+        StopListenTransaction(Uploader_->UploadTransaction);
+
+        NChunkClient::NProto::TDataStatistics dataStatistics;
+        dataStatistics.set_chunk_count(ChunkCount_);
+        dataStatistics.set_row_count(RowCount_);
+        dataStatistics.set_compressed_data_size(DataSize_);
+        dataStatistics.set_uncompressed_data_size(DataSize_);
+        dataStatistics.set_data_weight(DataSize_);
+        Uploader_->EndUpload(dataStatistics);
+
+        YT_LOG_DEBUG("Table closed after attaching external data (DataStatistics: %v)", dataStatistics);
+    }
+
+    void DoRun()
+    {
+        Open();
+        for (const auto& sourceUri : SourceUris_) {
+            AttachSource(sourceUri);
+        }
+        Close();
+    }
+};
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+
+TFuture<void> AttachTable(
+    const TRichYPath& richPath,
+    std::vector<std::string> sourceUris,
+    const NApi::TAttachTableOptions& options,
+    NApi::NNative::IClientPtr client,
+    NApi::ITransactionPtr transaction)
+{
+    return New<TTableAttacher>(
+        richPath,
+        std::move(sourceUris),
+        options,
+        std::move(client),
+        std::move(transaction))
+        ->Run();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NTableClient

--- a/yt/yt/ytlib/table_client/attach_table.h
+++ b/yt/yt/ytlib/table_client/attach_table.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <yt/yt/ytlib/api/native/public.h>
+
+#include <yt/yt/client/api/table_client.h>
+#include <yt/yt/client/ypath/public.h>
+
+#include <yt/yt/core/actions/future.h>
+
+namespace NYT::NTableClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Attaches one synthetic offshore chunk for each source URI.
+TFuture<void> AttachTable(
+    const NYPath::TRichYPath& richPath,
+    std::vector<std::string> sourceUris,
+    const NApi::TAttachTableOptions& options,
+    NApi::NNative::IClientPtr client,
+    NApi::ITransactionPtr transaction);
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NTableClient

--- a/yt/yt/ytlib/table_client/chunk_meta_extensions.cpp
+++ b/yt/yt/ytlib/table_client/chunk_meta_extensions.cpp
@@ -38,6 +38,7 @@ REGISTER_PROTO_EXTENSION(TVersionedRowDigestExt, 66, versioned_row_digest);
 REGISTER_PROTO_EXTENSION(TColumnGroupInfosExt, 67, column_group_infos);
 REGISTER_PROTO_EXTENSION(TCompressionDictionaryExt, 68, compression_dictionary);
 REGISTER_PROTO_EXTENSION(TLargeColumnarStatisticsExt, 69, large_columnar_statistics);
+REGISTER_PROTO_EXTENSION(TParquetFormatMetaExt, 70, parquet_format_meta);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/ytlib/table_client/chunk_meta_extensions.h
+++ b/yt/yt/ytlib/table_client/chunk_meta_extensions.h
@@ -32,6 +32,7 @@ DECLARE_PROTO_EXTENSION(NTableClient::NProto::TVersionedRowDigestExt, 66)
 DECLARE_PROTO_EXTENSION(NTableClient::NProto::TColumnGroupInfosExt, 67)
 DECLARE_PROTO_EXTENSION(NTableClient::NProto::TCompressionDictionaryExt, 68)
 DECLARE_PROTO_EXTENSION(NTableClient::NProto::TLargeColumnarStatisticsExt, 69)
+DECLARE_PROTO_EXTENSION(NTableClient::NProto::TParquetFormatMetaExt, 70)
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/ytlib/table_client/columnar_chunk_meta.cpp
+++ b/yt/yt/ytlib/table_client/columnar_chunk_meta.cpp
@@ -64,6 +64,9 @@ TColumnarChunkMeta::TColumnarChunkMeta(const TChunkMeta& chunkMeta, bool compres
     ChunkFeatures_ = FromProto<EChunkFeatures>(chunkMeta.features());
 
     Misc_ = GetProtoExtension<TMiscExt>(chunkMeta.extensions());
+    if (auto blocksExt = FindProtoExtension<TBlocksExt>(chunkMeta.extensions())) {
+        Blocks_ = New<TRefCountedBlocksExt>(std::move(*blocksExt));
+    }
     DataBlockMeta_ = New<TRefCountedDataBlockMeta>(GetProtoExtension<TDataBlockMetaExt>(chunkMeta.extensions()));
 
     if (auto columnGroupInfos = FindProtoExtension<TColumnGroupInfosExt>(chunkMeta.extensions())) {
@@ -80,6 +83,11 @@ TColumnarChunkMeta::TColumnarChunkMeta(const TChunkMeta& chunkMeta, bool compres
     if (auto nameTableExt = FindProtoExtension<TNameTableExt>(chunkMeta.extensions())) {
         ChunkNameTable_ = New<TNameTable>();
         FromProto(&ChunkNameTable_, *nameTableExt);
+    } else if (ChunkFormat_ == EChunkFormat::TableUnversionedArrowParquet) {
+        // External Parquet metadata uses the master extension budget for the
+        // footer and block layout, so its name table is reconstructed from its
+        // schema instead of being persisted as a separate extension.
+        ChunkNameTable_ = TNameTable::FromSchema(*ChunkSchema_);
     }
 
     auto buffer = New<TRowBuffer>(TBlockLastKeysBufferTag());
@@ -147,6 +155,7 @@ TColumnarChunkMeta::TColumnarChunkMeta(const TChunkMeta& chunkMeta, bool compres
 
     ColumnarStatisticsExt_ = FindProtoExtension<TColumnarStatisticsExt>(chunkMeta.extensions());
     LargeColumnarStatisticsExt_ = FindProtoExtension<TLargeColumnarStatisticsExt>(chunkMeta.extensions());
+    ParquetFormatMetaExt_ = FindProtoExtension<TParquetFormatMetaExt>(chunkMeta.extensions());
 }
 
 i64 TColumnarChunkMeta::GetMemoryUsage() const
@@ -158,6 +167,7 @@ i64 TColumnarChunkMeta::GetMemoryUsage() const
 
     return
         BlockLastKeysSize_ +
+        (Blocks_ ? Blocks_->GetSize() * metaMemoryFactor : 0) +
         Misc_.SpaceUsedLong() +
         (DataBlockMeta_ ? DataBlockMeta_->GetSize() * metaMemoryFactor : 0) +
         (ColumnGroupInfos_ ? ColumnGroupInfos_->GetSize() * metaMemoryFactor : 0) +

--- a/yt/yt/ytlib/table_client/columnar_chunk_meta.h
+++ b/yt/yt/ytlib/table_client/columnar_chunk_meta.h
@@ -21,6 +21,7 @@ public:
     DEFINE_BYVAL_RO_PROPERTY(NChunkClient::EChunkType, ChunkType);
     DEFINE_BYVAL_RO_PROPERTY(NChunkClient::EChunkFormat, ChunkFormat);
     DEFINE_BYVAL_RO_PROPERTY(NChunkClient::EChunkFeatures, ChunkFeatures);
+    DEFINE_BYREF_RO_PROPERTY(NChunkClient::TRefCountedBlocksExtPtr, Blocks);
     DEFINE_BYREF_RO_PROPERTY(TRefCountedDataBlockMetaPtr, DataBlockMeta);
     DEFINE_BYREF_RO_PROPERTY(TRefCountedColumnGroupInfosExtPtr, ColumnGroupInfos);
     DEFINE_BYREF_RO_PROPERTY(TRefCountedColumnMetaPtr, ColumnMeta);
@@ -31,6 +32,8 @@ public:
     DEFINE_BYREF_RO_PROPERTY(std::vector<THunkChunkMeta>, HunkChunkMetas);
     DEFINE_BYREF_RO_PROPERTY(std::optional<NTableClient::NProto::TColumnarStatisticsExt>, ColumnarStatisticsExt);
     DEFINE_BYREF_RO_PROPERTY(std::optional<NTableClient::NProto::TLargeColumnarStatisticsExt>, LargeColumnarStatisticsExt);
+    //! Format-specific metadata for externally attached Parquet chunks.
+    DEFINE_BYREF_RO_PROPERTY(std::optional<NTableClient::NProto::TParquetFormatMetaExt>, ParquetFormatMetaExt);
 
 public:
     explicit TColumnarChunkMeta(const NChunkClient::NProto::TChunkMeta& chunkMeta, bool compressBlockLastKeys = false);

--- a/yt/yt/ytlib/table_client/schemaless_block_reader.cpp
+++ b/yt/yt/ytlib/table_client/schemaless_block_reader.cpp
@@ -1,14 +1,22 @@
 #include "schemaless_block_reader.h"
 #include "helpers.h"
 #include "hunks.h"
+#include "columnar_chunk_meta.h"
 
+#include <yt/yt/client/table_client/name_table.h>
 #include <yt/yt/client/table_client/key_bound.h>
 #include <yt/yt/client/table_client/logical_type.h>
 #include <yt/yt/client/table_client/schema.h>
 #include <yt/yt/client/table_client/helpers.h>
 #include <yt/yt/client/table_client/private.h>
+#include <yt/yt/client/table_client/value_consumer.h>
 
+#include <yt/yt/library/arrow_adapter/arrow.h>
+#include <yt/yt/library/formats/arrow_parser.h>
 #include <yt/yt/library/numeric/algorithm_helpers.h>
+
+#include <contrib/libs/apache/arrow_next/cpp/src/arrow/table.h>
+#include <contrib/libs/apache/arrow_next/cpp/src/parquet/arrow/reader.h>
 
 namespace NYT::NTableClient {
 
@@ -347,6 +355,212 @@ bool THorizontalBlockReader::JumpToRowIndex(i64 rowIndex)
     }
 
     return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace {
+
+std::shared_ptr<arrow20::RecordBatchReader> CreateParquetRecordBatchReader(
+    const TSharedRef& block,
+    const NProto::TDataBlockMeta& dataBlockMeta,
+    const TColumnarChunkMetaPtr& chunkMeta)
+{
+    YT_VERIFY(chunkMeta->Blocks());
+    YT_VERIFY(chunkMeta->ParquetFormatMetaExt());
+
+    const auto& parquetFormatMeta = *chunkMeta->ParquetFormatMetaExt();
+    const auto& footer = parquetFormatMeta.footer();
+    auto footerSize = static_cast<uint32_t>(footer.size());
+    auto fileMeta = parquet20::FileMetaData::Make(footer.data(), &footerSize);
+    const auto parquetFileSize = parquetFormatMeta.file_size();
+
+    const auto blockIndex = dataBlockMeta.block_index();
+    const auto rowGroupOffset = chunkMeta->Blocks()->blocks(blockIndex).offset();
+    auto rowGroupReader = std::make_shared<NArrow::TCompositeBufferArrowRandomAccessFile>(
+        std::vector<NArrow::TCompositeBufferArrowRandomAccessFile::TBufferDescriptor>{
+            {TSharedRef::FromString(TString("PAR1")), 0},
+            {block, rowGroupOffset},
+            {TSharedRef::FromString(TString("PAR1")), parquetFileSize - 4},
+        },
+        parquetFileSize);
+
+    auto parquetReader = parquet20::ParquetFileReader::Open(
+        std::move(rowGroupReader),
+        parquet20::default_reader_properties(),
+        std::move(fileMeta));
+    std::unique_ptr<parquet20::arrow20::FileReader> arrowParquetReader;
+    PARQUET_THROW_NOT_OK(parquet20::arrow20::FileReader::Make(
+        arrow20::default_memory_pool(),
+        std::move(parquetReader),
+        &arrowParquetReader));
+
+    std::shared_ptr<arrow20::Table> table;
+    PARQUET_THROW_NOT_OK(arrowParquetReader->ReadRowGroup(blockIndex, &table));
+    return std::make_shared<arrow20::TableBatchReader>(std::move(table));
+}
+
+} // namespace
+
+TArrowHorizontalBlockReader::TArrowHorizontalBlockReader(
+    const TSharedRef& block,
+    const NProto::TDataBlockMeta& dataBlockMeta,
+    const TColumnarChunkMetaPtr& chunkMeta,
+    const std::vector<int>& chunkToReaderIdMapping,
+    TRange<ESortOrder> sortOrders,
+    int commonKeyPrefix,
+    const TKeyWideningOptions& keyWideningOptions,
+    int extraColumnCount)
+    : DataBlockMeta_(dataBlockMeta)
+    , ChunkMeta_(chunkMeta)
+    , ChunkToReaderIdMapping_(chunkToReaderIdMapping)
+    , SortOrders_(sortOrders.begin(), sortOrders.end())
+    , CommonKeyPrefix_(commonKeyPrefix)
+    , KeyWideningOptions_(keyWideningOptions)
+    , ExtraColumnCount_(extraColumnCount)
+{
+    auto batchReader = CreateParquetRecordBatchReader(block, DataBlockMeta_, ChunkMeta_);
+    // Older branches do not have the collecting Arrow value consumer. Reuse
+    // the standard owning row builder and remap its schema-derived ids below.
+    TBuildingValueConsumer consumer(
+        ChunkMeta_->ChunkSchema(),
+        TableClientLogger(),
+        /*convertNullToEntity*/ false);
+
+    std::shared_ptr<arrow20::RecordBatch> batch;
+    while (true) {
+        PARQUET_THROW_NOT_OK(batchReader->ReadNext(&batch));
+        if (!batch) {
+            break;
+        }
+        PARQUET_THROW_NOT_OK(NFormats::DecodeRecordBatch(batch, &consumer));
+    }
+    const auto& consumerNameTable = consumer.GetNameTable();
+    const auto& chunkNameTable = ChunkMeta_->ChunkNameTable();
+    for (auto row : consumer.GetRows()) {
+        std::vector<TUnversionedValue> values(row.Begin(), row.End());
+        for (auto& value : values) {
+            value.Id = chunkNameTable->GetIdOrRegisterName(consumerNameTable->GetName(value.Id));
+        }
+        Rows_.emplace_back(TUnversionedValueRange(values.data(), values.size()));
+    }
+
+    KeyBuffer_.reserve(GetUnversionedRowByteSize(GetKeyColumnCount()));
+    Key_ = TMutableUnversionedRow::Create(KeyBuffer_.data(), GetKeyColumnCount());
+    for (int index = 0; index < GetKeyColumnCount(); ++index) {
+        Key_[index] = MakeUnversionedNullValue(index);
+    }
+    JumpToRowIndex(0);
+}
+
+bool TArrowHorizontalBlockReader::NextRow()
+{
+    return JumpToRowIndex(RowIndex_ + 1);
+}
+
+bool TArrowHorizontalBlockReader::SkipToRowIndex(i64 rowIndex)
+{
+    YT_VERIFY(rowIndex >= RowIndex_);
+    return JumpToRowIndex(rowIndex);
+}
+
+bool TArrowHorizontalBlockReader::SkipToKeyBound(const TKeyBoundRef& lowerBound)
+{
+    auto inBound = [&] (TUnversionedRow row) {
+        return TestKey(ToKeyRef(row), lowerBound, SortOrders_);
+    };
+    if (inBound(GetLegacyKey())) {
+        return true;
+    }
+    const auto index = BinarySearch(RowIndex_, DataBlockMeta_.row_count(), [&] (i64 rowIndex) {
+        YT_VERIFY(JumpToRowIndex(rowIndex));
+        return !inBound(GetLegacyKey());
+    });
+    return JumpToRowIndex(index);
+}
+
+bool TArrowHorizontalBlockReader::SkipToKey(TUnversionedRow lowerBound)
+{
+    return SkipToKeyBound(ToKeyBoundRef(lowerBound, /*upper*/ false, GetKeyColumnCount()));
+}
+
+bool TArrowHorizontalBlockReader::JumpToRowIndex(i64 rowIndex)
+{
+    if (rowIndex >= std::ssize(Rows_)) {
+        return false;
+    }
+    RowIndex_ = rowIndex;
+    std::memcpy(
+        Key_.Begin(),
+        Rows_[RowIndex_].Begin(),
+        sizeof(TUnversionedValue) * GetChunkKeyColumnCount());
+    return true;
+}
+
+TLegacyKey TArrowHorizontalBlockReader::GetLegacyKey() const
+{
+    return Key_;
+}
+
+TKey TArrowHorizontalBlockReader::GetKey() const
+{
+    return TKey::FromRowUnchecked(Key_, GetKeyColumnCount());
+}
+
+int TArrowHorizontalBlockReader::GetChunkKeyColumnCount() const
+{
+    return CommonKeyPrefix_;
+}
+
+int TArrowHorizontalBlockReader::GetKeyColumnCount() const
+{
+    return SortOrders_.Size();
+}
+
+TMutableUnversionedRow TArrowHorizontalBlockReader::GetRow(TChunkedMemoryPool* memoryPool, bool remapIds)
+{
+    YT_VERIFY(RowIndex_ >= 0 && RowIndex_ < std::ssize(Rows_));
+    const auto chunkRow = Rows_[RowIndex_];
+    auto row = TMutableUnversionedRow::Allocate(
+        memoryPool,
+        chunkRow.GetCount() + std::ssize(KeyWideningOptions_.InsertedColumnIds) + ExtraColumnCount_);
+
+    int valueCount = 0;
+    auto pushRegularValue = [&] (int chunkValueIndex) {
+        auto value = chunkRow[chunkValueIndex];
+        const auto remappedId = remapIds ? ChunkToReaderIdMapping_[value.Id] : value.Id;
+        if (remappedId >= 0) {
+            value.Id = remappedId;
+            row[valueCount++] = value;
+        }
+    };
+    auto pushNullValue = [&] (int id) {
+        row[valueCount++] = MakeUnversionedNullValue(id);
+    };
+
+    if (KeyWideningOptions_.InsertPosition < 0) {
+        for (int index = 0; index < chunkRow.GetCount(); ++index) {
+            pushRegularValue(index);
+        }
+    } else {
+        for (int index = 0; index < KeyWideningOptions_.InsertPosition; ++index) {
+            pushRegularValue(index);
+        }
+        for (int id : KeyWideningOptions_.InsertedColumnIds) {
+            pushNullValue(id);
+        }
+        for (int index = KeyWideningOptions_.InsertPosition; index < chunkRow.GetCount(); ++index) {
+            pushRegularValue(index);
+        }
+    }
+
+    row.SetCount(valueCount);
+    return row;
+}
+
+i64 TArrowHorizontalBlockReader::GetRowIndex() const
+{
+    return RowIndex_;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/table_client/schemaless_block_reader.h
+++ b/yt/yt/ytlib/table_client/schemaless_block_reader.h
@@ -32,10 +32,7 @@ std::vector<bool> GetHunkColumnFlags(
     NChunkClient::EChunkFeatures chunkFeatures,
     const TTableSchemaPtr& schema);
 
-////////////////////////////////////////////////////////////////////////////////
-
 class THorizontalBlockReader
-    : public TNonCopyable
 {
 public:
     /*!
@@ -116,6 +113,53 @@ private:
 
     bool IsHunkValue(TUnversionedValue value);
     TUnversionedValue DecodeAnyValue(TUnversionedValue value);
+    int GetChunkKeyColumnCount() const;
+    int GetKeyColumnCount() const;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Decodes an externally attached Parquet row group into regular YT rows.
+//! External chunks are unsorted; key-oriented methods remain available only to
+//! satisfy the common horizontal-reader interface.
+class TArrowHorizontalBlockReader
+{
+public:
+    TArrowHorizontalBlockReader(
+        const TSharedRef& block,
+        const NProto::TDataBlockMeta& dataBlockMeta,
+        const TColumnarChunkMetaPtr& chunkMeta,
+        const std::vector<int>& chunkToReaderIdMapping,
+        TRange<ESortOrder> sortOrders,
+        int commonKeyPrefix,
+        const TKeyWideningOptions& keyWideningOptions,
+        int extraColumnCount = 0);
+
+    bool NextRow();
+    bool SkipToRowIndex(i64 rowIndex);
+    bool SkipToKeyBound(const TKeyBoundRef& lowerBound);
+    bool SkipToKey(TUnversionedRow lowerBound);
+    bool JumpToRowIndex(i64 rowIndex);
+
+    TLegacyKey GetLegacyKey() const;
+    TKey GetKey() const;
+    TMutableUnversionedRow GetRow(TChunkedMemoryPool* memoryPool, bool remapIds);
+    i64 GetRowIndex() const;
+
+private:
+    const NProto::TDataBlockMeta DataBlockMeta_;
+    const TColumnarChunkMetaPtr ChunkMeta_;
+    const std::vector<int> ChunkToReaderIdMapping_;
+    const TRange<ESortOrder> SortOrders_;
+    const int CommonKeyPrefix_;
+    const TKeyWideningOptions KeyWideningOptions_;
+    const int ExtraColumnCount_;
+
+    i64 RowIndex_ = 0;
+    std::vector<TUnversionedOwningRow> Rows_;
+    TCompactVector<char, 128> KeyBuffer_;
+    TMutableUnversionedRow Key_;
+
     int GetChunkKeyColumnCount() const;
     int GetKeyColumnCount() const;
 };

--- a/yt/yt/ytlib/table_client/schemaless_chunk_reader.cpp
+++ b/yt/yt/ytlib/table_client/schemaless_chunk_reader.cpp
@@ -44,6 +44,8 @@
 
 #include <library/cpp/yt/memory/atomic.h>
 
+#include <variant>
+
 namespace NYT::NTableClient {
 
 using namespace NApi;
@@ -619,6 +621,79 @@ protected:
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// The legacy versioned reader derives from THorizontalBlockReader and exposes
+// a different row interface. Keep THorizontalBlockReader non-polymorphic and
+// erase only the two reader implementations used by schemaless chunk readers.
+class TAnyHorizontalBlockReader
+{
+public:
+    explicit TAnyHorizontalBlockReader(std::unique_ptr<THorizontalBlockReader> reader)
+        : Reader_(std::move(reader))
+    { }
+
+    explicit TAnyHorizontalBlockReader(std::unique_ptr<TArrowHorizontalBlockReader> reader)
+        : Reader_(std::move(reader))
+    { }
+
+    bool NextRow()
+    {
+        return std::visit([] (const auto& reader) {
+            return reader->NextRow();
+        }, Reader_);
+    }
+
+    bool SkipToRowIndex(i64 rowIndex)
+    {
+        return std::visit([&] (const auto& reader) {
+            return reader->SkipToRowIndex(rowIndex);
+        }, Reader_);
+    }
+
+    bool SkipToKeyBound(const TKeyBoundRef& lowerBound)
+    {
+        return std::visit([&] (const auto& reader) {
+            return reader->SkipToKeyBound(lowerBound);
+        }, Reader_);
+    }
+
+    bool SkipToKey(TUnversionedRow lowerBound)
+    {
+        return std::visit([&] (const auto& reader) {
+            return reader->SkipToKey(lowerBound);
+        }, Reader_);
+    }
+
+    TLegacyKey GetLegacyKey() const
+    {
+        return std::visit([] (const auto& reader) {
+            return reader->GetLegacyKey();
+        }, Reader_);
+    }
+
+    TMutableUnversionedRow GetRow(TChunkedMemoryPool* memoryPool, bool remapIds)
+    {
+        return std::visit([&] (const auto& reader) {
+            return reader->GetRow(memoryPool, remapIds);
+        }, Reader_);
+    }
+
+    i64 GetRowIndex() const
+    {
+        return std::visit([] (const auto& reader) {
+            return reader->GetRowIndex();
+        }, Reader_);
+    }
+
+private:
+    using TReader = std::variant<
+        std::unique_ptr<THorizontalBlockReader>,
+        std::unique_ptr<TArrowHorizontalBlockReader>>;
+
+    TReader Reader_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
 class THorizontalSchemalessChunkReaderBase
     : public TChunkReaderBase
     , public TSchemalessChunkReaderBase
@@ -696,7 +771,7 @@ protected:
 
     int CurrentBlockIndex_ = 0;
 
-    std::unique_ptr<THorizontalBlockReader> BlockReader_;
+    std::unique_ptr<TAnyHorizontalBlockReader> BlockReader_;
 
     std::vector<int> BlockIndexes_;
 
@@ -734,6 +809,7 @@ protected:
     }
 
     TFuture<void> InitBlockFetcher();
+    void InitBlockReader();
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -768,6 +844,44 @@ TDataStatistics THorizontalSchemalessChunkReaderBase::GetDataStatistics() const
     dataStatistics.set_row_count(RowCount_);
     dataStatistics.set_data_weight(DataWeight_);
     return dataStatistics;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void THorizontalSchemalessChunkReaderBase::InitBlockReader()
+{
+    const int blockIndex = BlockIndexes_[CurrentBlockIndex_];
+    const auto& blockMeta = BlockMetaExt_->data_blocks(blockIndex);
+
+    YT_VERIFY(CurrentBlock_);
+    const auto& block = CurrentBlock_.GetOrCrash().ValueOrThrow().Data;
+
+    if (ChunkMeta_->GetChunkFormat() == EChunkFormat::TableUnversionedArrowParquet) {
+        BlockReader_ = std::make_unique<TAnyHorizontalBlockReader>(
+            std::make_unique<TArrowHorizontalBlockReader>(
+                block,
+                blockMeta,
+                ChunkMeta_,
+                ChunkToReaderIdMapping_,
+                SortOrders_,
+                CommonKeyPrefix_,
+                KeyWideningOptions_,
+                GetRootSystemColumnCount()));
+    } else {
+        BlockReader_ = std::make_unique<TAnyHorizontalBlockReader>(
+            std::make_unique<THorizontalBlockReader>(
+                block,
+                blockMeta,
+                GetCompositeColumnFlags(ChunkMeta_->ChunkSchema()),
+                GetHunkColumnFlags(ChunkMeta_->GetChunkFormat(), ChunkMeta_->GetChunkFeatures(), ChunkMeta_->ChunkSchema()),
+                &ChunkMeta_->HunkChunkRefs(),
+                &ChunkMeta_->HunkChunkMetas(),
+                ChunkToReaderIdMapping_,
+                SortOrders_,
+                CommonKeyPrefix_,
+                KeyWideningOptions_,
+                GetRootSystemColumnCount()));
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -911,19 +1025,7 @@ void THorizontalSchemalessRangeChunkReader::InitFirstBlock()
     int blockIndex = BlockIndexes_[CurrentBlockIndex_];
     const auto& blockMeta = BlockMetaExt_->data_blocks(blockIndex);
 
-    YT_VERIFY(CurrentBlock_);
-    BlockReader_.reset(new THorizontalBlockReader(
-        CurrentBlock_.GetOrCrash().ValueOrThrow().Data,
-        blockMeta,
-        GetCompositeColumnFlags(ChunkMeta_->ChunkSchema()),
-        GetHunkColumnFlags(ChunkMeta_->GetChunkFormat(), ChunkMeta_->GetChunkFeatures(), ChunkMeta_->ChunkSchema()),
-        &ChunkMeta_->HunkChunkRefs(),
-        &ChunkMeta_->HunkChunkMetas(),
-        ChunkToReaderIdMapping_,
-        SortOrders_,
-        CommonKeyPrefix_,
-        KeyWideningOptions_,
-        GetRootSystemColumnCount()));
+    InitBlockReader();
 
     RowIndex_ = blockMeta.chunk_row_count() - blockMeta.row_count();
 
@@ -1343,21 +1445,7 @@ void THorizontalSchemalessLookupChunkReaderBase::ComputeBlockIndexes(TRange<TLeg
 
 void THorizontalSchemalessLookupChunkReaderBase::InitFirstBlock()
 {
-    int blockIndex = BlockIndexes_[CurrentBlockIndex_];
-    const auto& blockMeta = BlockMetaExt_->data_blocks(blockIndex);
-
-    BlockReader_.reset(new THorizontalBlockReader(
-        CurrentBlock_.GetOrCrash().ValueOrThrow().Data,
-        blockMeta,
-        GetCompositeColumnFlags(ChunkMeta_->ChunkSchema()),
-        GetHunkColumnFlags(ChunkMeta_->GetChunkFormat(), ChunkMeta_->GetChunkFeatures(), ChunkMeta_->ChunkSchema()),
-        &ChunkMeta_->HunkChunkRefs(),
-        &ChunkMeta_->HunkChunkMetas(),
-        ChunkToReaderIdMapping_,
-        SortOrders_,
-        CommonKeyPrefix_,
-        KeyWideningOptions_,
-        GetRootSystemColumnCount()));
+    InitBlockReader();
 }
 
 void THorizontalSchemalessLookupChunkReaderBase::InitNextBlock()
@@ -2807,6 +2895,7 @@ ISchemalessChunkReaderPtr CreateSchemalessRangeChunkReader(
     auto sortOrders = GetSortOrders(sortColumns);
 
     switch (chunkMeta->GetChunkFormat()) {
+        case EChunkFormat::TableUnversionedArrowParquet:
         case EChunkFormat::TableUnversionedSchemalessHorizontal:
             return New<THorizontalSchemalessRangeChunkReader>(
                 columnEvaluatorCache,

--- a/yt/yt/ytlib/table_client/schemaless_multi_chunk_reader.cpp
+++ b/yt/yt/ytlib/table_client/schemaless_multi_chunk_reader.cpp
@@ -110,7 +110,8 @@ TFuture<TColumnarChunkMetaPtr> DownloadChunkMeta(
     IChunkReaderPtr chunkReader,
     const TClientChunkReadOptions& chunkReadOptions,
     const std::optional<TPartitionTags>& partitionTags,
-    const TDataSourcePtr& dataSource)
+    const TDataSourcePtr& dataSource,
+    const TChunkSpec& chunkSpec)
 {
     // Download chunk meta.
     std::vector<int> extensionTags{
@@ -125,6 +126,11 @@ TFuture<TColumnarChunkMetaPtr> DownloadChunkMeta(
     };
     if (chunkReadOptions.GranuleFilter || (dataSource->GetInputQuerySpec() && dataSource->GetInputQuerySpec()->CanCreateGranuleFilter())) {
         extensionTags.push_back(TProtoExtensionTag<NProto::TColumnarStatisticsExt>::Value);
+    }
+
+    if (FromProto<EChunkFormat>(chunkSpec.chunk_meta().format()) == EChunkFormat::TableUnversionedArrowParquet) {
+        extensionTags.push_back(TProtoExtensionTag<NChunkClient::NProto::TBlocksExt>::Value);
+        extensionTags.push_back(TProtoExtensionTag<NProto::TParquetFormatMetaExt>::Value);
     }
 
     return chunkReader->GetMeta(
@@ -244,7 +250,12 @@ std::vector<IReaderFactoryPtr> CreateReaderFactories(
                         return MakeFuture<ISchemalessChunkReaderPtr>(ex);
                     }
 
-                    auto asyncChunkMeta = DownloadChunkMeta(remoteReader, perClusterChunkReadOptions, partitionTags, dataSource);
+                    auto asyncChunkMeta = DownloadChunkMeta(
+                        remoteReader,
+                        perClusterChunkReadOptions,
+                        partitionTags,
+                        dataSource,
+                        chunkSpec);
 
                     return asyncChunkMeta.Apply(BIND([=] (const TColumnarChunkMetaPtr& chunkMeta) {
                         TReadRange readRange;

--- a/yt/yt/ytlib/table_client/schemaless_table_uploader.cpp
+++ b/yt/yt/ytlib/table_client/schemaless_table_uploader.cpp
@@ -1,0 +1,193 @@
+#include "schemaless_table_uploader.h"
+
+#include "config.h"
+#include "table_ypath_proxy.h"
+
+#include <yt/yt/ytlib/api/native/client.h>
+#include <yt/yt/ytlib/api/native/config.h>
+#include <yt/yt/ytlib/api/native/connection.h>
+
+#include <yt/yt/ytlib/chunk_client/helpers.h>
+#include <yt/yt/ytlib/cypress_client/rpc_helpers.h>
+
+#include <yt/yt/ytlib/table_client/helpers.h>
+
+#include <yt/yt/client/api/transaction.h>
+#include <yt/yt/client/table_client/private.h>
+#include <yt/yt/client/table_client/table_upload_options.h>
+
+namespace NYT::NTableClient {
+
+using namespace NApi;
+using namespace NChunkClient;
+using namespace NCypressClient;
+using namespace NObjectClient;
+using namespace NTransactionClient;
+using namespace NYPath;
+using namespace NYTree;
+
+////////////////////////////////////////////////////////////////////////////////
+
+// These helpers are intentionally shared with the ordinary schemaless writer.
+// They stay internal to table_client, but are non-static functions in its
+// NDetail namespace so alternate chunk producers use the identical protocol.
+namespace NDetail {
+
+TTableSchemaPtr GetChunkSchema(const TRichYPath& richPath, const TTableUploadOptions& options);
+
+void PatchWriterConfigs(
+    const TTableWriterOptionsPtr& options,
+    const TTableWriterConfigPtr& writerConfig,
+    const IAttributeDictionary& attributes,
+    const TTableUploadOptions& tableUploadOptions,
+    const TTableSchemaPtr& chunkSchema,
+    const TTableSchemaPtr& tableSchema,
+    const NLogging::TLogger& logger);
+
+INodePtr GetTableAttributes(
+    const NNative::IClientPtr& client,
+    const TRichYPath& path,
+    TCellTag externalCellTag,
+    const TYPath& objectIdPath,
+    const TUserObject& userObject);
+
+std::tuple<TMasterTableSchemaId, TTransactionId> BeginTableUpload(
+    const NNative::IClientPtr& client,
+    TRichYPath path,
+    TCellTag nativeCellTag,
+    TYPath objectIdPath,
+    TTransactionId transactionId,
+    const TTableUploadOptions& tableUploadOptions,
+    const TTableSchemaPtr& chunkSchema,
+    const NLogging::TLogger& logger,
+    bool setUploadTxTimeout);
+
+std::tuple<TLegacyOwningKey, TChunkListId, int> GetTableUploadParams(
+    const NNative::IClientPtr& client,
+    TRichYPath path,
+    TCellTag externalCellTag,
+    TYPath objectIdPath,
+    TTransactionId uploadTransactionId,
+    const TTableUploadOptions& tableUploadOptions,
+    const NLogging::TLogger& logger);
+
+void EndTableUpload(
+    const NNative::IClientPtr& client,
+    const TRichYPath& path,
+    TCellTag nativeCellTag,
+    TYPath objectIdPath,
+    TTransactionId transactionId,
+    const TTableUploadOptions& tableUploadOptions,
+    NChunkClient::NProto::TDataStatistics dataStatistics);
+
+} // namespace NDetail
+
+////////////////////////////////////////////////////////////////////////////////
+
+TSchemalessTableUploader::TSchemalessTableUploader(
+    TTableWriterOptionsPtr options,
+    const TRichYPath& richPath,
+    NNative::IClientPtr client,
+    TTransactionId transactionId)
+    : Options(std::move(options))
+    , RichPath_(richPath)
+    , Client_(std::move(client))
+    , Logger(TableClientLogger()
+        .WithTag("Path", richPath.GetPath())
+        .WithTag("TransactionId", transactionId))
+{
+    const auto& path = RichPath_.GetPath();
+    UserObject = TUserObject(path);
+    GetUserObjectBasicAttributes(Client_, {&UserObject}, transactionId, Logger, EPermission::Write);
+
+    if (UserObject.Type != EObjectType::Table) {
+        THROW_ERROR_EXCEPTION("Invalid type of %v: expected %Qlv, actual %Qlv",
+            path,
+            EObjectType::Table,
+            UserObject.Type);
+    }
+
+    ObjectId_ = UserObject.ObjectId;
+    auto nativeCellTag = CellTagFromId(ObjectId_);
+    auto externalCellTag = UserObject.ExternalCellTag;
+    auto objectIdPath = FromObjectId(ObjectId_);
+
+    auto attributes = NDetail::GetTableAttributes(
+        Client_,
+        RichPath_,
+        externalCellTag,
+        objectIdPath,
+        UserObject);
+    const auto& attributeDictionary = attributes->Attributes();
+
+    if (attributeDictionary.Get<bool>("dynamic")) {
+        THROW_ERROR_EXCEPTION("Attaching external data to dynamic tables is not supported");
+    }
+
+    TableUploadOptions = GetTableUploadOptions(
+        RichPath_,
+        attributeDictionary,
+        attributeDictionary.Get<TTableSchemaPtr>("schema"),
+        attributeDictionary.Get<i64>("row_count"));
+    ChunkSchema = NDetail::GetChunkSchema(RichPath_, TableUploadOptions);
+
+    // Attach does not write blocks, but the standard option patching determines
+    // the account, medium and chunk properties passed to CreateChunk.
+    NDetail::PatchWriterConfigs(
+        Options,
+        New<TTableWriterConfig>(),
+        attributeDictionary,
+        TableUploadOptions,
+        ChunkSchema,
+        GetSchema(),
+        Logger);
+
+    auto [chunkSchemaId, uploadTransactionId] = NDetail::BeginTableUpload(
+        Client_,
+        RichPath_,
+        nativeCellTag,
+        objectIdPath,
+        transactionId,
+        TableUploadOptions,
+        ChunkSchema,
+        Logger,
+        /*setUploadTxTimeout*/ true);
+    ChunkSchemaId = chunkSchemaId;
+
+    TTransactionAttachOptions attachOptions;
+    attachOptions.AutoAbort = true;
+    attachOptions.PingPeriod = Client_->GetNativeConnection()->GetConfig()->UploadTransactionPingPeriod;
+    UploadTransaction = Client_->AttachTransaction(uploadTransactionId, attachOptions);
+
+    TLegacyOwningKey writerLastKey;
+    std::tie(writerLastKey, ChunkListId, Options->MaxHeavyColumns) = NDetail::GetTableUploadParams(
+        Client_,
+        path,
+        externalCellTag,
+        objectIdPath,
+        UploadTransaction->GetId(),
+        TableUploadOptions,
+        Logger);
+}
+
+const TTableSchemaPtr& TSchemalessTableUploader::GetSchema() const
+{
+    return TableUploadOptions.TableSchema.Get();
+}
+
+void TSchemalessTableUploader::EndUpload(NChunkClient::NProto::TDataStatistics dataStatistics)
+{
+    NDetail::EndTableUpload(
+        Client_,
+        RichPath_,
+        CellTagFromId(ObjectId_),
+        FromObjectId(ObjectId_),
+        UploadTransaction ? UploadTransaction->GetId() : NullTransactionId,
+        TableUploadOptions,
+        std::move(dataStatistics));
+    UploadTransaction->Detach();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NTableClient

--- a/yt/yt/ytlib/table_client/schemaless_table_uploader.h
+++ b/yt/yt/ytlib/table_client/schemaless_table_uploader.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "public.h"
+
+#include <yt/yt/ytlib/api/native/public.h>
+#include <yt/yt/ytlib/chunk_client/helpers.h>
+
+#include <yt/yt/client/api/table_client.h>
+#include <yt/yt/client/ypath/rich.h>
+#include <yt/yt/client/table_client/table_upload_options.h>
+
+namespace NYT::NTableClient {
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Shared upload setup for writers that create their chunks outside the normal
+// schemaless row writer, such as externally attached source objects.
+struct TSchemalessTableUploader
+{
+    TSchemalessTableUploader(
+        TTableWriterOptionsPtr options,
+        const NYPath::TRichYPath& richPath,
+        NApi::NNative::IClientPtr client,
+        NTransactionClient::TTransactionId transactionId);
+
+    TTableWriterOptionsPtr Options;
+    NChunkClient::TUserObject UserObject;
+    TTableSchemaPtr ChunkSchema;
+    NChunkClient::TChunkListId ChunkListId;
+    TMasterTableSchemaId ChunkSchemaId;
+    NApi::ITransactionPtr UploadTransaction;
+    TTableUploadOptions TableUploadOptions;
+
+    const TTableSchemaPtr& GetSchema() const;
+
+    void EndUpload(NChunkClient::NProto::TDataStatistics dataStatistics);
+
+private:
+    const NYPath::TRichYPath RichPath_;
+    const NApi::NNative::IClientPtr Client_;
+    const NLogging::TLogger Logger;
+    NObjectClient::TObjectId ObjectId_;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NTableClient

--- a/yt/yt/ytlib/ya.make
+++ b/yt/yt/ytlib/ya.make
@@ -176,6 +176,7 @@ SRCS(
     chunk_client/erasure_reader.cpp
     chunk_client/erasure_repair.cpp
     chunk_client/erasure_writer.cpp
+    chunk_client/external_parquet.cpp
     chunk_client/fetcher.cpp
     chunk_client/format.cpp
     chunk_client/helpers.cpp
@@ -473,6 +474,7 @@ SRCS(
     table_chunk_format/timestamp_writer.cpp
 
     table_client/blob_table_writer.cpp
+    table_client/attach_table.cpp
     table_client/cache_based_versioned_chunk_reader.cpp
     table_client/cached_versioned_chunk_meta.cpp
     table_client/chunk_column_mapping.cpp
@@ -519,6 +521,7 @@ SRCS(
     table_client/schemaless_buffered_table_writer.cpp
     table_client/schemaless_chunk_reader.cpp
     table_client/schemaless_chunk_writer.cpp
+    table_client/schemaless_table_uploader.cpp
     table_client/schemaless_multi_chunk_reader.cpp
     table_client/skynet_column_evaluator.cpp
     table_client/slice_boundary_key.cpp
@@ -838,6 +841,7 @@ PEERDIR(
     yt/yt/core
     yt/yt/core/http
     yt/yt/library/auth_server
+    yt/yt/library/arrow_adapter
     yt/yt/library/event_log
     yt/yt/library/heavy_schema_validation
     yt/yt/library/min_hash_digest
@@ -846,6 +850,7 @@ PEERDIR(
     yt/yt/library/tvm/service
     yt/yt/library/xor_filter
     yt/yt/client
+    yt/yt/client/arrow
     yt/yt/client/federated
     yt/yt/client/logging
     yt/yt/library/formats

--- a/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
+++ b/yt/yt_proto/yt/client/api/rpc_proxy/proto/api_service.proto
@@ -2971,6 +2971,24 @@ message TRspWriteTable
 
 ////////////////////////////////////////////////////////////////////////////////
 
+message TReqAttachTable
+{
+    required bytes path = 1; // RichYPath
+    repeated string source_uris = 2;
+
+    optional bool allow_incompatible_source_schemas = 3 [default = false];
+    optional string medium = 4;
+    optional int32 source_format = 5;
+
+    optional TTransactionalOptions transactional_options = 100;
+}
+
+message TRspAttachTable
+{
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 message TReqGetJobTrace
 {
     oneof operation_id_or_alias {

--- a/yt/yt_proto/yt/client/chunk_client/proto/chunk_spec.proto
+++ b/yt/yt_proto/yt/client/chunk_client/proto/chunk_spec.proto
@@ -13,6 +13,10 @@ message TChunkReplicaSpec
 {
     // See TChunkReplicaWithMedium.
     required fixed64 encoded_chunk_replica_with_medium = 1;
+
+    // Source object for an externally attached chunk replica. Empty for ordinary
+    // replicas stored by data nodes.
+    optional string source_uri = 2;
 }
 
 // Describes a portion of table chunk.

--- a/yt/yt_proto/yt/client/chunk_client/proto/confirm_chunk_replica_info.proto
+++ b/yt/yt_proto/yt/client/chunk_client/proto/confirm_chunk_replica_info.proto
@@ -1,6 +1,7 @@
 package NYT.NChunkClient.NProto;
 
 import "yt_proto/yt/core/misc/proto/guid.proto";
+import "yt_proto/yt/client/chunk_client/proto/chunk_spec.proto";
 
 option go_package = "go.ytsaurus.tech/yt/go/proto/client/chunk_client";
 
@@ -12,6 +13,9 @@ message TConfirmChunkReplicaInfo
     // COMPAT(cherepashka): drop and make reserved after 25.4.
     required NYT.NProto.TGuid location_uuid = 2;
     optional uint32 location_index = 3;
+    // Carries optional external-replica fields while retaining the legacy
+    // packed representation above for existing confirmations.
+    optional TChunkReplicaSpec replica_spec = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt_proto/yt/client/table_chunk_format/proto/chunk_meta.proto
+++ b/yt/yt_proto/yt/client/table_chunk_format/proto/chunk_meta.proto
@@ -390,4 +390,12 @@ message TColumnNameToConstraintMap
     repeated TColumnNameToConstraintEntry entries = 3;
 }
 
+// The footer is retained because an externally attached Parquet row group is
+// read as an isolated block rather than as a complete Parquet file.
+message TParquetFormatMetaExt
+{
+    optional bytes footer = 1;
+    optional int64 file_size = 2;
+}
+
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Adds initial support for attaching S3-hosted Parquet files as YT tables via `attach_table`:
- Adds native/RPC APIs, Python SDK, and CLI commands.
- Generates YT chunk metadata from Parquet row groups using Arrow, and reads attached chunks through the offshore data gateway.
- Ports required master/replica source-URI handling for externally attached chunks.
- Adds `TestAttachTable` S3 integration coverage.

Main changes:
- `yt/yt/ytlib/table_client/attach_table.cpp`: attach workflow, validation, and master confirmation.
- `yt/yt/ytlib/chunk_client/external_parquet.*` and Arrow reader changes: Parquet-to-chunk metadata and row-group decoding.
- Master/ODG/replica changes: propagation of external S3 source URIs.
- Public API/CLI/Python bindings and integration tests.
