### PR TITLE
Add source URIs to external offshore replicas

### DIFF
--- a/yt/yt/client/chunk_client/chunk_replica-inl.h
+++ b/yt/yt/client/chunk_client/chunk_replica-inl.h
@@ -46,6 +46,16 @@ Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium(
 }
 
 Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium(
+    NNodeTrackerClient::TNodeId nodeId,
+    int replicaIndex,
+    int mediumIndex,
+    std::string sourceUri)
+    : TChunkReplicaWithMedium(nodeId, replicaIndex, mediumIndex)
+{
+    SourceUri_ = std::move(sourceUri);
+}
+
+Y_FORCE_INLINE TChunkReplicaWithMedium::TChunkReplicaWithMedium(
     TChunkReplica replica)
     : TChunkReplicaWithMedium(
         replica.GetNodeId(),
@@ -68,6 +78,11 @@ Y_FORCE_INLINE int TChunkReplicaWithMedium::GetMediumIndex() const
     return Value_ >> 29;
 }
 
+Y_FORCE_INLINE TStringBuf TChunkReplicaWithMedium::GetSourceUri() const
+{
+    return SourceUri_;
+}
+
 Y_FORCE_INLINE TChunkReplica TChunkReplicaWithMedium::ToChunkReplica() const
 {
     return TChunkReplica(GetNodeId(), GetReplicaIndex());
@@ -76,6 +91,9 @@ Y_FORCE_INLINE TChunkReplica TChunkReplicaWithMedium::ToChunkReplica() const
 Y_FORCE_INLINE void ToProto(NProto::TChunkReplicaSpec* protoReplica, TChunkReplicaWithMedium replica)
 {
     protoReplica->set_encoded_chunk_replica_with_medium(replica.Value_);
+    if (!replica.SourceUri_.empty()) {
+        protoReplica->set_source_uri(replica.SourceUri_);
+    }
 }
 
 Y_FORCE_INLINE void ToProto(ui64* protoReplica, TChunkReplicaWithMedium replica)
@@ -86,6 +104,7 @@ Y_FORCE_INLINE void ToProto(ui64* protoReplica, TChunkReplicaWithMedium replica)
 Y_FORCE_INLINE void FromProto(TChunkReplicaWithMedium* replica, NProto::TChunkReplicaSpec protoReplica)
 {
     replica->Value_ = protoReplica.encoded_chunk_replica_with_medium();
+    replica->SourceUri_ = protoReplica.source_uri();
 }
 
 Y_FORCE_INLINE void ToProto(ui32* protoReplica, TChunkReplicaWithMedium replica)
@@ -96,6 +115,7 @@ Y_FORCE_INLINE void ToProto(ui32* protoReplica, TChunkReplicaWithMedium replica)
 Y_FORCE_INLINE void FromProto(TChunkReplicaWithMedium* replica, ui64 protoReplica)
 {
     replica->Value_ = protoReplica;
+    replica->SourceUri_.clear();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/client/chunk_client/chunk_replica.cpp
+++ b/yt/yt/client/chunk_client/chunk_replica.cpp
@@ -93,6 +93,9 @@ void ToProto(NProto::TConfirmChunkReplicaInfo* value, TChunkReplicaWithLocation 
     value->set_replica(replica.Value_);
     ToProto(value->mutable_location_uuid(), replica.ChunkLocationUuid_);
     value->set_location_index(ToProto<ui32>(replica.ChunkLocationIndex_));
+    if (!replica.SourceUri_.empty()) {
+        ToProto(value->mutable_replica_spec(), static_cast<TChunkReplicaWithMedium>(replica));
+    }
 }
 
 void FromProto(TChunkReplicaWithLocation* replica, NProto::TConfirmChunkReplicaInfo value)
@@ -100,6 +103,12 @@ void FromProto(TChunkReplicaWithLocation* replica, NProto::TConfirmChunkReplicaI
     using NYT::FromProto;
 
     replica->Value_ = value.replica();
+    replica->SourceUri_.clear();
+    if (value.has_replica_spec()) {
+        auto replicaWithMedium = FromProto<TChunkReplicaWithMedium>(value.replica_spec());
+        YT_VERIFY(replicaWithMedium.Value_ == replica->Value_);
+        replica->SourceUri_ = std::move(replicaWithMedium.SourceUri_);
+    }
     replica->ChunkLocationUuid_ = FromProto<TChunkLocationUuid>(value.location_uuid());
     // COMPAT(cherepashka)
     if (value.has_location_index()) {

--- a/yt/yt/client/chunk_client/chunk_replica.h
+++ b/yt/yt/client/chunk_client/chunk_replica.h
@@ -11,6 +11,8 @@
 
 #include <yt/yt/core/misc/protobuf_helpers.h>
 
+#include <string>
+
 namespace NYT::NChunkClient {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -24,6 +26,11 @@ public:
         NNodeTrackerClient::TNodeId nodeId,
         int replicaIndex,
         int mediumIndex);
+    TChunkReplicaWithMedium(
+        NNodeTrackerClient::TNodeId nodeId,
+        int replicaIndex,
+        int mediumIndex,
+        std::string sourceUri);
     // NB: Will be assigned to generic medium.
     explicit TChunkReplicaWithMedium(TChunkReplica replica);
 
@@ -32,6 +39,7 @@ public:
     NNodeTrackerClient::TNodeId GetNodeId() const;
     int GetReplicaIndex() const;
     int GetMediumIndex() const;
+    TStringBuf GetSourceUri() const;
 
     TChunkReplica ToChunkReplica() const;
     static TChunkReplicaList ToChunkReplicas(TRange<TChunkReplicaWithMedium> replicasWithMedia);
@@ -55,6 +63,7 @@ private:
      *  29-37: medium index (7 bits)
      */
     ui64 Value_;
+    std::string SourceUri_;
 
     explicit TChunkReplicaWithMedium(ui64 value);
 };

--- a/yt/yt/client/chunk_client/helpers.cpp
+++ b/yt/yt/client/chunk_client/helpers.cpp
@@ -50,4 +50,26 @@ void SetObjectId(NProto::TChunkSpec* chunkSpec, NObjectClient::TObjectId objectI
 
 ////////////////////////////////////////////////////////////////////////////////
 
+EExternalSourceFormat DeduceExternalSourceFormatOrThrow(TStringBuf fileName)
+{
+    if (fileName.ends_with(".parquet")) {
+        return EExternalSourceFormat::Parquet;
+    }
+
+    THROW_ERROR_EXCEPTION(
+        "Cannot deduce an enabled external source format from file name %Qv; only .parquet is supported",
+        fileName);
+}
+
+EChunkFormat GetChunkFormatFromExternalSourceFormat(EExternalSourceFormat externalFormat)
+{
+    switch (externalFormat) {
+        case EExternalSourceFormat::Parquet:
+            return EChunkFormat::TableUnversionedArrowParquet;
+    }
+    YT_ABORT();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 } // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/helpers.h
+++ b/yt/yt/client/chunk_client/helpers.h
@@ -18,6 +18,12 @@ TChunkReplicaList GetReplicasFromChunkSpec(const NProto::TChunkSpec& chunkSpec);
 void SetTabletId(NProto::TChunkSpec* chunkSpec, NTabletClient::TTabletId tabletId);
 void SetObjectId(NProto::TChunkSpec* chunkSpec, NObjectClient::TObjectId objectId);
 
+//! Deduces an enabled external source format from a source object name.
+EExternalSourceFormat DeduceExternalSourceFormatOrThrow(TStringBuf fileName);
+
+//! Maps an external source format to its synthetic chunk format.
+EChunkFormat GetChunkFormatFromExternalSourceFormat(EExternalSourceFormat externalFormat);
+
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace NYT::NChunkClient

--- a/yt/yt/client/chunk_client/public.h
+++ b/yt/yt/client/chunk_client/public.h
@@ -219,6 +219,9 @@ DEFINE_ENUM_WITH_UNDERLYING_TYPE(EChunkFormat, i8,
     ((TableVersionedIndexed)                (8))
     ((TableVersionedSlim)                   (9))
 
+    // External table chunks. The data remains in the source object.
+    ((TableUnversionedArrowParquet)         (12))
+
     // Journal chunks.
     ((JournalDefault)                       (0))
     ((JournalDistributed)                  (11))
@@ -233,6 +236,12 @@ DEFINE_ENUM_WITH_UNDERLYING_TYPE(EChunkReplicaState, i8,
     ((Active)                (1))
     ((Unsealed)              (2))
     ((Sealed)                (3))
+);
+
+//! User-visible formats supported by the external-source attach pipeline.
+//! More source formats can be added without changing the attach protocol.
+DEFINE_ENUM(EExternalSourceFormat,
+    (Parquet)
 );
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/library/s3/object.cpp
+++ b/yt/yt/library/s3/object.cpp
@@ -1,0 +1,51 @@
+#include "object.h"
+
+#include <yt/yt/core/misc/error.h>
+
+#include <contrib/libs/poco/Foundation/include/Poco/URI.h>
+
+namespace NYT::NS3 {
+
+////////////////////////////////////////////////////////////////////////////////
+
+TObjectDescriptor::TObjectDescriptor(std::string bucket, std::string key, bool allowEmptyKey)
+    : Bucket_(std::move(bucket))
+    , Key_(std::move(key))
+{
+    Key_.erase(0, Key_.find_first_not_of('/'));
+
+    THROW_ERROR_EXCEPTION_IF(Bucket_.empty(), "S3 object bucket should not be empty");
+    THROW_ERROR_EXCEPTION_IF(Key_.empty() && !allowEmptyKey, "S3 object key should not be empty");
+}
+
+TObjectDescriptor TObjectDescriptor::FromUri(const std::string& uri, bool allowEmptyKey)
+{
+    Poco::URI parsedUri(uri);
+    THROW_ERROR_EXCEPTION_IF(
+        parsedUri.getScheme() != "s3",
+        "Failed to parse S3 URI %Qv: unexpected scheme %Qv",
+        uri,
+        parsedUri.getScheme());
+    THROW_ERROR_EXCEPTION_IF(
+        !parsedUri.getQuery().empty() || !parsedUri.getFragment().empty(),
+        "Failed to parse S3 URI %Qv: query and fragment are not supported",
+        uri);
+
+    try {
+        return TObjectDescriptor(parsedUri.getHost(), parsedUri.getPath(), allowEmptyKey);
+    } catch (const std::exception& ex) {
+        THROW_ERROR_EXCEPTION("Failed to parse S3 URI %Qv", uri)
+            << ex;
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void FormatValue(TStringBuilderBase* builder, const TObjectDescriptor& object, TStringBuf spec)
+{
+    FormatValue(builder, Format("s3://%v/%v", object.Bucket(), object.Key()), spec);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NS3

--- a/yt/yt/library/s3/object.h
+++ b/yt/yt/library/s3/object.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "public.h"
+
+#include <library/cpp/yt/misc/property.h>
+
+namespace NYT::NS3 {
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Identifies an S3 object by bucket and key.
+//!
+//! Only s3:// URIs are accepted. Leading slashes in the object key are removed
+//! so that the value can be used directly in an S3 request.
+class TObjectDescriptor
+{
+public:
+    TObjectDescriptor(std::string bucket, std::string key, bool allowEmptyKey = false);
+
+    static TObjectDescriptor FromUri(const std::string& uri, bool allowEmptyKey = false);
+
+    DEFINE_BYREF_RO_PROPERTY(std::string, Bucket);
+    DEFINE_BYREF_RO_PROPERTY(std::string, Key);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+void FormatValue(TStringBuilderBase* builder, const TObjectDescriptor& object, TStringBuf spec);
+
+////////////////////////////////////////////////////////////////////////////////
+
+} // namespace NYT::NS3

--- a/yt/yt/library/s3/ya.make
+++ b/yt/yt/library/s3/ya.make
@@ -8,6 +8,7 @@ SRCS(
     credential_provider.cpp
     crypto_helpers.cpp
     http.cpp
+    object.cpp
 )
 
 PEERDIR(

--- a/yt/yt/server/master/CMakeLists.txt
+++ b/yt/yt/server/master/CMakeLists.txt
@@ -56,6 +56,7 @@ target_link_libraries(yt-server-master PUBLIC
   cpp-yt-phdr_cache
   yt-core-https
   yt-library-orchid
+  yt-library-s3
   yt-library-server_program
   yt-library-monitoring
   library-tracing-jaeger

--- a/yt/yt/server/master/cell_master/serialize.h
+++ b/yt/yt/server/master/cell_master/serialize.h
@@ -214,6 +214,7 @@ DEFINE_ENUM(EMasterReign,
     ((FixWaitableLocksAccumulation)                                 (3339))  // ivpiskarev
     ((DetachChunkTrees)                                             (3340))  // babenko
     ((ChunkMergerInfo)                                              (3341))  // aleksandra-zh
+    ((ExternalOffshoreChunkSourceUri)                               (3342))  // pavel-bash
 );
 
 static_assert(TEnumTraits<EMasterReign>::IsMonotonic, "Master reign enum is not monotonic");

--- a/yt/yt/server/master/chunk_server/chunk.cpp
+++ b/yt/yt/server/master/chunk_server/chunk.cpp
@@ -260,6 +260,13 @@ void TChunk::Save(NCellMaster::TSaveContext& context) const
 
     Save(context, EndorsementRequired_);
     Save(context, ConsistentReplicaPlacementHash_);
+
+    if (ExternalOffshoreSourceUri_) {
+        Save(context, true);
+        Save(context, *ExternalOffshoreSourceUri_);
+    } else {
+        Save(context, false);
+    }
 }
 
 void TChunk::Load(NCellMaster::TLoadContext& context)
@@ -310,6 +317,11 @@ void TChunk::Load(NCellMaster::TLoadContext& context)
 
     Load(context, ConsistentReplicaPlacementHash_);
 
+    if (context.GetVersion() >= EMasterReign::ExternalOffshoreChunkSourceUri && Load<bool>(context)) {
+        ExternalOffshoreSourceUri_ = std::make_unique<std::string>();
+        Load(context, *ExternalOffshoreSourceUri_);
+    }
+
     if (auto miscExt = ChunkMeta_->FindExtension<TMiscExt>()) {
         // NB: For hunk chunks can still be not confirmed because we create meta when the chunk is referenced via hunk refs.
 
@@ -330,6 +342,21 @@ void TChunk::Load(NCellMaster::TLoadContext& context)
     } else {
         YT_VERIFY(!IsConfirmed());
     }
+}
+
+void TChunk::SetExternalOffshoreSourceUri(std::string sourceUri)
+{
+    YT_VERIFY(!sourceUri.empty());
+    if (ExternalOffshoreSourceUri_) {
+        YT_VERIFY(*ExternalOffshoreSourceUri_ == sourceUri);
+    } else {
+        ExternalOffshoreSourceUri_ = std::make_unique<std::string>(std::move(sourceUri));
+    }
+}
+
+TStringBuf TChunk::GetExternalOffshoreSourceUri() const
+{
+    return ExternalOffshoreSourceUri_ ? TStringBuf(*ExternalOffshoreSourceUri_) : TStringBuf();
 }
 
 void TChunk::AddParent(TChunkTree* parent)

--- a/yt/yt/server/master/chunk_server/chunk.h
+++ b/yt/yt/server/master/chunk_server/chunk.h
@@ -26,7 +26,9 @@
 
 #include <library/cpp/yt/misc/property.h>
 
+#include <memory>
 #include <optional>
+#include <string>
 
 namespace NYT::NChunkServer {
 
@@ -184,6 +186,11 @@ public:
         const TMedium* medium,
         bool approved);
     void RemoveReplica(TChunkLocationPtrWithReplicaIndex replica, bool approved);
+
+    // An attached external object has one offshore replica. Keep its URI
+    // separately from the compact replica record used for native S3 chunks.
+    void SetExternalOffshoreSourceUri(std::string sourceUri);
+    TStringBuf GetExternalOffshoreSourceUri() const;
 
     void ApproveReplica(TAugmentedStoredChunkReplicaPtr replica);
     int GetApprovedReplicaCount() const;
@@ -480,6 +487,9 @@ private:
     //! which helps to avoid excessive CoW during snapshot construction.
     std::unique_ptr<TReplicasDataBase> ReplicasData_;
 
+    // Allocated only for an externally attached offshore chunk.
+    std::unique_ptr<std::string> ExternalOffshoreSourceUri_;
+
     TChunkRequisition ComputeAggregatedRequisition(const TChunkRequisitionRegistry* registry);
 
     const TReplicasDataBase& ReplicasData() const;
@@ -500,7 +510,7 @@ private:
 DEFINE_MASTER_OBJECT_TYPE(TChunk)
 
 // Think twice before increasing this.
-YT_STATIC_ASSERT_SIZEOF_SANITY(TChunk, 288);
+YT_STATIC_ASSERT_SIZEOF_SANITY(TChunk, 296);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt/server/master/chunk_server/chunk_manager.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_manager.cpp
@@ -98,6 +98,8 @@
 #include <yt/yt/ytlib/node_tracker_client/helpers.h>
 
 #include <yt/yt/ytlib/chunk_client/chunk_meta_extensions.h>
+
+#include <yt/yt/library/s3/object.h>
 #include <yt/yt/ytlib/chunk_client/session_id.h>
 #include <yt/yt/ytlib/chunk_client/helpers.h>
 #include <yt/yt/ytlib/chunk_client/proto/chunk_service.pb.h>
@@ -930,7 +932,22 @@ public:
                     const_cast<TMedium*>(medium),
                     replica.GetReplicaIndex());
                 chunk->AddReplica(storedReplica, medium, /*approved*/ true);
+                if (!replica.GetSourceUri().empty()) {
+                    // Parse eagerly so an invalid external object cannot be
+                    // persisted as an otherwise healthy offshore replica.
+                    NS3::TObjectDescriptor::FromUri(std::string(replica.GetSourceUri()));
+                    chunk->SetExternalOffshoreSourceUri(std::string(replica.GetSourceUri()));
+                }
                 ScheduleChunkRefresh(chunk);
+                continue;
+            }
+
+            if (!replica.GetSourceUri().empty()) {
+                YT_LOG_ALERT(
+                    "Confirmed domestic replica unexpectedly contains an external source URI "
+                    "(ChunkId: %v, NodeId: %v)",
+                    chunk->GetId(),
+                    nodeId);
                 continue;
             }
 

--- a/yt/yt/server/master/chunk_server/chunk_owner_node_proxy.cpp
+++ b/yt/yt/server/master/chunk_server/chunk_owner_node_proxy.cpp
@@ -116,6 +116,7 @@ bool IsAccessLoggedMethod(const std::string& method)
 }
 
 static void PopulateChunkSpecWithReplicas(
+    const TChunk* chunk,
     const TStoredChunkReplicaList& chunkReplicas,
     bool fetchParityReplicas,
     NNodeTrackerServer::TNodeDirectoryBuilder* nodeDirectoryBuilder,
@@ -138,6 +139,11 @@ static void PopulateChunkSpecWithReplicas(
                 replica.GetReplicaIndex(),
                 replica.GetEffectiveMediumIndex());
             chunkSpec->add_replicas(ToProto<ui64>(nodeReplica));
+            NChunkClient::TChunkReplicaWithMedium replicaWithMedium(
+                location->GetNode()->GetId(),
+                replica.GetReplicaIndex(),
+                replica.GetEffectiveMediumIndex());
+            ToProto(chunkSpec->add_replica_specs(), replicaWithMedium);
             nodeDirectoryBuilder->Add(nodeReplica);
         }
 
@@ -145,8 +151,10 @@ static void PopulateChunkSpecWithReplicas(
             NChunkClient::TChunkReplicaWithMedium offshoreReplica(
                 OffshoreNodeId,
                 replica.GetReplicaIndex(),
-                replica.GetEffectiveMediumIndex());
+                replica.GetEffectiveMediumIndex(),
+                std::string(chunk->GetExternalOffshoreSourceUri()));
             chunkSpec->add_replicas(ToProto<ui64>(offshoreReplica));
+            ToProto(chunkSpec->add_replica_specs(), offshoreReplica);
         }
     }
 }
@@ -271,6 +279,7 @@ void BuildChunkSpec(
         extensionTags,
         chunkSpec);
     PopulateChunkSpecWithReplicas(
+        chunk,
         chunkReplicas,
         fetchParityReplicas,
         nodeDirectoryBuilder,
@@ -427,7 +436,13 @@ private:
             }
 
             const auto& chunkReplicas = chunkReplicasOrError.Value();
+            auto* chunk = chunkManager->FindChunk(chunkId);
+            if (!IsObjectAlive(chunk)) {
+                ReplyError(TError("Chunk %v died during replica fetch", chunkId));
+                return false;
+            }
             PopulateChunkSpecWithReplicas(
+                chunk,
                 chunkReplicas,
                 FetchContext_.FetchParityReplicas,
                 &NodeDirectoryBuilder_,

--- a/yt/yt/server/master/chunk_server/private.cpp
+++ b/yt/yt/server/master/chunk_server/private.cpp
@@ -14,7 +14,7 @@ constinit const auto Logger = ChunkServerLogger;
 TStringBuf SerializeChunkFormatAsTableChunkFormat(EChunkFormat chunkFormat)
 {
     // Update the switch below when adding new EChunkFormat values.
-    static_assert(TEnumTraits<EChunkFormat>::GetDomainSize() == 13);
+    static_assert(TEnumTraits<EChunkFormat>::GetDomainSize() == 14);
 
     switch (chunkFormat) {
         case EChunkFormat::FileDefault:
@@ -25,6 +25,8 @@ TStringBuf SerializeChunkFormatAsTableChunkFormat(EChunkFormat chunkFormat)
             return TStringBuf("unversioned_schemaless_horizontal");
         case EChunkFormat::TableUnversionedColumnar:
             return TStringBuf("unversioned_columnar");
+        case EChunkFormat::TableUnversionedArrowParquet:
+            return TStringBuf("unversioned_arrow_parquet");
         case EChunkFormat::TableVersionedSimple:
             return TStringBuf("versioned_simple");
         case EChunkFormat::TableVersionedColumnar:

--- a/yt/yt/server/master/ya.make
+++ b/yt/yt/server/master/ya.make
@@ -466,6 +466,7 @@ PEERDIR(
     yt/yt/core/https
 
     yt/yt/library/orchid
+    yt/yt/library/s3
     yt/yt/library/server_program
     yt/yt/library/monitoring
     yt/yt/library/tracing/jaeger

--- a/yt/yt/ytlib/chunk_client/helpers.cpp
+++ b/yt/yt/ytlib/chunk_client/helpers.cpp
@@ -756,9 +756,21 @@ IChunkReaderPtr CreateRemoteReader(
     TChunkReaderHostPtr chunkReaderHost)
 {
     auto chunkId = FromProto<TChunkId>(chunkSpec.chunk_id());
-    // Decode replicas as TChunkReplicaWithMedium to preserve the full 64-bit value,
-    // including medium index (which TChunkReplica truncates to 29 bits).
-    auto replicas = FromProto<TChunkReplicaWithMediumList>(chunkSpec.replicas());
+    auto chunkFormat = chunkSpec.has_chunk_meta()
+        ? FromProto<EChunkFormat>(chunkSpec.chunk_meta().format())
+        : EChunkFormat::Unknown;
+    // Prefer replica specs since externally attached S3 replicas carry their
+    // source URI there. Keep the packed representation as a compatibility
+    // fallback for ordinary chunks and old masters.
+    TChunkReplicaWithMediumList replicas;
+    if (chunkSpec.replica_specs_size() > 0) {
+        replicas.reserve(chunkSpec.replica_specs_size());
+        for (const auto& replicaSpec : chunkSpec.replica_specs()) {
+            replicas.push_back(FromProto<TChunkReplicaWithMedium>(replicaSpec));
+        }
+    } else {
+        replicas = FromProto<TChunkReplicaWithMediumList>(chunkSpec.replicas());
+    }
 
     auto Logger = ChunkClientLogger().WithTag("ChunkId", chunkId);
 
@@ -821,7 +833,8 @@ IChunkReaderPtr CreateRemoteReader(
             std::move(optionsPerChunk),
             std::move(chunkReaderHost),
             chunkId,
-            std::move(replicas));
+            std::move(replicas),
+            chunkFormat);
     }
 }
 

--- a/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
+++ b/yt/yt/ytlib/chunk_client/proto/data_node_service.proto
@@ -302,6 +302,9 @@ message TReqGetBlockSet
 
     optional double io_fair_share_weight = 18;
 
+    // Required by offshore readers for externally attached source objects.
+    optional int32 chunk_format = 19;
+
     reserved 3, 4, 9;
 }
 
@@ -337,6 +340,9 @@ message TReqGetBlockRange
     optional int64 io_consumed = 8;
 
     optional double io_fair_share_weight = 9;
+
+    // Required by offshore readers for externally attached source objects.
+    optional int32 chunk_format = 10;
 }
 
 message TRspGetBlockRange
@@ -503,6 +509,9 @@ message TReqGetChunkMeta
     optional int64 io_consumed = 11;
 
     optional double io_fair_share_weight = 12;
+
+    // Required by offshore readers for externally attached source objects.
+    optional int32 chunk_format = 13;
 }
 
 message TRspGetChunkMeta

--- a/yt/yt/ytlib/chunk_client/replication_reader.cpp
+++ b/yt/yt/ytlib/chunk_client/replication_reader.cpp
@@ -300,7 +300,8 @@ public:
         TRemoteReaderOptionsPtr options,
         TChunkReaderHostPtr chunkReaderHost,
         TChunkId chunkId,
-        TChunkReplicaWithMediumList seedReplicas)
+        TChunkReplicaWithMediumList seedReplicas,
+        EChunkFormat chunkFormat)
         : Config_(std::move(config))
         , Options_(std::move(options))
         , Client_(chunkReaderHost->Client)
@@ -309,6 +310,7 @@ public:
         , MediumDirectory_(Client_->GetNativeConnection()->GetMediumDirectory())
         , LocalDescriptor_(chunkReaderHost->LocalDescriptor)
         , ChunkId_(chunkId)
+        , ChunkFormat_(chunkFormat)
         , BlockCache_(chunkReaderHost->BlockCache)
         , ChunkMetaCache_(chunkReaderHost->ChunkMetaCache)
         , TrafficMeter_(chunkReaderHost->TrafficMeter)
@@ -412,6 +414,7 @@ private:
     const TMediumDirectoryPtr MediumDirectory_;
     const TNodeDescriptor LocalDescriptor_;
     const TChunkId ChunkId_;
+    const EChunkFormat ChunkFormat_;
     const IBlockCachePtr BlockCache_;
     const IClientChunkMetaCachePtr ChunkMetaCache_;
     const TTrafficMeterPtr TrafficMeter_;
@@ -3548,6 +3551,7 @@ private:
         req->set_block_count(BlockCount_);
         if (peerId.IsOffshore) {
             ToProto(req->mutable_replica_spec(), peer.Replica);
+            req->set_chunk_format(ToUnderlying(reader->ChunkFormat_));
         }
 
         auto rspFuture = req->Invoke();
@@ -3877,6 +3881,7 @@ private:
         YT_OPTIONAL_TO_PROTO(req, extension_tags, ExtensionTags_);
         req->set_supported_chunk_features(ToUnderlying(GetSupportedChunkFeatures()));
         ToProto(req->mutable_replica_spec(), peers[0].Replica);
+        req->set_chunk_format(ToUnderlying(reader->ChunkFormat_));
 
         auto rspFuture = req->Invoke();
         SetSessionFuture(rspFuture.As<void>());
@@ -4738,6 +4743,7 @@ public:
         , ReaderConfig_(reader->Config_)
         , ReaderOptions_(reader->Options_)
         , ChunkId_(reader->ChunkId_)
+        , ChunkFormat_(reader->ChunkFormat_)
         , Logger(reader->Logger)
     { }
 
@@ -4799,6 +4805,7 @@ private:
     const TReplicationReaderConfigPtr ReaderConfig_;
     const TRemoteReaderOptionsPtr ReaderOptions_;
     const TChunkId ChunkId_;
+    const EChunkFormat ChunkFormat_;
     const NLogging::TLogger Logger;
 
     YT_DECLARE_SPIN_LOCK(NThreading::TSpinLock, Lock_);
@@ -4973,6 +4980,7 @@ private:
         }
 
         ToProto(req->mutable_replica_spec(), queuedBatch.PrimaryPeer.Replica);
+        req->set_chunk_format(ToUnderlying(ChunkFormat_));
 
         return req->Invoke()
             .AsUnique().Apply(BIND(
@@ -5139,7 +5147,8 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaList seedReplicas)
+    TChunkReplicaList seedReplicas,
+    EChunkFormat chunkFormat)
 {
     TChunkReplicaWithMediumList replicaList;
     replicaList.reserve(seedReplicas.size());
@@ -5152,7 +5161,8 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
         std::move(options),
         std::move(chunkReaderHost),
         chunkId,
-        std::move(replicaList));
+        std::move(replicaList),
+        chunkFormat);
 }
 
 IChunkReaderAllowingRepairPtr CreateReplicationReader(
@@ -5160,14 +5170,16 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaWithMediumList seedReplicas)
+    TChunkReplicaWithMediumList seedReplicas,
+    EChunkFormat chunkFormat)
 {
     return New<TReplicationReader>(
         std::move(config),
         std::move(options),
         std::move(chunkReaderHost),
         chunkId,
-        std::move(seedReplicas));
+        std::move(seedReplicas),
+        chunkFormat);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/yt/yt/ytlib/chunk_client/replication_reader.h
+++ b/yt/yt/ytlib/chunk_client/replication_reader.h
@@ -24,14 +24,16 @@ IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaList seedReplicas);
+    TChunkReplicaList seedReplicas,
+    EChunkFormat chunkFormat = EChunkFormat::Unknown);
 
 IChunkReaderAllowingRepairPtr CreateReplicationReader(
     TReplicationReaderConfigPtr config,
     TRemoteReaderOptionsPtr options,
     TChunkReaderHostPtr chunkReaderHost,
     TChunkId chunkId,
-    TChunkReplicaWithMediumList seedReplicas);
+    TChunkReplicaWithMediumList seedReplicas,
+    EChunkFormat chunkFormat = EChunkFormat::Unknown);
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yt/yt_proto/yt/client/chunk_client/proto/chunk_spec.proto
+++ b/yt/yt_proto/yt/client/chunk_client/proto/chunk_spec.proto
@@ -13,6 +13,10 @@ message TChunkReplicaSpec
 {
     // See TChunkReplicaWithMedium.
     required fixed64 encoded_chunk_replica_with_medium = 1;
+
+    // Source object for an externally attached chunk replica. Empty for ordinary
+    // replicas stored by data nodes.
+    optional string source_uri = 2;
 }
 
 // Describes a portion of table chunk.

--- a/yt/yt_proto/yt/client/chunk_client/proto/confirm_chunk_replica_info.proto
+++ b/yt/yt_proto/yt/client/chunk_client/proto/confirm_chunk_replica_info.proto
@@ -1,6 +1,7 @@
 package NYT.NChunkClient.NProto;
 
 import "yt_proto/yt/core/misc/proto/guid.proto";
+import "yt_proto/yt/client/chunk_client/proto/chunk_spec.proto";
 
 option go_package = "go.ytsaurus.tech/yt/go/proto/client/chunk_client";
 
@@ -12,6 +13,9 @@ message TConfirmChunkReplicaInfo
     // COMPAT(cherepashka): drop and make reserved after 25.4.
     required NYT.NProto.TGuid location_uuid = 2;
     optional uint32 location_index = 3;
+    // Carries optional external-replica fields while retaining the legacy
+    // packed representation above for existing confirmations.
+    optional TChunkReplicaSpec replica_spec = 4;
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Description

Part 1 of the bigger work "Attach Parquet table from S3 storages" ([original PR](https://github.com/ytsaurus/ytsaurus/pull/1796)).

This PR adds source URI and format metadata to offshore chunk replicas:
- `server/master/chunk_server/chunk.*` — stores external replica source URI and file format.
- `client/chunk_client/helpers.*` — propagates replica metadata to clients.
- `library/s3/object.*` — parses and represents S3 object locations.