### PR TITLE
Wait for open sessions futures in case prefetching enabled

### DIFF
--- a/yt/yt/server/node/tablet_node/lookup.cpp
+++ b/yt/yt/server/node/tablet_node/lookup.cpp
@@ -1165,6 +1165,8 @@ struct TPartitionSession
     // TODO(akozhikhov): Proper block fetcher: Create all partition sessions at the beginning of the lookup session.
     // Right know we cannot do that because chunk reader may call Open in ctor and start reading blocks.
     bool SessionStarted = false;
+    // Prevents reading the partition until all its store sessions are open.
+    TFuture<void> OpenStoreSessionsFuture = VoidFuture;
 
     TStoreSessionList StoreSessions;
     bool StoreSessionsPrepared = false;
@@ -1362,6 +1364,7 @@ private:
         const TSharedRange<TLegacyKey>& keys);
 
     std::vector<TFuture<void>> OpenStoreSessions(const TStoreSessionList& sessions);
+    void StartPartitionSession(TPartitionSession* partitionSession);
 
     void LookupInPartitions(const TError& error);
 
@@ -2089,11 +2092,10 @@ auto TTabletLookupSession<TPipeline>::Run() -> TFuture<typename decltype(TPipeli
     openStoreSessions(ChunkEdenSessions_);
 
     YT_VERIFY(!PartitionSessions_.empty());
-    PartitionSessions_[0].SessionStarted = true;
-    PartitionSessions_[0].StoreSessions = CreateStoreSessions(
-        PartitionSessions_[0].PartitionSnapshot->Stores,
-        PartitionSessions_[0].ChunkLookupKeys);
-    openStoreSessions(PartitionSessions_[0].StoreSessions);
+    StartPartitionSession(&PartitionSessions_[0]);
+    if (PartitionSessions_[0].OpenStoreSessionsFuture != VoidFuture) {
+        openFutures.push_back(PartitionSessions_[0].OpenStoreSessionsFuture);
+    }
 
     InflightKeyLookupCount_ += std::ssize(PartitionSessions_[0].ChunkLookupKeys);
     ++OpenedPartitionSessionCount_;
@@ -2171,6 +2173,21 @@ std::vector<TFuture<void>> TTabletLookupSession<TPipeline>::OpenStoreSessions(
     }
 
     return futures;
+}
+
+template <class TPipeline>
+void TTabletLookupSession<TPipeline>::StartPartitionSession(TPartitionSession* partitionSession)
+{
+    YT_VERIFY(!std::exchange(partitionSession->SessionStarted, true));
+
+    partitionSession->StoreSessions = CreateStoreSessions(
+        partitionSession->PartitionSnapshot->Stores,
+        partitionSession->ChunkLookupKeys);
+
+    auto openFutures = OpenStoreSessions(partitionSession->StoreSessions);
+    partitionSession->OpenStoreSessionsFuture = openFutures.empty()
+        ? VoidFuture
+        : AllSucceeded(std::move(openFutures));
 }
 
 template <class TPipeline>
@@ -2280,11 +2297,7 @@ void TTabletLookupSession<TPipeline>::MaybePrefetchPartitionSessions()
         prefetched = true;
 
         auto& partitionSession = PartitionSessions_[OpenedPartitionSessionCount_];
-        YT_VERIFY(!std::exchange(partitionSession.SessionStarted, true));
-        partitionSession.StoreSessions = CreateStoreSessions(
-            partitionSession.PartitionSnapshot->Stores,
-            partitionSession.ChunkLookupKeys);
-        OpenStoreSessions(partitionSession.StoreSessions);
+        StartPartitionSession(&partitionSession);
 
         InflightKeyLookupCount_ += std::ssize(partitionSession.ChunkLookupKeys);
         ++OpenedPartitionSessionCount_;
@@ -2307,24 +2320,22 @@ bool TTabletLookupSession<TPipeline>::LookupInCurrentPartition()
     if (!partitionSession.SessionStarted) {
         YT_VERIFY(CurrentPartitionSessionIndex_ == OpenedPartitionSessionCount_);
 
-        partitionSession.SessionStarted = true;
-        partitionSession.StoreSessions = CreateStoreSessions(
-            partitionSession.PartitionSnapshot->Stores,
-            partitionSession.ChunkLookupKeys);
-        auto openFutures = OpenStoreSessions(partitionSession.StoreSessions);
+        StartPartitionSession(&partitionSession);
 
         ++OpenedPartitionSessionCount_;
         InflightKeyLookupCount_ += std::ssize(partitionSession.ChunkLookupKeys);
+    }
 
-        if (!openFutures.empty()) {
-            auto sessionFuture = AllSucceeded(std::move(openFutures));
-            sessionFuture.Subscribe(BIND(
-                &TTabletLookupSession::LookupInPartitions,
-                MakeStrong(this))
-                .Via(Invoker_));
-            SetSessionFuture(std::move(sessionFuture));
-            return true;
-        }
+    if (const auto& maybeError = partitionSession.OpenStoreSessionsFuture.TryGet()) {
+        maybeError->ThrowOnError();
+    } else {
+        auto sessionFuture = partitionSession.OpenStoreSessionsFuture;
+        sessionFuture.Subscribe(BIND(
+            &TTabletLookupSession::LookupInPartitions,
+            MakeStrong(this))
+            .Via(Invoker_));
+        SetSessionFuture(std::move(sessionFuture));
+        return true;
     }
 
     return DoLookupInCurrentPartition();

--- a/yt/yt/server/node/tablet_node/lookup.cpp
+++ b/yt/yt/server/node/tablet_node/lookup.cpp
@@ -1166,7 +1166,7 @@ struct TPartitionSession
     // Right know we cannot do that because chunk reader may call Open in ctor and start reading blocks.
     bool SessionStarted = false;
     // Prevents reading the partition until all its store sessions are open.
-    TFuture<void> OpenStoreSessionsFuture = VoidFuture;
+    TFuture<void> OpenStoreSessionsFuture;
 
     TStoreSessionList StoreSessions;
     bool StoreSessionsPrepared = false;
@@ -2093,7 +2093,7 @@ auto TTabletLookupSession<TPipeline>::Run() -> TFuture<typename decltype(TPipeli
 
     YT_VERIFY(!PartitionSessions_.empty());
     StartPartitionSession(&PartitionSessions_[0]);
-    if (PartitionSessions_[0].OpenStoreSessionsFuture != VoidFuture) {
+    if (PartitionSessions_[0].OpenStoreSessionsFuture != OKFuture) {
         openFutures.push_back(PartitionSessions_[0].OpenStoreSessionsFuture);
     }
 
@@ -2186,7 +2186,7 @@ void TTabletLookupSession<TPipeline>::StartPartitionSession(TPartitionSession* p
 
     auto openFutures = OpenStoreSessions(partitionSession->StoreSessions);
     partitionSession->OpenStoreSessionsFuture = openFutures.empty()
-        ? VoidFuture
+        ? OKFuture
         : AllSucceeded(std::move(openFutures));
 }
 
@@ -2326,6 +2326,7 @@ bool TTabletLookupSession<TPipeline>::LookupInCurrentPartition()
         InflightKeyLookupCount_ += std::ssize(partitionSession.ChunkLookupKeys);
     }
 
+    YT_VERIFY(partitionSession.OpenStoreSessionsFuture);
     if (const auto& maybeError = partitionSession.OpenStoreSessionsFuture.TryGet()) {
         maybeError->ThrowOnError();
     } else {

--- a/yt/yt/server/node/tablet_node/unittests/lookup_ut.cpp
+++ b/yt/yt/server/node/tablet_node/unittests/lookup_ut.cpp
@@ -79,7 +79,9 @@ public:
     void AddChunkStore(
         bool eden,
         const std::vector<TVersionedOwningRow>& rows,
-        const TTableSchemaPtr& chunkSchema = nullptr)
+        const TTableSchemaPtr& chunkSchema = nullptr,
+        TFuture<void> metaReadAllowedToProceedFuture = VoidFuture,
+        TPromise<void> notifyMetaReadStartedPromise = {})
     {
         NTabletNode::NProto::TAddStoreDescriptor descriptor;
         descriptor.set_store_type(ToProto(EStoreType::SortedChunk));
@@ -98,7 +100,11 @@ public:
 
         OnNewChunkStore(std::move(descriptor), eden);
 
-        TabletContext_.GetBackendChunkReadersHolder()->RegisterBackendChunkReader(storeId, chunkData);
+        TabletContext_.GetBackendChunkReadersHolder()->RegisterBackendChunkReader(
+            storeId,
+            chunkData,
+            std::move(metaReadAllowedToProceedFuture),
+            std::move(notifyMetaReadStartedPromise));
     }
 
     void OnChunkStoresAdded()
@@ -111,7 +117,7 @@ public:
         return YsonToSchemafulRow(rowString, *TableSchema_, /*treatMissingAsNull*/ false);
     }
 
-    std::vector<TUnversionedOwningRow> DoLookupRows(
+    TFuture<std::vector<TUnversionedOwningRow>> StartDoLookupRows(
         const std::vector<TUnversionedRow>& keys,
         TTimestamp timestamp = SyncLastCommittedTimestamp,
         std::optional<TTimestamp> retentionTimestamp = std::nullopt,
@@ -128,7 +134,7 @@ public:
 
         chunkReadOptions.InitialQueryKind = EInitialQueryKind::LookupRows;
 
-        return WaitFor(BIND(&LookupRowsImpl,
+        return BIND(&LookupRowsImpl,
             Tablet_.get(),
             keys,
             timestampRange,
@@ -136,7 +142,24 @@ public:
             tabletSnapshot,
             chunkReadOptions)
             .AsyncVia(LookupQueue_->GetInvoker())
-            .Run())
+            .Run();
+    }
+
+    std::vector<TUnversionedOwningRow> DoLookupRows(
+        const std::vector<TUnversionedRow>& keys,
+        TTimestamp timestamp = SyncLastCommittedTimestamp,
+        std::optional<TTimestamp> retentionTimestamp = std::nullopt,
+        const std::vector<int>& columnIndexes = {},
+        TTabletSnapshotPtr tabletSnapshot = nullptr,
+        NChunkClient::TClientChunkReadOptions chunkReadOptions = TClientChunkReadOptions())
+    {
+        return WaitFor(StartDoLookupRows(
+            keys,
+            timestamp,
+            retentionTimestamp,
+            columnIndexes,
+            tabletSnapshot,
+            chunkReadOptions))
             .ValueOrThrow();
     }
 
@@ -541,6 +564,56 @@ TEST_F(TLookupTest, TwoPartitions)
     ValidateLookup(
         {YsonToKey("0"), YsonToKey("1")},
         {BuildRow("k=0;v=1"), BuildRow("k=1;v=2")});
+}
+
+TEST_F(TLookupTest, WaitForPrefetchedPartitionStoreSessions)
+{
+    // Put the keys into two partitions to verify that the prefetched second
+    // partition is not read before its store sessions finish opening.
+    AddChunkStore(
+        /*eden*/ false,
+        {
+            YsonToVersionedRow(
+                "<id=0> 0",
+                "<id=1;ts=100> 0"),
+        });
+
+    // With this two futures keep the prefetched store from finishing its asynchronous Open.
+    auto metaReadStartedPromise = NewPromise<void>();
+    auto metaReadAllowToProceedPromise = NewPromise<void>();
+    AddChunkStore(
+        /*eden*/ false,
+        {
+            YsonToVersionedRow(
+                "<id=0> 1",
+                "<id=1;ts=100> 1"),
+        },
+        /*chunkSchema*/ nullptr,
+        metaReadAllowToProceedPromise.ToFuture(),
+        metaReadStartedPromise);
+
+    TableSettings_.MountConfig->MinPartitionDataSize = 1;
+    TableSettings_.MountConfig->EnableHashChunkIndexForLookup = true;
+    TableSettings_.MountConfig->PartitionReaderPrefetchKeyLimit = 2;
+
+    OnChunkStoresAdded();
+
+    EXPECT_EQ(2, std::ssize(Tablet_->PartitionList()));
+
+    auto key0 = YsonToKey("0");
+    auto key1 = YsonToKey("1");
+    auto lookupRowsFuture = StartDoLookupRows({key0, key1});
+
+    // The lookup must wait for the prefetched store session to finish opening.
+    WaitFor(metaReadStartedPromise.ToFuture()).ThrowOnError();
+    TDelayedExecutor::WaitForDuration(TDuration::MilliSeconds(100));
+    EXPECT_FALSE(lookupRowsFuture.IsSet());
+
+    // Complete metadata loading and let the lookup finish.
+    metaReadAllowToProceedPromise.Set();
+    EXPECT_EQ(
+        (std::vector{BuildRow("k=0;v=0"), BuildRow("k=1;v=1")}),
+        WaitFor(lookupRowsFuture).ValueOrThrow());
 }
 
 TEST_F(TLookupTest, VersionedLookup)

--- a/yt/yt/server/node/tablet_node/unittests/lookup_ut.cpp
+++ b/yt/yt/server/node/tablet_node/unittests/lookup_ut.cpp
@@ -80,7 +80,7 @@ public:
         bool eden,
         const std::vector<TVersionedOwningRow>& rows,
         const TTableSchemaPtr& chunkSchema = nullptr,
-        TFuture<void> metaReadAllowedToProceedFuture = VoidFuture,
+        TFuture<void> metaReadAllowedToProceedFuture = OKFuture,
         TPromise<void> notifyMetaReadStartedPromise = {})
     {
         NTabletNode::NProto::TAddStoreDescriptor descriptor;

--- a/yt/yt/server/node/tablet_node/unittests/sorted_store_helpers.h
+++ b/yt/yt/server/node/tablet_node/unittests/sorted_store_helpers.h
@@ -36,9 +36,15 @@ class TMockChunkReader
     : public IChunkReader
 {
 public:
-    TMockChunkReader(TChunkId chunkId, TChunkData chunkData)
+    TMockChunkReader(
+        TChunkId chunkId,
+        TChunkData chunkData,
+        TFuture<void> metaReadAllowedToProceedFuture = VoidFuture,
+        TPromise<void> notifyMetaReadStartedPromise = {})
         : ChunkId_(chunkId)
         , ChunkData_(std::move(chunkData))
+        , MetaReadAllowedToProceedFuture_(std::move(metaReadAllowedToProceedFuture))
+        , NotifyMetaReadStartedPromise_(std::move(notifyMetaReadStartedPromise))
     { }
 
     // IChunkReader implementation.
@@ -67,7 +73,12 @@ public:
         const std::optional<TPartitionTags>& /*partitionTags*/,
         const std::optional<std::vector<int>>& /*extensionTags*/) override
     {
-        return MakeFuture(ChunkData_.Meta);
+        if (NotifyMetaReadStartedPromise_) {
+            NotifyMetaReadStartedPromise_.TrySet();
+        }
+        return MetaReadAllowedToProceedFuture_.Apply(BIND([meta = ChunkData_.Meta] {
+            return meta;
+        }));
     }
 
     TChunkId GetChunkId() const override
@@ -83,6 +94,8 @@ public:
 private:
     const TChunkId ChunkId_;
     const TChunkData ChunkData_;
+    const TFuture<void> MetaReadAllowedToProceedFuture_;
+    const TPromise<void> NotifyMetaReadStartedPromise_;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -93,12 +106,20 @@ class TMockBackendChunkReadersHolder
     : public IBackendChunkReadersHolder
 {
 public:
-    void RegisterBackendChunkReader(TChunkId chunkId, TChunkData chunkData)
+    void RegisterBackendChunkReader(
+        TChunkId chunkId,
+        TChunkData chunkData,
+        TFuture<void> metaReadAllowedToProceedFuture = VoidFuture,
+        TPromise<void> notifyMetaReadStartedPromise = {})
     {
         EmplaceOrCrash(
             ChunkIdToReaders_,
             chunkId,
-            New<TMockChunkReader>(chunkId, std::move(chunkData)));
+            New<TMockChunkReader>(
+                chunkId,
+                std::move(chunkData),
+                std::move(metaReadAllowedToProceedFuture),
+                std::move(notifyMetaReadStartedPromise)));
     }
 
     // IBackendChunkReadersHolder implementation.

--- a/yt/yt/server/node/tablet_node/unittests/sorted_store_helpers.h
+++ b/yt/yt/server/node/tablet_node/unittests/sorted_store_helpers.h
@@ -39,7 +39,7 @@ public:
     TMockChunkReader(
         TChunkId chunkId,
         TChunkData chunkData,
-        TFuture<void> metaReadAllowedToProceedFuture = VoidFuture,
+        TFuture<void> metaReadAllowedToProceedFuture = OKFuture,
         TPromise<void> notifyMetaReadStartedPromise = {})
         : ChunkId_(chunkId)
         , ChunkData_(std::move(chunkData))
@@ -109,7 +109,7 @@ public:
     void RegisterBackendChunkReader(
         TChunkId chunkId,
         TChunkData chunkData,
-        TFuture<void> metaReadAllowedToProceedFuture = VoidFuture,
+        TFuture<void> metaReadAllowedToProceedFuture = OKFuture,
         TPromise<void> notifyMetaReadStartedPromise = {})
     {
         EmplaceOrCrash(

--- a/yt/yt/tests/integration/dynamic_tables/test_lookup.py
+++ b/yt/yt/tests/integration/dynamic_tables/test_lookup.py
@@ -1882,6 +1882,53 @@ class TestAlternativeLookupMethods(TestSortedDynamicTablesBase):
         remount_table("//tmp/t")
         assert lookup_rows("//tmp/t", [{"key": i} for i in range(0, 100)]) == rows
 
+    @authors("sagishev")
+    def test_data_node_lookup_waits_for_prefetched_partition_store_sessions(self):
+        sync_create_cells(1)
+        update_nodes_dynamic_config({
+            "tablet_node": {
+                "versioned_chunk_meta_cache": {"capacity": 1},
+            },
+            "out_throttlers": {
+                "default": {"relative_limit": 0.000008},
+            },
+        })
+
+        self._create_simple_table("//tmp/t", erasure_codec="reed_solomon_3_3")
+        self._enable_data_node_lookup("//tmp/t")
+        set("//tmp/t/@mount_config/enable_key_filter_for_lookup", True)
+        set("//tmp/t/@compression_codec", "none")
+        set("//tmp/t/@max_partition_data_size", 640)
+        set("//tmp/t/@desired_partition_data_size", 512)
+        set("//tmp/t/@min_partition_data_size", 256)
+        set("//tmp/t/@min_partitioning_data_size", 1)
+        set("//tmp/t/@chunk_writer", {
+            "block_size": 64,
+            "key_filter": {"enable": True},
+        })
+        sync_mount_table("//tmp/t")
+
+        tablet_id = get("//tmp/t/@tablets/0/tablet_id")
+        address = get_tablet_leader_address(tablet_id)
+        assert len(self._find_tablet_orchid(address, tablet_id)["partitions"]) == 1
+
+        rows = [{"key": i, "value": str(i) * 32} for i in range(100)]
+        for chunk_index in range(2):
+            insert_rows("//tmp/t", rows[chunk_index * 50:(chunk_index + 1) * 50])
+            sync_flush_table("//tmp/t")
+
+        wait(lambda: len(self._find_tablet_orchid(address, tablet_id)["partitions"]) > 10)
+        wait(lambda: any(
+            partition["stores"]
+            for partition in self._find_tablet_orchid(address, tablet_id)["partitions"]
+        ))
+
+        set("//tmp/t/@mount_config/partition_reader_prefetch_key_limit", 50)
+        remount_table("//tmp/t")
+        assert lookup_rows("//tmp/t", [{"key": 0}]) == rows[:1]
+        keys = [{"key": 0}, {"key": 50}]
+        assert lookup_rows("//tmp/t", keys) == [rows[0], rows[50]]
+
     @authors("akozhikhov")
     def test_indexed_format_and_hunk_erasure_incompatibility(self):
         sync_create_cells(1)


### PR DESCRIPTION
* Changelog entry
Type: fix
Component: dynamic-tables

Fix a race condition that occurs when `partition_reader_prefetch_key_limit` is enabled. Previously, futures created in `MaybePrefetchPartitionSessions` were not awaited, resulting in tablet-node crashes.
Bug can be reproduced consistently on a dynamic table with 100 chunks and the following @mount_config
```
  {
      "enable_data_node_lookup" = %true;
      "enable_key_filter_for_lookup" = %true;
      "partition_reader_prefetch_key_limit" = 50;
  }
```
