### PR TITLE
fix: escape ypath specific symbols in vanilla task paths

### DIFF
--- a/yt/yt/server/controller_agent/experiments.cpp
+++ b/yt/yt/server/controller_agent/experiments.cpp
@@ -155,8 +155,9 @@ TPatchPaths ComputePatchPaths(const IMapNodePtr& spec, EOperationType type)
         case EOperationType::Vanilla: {
             auto tasks = GetNodeByYPath(spec, "/tasks");
             for (const auto& key : tasks->AsMap()->GetKeys()) {
-                userJobPaths.push_back("/tasks/" + key);
-                jobIOPaths.push_back("/tasks/" + key + "/job_io");
+                auto escapedKey = ToYPathLiteral(key);
+                userJobPaths.push_back("/tasks/" + escapedKey);
+                jobIOPaths.push_back("/tasks/" + escapedKey + "/job_io");
             }
             break;
         }

--- a/yt/yt/server/controller_agent/unittests/experiments_ut.cpp
+++ b/yt/yt/server/controller_agent/unittests/experiments_ut.cpp
@@ -199,6 +199,32 @@ TEST(TApplyExperimentsTest, VanillaSimple)
         })");
 }
 
+TEST(TApplyExperimentsTest, VanillaTaskNameWithSlashes)
+{
+    auto spec = ParseSpec(R"({tasks={"process: //path/to/table"={command=true}}})");
+    auto assignment = MakeAssignment(
+        "{controller_job_io_patch={foo_spec=patched}}");
+
+    INodePtr optionsPatch;
+    ApplyExperiments(
+        spec,
+        EOperationType::Vanilla,
+        {assignment},
+        &optionsPatch);
+
+    ExpectSpecEquals(
+        spec,
+        R"({
+            tasks = {
+                "process: //path/to/table" = {
+                    command = true;
+                    job_io = {foo_spec = patched};
+                };
+            };
+            auto_merge = {job_io = {foo_spec = patched}};
+        })");
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 } // namespace


### PR DESCRIPTION
Fixes #1813