### PR TITLE
blockcodecs: switch the snappy codec to klauspost s2

### DIFF
--- a/library/go/blockcodecs/blocksnappy/gotest/ya.make
+++ b/library/go/blockcodecs/blocksnappy/gotest/ya.make
@@ -1,0 +1,3 @@
+GO_TEST_FOR(library/go/blockcodecs/blocksnappy)
+
+END()

--- a/library/go/blockcodecs/blocksnappy/snappy.go
+++ b/library/go/blockcodecs/blocksnappy/snappy.go
@@ -1,7 +1,7 @@
 package blocksnappy
 
 import (
-	"github.com/golang/snappy"
+	"github.com/klauspost/compress/s2"
 
 	"go.ytsaurus.tech/library/go/blockcodecs"
 )
@@ -17,15 +17,15 @@ func (s snappyCodec) Name() string {
 }
 
 func (s snappyCodec) DecodedLen(in []byte) (int, error) {
-	return snappy.DecodedLen(in)
+	return s2.DecodedLen(in)
 }
 
 func (s snappyCodec) Encode(dst, src []byte) ([]byte, error) {
-	return snappy.Encode(dst, src), nil
+	return s2.EncodeSnappy(dst, src), nil
 }
 
 func (s snappyCodec) Decode(dst, src []byte) ([]byte, error) {
-	return snappy.Decode(dst, src)
+	return s2.Decode(dst, src)
 }
 
 func init() {

--- a/library/go/blockcodecs/blocksnappy/snappy_test.go
+++ b/library/go/blockcodecs/blocksnappy/snappy_test.go
@@ -1,0 +1,46 @@
+package blocksnappy
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/golang/snappy"
+)
+
+func TestSnappyCodec_CrossCompatible(t *testing.T) {
+	payloads := [][]byte{
+		nil,
+		[]byte("hello"),
+		bytes.Repeat([]byte("compressible payload "), 1000),
+		make([]byte, 65536),
+	}
+
+	c := snappyCodec{}
+	for _, payload := range payloads {
+		encoded, err := c.Encode(nil, payload)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		decoded, err := snappy.Decode(nil, encoded)
+		if err != nil {
+			t.Fatalf("reference decoder rejected output: %v", err)
+		}
+		if !bytes.Equal(payload, decoded) {
+			t.Fatalf("reference decoder round trip mismatch")
+		}
+
+		refEncoded := snappy.Encode(nil, payload)
+		decoded, err = c.Decode(nil, refEncoded)
+		if err != nil {
+			t.Fatalf("decode reference output: %v", err)
+		}
+		if !bytes.Equal(payload, decoded) {
+			t.Fatalf("round trip of reference output mismatch")
+		}
+
+		n, err := c.DecodedLen(refEncoded)
+		if err != nil || n != len(payload) {
+			t.Fatalf("DecodedLen = %d, %v; want %d", n, err, len(payload))
+		}
+	}
+}

--- a/library/go/blockcodecs/blocksnappy/ya.make
+++ b/library/go/blockcodecs/blocksnappy/ya.make
@@ -2,4 +2,10 @@ GO_LIBRARY()
 
 SRCS(snappy.go)
 
+GO_TEST_SRCS(snappy_test.go)
+
 END()
+
+RECURSE(
+    gotest
+)


### PR DESCRIPTION
s2.EncodeSnappy/Decode emit and read the standard snappy block format (same codec ID 50986, interoperable with the reference implementation) while encoding ~15-50% faster with slightly better ratio, depending on the platform. klauspost/compress is already a dependency via blockzstd.

The new test round-trips the codec against github.com/golang/snappy in both directions.