### PR TITLE
yt/cpp/mapreduce: add supported erasure codecs into EErasureCodecAttr

### DIFF
--- a/yt/cpp/mapreduce/interface/common.h
+++ b/yt/cpp/mapreduce/interface/common.h
@@ -459,6 +459,8 @@ enum EErasureCodecAttr : i8
     EC_REED_SOLOMON_6_3_ATTR    /* "reed_solomon_6_3" */,
     EC_LRC_12_2_2_ATTR          /* "lrc_12_2_2" */,
     EC_ISA_LRC_12_2_2_ATTR      /* "isa_lrc_12_2_2" */,
+    EC_ISA_REED_SOLOMON_6_3_ATTR    /* "isa_reed_solomon_6_3" */,
+    EC_ISA_REED_SOLOMON_3_3_ATTR    /* "isa_reed_solomon_3_3" */,
     /// @endcond
 };
 

--- a/yt/yt/library/erasure/impl/codec_opensource.cpp
+++ b/yt/yt/library/erasure/impl/codec_opensource.cpp
@@ -16,8 +16,8 @@ ICodec* FindCodec(ECodec codecId)
     // NB: Changing the set of supported codecs or their properties requires master reign promotion.
     switch (codecId) {
         // These codecs use ISA-l as a backend.
-        case ECodec::ReedSolomon_3_3: {
-            static NDetail::TCodec<TReedSolomonIsa<3, 3, 8, NDetail::TCodecTraits>> result(ECodec::ReedSolomon_3_3, /*bytewise*/ true);
+        case ECodec::IsaReedSolomon_3_3: {
+            static NDetail::TCodec<TReedSolomonIsa<3, 3, 8, NDetail::TCodecTraits>> result(ECodec::IsaReedSolomon_3_3, /*bytewise*/ true);
             return &result;
         }
         case ECodec::IsaReedSolomon_6_3: {


### PR DESCRIPTION
Add support for canonic (effective) names for "isa_*" codecs.

See:
yt/yt/library/erasure/public.h
yt/yt/library/erasure/impl/codec.cpp
yt/yt/library/erasure/impl/codec_opensource.cpp

Use canonic `ECodec::IsaReedSolomon_3_3` FindCodec() which exactly same (4).

Issue: #1825
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>

---

* Changelog entry
Type: fix
Component: cpp-sdk

Fix support of erasure codecs isa_reed_solomon_3_3 and isa_reed_solomon_6_3
