### PR TITLE
Evict removed local changelogs from reader cache

### DIFF
--- a/yt/yt/server/lib/hydra/local_changelog_store.cpp
+++ b/yt/yt/server/lib/hydra/local_changelog_store.cpp
@@ -475,6 +475,7 @@ private:
 
         auto path = GetChangelogPath(Config_->Path, id);
         RemoveChangelogFiles(path);
+        TryRemove(id, /*forbidResurrection*/ true);
 
         YT_TLOG_INFO("Local changelog removed")
             .With("ChangelogId", id)

--- a/yt/yt/server/lib/hydra/unittests/changelog_ut.cpp
+++ b/yt/yt/server/lib/hydra/unittests/changelog_ut.cpp
@@ -142,6 +142,23 @@ TEST_F(TChangelogTest, Truncate)
     CheckRecords(records, 0, NewRecordCount);
 }
 
+TEST_F(TChangelogTest, RemovedChangelogCannotBeOpenedFromCache)
+{
+    WaitFor(Changelog_->Close())
+        .ThrowOnError();
+    Changelog_.Reset();
+
+    WaitFor(ChangelogStore_->RemoveChangelog(/*id*/ 0))
+        .ThrowOnError();
+
+    EXPECT_THROW_WITH_SUBSTRING(
+        WaitFor(ChangelogStore_->OpenChangelog(/*id*/ 0)).ValueOrThrow(),
+        "No such changelog");
+
+    Changelog_ = WaitFor(ChangelogStore_->CreateChangelog(/*id*/ 0, /*meta*/ {}))
+        .ValueOrThrow();
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 class TChangelogTestNoAutoFlush


### PR DESCRIPTION
Local changelog files were unlinked from disk but stayed open by cache.
This prevents freeing disk space.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
