### PR TITLE
[go] add get_table_columnar_statistics to yt go sdk

### DIFF
--- a/yt/go/yt/integration/columnar_statistics_test.go
+++ b/yt/go/yt/integration/columnar_statistics_test.go
@@ -1,0 +1,119 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.ytsaurus.tech/library/go/ptr"
+	"go.ytsaurus.tech/yt/go/schema"
+	"go.ytsaurus.tech/yt/go/ypath"
+	"go.ytsaurus.tech/yt/go/yt"
+)
+
+func TestGetTableColumnarStatistics(t *testing.T) {
+	suite := NewSuite(t)
+
+	suite.RunClientTests(t, []ClientTest{
+		{Name: "GetTableColumnarStatistics", Test: suite.TestGetTableColumnarStatistics, SkipRPC: true},
+	})
+}
+
+type columnarStatisticsRow struct {
+	Filled  string  `yson:"filled"`
+	Partial *string `yson:"partial"`
+	Empty   *string `yson:"empty"`
+}
+
+func (s *Suite) TestGetTableColumnarStatistics(ctx context.Context, t *testing.T, yc yt.Client) {
+	t.Parallel()
+
+	const (
+		rowCount     = 10
+		filledValue  = "filled-value"
+		partialValue = "partial"
+	)
+
+	path := tmpPath()
+	_, err := yc.CreateNode(ctx, path, yt.NodeTable, &yt.CreateNodeOptions{
+		Attributes: map[string]any{
+			"schema": schema.MustInfer(&columnarStatisticsRow{}),
+		},
+	})
+	require.NoError(t, err)
+
+	// "filled" is set in every row, "partial" in every other row, "empty" is never set.
+	w, err := yc.WriteTable(ctx, path, nil)
+	require.NoError(t, err)
+	for i := 0; i < rowCount; i++ {
+		row := columnarStatisticsRow{Filled: filledValue}
+		if i%2 == 0 {
+			row.Partial = ptr.String(partialValue)
+		}
+		require.NoError(t, w.Write(row))
+	}
+	require.NoError(t, w.Commit())
+
+	partialCount := int64(rowCount / 2)
+
+	t.Run("AllColumns", func(t *testing.T) {
+		stats, err := yc.GetTableColumnarStatistics(ctx, []ypath.YPath{path}, nil)
+		require.NoError(t, err)
+		require.Len(t, stats, 1)
+
+		require.Equal(t, map[string]int64{
+			"filled":  int64(rowCount * len(filledValue)),
+			"partial": partialCount * int64(len(partialValue)),
+			"empty":   0,
+		}, stats[0].ColumnDataWeights)
+
+		require.Equal(t, map[string]int64{
+			"filled":  rowCount,
+			"partial": partialCount,
+			"empty":   0,
+		}, stats[0].ColumnNonNullValueCounts)
+
+		require.NotNil(t, stats[0].ChunkRowCount)
+		require.Equal(t, int64(rowCount), *stats[0].ChunkRowCount)
+		require.Equal(t, int64(0), stats[0].LegacyChunksDataWeight)
+	})
+
+	t.Run("ColumnSelector", func(t *testing.T) {
+		rich := ypath.NewRich(path.String()).SetColumns([]string{"empty", "filled"})
+
+		stats, err := yc.GetTableColumnarStatistics(ctx, []ypath.YPath{rich, path}, nil)
+		require.NoError(t, err)
+		require.Len(t, stats, 2)
+
+		require.Equal(t, map[string]int64{
+			"filled": int64(rowCount * len(filledValue)),
+			"empty":  0,
+		}, stats[0].ColumnDataWeights)
+		require.Equal(t, map[string]int64{
+			"filled": rowCount,
+			"empty":  0,
+		}, stats[0].ColumnNonNullValueCounts)
+
+		// Second path has no column selector and reports all schema columns.
+		require.Len(t, stats[1].ColumnDataWeights, 3)
+		require.Equal(t, stats[0].ColumnDataWeights["filled"], stats[1].ColumnDataWeights["filled"])
+	})
+
+	t.Run("Options", func(t *testing.T) {
+		stats, err := yc.GetTableColumnarStatistics(ctx, []ypath.YPath{path}, &yt.GetTableColumnarStatisticsOptions{
+			FetcherMode:              ptr.T(yt.ColumnarStatisticsFetcherModeFallback),
+			MaxChunksPerNodeFetch:    ptr.Int(1),
+			EnableEarlyFinish:        ptr.Bool(false),
+			EnableReadSizeEstimation: ptr.Bool(true),
+		})
+		require.NoError(t, err)
+		require.Len(t, stats, 1)
+		require.Equal(t, int64(rowCount*len(filledValue)), stats[0].ColumnDataWeights["filled"])
+	})
+
+	t.Run("MissingTable", func(t *testing.T) {
+		_, err := yc.GetTableColumnarStatistics(ctx, []ypath.YPath{tmpPath()}, nil)
+		require.Error(t, err)
+	})
+}

--- a/yt/go/yt/integration/ya.make
+++ b/yt/go/yt/integration/ya.make
@@ -23,6 +23,7 @@ GO_TEST_SRCS(
     auth_client_test.go
     batch_request_test.go
     client_test.go
+    columnar_statistics_test.go
     complex_types_test.go
     compression_test.go
     credentials_provider_test.go

--- a/yt/go/yt/interface.go
+++ b/yt/go/yt/interface.go
@@ -592,6 +592,32 @@ type TablePartitionReader interface {
 	TableReader
 }
 
+type GetTableColumnarStatisticsOptions struct {
+	FetcherMode              *ColumnarStatisticsFetcherMode `http:"fetcher_mode,omitnil"`
+	MaxChunksPerNodeFetch    *int                           `http:"max_chunks_per_node_fetch,omitnil"`
+	EnableEarlyFinish        *bool                          `http:"enable_early_finish,omitnil"`
+	EnableReadSizeEstimation *bool                          `http:"enable_read_size_estimation,omitnil"`
+
+	*TransactionOptions
+}
+
+// ColumnarStatistics holds per-column statistics of a single table (or table range).
+//
+// Maps are keyed by column name. Value statistics (min, max, non-null counts) and
+// estimated unique counts are present only when the table chunks carry them.
+type ColumnarStatistics struct {
+	ColumnDataWeights           map[string]int64 `yson:"column_data_weights"`
+	TimestampTotalWeight        *int64           `yson:"timestamp_total_weight,omitempty"`
+	LegacyChunksDataWeight      int64            `yson:"legacy_chunks_data_weight"`
+	ColumnMinValues             map[string]any   `yson:"column_min_values,omitempty"`
+	ColumnMaxValues             map[string]any   `yson:"column_max_values,omitempty"`
+	ColumnNonNullValueCounts    map[string]int64 `yson:"column_non_null_value_counts,omitempty"`
+	ColumnEstimatedUniqueCounts map[string]int64 `yson:"column_estimated_unique_counts,omitempty"`
+	ChunkRowCount               *int64           `yson:"chunk_row_count,omitempty"`
+	LegacyChunkRowCount         *int64           `yson:"legacy_chunk_row_count,omitempty"`
+	ReadSizeEstimate            *int64           `yson:"read_size_estimate,omitempty"`
+}
+
 type TableClient interface {
 	// WriteTable opens low-level table writer. Use yt.WriteTable() function instead of calling this method directly.
 	//
@@ -634,6 +660,19 @@ type TableClient interface {
 		cookie []byte,
 		options *ReadTablePartitionOptions,
 	) (r TablePartitionReader, err error)
+
+	// GetTableColumnarStatistics returns per-column statistics for each of the given tables.
+	//
+	// Columns are taken from the column selector of each path (e.g. ypath.Rich with Columns set).
+	// For a path without a column selector, statistics are reported for all columns of the table schema.
+	//
+	// http:verb:"get_table_columnar_statistics"
+	// http:params:"paths"
+	GetTableColumnarStatistics(
+		ctx context.Context,
+		paths []ypath.YPath,
+		options *GetTableColumnarStatisticsOptions,
+	) (statistics []ColumnarStatistics, err error)
 }
 
 type StartOperationOptions struct {

--- a/yt/go/yt/internal/decoder.go
+++ b/yt/go/yt/internal/decoder.go
@@ -78,6 +78,7 @@ var (
 	LocateSkynetShareResultDecoder          AnyValueResultDecoder       = newValueResultDecoder()
 	GenerateTimestampResultDecoder          AnyValueResultDecoder       = newSingleValueResultDecoder("timestamp")
 	GetInSyncReplicasResultDecoder          AnyValueResultDecoder       = newValueResultDecoder()
+	GetTableColumnarStatisticsResultDecoder AnyValueResultDecoder       = newValueResultDecoder()
 	StartQueryResultDecoder                 AnyValueResultDecoder       = newSingleValueResultDecoder("query_id")
 	GetQueryResultDecoder                   AnyValueResultDecoder       = newValueResultDecoder()
 	ListQueriesResultDecoder                AnyValueResultDecoder       = newValueResultDecoder()

--- a/yt/go/yt/internal/encoder.go
+++ b/yt/go/yt/internal/encoder.go
@@ -840,6 +840,16 @@ func (e *Encoder) ReadTablePartition(
 	return e.InvokeReadRow(ctx, call)
 }
 
+func (e *Encoder) GetTableColumnarStatistics(
+	ctx context.Context,
+	paths []ypath.YPath,
+	options *yt.GetTableColumnarStatisticsOptions,
+) (statistics []yt.ColumnarStatistics, err error) {
+	call := e.newCall(NewGetTableColumnarStatisticsParams(paths, options))
+	err = e.do(ctx, call, GetTableColumnarStatisticsResultDecoder(&statistics))
+	return statistics, err
+}
+
 func (e *Encoder) tableSchema(ctx context.Context, path ypath.YPath) (*schema.Schema, error) {
 	var attrs struct {
 		Schema     schema.Schema `yson:"schema"`

--- a/yt/go/yt/internal/params_gen.go
+++ b/yt/go/yt/internal/params_gen.go
@@ -1072,6 +1072,50 @@ func logReadTablePartitionOptions(o *yt.ReadTablePartitionOptions) []log.Field {
 	return fields
 }
 
+func writeGetTableColumnarStatisticsOptions(w *yson.Writer, o *yt.GetTableColumnarStatisticsOptions) {
+	if o == nil {
+		return
+	}
+	if o.FetcherMode != nil {
+		w.MapKeyString("fetcher_mode")
+		w.Any(o.FetcherMode)
+	}
+	if o.MaxChunksPerNodeFetch != nil {
+		w.MapKeyString("max_chunks_per_node_fetch")
+		w.Any(o.MaxChunksPerNodeFetch)
+	}
+	if o.EnableEarlyFinish != nil {
+		w.MapKeyString("enable_early_finish")
+		w.Any(o.EnableEarlyFinish)
+	}
+	if o.EnableReadSizeEstimation != nil {
+		w.MapKeyString("enable_read_size_estimation")
+		w.Any(o.EnableReadSizeEstimation)
+	}
+	writeTransactionOptions(w, o.TransactionOptions)
+}
+
+func logGetTableColumnarStatisticsOptions(o *yt.GetTableColumnarStatisticsOptions) []log.Field {
+	if o == nil {
+		return nil
+	}
+	fields := []log.Field{}
+	if o.FetcherMode != nil {
+		fields = append(fields, log.Any("fetcher_mode", o.FetcherMode))
+	}
+	if o.MaxChunksPerNodeFetch != nil {
+		fields = append(fields, log.Any("max_chunks_per_node_fetch", o.MaxChunksPerNodeFetch))
+	}
+	if o.EnableEarlyFinish != nil {
+		fields = append(fields, log.Any("enable_early_finish", o.EnableEarlyFinish))
+	}
+	if o.EnableReadSizeEstimation != nil {
+		fields = append(fields, log.Any("enable_read_size_estimation", o.EnableReadSizeEstimation))
+	}
+	fields = append(fields, logTransactionOptions(o.TransactionOptions)...)
+	return fields
+}
+
 func writeStartOperationOptions(w *yson.Writer, o *yt.StartOperationOptions) {
 	if o == nil {
 		return
@@ -4466,6 +4510,51 @@ func (p *ReadTablePartitionParams) TransactionOptions() **yt.TransactionOptions 
 
 func (p *ReadTablePartitionParams) AccessTrackingOptions() **yt.AccessTrackingOptions {
 	return &p.options.AccessTrackingOptions
+}
+
+type GetTableColumnarStatisticsParams struct {
+	verb    Verb
+	paths   []ypath.YPath
+	options *yt.GetTableColumnarStatisticsOptions
+}
+
+func NewGetTableColumnarStatisticsParams(
+	paths []ypath.YPath,
+	options *yt.GetTableColumnarStatisticsOptions,
+) *GetTableColumnarStatisticsParams {
+	if options == nil {
+		options = &yt.GetTableColumnarStatisticsOptions{}
+	}
+	optionsCopy := *options
+	return &GetTableColumnarStatisticsParams{
+		Verb("get_table_columnar_statistics"),
+		paths,
+		&optionsCopy,
+	}
+}
+
+func (p *GetTableColumnarStatisticsParams) HTTPVerb() Verb {
+	return p.verb
+}
+func (p *GetTableColumnarStatisticsParams) YPath() (ypath.YPath, bool) {
+	return nil, false
+}
+func (p *GetTableColumnarStatisticsParams) Log() []log.Field {
+	fields := []log.Field{
+		log.Any("paths", p.paths),
+	}
+	fields = append(fields, logGetTableColumnarStatisticsOptions(p.options)...)
+	return fields
+}
+
+func (p *GetTableColumnarStatisticsParams) MarshalHTTP(w *yson.Writer) {
+	w.MapKeyString("paths")
+	w.Any(p.paths)
+	writeGetTableColumnarStatisticsOptions(w, p.options)
+}
+
+func (p *GetTableColumnarStatisticsParams) TransactionOptions() **yt.TransactionOptions {
+	return &p.options.TransactionOptions
 }
 
 type StartOperationParams struct {

--- a/yt/go/yt/internal/rpcclient/encoder.go
+++ b/yt/go/yt/internal/rpcclient/encoder.go
@@ -540,6 +540,14 @@ func (e *Encoder) ReadTablePartition(
 	return nil, xerrors.New("implement me")
 }
 
+func (e *Encoder) GetTableColumnarStatistics(
+	ctx context.Context,
+	paths []ypath.YPath,
+	options *yt.GetTableColumnarStatisticsOptions,
+) (statistics []yt.ColumnarStatistics, err error) {
+	return nil, xerrors.New("implement me")
+}
+
 var _ yt.DistributedWriteClient = (*client)(nil)
 
 func (e *Encoder) StartDistributedWriteSession(

--- a/yt/go/yt/internal/verb.go
+++ b/yt/go/yt/internal/verb.go
@@ -88,6 +88,8 @@ const (
 
 	VerbPartitionTables    Verb = "partition_tables"
 	VerbReadTablePartition Verb = "read_table_partition"
+
+	VerbGetTableColumnarStatistics Verb = "get_table_columnar_statistics"
 )
 
 func (v Verb) hasInput() bool {
@@ -128,7 +130,7 @@ func (v Verb) IsHeavy() bool {
 	case VerbPullQueueConsumer:
 		return true
 
-	case VerbPartitionTables, VerbReadTablePartition:
+	case VerbPartitionTables, VerbReadTablePartition, VerbGetTableColumnarStatistics:
 		return true
 	}
 
@@ -158,7 +160,7 @@ func (v Verb) volatile() bool {
 	case VerbPullQueueConsumer:
 		return false
 
-	case VerbPartitionTables, VerbReadTablePartition:
+	case VerbPartitionTables, VerbReadTablePartition, VerbGetTableColumnarStatistics:
 		return false
 	}
 

--- a/yt/go/yt/internal/verb_test.go
+++ b/yt/go/yt/internal/verb_test.go
@@ -9,3 +9,9 @@ import (
 func TestVerbHttpMethod(t *testing.T) {
 	require.Equal(t, "GET", VerbSelectRows.HTTPMethod())
 }
+
+func TestVerbGetTableColumnarStatistics(t *testing.T) {
+	// Read-only command routed to heavy proxies, like in the python client.
+	require.Equal(t, "GET", VerbGetTableColumnarStatistics.HTTPMethod())
+	require.True(t, VerbGetTableColumnarStatistics.IsHeavy())
+}

--- a/yt/go/yt/types.go
+++ b/yt/go/yt/types.go
@@ -434,6 +434,18 @@ const (
 	PartitionModeUnordered PartitionMode = "unordered"
 )
 
+// ColumnarStatisticsFetcherMode selects where columnar statistics are fetched from.
+type ColumnarStatisticsFetcherMode string
+
+const (
+	// ColumnarStatisticsFetcherModeFromNodes fetches statistics from data nodes. This is the default.
+	ColumnarStatisticsFetcherModeFromNodes ColumnarStatisticsFetcherMode = "from_nodes"
+	// ColumnarStatisticsFetcherModeFromMaster uses statistics stored in chunk meta on master.
+	ColumnarStatisticsFetcherModeFromMaster ColumnarStatisticsFetcherMode = "from_master"
+	// ColumnarStatisticsFetcherModeFallback fetches from master and falls back to data nodes when needed.
+	ColumnarStatisticsFetcherModeFallback ColumnarStatisticsFetcherMode = "fallback"
+)
+
 type OrderedTableBackupMode string
 
 const (


### PR DESCRIPTION
### Summary

Adds `GetTableColumnarStatistics` to `yt.TableClient`, a wrapper over the `get_table_columnar_statistics` driver command. It returns one `yt.ColumnarStatistics` per input path: `column_data_weights`, `column_non_null_value_counts`, `column_min_values`/`column_max_values`, `column_estimated_unique_counts`, `chunk_row_count`, `legacy_chunk_row_count`, `legacy_chunks_data_weight`, `timestamp_total_weight` and `read_size_estimate`, keyed by column name. Columns come from the path column selector (`ypath.Rich` with `Columns`); for a path without a selector the proxy uses all schema columns, as the C++ command does.

Options mirror the command parameters: `fetcher_mode` (`yt.ColumnarStatisticsFetcherMode`: `from_nodes`, `from_master`, `fallback`), `max_chunks_per_node_fetch`, `enable_early_finish`, `enable_read_size_estimation`, plus `TransactionOptions`.

The verb is a read-only GET routed to heavy proxies, matching `use_heavy_proxy=True` in the python client.

Implemented in the HTTP client. The RPC client returns `implement me`, like `ReadTable` and `PartitionTables`: the RPC proxy passes paths through as-is and the native client requires column selectors, so a full RPC implementation would also need schema lookups and wire decoding of min/max values.

### Tests

- `internal/verb_test.go`: verb classification (GET, heavy).
- `integration/columnar_statistics_test.go`: a table with a column set in every row, a column set in every other row and a column that is never set. Checks exact data weights (sum of string lengths), exact non-null counts (10 / 5 / 0), `chunk_row_count`, column selectors on one path next to a selector-less path, all options, and the error for a missing table. Runs against the HTTP client via the existing `Suite` (`SkipRPC`).

`params_gen.go` is regenerated with `yt-gen-client`.

* Changelog entry
Type: feature
Component: go-sdk

Add `GetTableColumnarStatistics` (`get_table_columnar_statistics`) to `TableClient`.
